### PR TITLE
feat(build): Add extern_path config support

### DIFF
--- a/tonic-build/src/lib.rs
+++ b/tonic-build/src/lib.rs
@@ -76,6 +76,7 @@ mod server;
 pub struct Builder {
     build_client: bool,
     build_server: bool,
+    extern_path: Vec<(String, String)>,
     field_attributes: Vec<(String, String)>,
     type_attributes: Vec<(String, String)>,
     out_dir: Option<PathBuf>,
@@ -111,6 +112,17 @@ impl Builder {
         self
     }
 
+    /// Declare externally provided Protobuf package or type.
+    ///
+    /// Passed directly to `prost_build::Config.extern_path`.
+    pub fn extern_path<T: AsRef<str>>(mut self, proto_path: T, rust_path: T) -> Self {
+        self.extern_path.push((
+            proto_path.as_ref().to_string(),
+            rust_path.as_ref().to_string(),
+        ));
+        self
+    }
+
     /// Add additional attribute to matched messages, enums, and one-offs.
     ///
     /// Passed directly to `prost_build::Config.field_attribute`.
@@ -142,6 +154,9 @@ impl Builder {
             .unwrap_or_else(|| PathBuf::from(std::env::var("OUT_DIR").unwrap()));
 
         config.out_dir(out_dir.clone());
+        for (proto_path, rust_path) in self.extern_path.iter() {
+            config.extern_path(proto_path, rust_path);
+        }
         for (path, attr) in self.field_attributes.iter() {
             config.field_attribute(path, attr);
         }
@@ -171,6 +186,7 @@ pub fn configure() -> Builder {
         build_client: true,
         build_server: true,
         out_dir: None,
+        extern_path: Vec::new(),
         field_attributes: Vec::new(),
         type_attributes: Vec::new(),
         #[cfg(feature = "rustfmt")]

--- a/tonic-build/src/lib.rs
+++ b/tonic-build/src/lib.rs
@@ -115,7 +115,7 @@ impl Builder {
     /// Declare externally provided Protobuf package or type.
     ///
     /// Passed directly to `prost_build::Config.extern_path`.
-    pub fn extern_path<T: AsRef<str>>(mut self, proto_path: T, rust_path: T) -> Self {
+    pub fn extern_path(mut self, proto_path: impl AsRef<str>, rust_path: impl AsRef<str>) -> Self {
         self.extern_path.push((
             proto_path.as_ref().to_string(),
             rust_path.as_ref().to_string(),


### PR DESCRIPTION
Adds support for prost-build's "extern_path" feature. This allows you to
reference another prost-generated protobuf, including any traits that
may have been defined for it, from another crate or location.

## Motivation

When using protobuf definitions not only defined in, but also extended by, another crate - you need to use prost's `extern_path` feature, so that the generated code references your extended external definitions, rather than creating new ones.

## Solution

Add `extern_path` to `tonic-build`.

There are no tests, as there were none to begin with. It does Work On My Machine, though. 
