### PR TITLE
failing unit test / tls feature import for unit test

### DIFF
--- a/tonic/src/transport/mod.rs
+++ b/tonic/src/transport/mod.rs
@@ -19,6 +19,7 @@
 //! ## Client
 //!
 //! ```no_run
+//! # # [cfg(feature = "tls")]
 //! # use tonic::transport::{Channel, Certificate, ClientTlsConfig};
 //! # use std::time::Duration;
 //! # use tonic::body::BoxBody;
@@ -45,6 +46,7 @@
 //! ## Server
 //!
 //! ```no_run
+//! # #[cfg(feature = "tls")]
 //! # use tonic::transport::{Server, Identity, ServerTlsConfig};
 //! # use tower::{Service, service_fn};
 //! # use futures_util::future::{err, ok};


### PR DESCRIPTION
Was looking into #93 and saw a couple failing unit tests in the main Tonic crate -  on the import of ServerTlsConfig and ClientTlsConfig... added cfg attribute.