### PR TITLE
feat(transport): Expose tcp keepalive to clients & servers

### DIFF
--- a/tonic/src/transport/endpoint.rs
+++ b/tonic/src/transport/endpoint.rs
@@ -29,6 +29,7 @@ pub struct Endpoint {
         Option<Arc<dyn Fn(&mut http::HeaderMap) + Send + Sync + 'static>>,
     pub(super) init_stream_window_size: Option<u32>,
     pub(super) init_connection_window_size: Option<u32>,
+    pub(super) tcp_keepalive: Option<Duration>,
 }
 
 impl Endpoint {
@@ -79,6 +80,21 @@ impl Endpoint {
     pub fn timeout(self, dur: Duration) -> Self {
         Endpoint {
             timeout: Some(dur),
+            ..self
+        }
+    }
+
+    /// Set whether TCP keepalive messages are enabled on accepted connections.
+    ///
+    /// If `None` is specified, keepalive is disabled, otherwise the duration
+    /// specified will be the time to remain idle before sending TCP keepalive
+    /// probes.
+    ///
+    /// Default is no keepalive (`None`)
+    ///
+    pub fn tcp_keepalive(self, tcp_keepalive: Option<Duration>) -> Self {
+        Endpoint {
+            tcp_keepalive,
             ..self
         }
     }
@@ -174,6 +190,7 @@ impl From<Uri> for Endpoint {
             interceptor_headers: None,
             init_stream_window_size: None,
             init_connection_window_size: None,
+            tcp_keepalive: None,
         }
     }
 }

--- a/tonic/src/transport/server.rs
+++ b/tonic/src/transport/server.rs
@@ -11,6 +11,7 @@ use hyper::{
     server::{accept::Accept, conn},
     Body,
 };
+use std::time::Duration;
 use std::{
     fmt,
     future::Future,
@@ -51,6 +52,7 @@ pub struct Server {
     init_stream_window_size: Option<u32>,
     init_connection_window_size: Option<u32>,
     max_concurrent_streams: Option<u32>,
+    tcp_keepalive: Option<Duration>,
 }
 
 /// A stack based `Service` router.
@@ -144,6 +146,21 @@ impl Server {
         }
     }
 
+    /// Set whether TCP keepalive messages are enabled on accepted connections.
+    ///
+    /// If `None` is specified, keepalive is disabled, otherwise the duration
+    /// specified will be the time to remain idle before sending TCP keepalive
+    /// probes.
+    ///
+    /// Default is no keepalive (`None`)
+    ///
+    pub fn tcp_keepalive(self, tcp_keepalive: Option<Duration>) -> Self {
+        Server {
+            tcp_keepalive,
+            ..self
+        }
+    }
+
     /// Intercept the execution of gRPC methods.
     ///
     /// ```
@@ -201,12 +218,14 @@ impl Server {
         let init_connection_window_size = self.init_connection_window_size;
         let init_stream_window_size = self.init_stream_window_size;
         let max_concurrent_streams = self.max_concurrent_streams;
+        let tcp_keepalive = self.tcp_keepalive;
         // let timeout = self.timeout.clone();
 
         let incoming = hyper::server::accept::from_stream(async_stream::try_stream! {
-            let mut tcp = TcpIncoming::bind(addr)?;
+            let mut tcp = TcpIncoming::bind(addr, tcp_keepalive)?;
 
             while let Some(stream) = tcp.try_next().await? {
+
                 #[cfg(feature = "tls")]
                 {
                     if let Some(tls) = &self.tls {
@@ -395,9 +414,10 @@ struct TcpIncoming {
 }
 
 impl TcpIncoming {
-    fn bind(addr: SocketAddr) -> Result<Self, crate::Error> {
+    fn bind(addr: SocketAddr, tcp_keepalive: Option<Duration>) -> Result<Self, crate::Error> {
         let mut inner = conn::AddrIncoming::bind(&addr).map_err(Box::new)?;
         inner.set_nodelay(true);
+        inner.set_keepalive(tcp_keepalive);
 
         Ok(Self { inner })
     }

--- a/tonic/src/transport/service/connection.rs
+++ b/tonic/src/transport/service/connection.rs
@@ -28,10 +28,10 @@ pub(crate) struct Connection {
 impl Connection {
     pub(crate) async fn new(endpoint: Endpoint) -> Result<Self, crate::Error> {
         #[cfg(feature = "tls")]
-        let connector = connector(endpoint.tls.clone());
+        let connector = connector(endpoint.tls.clone(), endpoint.tcp_keepalive.clone());
 
         #[cfg(not(feature = "tls"))]
-        let connector = connector();
+        let connector = connector(endpoint.tcp_keepalive.clone());
 
         let settings = Builder::new()
             .http2_initial_stream_window_size(endpoint.init_stream_window_size)

--- a/tonic/src/transport/service/connection.rs
+++ b/tonic/src/transport/service/connection.rs
@@ -28,10 +28,10 @@ pub(crate) struct Connection {
 impl Connection {
     pub(crate) async fn new(endpoint: Endpoint) -> Result<Self, crate::Error> {
         #[cfg(feature = "tls")]
-        let connector = connector(endpoint.tls.clone(), endpoint.tcp_keepalive.clone());
+        let connector = connector(endpoint.tls.clone(), endpoint.tcp_keepalive);
 
         #[cfg(not(feature = "tls"))]
-        let connector = connector(endpoint.tcp_keepalive.clone());
+        let connector = connector(endpoint.tcp_keepalive);
 
         let settings = Builder::new()
             .http2_initial_stream_window_size(endpoint.init_stream_window_size)

--- a/tonic/src/transport/service/connector.rs
+++ b/tonic/src/transport/service/connector.rs
@@ -6,20 +6,22 @@ use hyper::client::connect::HttpConnector;
 use std::future::Future;
 use std::pin::Pin;
 use std::task::{Context, Poll};
+use std::time::Duration;
 use tower_make::MakeConnection;
 use tower_service::Service;
 
 #[cfg(not(feature = "tls"))]
-pub(crate) fn connector() -> HttpConnector {
+pub(crate) fn connector(tcp_keepalive: Option<Duration>) -> HttpConnector {
     let mut http = HttpConnector::new();
     http.enforce_http(false);
     http.set_nodelay(true);
+    http.set_keepalive(tcp_keepalive);
     http
 }
 
 #[cfg(feature = "tls")]
-pub(crate) fn connector(tls: Option<TlsConnector>) -> Connector {
-    Connector::new(tls)
+pub(crate) fn connector(tls: Option<TlsConnector>, tcp_keepalive: Option<Duration>) -> Connector {
+    Connector::new(tls, tcp_keepalive)
 }
 
 pub(crate) struct Connector {
@@ -30,11 +32,11 @@ pub(crate) struct Connector {
 
 impl Connector {
     #[cfg(feature = "tls")]
-    pub(crate) fn new(tls: Option<TlsConnector>) -> Self {
+    pub(crate) fn new(tls: Option<TlsConnector>, tcp_keepalive: Option<Duration>) -> Self {
         let mut http = HttpConnector::new();
         http.enforce_http(false);
         http.set_nodelay(true);
-
+        http.set_keepalive(tcp_keepalive);
         Self { http, tls }
     }
 }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/hyperium/tonic/blob/master/CONTRIBUTING.md
-->

## Motivation

Long running tcp connections (grpc streaming), with very low activity may be silently disconnected if done though firewalls or NAT routers. TCP keepalive fixes this.

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? If a new feature is being added, describe the intended
use case that feature fulfills.
-->

## Solution

Expose hyper tcp_keepalive api on `Endpoint` and `Server`.

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
