### PR TITLE
fix(transport): Improve `Error` type

### DIFF
--- a/tonic/src/transport/channel/endpoint.rs
+++ b/tonic/src/transport/channel/endpoint.rs
@@ -4,7 +4,7 @@ use super::Channel;
 use super::ClientTlsConfig;
 #[cfg(feature = "tls")]
 use crate::transport::service::TlsConnector;
-use crate::transport::{Error, ErrorKind};
+use crate::transport::Error;
 use bytes::Bytes;
 use http::uri::{InvalidUri, Uri};
 use std::{
@@ -44,9 +44,7 @@ impl Endpoint {
         D: TryInto<Self>,
         D::Error: Into<crate::Error>,
     {
-        let me = dst
-            .try_into()
-            .map_err(|e| Error::from_source(ErrorKind::Client, e.into()))?;
+        let me = dst.try_into().map_err(|e| Error::from_source(e.into()))?;
         Ok(me)
     }
 

--- a/tonic/src/transport/channel/mod.rs
+++ b/tonic/src/transport/channel/mod.rs
@@ -136,7 +136,7 @@ impl Channel {
 
         let svc = Connection::new(connector, endpoint)
             .await
-            .map_err(|e| super::Error::from_source(super::ErrorKind::Client, e))?;
+            .map_err(|e| super::Error::from_source(e))?;
 
         let svc = Buffer::new(Either::A(svc), buffer_size);
 
@@ -174,8 +174,7 @@ impl GrpcService<BoxBody> for Channel {
     type Future = ResponseFuture;
 
     fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
-        GrpcService::poll_ready(&mut self.svc, cx)
-            .map_err(|e| super::Error::from_source(super::ErrorKind::Client, e))
+        GrpcService::poll_ready(&mut self.svc, cx).map_err(|e| super::Error::from_source(e))
     }
 
     fn call(&mut self, mut request: Request<BoxBody>) -> Self::Future {
@@ -193,7 +192,7 @@ impl Future for ResponseFuture {
 
     fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         let val = futures_util::ready!(Pin::new(&mut self.inner).poll(cx))
-            .map_err(|e| super::Error::from_source(super::ErrorKind::Client, e))?;
+            .map_err(|e| super::Error::from_source(e))?;
         Ok(val).into()
     }
 }

--- a/tonic/src/transport/error.rs
+++ b/tonic/src/transport/error.rs
@@ -1,57 +1,23 @@
 use std::{error, fmt};
 
 /// Error's that originate from the client or server;
-pub struct Error {
-    kind: ErrorKind,
-    source: Option<crate::Error>,
-}
+#[derive(Debug)]
+pub struct Error(crate::Error);
 
 impl Error {
-    pub(crate) fn from_source(kind: ErrorKind, source: crate::Error) -> Self {
-        Self {
-            kind,
-            source: Some(source),
-        }
-    }
-}
-
-#[derive(Debug)]
-pub(crate) enum ErrorKind {
-    Client,
-    Server,
-}
-
-impl fmt::Debug for Error {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let mut f = f.debug_tuple("Error");
-        f.field(&self.kind);
-        if let Some(source) = &self.source {
-            f.field(source);
-        }
-        f.finish()
+    pub(crate) fn from_source(source: impl Into<crate::Error>) -> Self {
+        Self(source.into())
     }
 }
 
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        if let Some(source) = &self.source {
-            write!(f, "{}: {}", self.kind, source)
-        } else {
-            write!(f, "{}", self.kind)
-        }
+        self.0.fmt(f)
     }
 }
 
 impl error::Error for Error {
     fn source(&self) -> Option<&(dyn error::Error + 'static)> {
-        self.source
-            .as_ref()
-            .map(|e| &**e as &(dyn error::Error + 'static))
-    }
-}
-
-impl fmt::Display for ErrorKind {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{:?}", self)
+        self.0.source()
     }
 }

--- a/tonic/src/transport/mod.rs
+++ b/tonic/src/transport/mod.rs
@@ -112,5 +112,3 @@ pub use self::channel::ClientTlsConfig;
 #[cfg(feature = "tls")]
 #[cfg_attr(docsrs, doc(cfg(feature = "tls")))]
 pub use self::server::ServerTlsConfig;
-
-pub(crate) use self::error::ErrorKind;

--- a/tonic/src/transport/server/mod.rs
+++ b/tonic/src/transport/server/mod.rs
@@ -300,9 +300,9 @@ impl Server {
                 .serve(svc)
                 .with_graceful_shutdown(signal)
                 .await
-                .map_err(map_err)?
+                .map_err(super::Error::from_source)?
         } else {
-            server.serve(svc).await.map_err(map_err)?;
+            server.serve(svc).await.map_err(super::Error::from_source)?;
         }
 
         Ok(())
@@ -374,7 +374,7 @@ where
     /// [`Server`]: struct.Server.html
     pub async fn serve(self, addr: SocketAddr) -> Result<(), super::Error> {
         let incoming = TcpIncoming::new(addr, self.server.tcp_nodelay, self.server.tcp_keepalive)
-            .map_err(map_err)?;
+            .map_err(super::Error::from_source)?;
         self.server
             .serve_with_shutdown::<_, _, future::Ready<()>, _, _>(self.routes, incoming, None)
             .await
@@ -391,7 +391,7 @@ where
         f: F,
     ) -> Result<(), super::Error> {
         let incoming = TcpIncoming::new(addr, self.server.tcp_nodelay, self.server.tcp_keepalive)
-            .map_err(map_err)?;
+            .map_err(super::Error::from_source)?;
         self.server
             .serve_with_shutdown(self.routes, incoming, Some(f))
             .await
@@ -411,10 +411,6 @@ where
             .serve_with_shutdown::<_, _, future::Ready<()>, _, _>(self.routes, incoming, None)
             .await
     }
-}
-
-fn map_err(e: impl Into<crate::Error>) -> super::Error {
-    super::Error::from_source(super::ErrorKind::Server, e.into())
 }
 
 impl fmt::Debug for Server {


### PR DESCRIPTION
## Motivation

Fixes #213 

## Solution

Makes the `tonic::transport::Error` type much simpler. It just forwards what's in the source error now. It was previously opaque anyway so a user of the library could not match on the `ErrorKind` or anything like that anyway.

However, this just solves the problem of the error not having redundant information in it. The library still uses a lot of opaque `Box<dyn Error>` internally. I personally think it would be nicer if `tonic` exposed a proper `hyper::Error` where the error comes from `hyper` etc. But I did not feel that was in scope for getting this part done.