### PR TITLE
Improve tonic-build configuration

### DIFF
--- a/tonic-build/Cargo.toml
+++ b/tonic-build/Cargo.toml
@@ -11,7 +11,6 @@ prost-build = "0.5"
 syn = "1.0"
 quote = "1.0"
 proc-macro2 = "1.0"
-walkdir = "2"
 
 [features]
 rustfmt = []

--- a/tonic-examples/build.rs
+++ b/tonic-examples/build.rs
@@ -1,3 +1,4 @@
 fn main() {
-    tonic_build::compile_protos().unwrap();
+    tonic_build::compile_protos("proto/helloworld/helloworld.proto").unwrap();
+    tonic_build::compile_protos("proto/routeguide/route_guide.proto").unwrap();
 }

--- a/tonic-interop/build.rs
+++ b/tonic-interop/build.rs
@@ -1,13 +1,8 @@
 fn main() {
-    let files = &["proto/grpc/testing/test.proto"];
-    let dirs = &["proto/grpc/testing"];
+    let proto = "proto/grpc/testing/test.proto";
 
-    tonic_build::configure()
-        .compile(files, dirs, "grpc.testing")
-        .unwrap();
+    tonic_build::compile_protos(proto).unwrap();
 
     // prevent needing to rebuild if files (or deps) haven't changed
-    for file in files {
-        println!("cargo:rerun-if-changed={}", file);
-    }
+    println!("cargo:rerun-if-changed={}", proto);
 }


### PR DESCRIPTION
Adds additional configuration options via the builder pattern as well as a simplified `compile_protos` option to tonic-build.