### PR TITLE
chore(codec): Set default buffer size to 8kb

### DIFF
--- a/tonic/src/codec/decode.rs
+++ b/tonic/src/codec/decode.rs
@@ -12,6 +12,8 @@ use std::{
 };
 use tracing::{debug, trace};
 
+const BUFFER_SIZE: usize = 8 * 1024;
+
 /// Streaming requests and responses.
 ///
 /// This will wrap some inner [`Body`] and [`Decoder`] and provide an interface
@@ -82,8 +84,7 @@ impl<T> Streaming<T> {
             body: BoxBody::map_from(body),
             state: State::ReadHeader,
             direction,
-            // FIXME: update this with a reasonable size
-            buf: BytesMut::with_capacity(1024 * 1024),
+            buf: BytesMut::with_capacity(BUFFER_SIZE),
             trailers: None,
         }
     }

--- a/tonic/src/codec/encode.rs
+++ b/tonic/src/codec/encode.rs
@@ -9,6 +9,8 @@ use std::pin::Pin;
 use std::task::{Context, Poll};
 use tokio_codec::Encoder;
 
+const BUFFER_SIZE: usize = 8 * 1024;
+
 pub(crate) fn encode_server<T, U>(
     encoder: T,
     source: U,
@@ -39,7 +41,7 @@ where
     U: Stream<Item = Result<T::Item, Status>>,
 {
     async_stream::stream! {
-        let mut buf = BytesMut::with_capacity(1024 * 1024);
+        let mut buf = BytesMut::with_capacity(BUFFER_SIZE);
         futures_util::pin_mut!(source);
 
         loop {


### PR DESCRIPTION
Set the default buffer size to 8kb for now. We should explore in the future what other implementations do.
