### PR TITLE
chore(examples): enable the macros feature for tokio::main

### DIFF
--- a/tonic-examples/Cargo.toml
+++ b/tonic-examples/Cargo.toml
@@ -71,7 +71,7 @@ tonic = { path = "../tonic", features = ["tls"] }
 bytes = "0.4"
 prost = "0.5"
 
-tokio = { version = "0.2", features = ["rt-threaded", "time", "stream", "fs"] }
+tokio = { version = "0.2", features = ["rt-threaded", "time", "stream", "fs", "macros"] }
 futures = { version = "0.3", default-features = false, features = ["alloc"]}
 async-stream = "0.2"
 http = "0.2"


### PR DESCRIPTION
tokio 0.2 split out its macros into [a feature that is disabled by default](https://docs.rs/tokio/0.2.3/tokio/attr.main.html), so we'll re-enable it to allow example builds to work once more.