### PR TITLE
feat(transport): Add system root anchors for TLS

### DIFF
--- a/tonic/Cargo.toml
+++ b/tonic/Cargo.toml
@@ -34,6 +34,8 @@ transport = [
 ]
 openssl = ["openssl1", "tokio-openssl", "tls"]
 rustls = ["tokio-rustls", "tls"]
+openssl-roots = ["openssl-probe"]
+rustls-roots = ["rustls-native-certs"]
 tls = []
 
 [[bench]]
@@ -73,9 +75,11 @@ tower-load = { version = "=0.3.0-alpha.2", optional = true }
 # openssl
 tokio-openssl = { version = "=0.4.0-alpha.6", optional = true }
 openssl1 = { package = "openssl", version = "0.10", optional = true }
+openssl-probe = { version = "0.1", optional = true }
 
 # rustls
 tokio-rustls = { version = "=0.12.0-alpha.5", optional = true }
+rustls-native-certs = { version = "0.1", optional = true }
 
 [dev-dependencies]
 static_assertions = "1.0"

--- a/tonic/src/lib.rs
+++ b/tonic/src/lib.rs
@@ -22,8 +22,14 @@
 //! for [`tonic-build`]. Enabled by default.
 //! - `openssl`: Enables the `openssl` based tls options for the `transport` feature`. Not
 //! enabled by default.
+//! - `openssl-roots`: Adds system trust roots to `openssl`-based gRPC clients using the
+//! `openssl-probe` crate. Not enabled by default. `openssl` must be enabled to use
+//! `openssl-roots`.
 //! - `rustls`: Enables the `ruslts` based tls options for the `transport` feature`. Not
 //! enabled by default.
+//! - `rustls-roots`: Adds system trust roots to `rustls`-based gRPC clients using the
+//! `rustls-native-certs` crate. Not enabled by default. `rustls` must be enabled to use
+//! `openssl-roots`.
 //! - `prost`: Enables the [`prost`] based gRPC [`Codec`] implementation.
 //!
 //! # Structure

--- a/tonic/src/transport/endpoint.rs
+++ b/tonic/src/transport/endpoint.rs
@@ -259,18 +259,27 @@ impl ClientTlsConfig {
     }
 
     /// Sets the domain name against which to verify the server's TLS certificate.
+    ///
+    /// This has no effect if `rustls_client_config` or `openssl_connector` is used to configure
+    /// Rustls or OpenSSL respectively.
     pub fn domain_name(&mut self, domain_name: impl Into<String>) -> &mut Self {
         self.domain = Some(domain_name.into());
         self
     }
 
     /// Sets the CA Certificate against which to verify the server's TLS certificate.
+    ///
+    /// This has no effect if `rustls_client_config` or `openssl_connector` is used to configure
+    /// Rustls or OpenSSL respectively.
     pub fn ca_certificate(&mut self, ca_certificate: Certificate) -> &mut Self {
         self.cert = Some(ca_certificate);
         self
     }
 
     /// Sets the client identity to present to the server.
+    ///
+    /// This has no effect if `rustls_client_config` or `openssl_connector` is used to configure
+    /// Rustls or OpenSSL respectively.
     pub fn identity(&mut self, identity: Identity) -> &mut Self {
         self.identity = Some(identity);
         self


### PR DESCRIPTION
As per #101, it is sometimes desirable to use standard web PKI roots for gRPC clients. This commit adds a method to `ClientTlsConfig` to allow this. The behaviour differs per TLS library:

- OpenSSL uses `openssl-probe` to search the system for roots and add them.
- ~Rustls adds the Mozilla-supplied roots from the `webpki-roots` crate.~

~This is not feature flagged, as there appears to be no convenient way to gate a dependency on multiple conditions.~
