### PR TITLE
fix error in routeguide tutorial

### DIFF
--- a/tonic-examples/routeguide-tutorial.md
+++ b/tonic-examples/routeguide-tutorial.md
@@ -299,7 +299,7 @@ impl server::RouteGuide for RouteGuide {
         unimplemented!()
     }
 
-    type RouteChatStream = Pin<Box<dyn Stream<Item = Result<RouteNote, Status>> + Send + 'static>>;
+    type RouteChatStream = Pin<Box<dyn Stream<Item = Result<RouteNote, Status>> + Send + Sync + 'static>>;
 
     async fn route_chat(
         &self,
@@ -521,7 +521,7 @@ async fn route_chat(
 
     Ok(Response::new(Box::pin(output)
         as Pin<
-            Box<dyn Stream<Item = Result<RouteNote, Status>> + Send + 'static>,
+            Box<dyn Stream<Item = Result<RouteNote, Status>> + Send + Sync + 'static>,
         >))
 
 }
@@ -658,7 +658,6 @@ Here's where we call the server-side streaming method `list_features`, which ret
 geographical `Feature`s.
 
 ```rust
-use futures::TryStreamExt;
 use tonic::transport::Channel;
 use std::error::Error;
 ```


### PR DESCRIPTION
This patch updates  the route-guide tutorial to work with latest release.
