### PR TITLE
Temporarily allow duplicate crossbeam-queue crates

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -16,6 +16,7 @@ deny = [
 ]
 skip = [
     { name = "crossbeam-utils", version = "=0.6.6" },
+    { name = "crossbeam-queue", version = "=0.2.0" },
 ]
 skip-tree = [
     { name = "rand", version = "=0.6.5" },


### PR DESCRIPTION
`crossbeam-queue` is currently brought in both by Rayon (up to date v0.2.0) and Hyper's dependency chain (0.1.x). Since Hyper is in the process of updating things, I proposed we temporarily allow this to pass CI and revisit it when there is a new release of Hyper or the relevant dependencies thereof.

This will fix the build of #151, #148 etc.