### PR TITLE
chore(docs): Add documentation for modified tonic-build output directory

### DIFF
--- a/tonic/src/macros.rs
+++ b/tonic/src/macros.rs
@@ -9,9 +9,9 @@
 /// ```
 ///
 /// # Note:
-/// **This only works if the tonic-build output directory has been unmodified**. 
+/// **This only works if the tonic-build output directory has been unmodified**.
 /// The default output directory is set to the [`OUT_DIR`] environment variable.
-/// If the output directory has been modified, the following pattern may be used 
+/// If the output directory has been modified, the following pattern may be used
 /// instead of this macro.
 ///
 /// ```rust,ignore

--- a/tonic/src/macros.rs
+++ b/tonic/src/macros.rs
@@ -7,6 +7,26 @@
 ///     tonic::include_proto("helloworld");
 /// }
 /// ```
+///
+/// # Note:
+/// **This only works if the tonic-build output directory has been unmodified**. 
+/// The default output directory is set to the [`OUT_DIR`] environment variable.
+/// If the output directory has been modified, the following pattern may be used 
+/// instead of this macro.
+///
+/// ```rust,ignore
+/// mod pb {
+///     include!("/relative/protobuf/directory/helloworld.rs");
+/// }
+/// ```
+/// You can also use a custom environment variable using the following pattern.
+/// ```rust,ignore
+/// mod pb {
+///     include!(concat!(env!("PROTOBUFS"), concat!("/helloworld.rs")));
+/// }
+/// ```
+///
+/// [`OUT_DIR`]: https://doc.rust-lang.org/cargo/reference/environment-variables.html#environment-variables-cargo-sets-for-build-scripts
 #[macro_export]
 macro_rules! include_proto {
     ($package: tt) => {


### PR DESCRIPTION
As mentioned in issue #37; The docs for `include_proto!` do not describe how to handle the situation where the tonic-build output directory has been modified.

This PR aims to improve the documentation by providing alternative methods to include generated files from tonic-build.