### PR TITLE
fix(transport): Remove support for OpenSSL

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -74,12 +74,12 @@ jobs:
     - name: Run tests
       run: cargo test --all --all-features
 
-  interop-unix:
-    name: Interop Tests (Rustls & OpenSSL)
+  interop:
+    name: Interop Tests
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, macOS-latest]
+        os: [ubuntu-latest, macOS-latest, windows-latest]
         rust: [stable]
 
     env:
@@ -98,30 +98,3 @@ jobs:
     - name: Run interop tests with Rustls
       run: ./tonic-interop/test.sh --use_tls tls_rustls
       shell: bash
-    - name: Run interop tests with OpenSSL
-      run: ./tonic-interop/test.sh --use_tls tls_openssl
-      shell: bash
-
-  interop-windows:
-    name: Interop Tests (Rustls) (Windows)
-    runs-on: windows-latest
-    strategy:
-      matrix:
-        rust: [stable]
-
-    env:
-      RUSTFLAGS: "-D warnings"
-
-    steps:
-      - uses: hecrj/setup-rust-action@master
-        with:
-          rust-version: ${{ matrix.rust }}
-      - name: Install rustfmt
-        run: rustup component add rustfmt
-      - uses: actions/checkout@master
-      - name: Run interop tests
-        run: ./tonic-interop/test.sh
-        shell: bash
-      - name: Run interop tests with Rustls
-        run: ./tonic-interop/test.sh --use_tls tls_rustls
-        shell: bash

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ contains the tools to build clients and servers from [`protobuf`] definitions.
 - Bi-directional streaming
 - High performance async io
 - Interoperability
-- TLS backed via either [`openssl`] or [`rustls`]
+- TLS backed by [`rustls`]
 - Load balancing
 - Custom metadata
 - Authentication
@@ -97,7 +97,6 @@ terms or conditions.
 [`prost`]: https://github.com/danburkert/prost
 [`protobuf`]: https://developers.google.com/protocol-buffers
 [`rustls`]: https://github.com/ctz/rustls
-[`openssl`]: https://www.openssl.org/
 [`tonic-examples`]: https://github.com/hyperium/tonic/tree/master/tonic-examples
 [`tonic-interop`]: https://github.com/hyperium/tonic/tree/master/tonic-interop
 [Examples]: https://github.com/hyperium/tonic/tree/master/tonic-examples

--- a/tonic-examples/Cargo.toml
+++ b/tonic-examples/Cargo.toml
@@ -67,7 +67,7 @@ name = "gcp-client"
 path = "src/gcp/client.rs"
 
 [dependencies]
-tonic = { path = "../tonic", features = ["rustls"] }
+tonic = { path = "../tonic", features = ["tls"] }
 bytes = "0.4"
 prost = "0.5"
 

--- a/tonic-interop/Cargo.toml
+++ b/tonic-interop/Cargo.toml
@@ -6,11 +6,6 @@ edition = "2018"
 publish = false
 license = "MIT"
 
-[features]
-default = ["tonic"]
-tls_openssl = ["tonic", "tonic/tls", "tonic/openssl"]
-tls_rustls = ["tonic", "tonic/tls", "tonic/rustls"]
-
 [[bin]]
 name = "client"
 path = "src/bin/client.rs"
@@ -21,7 +16,7 @@ path = "src/bin/server.rs"
 
 [dependencies]
 tokio = "=0.2.0-alpha.6"
-tonic = { path = "../tonic", optional = true }
+tonic = { path = "../tonic", features = ["tls"] }
 prost = "0.5"
 prost-derive = "0.5"
 bytes = "0.4"

--- a/tonic-interop/src/bin/client.rs
+++ b/tonic-interop/src/bin/client.rs
@@ -1,7 +1,6 @@
 use std::time::Duration;
 use structopt::{clap::arg_enum, StructOpt};
 use tonic::transport::Endpoint;
-#[cfg(any(feature = "tls_rustls", feature = "tls_openssl"))]
 use tonic::transport::{Certificate, ClientTlsConfig};
 use tonic_interop::client;
 
@@ -33,32 +32,13 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .concurrency_limit(30);
 
     if matches.use_tls {
-        #[cfg(not(any(feature = "tls_rustls", feature = "tls_openssl")))]
-        {
-            panic!("No TLS library feature selected");
-        }
-
-        #[cfg(feature = "tls_rustls")]
-        {
-            let pem = tokio::fs::read("tonic-interop/data/ca.pem").await?;
-            let ca = Certificate::from_pem(pem);
-            endpoint = endpoint.tls_config(
-                ClientTlsConfig::with_rustls()
-                    .ca_certificate(ca)
-                    .domain_name("foo.test.google.fr"),
-            );
-        }
-
-        #[cfg(feature = "tls_openssl")]
-        {
-            let pem = tokio::fs::read("tonic-interop/data/ca.pem").await?;
-            let ca = Certificate::from_pem(pem);
-            endpoint = endpoint.tls_config(
-                ClientTlsConfig::with_openssl()
-                    .ca_certificate(ca)
-                    .domain_name("foo.test.google.fr"),
-            );
-        }
+        let pem = tokio::fs::read("tonic-interop/data/ca.pem").await?;
+        let ca = Certificate::from_pem(pem);
+        endpoint = endpoint.tls_config(
+            ClientTlsConfig::with_rustls()
+                .ca_certificate(ca)
+                .domain_name("foo.test.google.fr"),
+        );
     }
 
     let channel = endpoint.connect().await?;

--- a/tonic-interop/test.sh
+++ b/tonic-interop/test.sh
@@ -15,15 +15,8 @@ case "$OSTYPE" in
 esac
 
 ARG="${1:-""}"
-TLS_PROVIDER="${2:-""}"
 
-if [[ -n "${TLS_PROVIDER}" ]] ; then
-  FEATURES="--features ${TLS_PROVIDER}"
-else
-  FEATURES=
-fi
-
-(cd tonic-interop && cargo build --bins ${FEATURES})
+(cd tonic-interop && cargo build --bins)
 
 SERVER="tonic-interop/bin/server_${OS}_amd64${EXT}"
 

--- a/tonic/Cargo.toml
+++ b/tonic/Cargo.toml
@@ -32,11 +32,8 @@ transport = [
     "tower-balance",
     "tower-load",
 ]
-openssl = ["openssl1", "tokio-openssl", "tls"]
-rustls = ["tokio-rustls", "tls"]
-openssl-roots = ["openssl-probe"]
-rustls-roots = ["rustls-native-certs"]
-tls = []
+tls = ["tokio-rustls"]
+tls-roots = ["rustls-native-certs"]
 
 [[bench]]
 name = "bench_main"
@@ -71,11 +68,6 @@ tower = { version = "=0.3.0-alpha.2", optional = true}
 tower-make = "=0.3.0-alpha.2a"
 tower-balance =  { version = "=0.3.0-alpha.2", optional = true }
 tower-load = { version = "=0.3.0-alpha.2", optional = true }
-
-# openssl
-tokio-openssl = { version = "=0.4.0-alpha.6", optional = true }
-openssl1 = { package = "openssl", version = "0.10", optional = true }
-openssl-probe = { version = "0.1", optional = true }
 
 # rustls
 tokio-rustls = { version = "=0.12.0-alpha.5", optional = true }

--- a/tonic/src/lib.rs
+++ b/tonic/src/lib.rs
@@ -20,16 +20,11 @@
 //! implementation based on [`hyper`], [`tower`] and [`tokio`]. Enabled by default.
 //! - `codegen`: Enables all the required exports and optional dependencies required
 //! for [`tonic-build`]. Enabled by default.
-//! - `openssl`: Enables the `openssl` based tls options for the `transport` feature`. Not
+//! - `tls`: Enables the `ruslts` based TLS options for the `transport` feature`. Not
 //! enabled by default.
-//! - `openssl-roots`: Adds system trust roots to `openssl`-based gRPC clients using the
-//! `openssl-probe` crate. Not enabled by default. `openssl` must be enabled to use
-//! `openssl-roots`.
-//! - `rustls`: Enables the `ruslts` based tls options for the `transport` feature`. Not
-//! enabled by default.
-//! - `rustls-roots`: Adds system trust roots to `rustls`-based gRPC clients using the
-//! `rustls-native-certs` crate. Not enabled by default. `rustls` must be enabled to use
-//! `rustls-roots`.
+//! - `tls-roots`: Adds system trust roots to `rustls`-based gRPC clients using the
+//! `rustls-native-certs` crate. Not enabled by default. `tls` must be enabled to use
+//! `tls-roots`.
 //! - `prost`: Enables the [`prost`] based gRPC [`Codec`] implementation.
 //!
 //! # Structure
@@ -48,8 +43,8 @@
 //! and [`Server`]. These implementations are built on top of [`tokio`], [`hyper`] and [`tower`].
 //! It also provides many of the features that the core gRPC libraries provide such as load balancing,
 //! tls, timeouts, and many more. This implementation can also be used as a reference implementation
-//! to build even more feature rich clients and servers. This module also provides the ability to choose
-//! between [`rustls`] and [`openssl`] for the tls backend.
+//! to build even more feature rich clients and servers. This module also provides the ability to
+//! enable TLS using [`rustls`], via the `tls` feature flag.
 //!
 //! [gRPC]: https://grpc.io
 //! [`tonic`]: https://github.com/hyperium/tonic
@@ -63,7 +58,6 @@
 //! [`Channel`]: transport/struct.Channel.html
 //! [`Server`]: transport/struct.Server.html
 //! [`rustls`]: https://docs.rs/rustls
-//! [`openssl`]: https://www.openssl.org
 //! [`client`]: client/index.html
 //! [`transport`]: transport/index.html
 

--- a/tonic/src/transport/mod.rs
+++ b/tonic/src/transport/mod.rs
@@ -1,13 +1,13 @@
 //! Batteries included server and client.
 //!
 //! This module provides a set of batteries included, fully featured and
-//! fast set of HTTP/2 server and client's. These components each provide either an
-//! `openssl` or `rustls` tls backend when the respective feature flags are enabled.
-//!They also provide may configurable knobs that can be used to tune how they work.
+//! fast set of HTTP/2 server and client's. These components each provide a or
+//! `rustls` tls backend when the respective feature flag is enabled, and
+//! provides builders to configure transport behavior.
 //!
 //! # Features
 //!
-//! - TLS support via either [OpenSSL] or [rustls].
+//! - TLS support via [rustls].
 //! - Load balancing
 //! - Timeouts
 //! - Concurrency Limits
@@ -89,7 +89,6 @@
 //! # }
 //! ```
 //!
-//! [OpenSSL]: https://www.openssl.org/
 //! [rustls]: https://docs.rs/rustls/0.16.0/rustls/
 
 pub mod channel;

--- a/tonic/src/transport/tls.rs
+++ b/tonic/src/transport/tls.rs
@@ -1,14 +1,3 @@
-/// Selects a library to provide TLS.
-#[derive(Clone, Debug)]
-pub(crate) enum TlsProvider {
-    /// Use OpenSSL for TLS.
-    #[cfg(feature = "openssl")]
-    OpenSsl,
-    /// Use OpenSSL for TLS.
-    #[cfg(feature = "rustls")]
-    Rustls,
-}
-
 /// Represents a X509 certificate.
 #[derive(Debug, Clone)]
 pub struct Certificate {


### PR DESCRIPTION
This pull request removes support for OpenSSL now that the interop tests can run using Rustls, as discussed in Discord.