### PR TITLE
chore(tutorials): Add .await after client connect call

### DIFF
--- a/tonic-examples/helloworld-tutorial.md
+++ b/tonic-examples/helloworld-tutorial.md
@@ -291,7 +291,7 @@ use hello_world::{client::GreeterClient, HelloRequest};
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let mut client = GreeterClient::connect("http://[::1]:50051")?;
+    let mut client = GreeterClient::connect("http://[::1]:50051").await?;
 
     let request = tonic::Request::new(HelloRequest {
         name: "Tonic".into(),

--- a/tonic-examples/routeguide-tutorial.md
+++ b/tonic-examples/routeguide-tutorial.md
@@ -615,7 +615,7 @@ use route_guide::{client::RouteGuideClient, Point, Rectangle, RouteNote};
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let mut client = RouteGuideClient::connect("http://[::1]:10000")?;
+    let mut client = RouteGuideClient::connect("http://[::1]:10000").await?;
 
      Ok(())
 }


### PR DESCRIPTION
## Motivation

Both tutorials were missing `.await` on the client connect call, causing the compiler to issue errors.
Thanks for alce#6260 on the #tonic-users discord channel for providing the answer.

## Solution

Add `.await?` to `let mut client = GreeterClient::connect("http://[::1]:50051")` in both tutorials