### PR TITLE
feat(build): Expose prost-build type_attributes and field_attribu…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /target
 **/*.rs.bk
 Cargo.lock
+tags

--- a/tonic-build/tests/wellknown.rs
+++ b/tonic-build/tests/wellknown.rs
@@ -4,6 +4,9 @@ fn wellknown() {
     tonic_build::configure()
         .out_dir(tmp)
         .format(false)
+        .type_attribute(".", "#[derive(Serialize, Deserialize)]")
+        .type_attribute(".", "#[serde(rename_all = \"camelCase\")]")
+        .field_attribute("in", "#[serde(rename = \"in\")]")
         .compile(&["tests/protos/wellknown.proto"], &["tests/protos"])
         .unwrap();
 }


### PR DESCRIPTION
## Motivation

When using tonic, you sometimes want to also serialize the generated types with Serde. 

## Solution

Expose the underlying `prost-build.Config` options for `type_attributes` and `field_attributes`, which allows you to extend the generated types.

```
   tonic_build::configure()
        .out_dir(tmp)
        .format(false)
        .type_attribute(".", "#[derive(Serialize, Deserialize)]")
        .type_attribute(".", "#[serde(rename_all = \"camelCase\")]")
        .field_attribute("in", "#[serde(rename = \"in\")]")
        .compile(&["tests/protos/wellknown.proto"], &["tests/protos"])
        .unwrap();
```

Would make the resulting generated code serializable, deserializable, camelCase, and preserve 'in' vs the prost generated 'in_'. 