### PR TITLE
fix(transport): Rename server tls config method

### DIFF
--- a/tonic/src/transport/server.rs
+++ b/tonic/src/transport/server.rs
@@ -286,7 +286,7 @@ impl ServerTlsConfig {
     ///
     /// This overrides all other TLS options set via other means.
     #[cfg(feature = "rustls")]
-    pub fn rustls_client_config(
+    pub fn rustls_server_config(
         &mut self,
         config: tokio_rustls::rustls::ServerConfig,
     ) -> &mut Self {


### PR DESCRIPTION
This naming error slipped in as part of #48 - in a `ServerTlsConfig` you should specify `ServerConfig` rather than a `ClientConfig` for `rustls`