### PR TITLE
Clarify what the Interop (Rustls) task is doing during CI

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -82,7 +82,7 @@ jobs:
       shell: bash
 
   interop-windows:
-    name: Interop Tests (Rustls)
+    name: Interop Tests (Rustls) (Windows)
     runs-on: windows-latest
     strategy:
       matrix:


### PR DESCRIPTION
This clarifies what CI is doing, since the `Interop (Rustls)` crate does not have a matrix.