### PR TITLE
Use Stable Rust in CI

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        rust: [beta]
+        rust: [stable]
 
     env:
       RUSTFLAGS: "-D warnings"
@@ -38,7 +38,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        rust: [beta]
+        rust: [stable]
 
     env:
       RUSTFLAGS: "-D warnings"
@@ -58,7 +58,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macOS-latest]
-        rust: [beta]
+        rust: [stable]
 
     env:
       RUSTFLAGS: "-D warnings"


### PR DESCRIPTION
This PR updates GitHub Actions to use stable Rust. It is complementary to #122 which updates the documentation around this.