### PR TITLE
feat(transport): Change channel connect to be async

### DIFF
--- a/tonic-build/src/client.rs
+++ b/tonic-build/src/client.rs
@@ -54,12 +54,13 @@ fn generate_connect(service_ident: &syn::Ident) -> TokenStream {
     quote! {
         impl #service_ident<tonic::transport::Channel> {
             /// Attempt to create a new client by connecting to a given endpoint.
-            pub fn connect<D>(dst: D) -> Result<Self, tonic::transport::Error>
+            pub async fn connect<D>(dst: D) -> Result<Self, tonic::transport::Error>
             where
                 D: std::convert::TryInto<tonic::transport::Endpoint>,
                 D::Error: Into<StdError>,
             {
-                tonic::transport::Endpoint::new(dst).map(|c| Self::new(c.channel()))
+                let conn = tonic::transport::Endpoint::new(dst)?.connect().await?;
+                Ok(Self::new(conn))
             }
         }
     }

--- a/tonic-examples/src/authentication/client.rs
+++ b/tonic-examples/src/authentication/client.rs
@@ -15,7 +15,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 HeaderValue::from_static("Bearer some-secret-token"),
             );
         })
-        .channel();
+        .connect()
+        .await?;
 
     let mut client = EchoClient::new(channel);
 

--- a/tonic-examples/src/gcp/client.rs
+++ b/tonic-examples/src/gcp/client.rs
@@ -37,7 +37,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             headers.insert("authorization", header_value.clone());
         })
         .tls_config(&tls_config)
-        .channel();
+        .connect()
+        .await?;
 
     let mut service = PublisherClient::new(channel);
 

--- a/tonic-examples/src/helloworld/client.rs
+++ b/tonic-examples/src/helloworld/client.rs
@@ -6,7 +6,7 @@ use hello_world::{client::GreeterClient, HelloRequest};
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let mut client = GreeterClient::connect("http://[::1]:50051")?;
+    let mut client = GreeterClient::connect("http://[::1]:50051").await?;
 
     let request = tonic::Request::new(HelloRequest {
         name: "Tonic".into(),

--- a/tonic-examples/src/multiplex/client.rs
+++ b/tonic-examples/src/multiplex/client.rs
@@ -12,7 +12,9 @@ use tonic::transport::Endpoint;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let channel = Endpoint::from_static("http://[::1]:50051").channel();
+    let channel = Endpoint::from_static("http://[::1]:50051")
+        .connect()
+        .await?;
 
     let mut greeter_client = GreeterClient::new(channel.clone());
     let mut echo_client = EchoClient::new(channel);

--- a/tonic-examples/src/routeguide/client.rs
+++ b/tonic-examples/src/routeguide/client.rs
@@ -91,7 +91,7 @@ async fn run_route_chat(client: &mut RouteGuideClient<Channel>) -> Result<(), Bo
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let mut client = RouteGuideClient::connect("http://[::1]:10000")?;
+    let mut client = RouteGuideClient::connect("http://[::1]:10000").await?;
 
     println!("*** SIMPLE RPC ***");
     let response = client

--- a/tonic-examples/src/tls/client.rs
+++ b/tonic-examples/src/tls/client.rs
@@ -17,7 +17,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let channel = Channel::from_static("http://[::1]:50051")
         .tls_config(&tls)
-        .channel();
+        .connect()
+        .await?;
 
     let mut client = EchoClient::new(channel);
     let request = tonic::Request::new(EchoRequest {

--- a/tonic-examples/src/tls_client_auth/client.rs
+++ b/tonic-examples/src/tls_client_auth/client.rs
@@ -21,8 +21,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let channel = Channel::from_static("http://[::1]:50051")
         .tls_config(&tls)
-        .clone()
-        .channel();
+        .connect()
+        .await?;
 
     let mut client = EchoClient::new(channel);
 

--- a/tonic-interop/src/bin/client.rs
+++ b/tonic-interop/src/bin/client.rs
@@ -41,7 +41,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         );
     }
 
-    let channel = endpoint.channel();
+    let channel = endpoint.connect().await?;
 
     let mut client = client::TestClient::new(channel.clone());
     let mut unimplemented_client = client::UnimplementedClient::new(channel);

--- a/tonic/Cargo.toml
+++ b/tonic/Cargo.toml
@@ -29,7 +29,6 @@ transport = [
     "hyper",
     "tokio",
     "tower",
-    "tower-reconnect",
     "tower-balance",
     "tower-load",
 ]
@@ -68,7 +67,6 @@ hyper = { version = "=0.13.0-alpha.4", features = ["unstable-stream"], optional 
 tokio = { version = "=0.2.0-alpha.6", default-features = false, features = ["tcp"], optional = true }
 tower = { version = "=0.3.0-alpha.2", optional = true}
 tower-make = "=0.3.0-alpha.2a"
-tower-reconnect = { version = "=0.3.0-alpha.2", optional = true }
 tower-balance =  { version = "=0.3.0-alpha.2", optional = true }
 tower-load = { version = "=0.3.0-alpha.2", optional = true }
 

--- a/tonic/benches/benchmarks/compiled_protos/helloworld.rs
+++ b/tonic/benches/benchmarks/compiled_protos/helloworld.rs
@@ -20,12 +20,13 @@ pub mod client {
     }
     impl GreeterClient<tonic::transport::Channel> {
         #[doc = r" Attempt to create a new client by connecting to a given endpoint."]
-        pub fn connect<D>(dst: D) -> Result<Self, tonic::transport::Error>
+        pub async fn connect<D>(dst: D) -> Result<Self, tonic::transport::Error>
         where
             D: std::convert::TryInto<tonic::transport::Endpoint>,
             D::Error: Into<StdError>,
         {
-            tonic::transport::Endpoint::new(dst).map(|c| Self::new(c.channel()))
+            let conn = tonic::transport::Endpoint::new(dst)?.connect().await?;
+            Ok(Self::new(conn))
         }
     }
     impl<T> GreeterClient<T>

--- a/tonic/src/transport/endpoint.rs
+++ b/tonic/src/transport/endpoint.rs
@@ -142,8 +142,8 @@ impl Endpoint {
     }
 
     /// Create a channel from this config.
-    pub fn channel(&self) -> Channel {
-        Channel::connect(self.clone())
+    pub async fn connect(&self) -> Result<Channel, super::Error> {
+        Channel::connect(self.clone()).await
     }
 }
 

--- a/tonic/src/transport/mod.rs
+++ b/tonic/src/transport/mod.rs
@@ -35,7 +35,8 @@
 //!     .timeout(Duration::from_secs(5))
 //!     .rate_limit(5, Duration::from_secs(1))
 //!     .concurrency_limit(256)
-//!     .channel();
+//!     .connect()
+//!     .await?;
 //!
 //! channel.call(Request::new(BoxBody::empty())).await?;
 //! # Ok(())

--- a/tonic/src/transport/service/mod.rs
+++ b/tonic/src/transport/service/mod.rs
@@ -5,6 +5,7 @@ mod discover;
 mod either;
 mod io;
 mod layer;
+mod reconnect;
 mod router;
 #[cfg(feature = "tls")]
 mod tls;

--- a/tonic/src/transport/service/reconnect.rs
+++ b/tonic/src/transport/service/reconnect.rs
@@ -1,0 +1,174 @@
+use crate::Error;
+use pin_project::pin_project;
+use std::fmt;
+use std::{
+    future::Future,
+    pin::Pin,
+    task::{Context, Poll},
+};
+use tower_make::MakeService;
+use tower_service::Service;
+use tracing::trace;
+
+pub(crate) struct Reconnect<M, Target>
+where
+    M: Service<Target>,
+{
+    mk_service: M,
+    state: State<M::Future, M::Response>,
+    target: Target,
+}
+
+#[derive(Debug)]
+enum State<F, S> {
+    Idle,
+    Connecting(F),
+    Connected(S),
+}
+
+impl<M, Target> Reconnect<M, Target>
+where
+    M: Service<Target>,
+{
+    pub(crate) fn new<S, Request>(initial_connection: S, mk_service: M, target: Target) -> Self
+    where
+        M: Service<Target, Response = S>,
+        S: Service<Request>,
+        Error: From<M::Error> + From<S::Error>,
+        Target: Clone,
+    {
+        Reconnect {
+            mk_service,
+            state: State::Connected(initial_connection),
+            target,
+        }
+    }
+}
+
+impl<M, Target, S, Request> Service<Request> for Reconnect<M, Target>
+where
+    M: Service<Target, Response = S>,
+    S: Service<Request>,
+    M::Future: Unpin,
+    Error: From<M::Error> + From<S::Error>,
+    Target: Clone,
+{
+    type Response = S::Response;
+    type Error = Error;
+    type Future = ResponseFuture<S::Future>;
+
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        let ret;
+        let mut state;
+
+        loop {
+            match self.state {
+                State::Idle => {
+                    trace!("poll_ready; idle");
+                    match self.mk_service.poll_ready(cx) {
+                        Poll::Ready(r) => r?,
+                        Poll::Pending => {
+                            trace!("poll_ready; MakeService not ready");
+                            return Poll::Pending;
+                        }
+                    }
+
+                    let fut = self.mk_service.make_service(self.target.clone());
+                    self.state = State::Connecting(fut);
+                    continue;
+                }
+                State::Connecting(ref mut f) => {
+                    trace!("poll_ready; connecting");
+                    match Pin::new(f).poll(cx) {
+                        Poll::Ready(Ok(service)) => {
+                            state = State::Connected(service);
+                        }
+                        Poll::Pending => {
+                            trace!("poll_ready; not ready");
+                            return Poll::Pending;
+                        }
+                        Poll::Ready(Err(e)) => {
+                            trace!("poll_ready; error");
+                            state = State::Idle;
+                            ret = Err(e.into());
+                            break;
+                        }
+                    }
+                }
+                State::Connected(ref mut inner) => {
+                    trace!("poll_ready; connected");
+                    match inner.poll_ready(cx) {
+                        Poll::Ready(Ok(())) => {
+                            trace!("poll_ready; ready");
+                            return Poll::Ready(Ok(()));
+                        }
+                        Poll::Pending => {
+                            trace!("poll_ready; not ready");
+                            return Poll::Pending;
+                        }
+                        Poll::Ready(Err(_)) => {
+                            trace!("poll_ready; error");
+                            state = State::Idle;
+                        }
+                    }
+                }
+            }
+
+            self.state = state;
+        }
+
+        self.state = state;
+        Poll::Ready(ret)
+    }
+
+    fn call(&mut self, request: Request) -> Self::Future {
+        let service = match self.state {
+            State::Connected(ref mut service) => service,
+            _ => panic!("service not ready; poll_ready must be called first"),
+        };
+
+        let fut = service.call(request);
+        ResponseFuture::new(fut)
+    }
+}
+
+impl<M, Target> fmt::Debug for Reconnect<M, Target>
+where
+    M: Service<Target> + fmt::Debug,
+    M::Future: fmt::Debug,
+    M::Response: fmt::Debug,
+    Target: fmt::Debug,
+{
+    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt.debug_struct("Reconnect")
+            .field("mk_service", &self.mk_service)
+            .field("state", &self.state)
+            .field("target", &self.target)
+            .finish()
+    }
+}
+
+#[pin_project]
+#[derive(Debug)]
+pub(crate) struct ResponseFuture<F> {
+    #[pin]
+    inner: F,
+}
+
+impl<F> ResponseFuture<F> {
+    pub(crate) fn new(inner: F) -> Self {
+        ResponseFuture { inner }
+    }
+}
+
+impl<F, T, E> Future for ResponseFuture<F>
+where
+    F: Future<Output = Result<T, E>>,
+    E: Into<Error>,
+{
+    type Output = Result<T, Error>;
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        self.project().inner.poll(cx).map_err(Into::into)
+    }
+}


### PR DESCRIPTION
This makes it so you can check if the initial connection
is established. Before this we used reconnect which would
lazily attempt to connect. So if you were trying to connect
to a non existant Server you wouldn't find out until after
you attempted your first RPC. This simplifies everything
by allowing you connect before creating the RPC client.

BREAKING CHANGE: `Endpoint::channel` was removed in favor of
an async `Endpoint::connect`.