### PR TITLE
Allow selection of TLS library in Interop tests

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -29,7 +29,7 @@ jobs:
     - name: Check fmt
       run: cargo fmt -- --check
     - name: Check features
-      run: cargo hack check --all --each-feature --no-dev-deps
+      run: cargo hack check --all --ignore-private --each-feature --no-dev-deps
     - name: Check all targets
       run: cargo check --all --all-targets --all-features
 
@@ -53,11 +53,12 @@ jobs:
     - name: Run tests
       run: cargo test --all --all-features
 
-  interop:
+  interop-unix:
+    name: Interop Tests (Rustls & OpenSSL)
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, macOS-latest, windows-latest]
+        os: [ubuntu-latest, macOS-latest]
         rust: [stable]
 
     env:
@@ -67,12 +68,39 @@ jobs:
     - uses: hecrj/setup-rust-action@master
       with:
         rust-version: ${{ matrix.rust }}
-    - uses: actions/checkout@master
     - name: Install rustfmt
       run: rustup component add rustfmt
+    - uses: actions/checkout@master
     - name: Run interop tests
       run: ./tonic-interop/test.sh
       shell: bash
-    - name: Run interop tests with tls
-      run: ./tonic-interop/test.sh --use_tls
+    - name: Run interop tests with Rustls
+      run: ./tonic-interop/test.sh --use_tls tls_rustls
       shell: bash
+    - name: Run interop tests with OpenSSL
+      run: ./tonic-interop/test.sh --use_tls tls_openssl
+      shell: bash
+
+  interop-windows:
+    name: Interop Tests (Rustls)
+    runs-on: windows-latest
+    strategy:
+      matrix:
+        rust: [stable]
+
+    env:
+      RUSTFLAGS: "-D warnings"
+
+    steps:
+      - uses: hecrj/setup-rust-action@master
+        with:
+          rust-version: ${{ matrix.rust }}
+      - name: Install rustfmt
+        run: rustup component add rustfmt
+      - uses: actions/checkout@master
+      - name: Run interop tests
+        run: ./tonic-interop/test.sh
+        shell: bash
+      - name: Run interop tests with Rustls
+        run: ./tonic-interop/test.sh --use_tls tls_rustls
+        shell: bash

--- a/tonic-examples/Cargo.toml
+++ b/tonic-examples/Cargo.toml
@@ -3,6 +3,7 @@ name = "tonic-examples"
 version = "0.1.0"
 authors = ["Lucio Franco <luciofranco14@gmail.com>"]
 edition = "2018"
+publish = false
 
 [[bin]]
 name = "helloworld-server"

--- a/tonic-interop/Cargo.toml
+++ b/tonic-interop/Cargo.toml
@@ -3,6 +3,12 @@ name = "tonic-interop"
 version = "0.1.0"
 authors = ["Lucio Franco <luciofranco14@gmail.com>"]
 edition = "2018"
+publish = false
+
+[features]
+default = ["tonic"]
+tls_openssl = ["tonic", "tonic/tls", "tonic/openssl"]
+tls_rustls = ["tonic", "tonic/tls", "tonic/rustls"]
 
 [[bin]]
 name = "client"
@@ -14,7 +20,7 @@ path = "src/bin/server.rs"
 
 [dependencies]
 tokio = "=0.2.0-alpha.6"
-tonic = { path = "../tonic", features = ["rustls"] }
+tonic = { path = "../tonic", optional = true }
 prost = "0.5"
 prost-derive = "0.5"
 bytes = "0.4"

--- a/tonic-interop/test.sh
+++ b/tonic-interop/test.sh
@@ -3,18 +3,28 @@
 set -eu
 set -o pipefail
 
+set -x
+
 echo "Running for OS: ${OSTYPE}"
 
 case "$OSTYPE" in
   darwin*)  OS="darwin"; EXT="" ;;
   linux*)   OS="linux"; EXT="" ;;
-  msys*) OS="windows"; EXT=".exe" ;;
+  msys*)    OS="windows"; EXT=".exe" ;;
   *)        exit 2 ;;
 esac
 
-cargo build -p tonic-interop --bins
-
 ARG="${1:-""}"
+TLS_PROVIDER="${2:-""}"
+
+if [[ -n "${TLS_PROVIDER}" ]] ; then
+  FEATURES="--features ${TLS_PROVIDER}"
+else
+  FEATURES=
+fi
+
+(cd tonic-interop && cargo build --bins ${FEATURES})
+
 SERVER="tonic-interop/bin/server_${OS}_amd64${EXT}"
 
 # TLS_CA="tonic-interop/data/ca.pem"
@@ -22,7 +32,7 @@ TLS_CRT="tonic-interop/data/server1.pem"
 TLS_KEY="tonic-interop/data/server1.key"
 
 # run the test server
-./"${SERVER}" $ARG --tls_cert_file $TLS_CRT --tls_key_file $TLS_KEY &
+./"${SERVER}" ${ARG} --tls_cert_file $TLS_CRT --tls_key_file $TLS_KEY &
 SERVER_PID=$!
 echo ":; started grpc-go test server."
 
@@ -35,12 +45,12 @@ sleep 1
 ./target/debug/client \
  --test_case=empty_unary,large_unary,client_streaming,server_streaming,ping_pong,\
 empty_stream,status_code_and_message,special_status_message,unimplemented_method,\
-unimplemented_service,custom_metadata $ARG
+unimplemented_service,custom_metadata ${ARG}
 
 echo ":; killing test server"; kill ${SERVER_PID};
 
 # run the test server
-./target/debug/server $ARG &
+./target/debug/server ${ARG} &
 SERVER_PID=$!
 echo ":; started tonic test server."
 
@@ -53,4 +63,4 @@ sleep 1
 ./target/debug/client \
 --test_case=empty_unary,large_unary,client_streaming,server_streaming,ping_pong,\
 empty_stream,status_code_and_message,special_status_message,unimplemented_method,\
-unimplemented_service,custom_metadata $ARG
+unimplemented_service,custom_metadata ${ARG}


### PR DESCRIPTION
This PR adds feature flags to `tonic-interop` to allow selection of OpenSSL or Rustls in order to allow both to be tested in CI under a wide variety of situations. Various small-level changes are needed throughout the Cargo files and test scripts to accommodate this.