### PR TITLE
Allow access to peer identity in a gRPC Server Interceptor

### DIFF
--- a/tonic/Cargo.toml
+++ b/tonic/Cargo.toml
@@ -35,6 +35,7 @@ transport = [
 ]
 openssl = ["openssl1", "tokio-openssl", "tls"]
 rustls = ["tokio-rustls", "tls"]
+tls_client_identity = ["x509-parser"]
 tls = []
 
 [[bench]]
@@ -82,6 +83,9 @@ openssl1 = { package = "openssl", version = "0.10", optional = true }
 
 # rustls
 tokio-rustls = { version = "=0.12.0-alpha.4", optional = true }
+
+# tls client identity
+x509-parser = { version = "0.6", optional = true }
 
 [package.metadata.docs.rs]
 all-features = true

--- a/tonic/src/transport/service/io.rs
+++ b/tonic/src/transport/service/io.rs
@@ -1,24 +1,98 @@
+use std::fmt::{Debug, Error, Formatter};
 use std::io;
 use std::pin::Pin;
 use std::task::{Context, Poll};
 use tokio::io::{AsyncRead, AsyncWrite};
 
 pub(in crate::transport) trait Io:
-    AsyncRead + AsyncWrite + Send + Unpin + 'static
-{
-}
+AsyncRead + AsyncWrite + Send + Unpin + 'static
+{}
 
 impl<T> Io for T where T: AsyncRead + AsyncWrite + Send + Unpin + 'static {}
 
-pub(crate) struct BoxedIo(Pin<Box<dyn Io>>);
+// IO structure used by GRPC servers
+pub(crate) struct ServerIo {
+    io: Pin<Box<dyn Io>>,
+    #[cfg(feature = "tls_client_identity")]
+    pub(crate) client_identity: Option<String>,
+}
 
-impl BoxedIo {
+impl ServerIo {
+    #[cfg(not(feature = "tls_client_identity"))]
     pub(in crate::transport) fn new<I: Io>(io: I) -> Self {
-        BoxedIo(Box::pin(io))
+        ServerIo {
+            io: Box::pin(io),
+        }
+    }
+
+    #[cfg(feature = "tls_client_identity")]
+    pub(in crate::transport) fn new<I: Io>(io: I, client_identity: Option<String>) -> Self {
+        ServerIo {
+            io: Box::pin(io),
+            client_identity,
+        }
     }
 }
 
-impl AsyncRead for BoxedIo {
+impl Debug for ServerIo {
+    #[cfg(feature = "tls_client_identity")]
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), Error> {
+        f.write_fmt(format_args!(
+            "ServerIo(Identity: {:?})",
+            self.client_identity
+        ))
+    }
+
+    #[cfg(not(feature = "tls_client_identity"))]
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), Error> {
+        f.write_str("ServerIo")
+    }
+}
+
+impl AsyncRead for ServerIo {
+    fn poll_read(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &mut [u8],
+    ) -> Poll<io::Result<usize>> {
+        Pin::new(&mut self.io).poll_read(cx, buf)
+    }
+}
+
+impl AsyncWrite for ServerIo {
+    fn poll_write(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &[u8],
+    ) -> Poll<io::Result<usize>> {
+        Pin::new(&mut self.io).poll_write(cx, buf)
+    }
+
+    fn poll_flush(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        Pin::new(&mut self.io).poll_flush(cx)
+    }
+
+    fn poll_shutdown(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        Pin::new(&mut self.io).poll_shutdown(cx)
+    }
+}
+
+/// IO structure used by GRPC clients
+pub(crate) struct ClientIo(Pin<Box<dyn Io>>);
+
+impl ClientIo {
+    pub(in crate::transport) fn new<I: Io>(io: I) -> Self {
+        ClientIo(Box::pin(io))
+    }
+}
+
+impl Debug for ClientIo {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), Error> {
+        f.write_str("ClientIo")
+    }
+}
+
+impl AsyncRead for ClientIo {
     fn poll_read(
         mut self: Pin<&mut Self>,
         cx: &mut Context<'_>,
@@ -28,7 +102,7 @@ impl AsyncRead for BoxedIo {
     }
 }
 
-impl AsyncWrite for BoxedIo {
+impl AsyncWrite for ClientIo {
     fn poll_write(
         mut self: Pin<&mut Self>,
         cx: &mut Context<'_>,

--- a/tonic/src/transport/service/mod.rs
+++ b/tonic/src/transport/service/mod.rs
@@ -12,7 +12,7 @@ pub(crate) use self::add_origin::AddOrigin;
 pub(crate) use self::connection::Connection;
 pub(crate) use self::connector::connector;
 pub(crate) use self::discover::ServiceList;
-pub(crate) use self::io::BoxedIo;
+pub(crate) use self::io::ServerIo;
 pub(crate) use self::layer::{layer_fn, ServiceBuilderExt};
 #[cfg(feature = "tls")]
 pub(crate) use self::tls::{TlsAcceptor, TlsConnector};


### PR DESCRIPTION
This is an initial work in progress of a mechanism to access the TLS identity of the client in a server interceptor.