### PR TITLE
Attach a context to requests

### DIFF
--- a/tonic-examples/Cargo.toml
+++ b/tonic-examples/Cargo.toml
@@ -66,6 +66,14 @@ path = "src/multiplex/client.rs"
 name = "gcp-client"
 path = "src/gcp/client.rs"
 
+[[bin]]
+name = "context-client"
+path = "src/context/client.rs"
+
+[[bin]]
+name = "context-server"
+path = "src/context/server.rs"
+
 [dependencies]
 tonic = { path = "../tonic", features = ["tls"] }
 bytes = "0.4"

--- a/tonic-examples/src/context/client.rs
+++ b/tonic-examples/src/context/client.rs
@@ -1,0 +1,21 @@
+pub mod pb {
+    tonic::include_proto!("grpc.examples.echo");
+}
+
+use pb::{echo_client::EchoClient, EchoRequest};
+use tonic::transport::Channel;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let channel = Channel::from_static("http://[::1]:50051").connect().await?;
+    let mut client = EchoClient::new(channel);
+
+    let request = tonic::Request::new(EchoRequest {
+        message: "hello".into(),
+    });
+
+    let response = client.unary_echo(request).await?;
+
+    println!("RESPONSE={:?}", response);
+    Ok(())
+}

--- a/tonic-examples/src/context/server.rs
+++ b/tonic-examples/src/context/server.rs
@@ -1,0 +1,71 @@
+pub mod pb {
+    tonic::include_proto!("grpc.examples.echo");
+}
+
+use futures::Stream;
+use pb::{EchoRequest, EchoResponse};
+use std::pin::Pin;
+use tonic::{
+    transport::{Ctx, CtxField, Server},
+    Request, Response, Status, Streaming,
+};
+use tower::Service;
+
+type EchoResult<T> = Result<Response<T>, Status>;
+type ResponseStream = Pin<Box<dyn Stream<Item = Result<EchoResponse, Status>> + Send + Sync>>;
+
+#[derive(Default)]
+pub struct EchoServer;
+
+#[tonic::async_trait]
+impl pb::echo_server::Echo for EchoServer {
+    async fn unary_echo(&self, request: Request<EchoRequest>) -> EchoResult<EchoResponse> {
+        let message = request.into_inner().message;
+        Ok(Response::new(EchoResponse { message }))
+    }
+
+    type ServerStreamingEchoStream = ResponseStream;
+
+    async fn server_streaming_echo(
+        &self,
+        _: Request<EchoRequest>,
+    ) -> EchoResult<Self::ServerStreamingEchoStream> {
+        Err(Status::unimplemented("not implemented"))
+    }
+
+    async fn client_streaming_echo(
+        &self,
+        _: Request<Streaming<EchoRequest>>,
+    ) -> EchoResult<EchoResponse> {
+        Err(Status::unimplemented("not implemented"))
+    }
+
+    type BidirectionalStreamingEchoStream = ResponseStream;
+
+    async fn bidirectional_streaming_echo(
+        &self,
+        _: Request<Streaming<EchoRequest>>,
+    ) -> EchoResult<Self::BidirectionalStreamingEchoStream> {
+        Err(Status::unimplemented("not implemented"))
+    }
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let addr = "[::1]:50051".parse().unwrap();
+    let server = EchoServer::default();
+
+    Server::builder()
+        .with_ctx_field(CtxField::PeerAddr)
+        .interceptor_fn(move |svc, req| {
+            let ctx: &Ctx = req.extensions().get().unwrap();
+            println!("{:?}", ctx.peer_addr);
+
+            svc.call(req)
+        })
+        .add_service(pb::echo_server::EchoServer::new(server))
+        .serve(addr)
+        .await?;
+
+    Ok(())
+}

--- a/tonic-examples/src/load_balance/client.rs
+++ b/tonic-examples/src/load_balance/client.rs
@@ -8,7 +8,7 @@ use tonic::transport::Channel;
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let endpoints = ["http://[::1]:50051", "http://[::1]:50052"]
-        .into_iter()
+        .iter()
         .map(|a| Channel::from_static(a));
 
     let channel = Channel::balance_list(endpoints);

--- a/tonic/src/transport/context.rs
+++ b/tonic/src/transport/context.rs
@@ -1,0 +1,20 @@
+use std::net::SocketAddr;
+
+/// This enumeration represents the different
+/// fields of `Ctx`.
+///
+/// It is used with `Server` to construct the
+/// context that is passed to the request.
+#[derive(Clone, Copy, Debug)]
+pub enum CtxField {
+    /// Add the peer address to the context.
+    PeerAddr,
+}
+
+/// A context passed to the request for use
+/// in interceptors.
+#[derive(Default, Clone, Copy, Debug)]
+pub struct Ctx {
+    /// The peer's IP (v4 or v6) address.
+    pub peer_addr: Option<SocketAddr>,
+}

--- a/tonic/src/transport/mod.rs
+++ b/tonic/src/transport/mod.rs
@@ -94,12 +94,14 @@
 pub mod channel;
 pub mod server;
 
+mod context;
 mod error;
 mod service;
 mod tls;
 
 #[doc(inline)]
 pub use self::channel::{Channel, Endpoint};
+pub use self::context::{Ctx, CtxField};
 pub use self::error::Error;
 #[doc(inline)]
 pub use self::server::{Server, ServiceName};


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/hyperium/tonic/blob/master/CONTRIBUTING.md
-->

## Motivation

Being able to access various things (ip address of the peer or other things) in server interceptors / future middleware implementations in tonic. This is mainly for logging, access control, etc...

This would solve #71.

I need this feature so I went ahead and implemented it in the way described below. It may not fit with what tonic intends to provide in the long term but since it's done, I may as well create this PR.

The implementation has some overlap with #85, since it's inspired by it, but tries to be a bit more flexible.

## Solution
Create a `Ctx` struct which is populated according to configuration passed to the `Server` builder. This struct is added to the `Request`'s extensions so it becomes available to interceptors.

Here's what the current usage looks like:

```rust
let mut builder = Server::builder();
builder
    .with_ctx_field(CtxField::PeerAddr) // Add the PeerAddr field in the Ctx struct
    .interceptor_fn(|svc, req| {
        let ctx: &Ctx = req.extensions().get().unwrap();
        // do something
    })
    .add_service(/* service */)
    .serve(/* addr */)
    .await?;
```
The context struct can be extended with more fields, which can also be gated behind features. This PR only adds a field to read the peer's ip address.

## Open questions
Provided the current implementation is acceptable for merging:

1. Would it make sense to do something similar for clients ?
2. @jen20 If this gets merged, how should we proceed for #85 ?

Let me know what you think.