### PR TITLE
Make Streaming<T> Sync

### DIFF
--- a/tonic/src/codec/decode.rs
+++ b/tonic/src/codec/decode.rs
@@ -27,6 +27,7 @@ pub struct Streaming<T> {
     trailers: Option<MetadataMap>,
 }
 
+unsafe impl<T> Sync for Streaming<T> {}
 impl<T> Unpin for Streaming<T> {}
 
 #[derive(Debug)]


### PR DESCRIPTION
Safe because there are no `&self` methods on `Streaming<T>` that access any of its non `Sync` members.

Fixes #81
Closes #84 