### PR TITLE
Fix examples link

### DIFF
--- a/examples/src/gcp/client.rs
+++ b/examples/src/gcp/client.rs
@@ -25,7 +25,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let bearer_token = format!("Bearer {}", token);
     let header_value = HeaderValue::from_str(&bearer_token)?;
 
-    let certs = tokio::fs::read("tonic-examples/data/gcp/roots.pem").await?;
+    let certs = tokio::fs::read("examples/data/gcp/roots.pem").await?;
 
     let tls_config = ClientTlsConfig::new()
         .ca_certificate(Certificate::from_pem(certs.as_slice()))

--- a/examples/src/tls/client.rs
+++ b/examples/src/tls/client.rs
@@ -7,7 +7,7 @@ use tonic::transport::{Certificate, Channel, ClientTlsConfig};
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let pem = tokio::fs::read("tonic-examples/data/tls/ca.pem").await?;
+    let pem = tokio::fs::read("examples/data/tls/ca.pem").await?;
     let ca = Certificate::from_pem(pem);
 
     let tls = ClientTlsConfig::new()

--- a/examples/src/tls/server.rs
+++ b/examples/src/tls/server.rs
@@ -51,8 +51,8 @@ impl pb::echo_server::Echo for EchoServer {
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let cert = tokio::fs::read("tonic-examples/data/tls/server.pem").await?;
-    let key = tokio::fs::read("tonic-examples/data/tls/server.key").await?;
+    let cert = tokio::fs::read("examples/data/tls/server.pem").await?;
+    let key = tokio::fs::read("examples/data/tls/server.key").await?;
 
     let identity = Identity::from_pem(cert, key);
 

--- a/examples/src/tls_client_auth/client.rs
+++ b/examples/src/tls_client_auth/client.rs
@@ -7,10 +7,10 @@ use tonic::transport::{Certificate, Channel, ClientTlsConfig, Identity};
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let server_root_ca_cert = tokio::fs::read("tonic-examples/data/tls/ca.pem").await?;
+    let server_root_ca_cert = tokio::fs::read("examples/data/tls/ca.pem").await?;
     let server_root_ca_cert = Certificate::from_pem(server_root_ca_cert);
-    let client_cert = tokio::fs::read("tonic-examples/data/tls/client1.pem").await?;
-    let client_key = tokio::fs::read("tonic-examples/data/tls/client1.key").await?;
+    let client_cert = tokio::fs::read("examples/data/tls/client1.pem").await?;
+    let client_key = tokio::fs::read("examples/data/tls/client1.key").await?;
     let client_identity = Identity::from_pem(client_cert, client_key);
 
     let tls = ClientTlsConfig::new()

--- a/examples/src/tls_client_auth/server.rs
+++ b/examples/src/tls_client_auth/server.rs
@@ -27,11 +27,11 @@ impl pb::echo_server::Echo for EchoServer {
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let cert = tokio::fs::read("tonic-examples/data/tls/server.pem").await?;
-    let key = tokio::fs::read("tonic-examples/data/tls/server.key").await?;
+    let cert = tokio::fs::read("examples/data/tls/server.pem").await?;
+    let key = tokio::fs::read("examples/data/tls/server.key").await?;
     let server_identity = Identity::from_pem(cert, key);
 
-    let client_ca_cert = tokio::fs::read("tonic-examples/data/tls/client_ca.pem").await?;
+    let client_ca_cert = tokio::fs::read("examples/data/tls/client_ca.pem").await?;
     let client_ca_cert = Certificate::from_pem(client_ca_cert);
 
     let addr = "[::1]:50051".parse().unwrap();

--- a/tonic/src/lib.rs
+++ b/tonic/src/lib.rs
@@ -53,7 +53,7 @@
 //! [`hyper`]: https://docs.rs/hyper
 //! [`tower`]: https://docs.rs/tower
 //! [`tonic-build`]: https://docs.rs/tonic-build
-//! [`tonic-examples`]: https://github.com/hyperium/tonic/tree/master/tonic-examples
+//! [`tonic-examples`]: https://github.com/hyperium/tonic/tree/master/examples
 //! [`Codec`]: codec/trait.Codec.html
 //! [`Channel`]: transport/struct.Channel.html
 //! [`Server`]: transport/struct.Server.html


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/hyperium/tonic/blob/master/CONTRIBUTING.md
-->

## Motivation
I noticed that the examples link in docs.rs was broken.  This fixes that along with some of the examples.

https://docs.rs/tonic/0.1.0-beta.1/tonic/

## Solution

Replace `tonic-examples` with just `examples`
