### PR TITLE
Suggestion: Add edition to example Cargo.toml snippet

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,8 @@ $ cargo +beta build
 #### `Cargo.toml`
 
 ```toml
+edition = "2018"
+
 [dependencies]
 tonic = "*"
 bytes = "0.4"


### PR DESCRIPTION
## Motivation

Developers who are adding tonic to an existing project may not have the edition set. This will cause errors in the generated service code.

## Solution

Explicitly specify the edition in the example to make the requirement clear.