### PR TITLE
chore(ci): Switch to use GitHub Action for cargo-deny

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -38,21 +38,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v1
-    - name: download cargo-deny
-      shell: bash
-      env:
-        DVS: "0.4.0"
-        DREPO: EmbarkStudios/cargo-deny
-        TARGET: x86_64-unknown-linux-musl
-      run: |
-        temp_archive=$(mktemp --suffix=.tar.gz)
-        curl -L --output "$temp_archive" https://github.com/$DREPO/releases/download/$DVS/cargo-deny-$DVS-$TARGET.tar.gz
-
-        tar -xzvf "$temp_archive" -C . --strip-components=1 --wildcards "*/cargo-deny"
-    - name: cargo-deny check licenses
-      run: ./cargo-deny -L debug check license
-    - name: cargo-deny check bans
-      run: ./cargo-deny -L debug check ban
+    - uses: EmbarkStudios/cargo-deny-action@v0
 
   test:
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
This upgrades CI from manually downloading cargo-deny to use our new [cargo-deny GitHub Action](https://github.com/EmbarkStudios/cargo-deny-action). 

Includes a lot of fixes, upgrades a new features as it brings cargo-deny from 0.4.0 to 0.5.2. List of changes:
https://github.com/EmbarkStudios/cargo-deny/releases

Biggest one here is that it will now also check the RUSTSEC security advisory database and will (by default) fail builds if any security advisories are detected for used crates

I was thinking first that we should wait until we have a v1 of the action and cargo-deny before using it, but as `tonic` is one of the first non-Embark repos using `cargo-deny` I think we can switch to the action here - but monitor how it works. Can always pin the action to an exact version also and/or disable advisories or other features.

cc @Jake-Shadle @LucioFranco 