### PR TITLE
chore: Upgrade to prost master and bytes 0.5

### DIFF
--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -88,8 +88,8 @@ path = "src/uds/server.rs"
 
 [dependencies]
 tonic = { path = "../tonic", features = ["tls"] }
-bytes = "0.4"
-prost = "0.5"
+bytes = "0.5"
+prost = { git = "https://github.com/danburkert/prost", branch = "master" }
 
 tokio = { version = "0.2", features = ["rt-threaded", "time", "stream", "fs", "macros", "uds"] }
 futures = { version = "0.3", default-features = false, features = ["alloc"]}
@@ -109,7 +109,7 @@ tracing-attributes = "0.1"
 tracing-futures = "0.2"
 
 # Required for wellknown types
-prost-types = "0.5"
+prost-types = { git = "https://github.com/danburkert/prost", branch = "master" }
 
 [build-dependencies]
 tonic-build = { path = "../tonic-build" }

--- a/examples/helloworld-tutorial.md
+++ b/examples/helloworld-tutorial.md
@@ -114,8 +114,8 @@ path = "src/client.rs"
 
 [dependencies]
 tonic = "0.1.0-beta.1"
-bytes = "0.4"
-prost = "0.5"
+bytes = "0.5"
+prost = { git = "https://github.com/danburkert/prost", branch = "master" }
 tokio = { version = "0.2", features = ["macros"] }
 
 [build-dependencies]

--- a/examples/routeguide-tutorial.md
+++ b/examples/routeguide-tutorial.md
@@ -181,8 +181,8 @@ Edit `Cargo.toml` and add all the dependencies we'll need for this example:
 ```toml
 [dependencies]
 tonic = "0.1.0-beta.1"
-bytes = "0.4"
-prost = "0.5"
+bytes = "0.5"
+prost = { git = "https://github.com/danburkert/prost", branch = "master" }
 futures-core = "0.3"
 futures-util = "0.3"
 tokio = { version = "0.2", features = ["macros", "sync", "stream", "time"] }

--- a/interop/Cargo.toml
+++ b/interop/Cargo.toml
@@ -17,9 +17,9 @@ path = "src/bin/server.rs"
 [dependencies]
 tokio = { version = "0.2", features = ["rt-threaded", "time", "macros", "stream", "fs"] }
 tonic = { path = "../tonic", features = ["tls"] }
-prost = "0.5"
-prost-derive = "0.5"
-bytes = "0.4"
+prost = { git = "https://github.com/danburkert/prost", branch = "master" }
+prost-derive = { git = "https://github.com/danburkert/prost", branch = "master" }
+bytes = "0.5"
 http = "0.2"
 futures-core = "0.3"
 futures-util = "0.3"

--- a/tests/included_service/Cargo.toml
+++ b/tests/included_service/Cargo.toml
@@ -10,8 +10,8 @@ license = "MIT"
 
 [dependencies]
 tonic = { path = "../../tonic" }
-bytes = "0.4"
-prost = "0.5"
+bytes = "0.5"
+prost = { git = "https://github.com/danburkert/prost", branch = "master" }
 
 [build-dependencies]
 tonic-build = { path = "../../tonic-build" }

--- a/tests/same_name/Cargo.toml
+++ b/tests/same_name/Cargo.toml
@@ -10,8 +10,8 @@ license = "MIT"
 
 [dependencies]
 tonic = { path = "../../tonic" }
-bytes = "0.4"
-prost = "0.5"
+bytes = "0.5"
+prost = { git = "https://github.com/danburkert/prost", branch = "master" }
 
 [build-dependencies]
 tonic-build = { path = "../../tonic-build" }

--- a/tests/wellknown/Cargo.toml
+++ b/tests/wellknown/Cargo.toml
@@ -11,8 +11,8 @@ license = "MIT"
 [dependencies]
 tonic = { path = "../../tonic" }
 bytes = "0.5"
-prost = "0.5"
-prost-types = "0.5"
+prost = { git = "https://github.com/danburkert/prost", branch = "master" }
+prost-types = { git = "https://github.com/danburkert/prost", branch = "master" }
 
 [build-dependencies]
 tonic-build = { path = "../../tonic-build" }

--- a/tonic-build/Cargo.toml
+++ b/tonic-build/Cargo.toml
@@ -16,7 +16,7 @@ keywords = ["rpc", "grpc", "async", "codegen", "protobuf"]
 
 
 [dependencies]
-prost-build = "0.5"
+prost-build = { git = "https://github.com/danburkert/prost", branch = "master" }
 syn = "1.0"
 quote = "1.0"
 proc-macro2 = "1.0"

--- a/tonic/Cargo.toml
+++ b/tonic/Cargo.toml
@@ -56,8 +56,8 @@ http-body = "0.3"
 pin-project = "0.4"
 
 # prost
-prost = { version = "0.5", optional = true }
-prost-derive = { version = "0.5", optional = true }
+prost = { git = "https://github.com/danburkert/prost", branch = "master", optional = true }
+prost-derive = { git = "https://github.com/danburkert/prost", branch = "master", optional = true }
 
 # codegen
 async-trait = { version = "0.1.13", optional = true }


### PR DESCRIPTION
This upgrades tonic to prost's master branch, and moves everything to
bytes 0.5.

## Motivation

Prost has lots of bug fixes and new features. Lets use them. 

## Solution

Move to prost master, pending a (very soon) release of prost.
