### PR TITLE
Enable multiple services in same package across multiple files

### DIFF
--- a/tests/included_service/src/lib.rs
+++ b/tests/included_service/src/lib.rs
@@ -5,4 +5,4 @@ pub mod pb {
 // Ensure that an RPC service, defined before including a file that defines
 // another service in a different protocol buffer package, is not incorrectly
 // cleared from the context of its package.
-type _Test = dyn pb::server::TopService;
+type _Test = dyn pb::topservice_server::TopService;

--- a/tonic-build/src/client.rs
+++ b/tonic-build/src/client.rs
@@ -5,44 +5,51 @@ use quote::{format_ident, quote};
 
 pub(crate) fn generate(service: &Service, proto: &str) -> TokenStream {
     let service_ident = quote::format_ident!("{}Client", service.name);
+    let client_mod = quote::format_ident!("{}_client", service.name.to_ascii_lowercase());
     let methods = generate_methods(service, proto);
 
     let connect = generate_connect(&service_ident);
     let service_doc = generate_doc_comments(&service.comments.leading);
 
     quote! {
-        #service_doc
-        pub struct #service_ident<T> {
-            inner: tonic::client::Grpc<T>,
-        }
+        /// Generated server implementations.
+        pub mod #client_mod {
+            #![allow(unused_variables, dead_code, missing_docs)]
+            use tonic::codegen::*;
 
-        #connect
-
-        impl<T> #service_ident<T>
-        where T: tonic::client::GrpcService<tonic::body::BoxBody>,
-              T::ResponseBody: Body + HttpBody + Send + 'static,
-              T::Error: Into<StdError>,
-              <T::ResponseBody as HttpBody>::Error: Into<StdError> + Send,
-              <T::ResponseBody as HttpBody>::Data: Into<bytes::Bytes> + Send, {
-            pub fn new(inner: T) -> Self {
-                let inner = tonic::client::Grpc::new(inner);
-                Self { inner }
+            #service_doc
+            pub struct #service_ident<T> {
+                inner: tonic::client::Grpc<T>,
             }
 
-            /// Check if the service is ready.
-            pub async fn ready(&mut self) -> Result<(), tonic::Status> {
-                self.inner.ready().await.map_err(|e| {
-                    tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
-                })
+            #connect
+
+            impl<T> #service_ident<T>
+            where T: tonic::client::GrpcService<tonic::body::BoxBody>,
+                  T::ResponseBody: Body + HttpBody + Send + 'static,
+                  T::Error: Into<StdError>,
+            <T::ResponseBody as HttpBody>::Error: Into<StdError> + Send,
+            <T::ResponseBody as HttpBody>::Data: Into<bytes::Bytes> + Send, {
+                pub fn new(inner: T) -> Self {
+                    let inner = tonic::client::Grpc::new(inner);
+                    Self { inner }
+                }
+
+                /// Check if the service is ready.
+                pub async fn ready(&mut self) -> Result<(), tonic::Status> {
+                    self.inner.ready().await.map_err(|e| {
+                        tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
+                    })
+                }
+
+                #methods
             }
 
-            #methods
-        }
-
-        impl<T: Clone> Clone for #service_ident<T> {
-            fn clone(&self) -> Self {
-                Self {
-                    inner: self.inner.clone(),
+            impl<T: Clone> Clone for #service_ident<T> {
+                fn clone(&self) -> Self {
+                    Self {
+                        inner: self.inner.clone(),
+                    }
                 }
             }
         }

--- a/tonic-build/src/lib.rs
+++ b/tonic-build/src/lib.rs
@@ -251,13 +251,7 @@ impl prost_build::ServiceGenerator for ServiceGenerator {
             let clients = &self.clients;
 
             let client_service = quote::quote! {
-                /// Generated client implementations.
-                pub mod client {
-                    #![allow(unused_variables, dead_code, missing_docs)]
-                    use tonic::codegen::*;
-
-                    #clients
-                }
+                #clients
             };
 
             let code = format!("{}", client_service);
@@ -270,13 +264,7 @@ impl prost_build::ServiceGenerator for ServiceGenerator {
             let servers = &self.servers;
 
             let server_service = quote::quote! {
-                /// Generated server implementations.
-                pub mod server {
-                    #![allow(unused_variables, dead_code, missing_docs)]
-                    use tonic::codegen::*;
-
-                    #servers
-                }
+                #servers
             };
 
             let code = format!("{}", server_service);

--- a/tonic-examples/src/authentication/client.rs
+++ b/tonic-examples/src/authentication/client.rs
@@ -3,7 +3,7 @@ pub mod pb {
 }
 
 use http::header::HeaderValue;
-use pb::{client::EchoClient, EchoRequest};
+use pb::{echo_client::EchoClient, EchoRequest};
 use tonic::transport::Channel;
 
 #[tokio::main]

--- a/tonic-examples/src/authentication/server.rs
+++ b/tonic-examples/src/authentication/server.rs
@@ -14,7 +14,7 @@ type Stream = VecDeque<Result<EchoResponse, Status>>;
 pub struct EchoServer;
 
 #[tonic::async_trait]
-impl pb::server::Echo for EchoServer {
+impl pb::echo_server::Echo for EchoServer {
     async fn unary_echo(&self, request: Request<EchoRequest>) -> EchoResult<EchoResponse> {
         let message = request.into_inner().message;
         Ok(Response::new(EchoResponse { message }))
@@ -78,7 +78,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 }
             }
         })
-        .add_service(pb::server::EchoServer::new(server))
+        .add_service(pb::echo_server::EchoServer::new(server))
         .serve(addr)
         .await?;
 

--- a/tonic-examples/src/gcp/client.rs
+++ b/tonic-examples/src/gcp/client.rs
@@ -2,7 +2,7 @@ pub mod api {
     tonic::include_proto!("google.pubsub.v1");
 }
 
-use api::{client::PublisherClient, ListTopicsRequest};
+use api::{publisher_client::PublisherClient, ListTopicsRequest};
 use http::header::HeaderValue;
 use tonic::{
     transport::{Certificate, Channel, ClientTlsConfig},

--- a/tonic-examples/src/helloworld/client.rs
+++ b/tonic-examples/src/helloworld/client.rs
@@ -2,7 +2,7 @@ pub mod hello_world {
     tonic::include_proto!("helloworld");
 }
 
-use hello_world::{client::GreeterClient, HelloRequest};
+use hello_world::{greeter_client::GreeterClient, HelloRequest};
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {

--- a/tonic-examples/src/helloworld/server.rs
+++ b/tonic-examples/src/helloworld/server.rs
@@ -5,7 +5,7 @@ pub mod hello_world {
 }
 
 use hello_world::{
-    server::{Greeter, GreeterServer},
+    greeter_server::{Greeter, GreeterServer},
     HelloReply, HelloRequest,
 };
 

--- a/tonic-examples/src/load_balance/client.rs
+++ b/tonic-examples/src/load_balance/client.rs
@@ -2,7 +2,7 @@ pub mod pb {
     tonic::include_proto!("grpc.examples.echo");
 }
 
-use pb::{client::EchoClient, EchoRequest};
+use pb::{echo_client::EchoClient, EchoRequest};
 use tonic::transport::Channel;
 
 #[tokio::main]

--- a/tonic-examples/src/load_balance/server.rs
+++ b/tonic-examples/src/load_balance/server.rs
@@ -16,7 +16,7 @@ pub struct EchoServer {
 }
 
 #[tonic::async_trait]
-impl pb::server::Echo for EchoServer {
+impl pb::echo_server::Echo for EchoServer {
     async fn unary_echo(&self, request: Request<EchoRequest>) -> EchoResult<EchoResponse> {
         let message = format!("{} (from {})", request.into_inner().message, self.addr);
 
@@ -61,7 +61,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
         let server = EchoServer { addr };
         let serve = Server::builder()
-            .add_service(pb::server::EchoServer::new(server))
+            .add_service(pb::echo_server::EchoServer::new(server))
             .serve(addr);
 
         tokio::spawn(async move {

--- a/tonic-examples/src/multiplex/client.rs
+++ b/tonic-examples/src/multiplex/client.rs
@@ -6,8 +6,8 @@ pub mod echo {
     tonic::include_proto!("grpc.examples.echo");
 }
 
-use echo::{client::EchoClient, EchoRequest};
-use hello_world::{client::GreeterClient, HelloRequest};
+use echo::{echo_client::EchoClient, EchoRequest};
+use hello_world::{greeter_client::GreeterClient, HelloRequest};
 use tonic::transport::Endpoint;
 
 #[tokio::main]

--- a/tonic-examples/src/multiplex/server.rs
+++ b/tonic-examples/src/multiplex/server.rs
@@ -10,12 +10,12 @@ pub mod echo {
 }
 
 use hello_world::{
-    server::{Greeter, GreeterServer},
+    greeter_server::{Greeter, GreeterServer},
     HelloReply, HelloRequest,
 };
 
 use echo::{
-    server::{Echo, EchoServer},
+    echo_server::{Echo, EchoServer},
     EchoRequest, EchoResponse,
 };
 

--- a/tonic-examples/src/routeguide/client.rs
+++ b/tonic-examples/src/routeguide/client.rs
@@ -12,7 +12,7 @@ pub mod route_guide {
     tonic::include_proto!("routeguide");
 }
 
-use route_guide::client::RouteGuideClient;
+use route_guide::routeguide_client::RouteGuideClient;
 
 async fn print_features(client: &mut RouteGuideClient<Channel>) -> Result<(), Box<dyn Error>> {
     let rectangle = Rectangle {

--- a/tonic-examples/src/routeguide/server.rs
+++ b/tonic-examples/src/routeguide/server.rs
@@ -14,7 +14,7 @@ pub mod routeguide {
     tonic::include_proto!("routeguide");
 }
 
-use routeguide::{server, Feature, Point, Rectangle, RouteNote, RouteSummary};
+use routeguide::{routeguide_server, Feature, Point, Rectangle, RouteNote, RouteSummary};
 
 #[derive(Debug)]
 pub struct RouteGuide {
@@ -22,7 +22,7 @@ pub struct RouteGuide {
 }
 
 #[tonic::async_trait]
-impl server::RouteGuide for RouteGuide {
+impl routeguide_server::RouteGuide for RouteGuide {
     async fn get_feature(&self, request: Request<Point>) -> Result<Response<Feature>, Status> {
         println!("GetFeature = {:?}", request);
 
@@ -154,7 +154,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         features: Arc::new(data::load()),
     };
 
-    let svc = server::RouteGuideServer::new(route_guide);
+    let svc = routeguide_server::RouteGuideServer::new(route_guide);
 
     Server::builder().add_service(svc).serve(addr).await?;
 

--- a/tonic-examples/src/tls/client.rs
+++ b/tonic-examples/src/tls/client.rs
@@ -2,7 +2,7 @@ pub mod pb {
     tonic::include_proto!("/grpc.examples.echo");
 }
 
-use pb::{client::EchoClient, EchoRequest};
+use pb::{echo_client::EchoClient, EchoRequest};
 use tonic::transport::{Certificate, Channel, ClientTlsConfig};
 
 #[tokio::main]

--- a/tonic-examples/src/tls/server.rs
+++ b/tonic-examples/src/tls/server.rs
@@ -16,7 +16,7 @@ type Stream = VecDeque<Result<EchoResponse, Status>>;
 pub struct EchoServer;
 
 #[tonic::async_trait]
-impl pb::server::Echo for EchoServer {
+impl pb::echo_server::Echo for EchoServer {
     async fn unary_echo(&self, request: Request<EchoRequest>) -> EchoResult<EchoResponse> {
         let message = request.into_inner().message;
         Ok(Response::new(EchoResponse { message }))
@@ -60,7 +60,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     Server::builder()
         .tls_config(ServerTlsConfig::with_rustls().identity(identity))
-        .add_service(pb::server::EchoServer::new(server))
+        .add_service(pb::echo_server::EchoServer::new(server))
         .serve(addr)
         .await?;
 

--- a/tonic-examples/src/tls_client_auth/client.rs
+++ b/tonic-examples/src/tls_client_auth/client.rs
@@ -2,7 +2,7 @@ pub mod pb {
     tonic::include_proto!("grpc.examples.echo");
 }
 
-use pb::{client::EchoClient, EchoRequest};
+use pb::{echo_client::EchoClient, EchoRequest};
 use tonic::transport::{Certificate, Channel, ClientTlsConfig, Identity};
 
 #[tokio::main]

--- a/tonic-examples/src/tls_client_auth/server.rs
+++ b/tonic-examples/src/tls_client_auth/server.rs
@@ -15,7 +15,7 @@ type Stream = VecDeque<Result<EchoResponse, Status>>;
 pub struct EchoServer;
 
 #[tonic::async_trait]
-impl pb::server::Echo for EchoServer {
+impl pb::echo_server::Echo for EchoServer {
     async fn unary_echo(&self, request: Request<EchoRequest>) -> EchoResult<EchoResponse> {
         let message = request.into_inner().message;
         Ok(Response::new(EchoResponse { message }))
@@ -43,7 +43,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     Server::builder()
         .tls_config(tls)
-        .add_service(pb::server::EchoServer::new(server))
+        .add_service(pb::echo_server::EchoServer::new(server))
         .serve(addr)
         .await?;
 

--- a/tonic-interop/src/client.rs
+++ b/tonic-interop/src/client.rs
@@ -1,4 +1,7 @@
-use crate::{pb::client::*, pb::*, test_assert, TestAssertion};
+use crate::{
+    pb::testservice_client::*, pb::unimplementedservice_client::*, pb::*, test_assert,
+    TestAssertion,
+};
 use futures_util::{future, stream, SinkExt, StreamExt};
 use tokio::sync::mpsc;
 use tonic::transport::Channel;

--- a/tonic-interop/src/server.rs
+++ b/tonic-interop/src/server.rs
@@ -5,7 +5,8 @@ use std::pin::Pin;
 use std::time::{Duration, Instant};
 use tonic::{Code, Request, Response, Status};
 
-pub use pb::server::{TestServiceServer, UnimplementedServiceServer};
+pub use pb::testservice_server::TestServiceServer;
+pub use pb::unimplementedservice_server::UnimplementedServiceServer;
 
 #[derive(Default, Clone)]
 pub struct TestService;
@@ -17,7 +18,7 @@ type Stream<T> = Pin<
 >;
 
 #[tonic::async_trait]
-impl pb::server::TestService for TestService {
+impl pb::testservice_server::TestService for TestService {
     async fn empty_call(&self, _request: Request<Empty>) -> Result<Empty> {
         Ok(Response::new(Empty {}))
     }
@@ -155,7 +156,7 @@ impl pb::server::TestService for TestService {
 pub struct UnimplementedService;
 
 #[tonic::async_trait]
-impl pb::server::UnimplementedService for UnimplementedService {
+impl pb::unimplementedservice_server::UnimplementedService for UnimplementedService {
     async fn unimplemented_call(&self, _req: Request<Empty>) -> Result<Empty> {
         Err(Status::unimplemented(""))
     }


### PR DESCRIPTION
## Motivation

Prior to this change, for each _file_ containing one or more
services, the code generator would generate with the following
modules:

```
pub mod client {
 //...
}

pub mod server {
 //...
}
```

While this works fine if all the services in the same protobuf
package are declared in a single file, this breaks horribly if
multiple files belonging to the same protobuf package declare
services. In that case, the code generator would generate several
modules with the same name in the same `.rs` file, which is
invalid.

For instance, given two files `foo.proto` and `bar.proto` like:

```
// foo.proto
package mypackage;
service Foo {
}

// bar.proto
package mypackage;
service Bar {
}
```

The generated code would result in a `mypackage.rs` such as:

```
// Generated from foo.proto
pub mod client {
  //...
}

pub mod server {
  //...
}

// Generated from bar.proto
pub mod client {
  //...
}

pub mod server {
  //...
}
```

One codebase where this scenario could be found is in [Open Match](https://github.com/googleforgames/open-match/tree/master/api)

## Solution

This change makes it so the name of the service is prepended to
the generated module, and therefore we avoid module name collisions.

After this change, given the two proto files mentioned previously,
we will generate the following modules inside `mypackage.rs`:

```
pub mod foo_client {
 //...
}

pub mod foo_server {
 //...
}

pub mod bar_client {
 //...
}

pub mod bar_server {
 //...
}
```