### PR TITLE
chore: Remove required bytes dep and clean up deny

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -14,12 +14,9 @@ deny = [
     # term is not fully maintained, and termcolor is replacing it
     { name = "term" },
 ]
-skip = [
-    { name = "bytes", version = "=0.4.12" },
-]
-skip-tree = [
-    { name = "rand", version = "=0.6.5" },
-    { name = "syn",  version = "=0.15.44" },
+skip-tree = [ 
+    { name = "winapi", version = "<= 0.3" },
+    { name = "autocfg", version = "<= 1" },
 ]
 
 [licenses]

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -88,7 +88,6 @@ path = "src/uds/server.rs"
 
 [dependencies]
 tonic = { path = "../tonic", features = ["tls"] }
-bytes = "0.5"
 prost = { git = "https://github.com/danburkert/prost", branch = "master" }
 
 tokio = { version = "0.2", features = ["rt-threaded", "time", "stream", "fs", "macros", "uds"] }
@@ -100,7 +99,7 @@ tower = "0.3"
 # Required for routeguide
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-rand = "0.6"
+rand = "0.7"
 
 # Tracing
 tracing = "0.1"

--- a/examples/helloworld-tutorial.md
+++ b/examples/helloworld-tutorial.md
@@ -114,7 +114,6 @@ path = "src/client.rs"
 
 [dependencies]
 tonic = "0.1.0-beta.1"
-bytes = "0.5"
 prost = { git = "https://github.com/danburkert/prost", branch = "master" }
 tokio = { version = "0.2", features = ["macros"] }
 

--- a/examples/routeguide-tutorial.md
+++ b/examples/routeguide-tutorial.md
@@ -181,7 +181,6 @@ Edit `Cargo.toml` and add all the dependencies we'll need for this example:
 ```toml
 [dependencies]
 tonic = "0.1.0-beta.1"
-bytes = "0.5"
 prost = { git = "https://github.com/danburkert/prost", branch = "master" }
 futures-core = "0.3"
 futures-util = "0.3"

--- a/interop/Cargo.toml
+++ b/interop/Cargo.toml
@@ -28,7 +28,7 @@ tower = "0.3"
 http-body = "0.3"
 
 console = "0.9"
-structopt = "0.2"
+structopt = "0.3"
 
 tracing = "0.1"
 tracing-subscriber = "0.2.0-alpha"

--- a/interop/src/bin/client.rs
+++ b/interop/src/bin/client.rs
@@ -6,6 +6,9 @@ use tonic_interop::client;
 
 #[derive(StructOpt)]
 struct Opts {
+    #[structopt(name = "use_tls", long)]
+    use_tls: bool,
+
     #[structopt(
         long = "test_case",
         use_delimiter = true,
@@ -13,9 +16,6 @@ struct Opts {
         possible_values = &Testcase::variants()
     )]
     test_case: Vec<Testcase>,
-
-    #[structopt(long)]
-    use_tls: bool,
 }
 
 #[tokio::main]

--- a/interop/src/bin/client.rs
+++ b/interop/src/bin/client.rs
@@ -10,7 +10,7 @@ struct Opts {
         long = "test_case",
         use_delimiter = true,
         min_values = 1,
-        raw(possible_values = r#"&Testcase::variants()"#)
+        possible_values = &Testcase::variants()
     )]
     test_case: Vec<Testcase>,
 

--- a/interop/src/bin/server.rs
+++ b/interop/src/bin/server.rs
@@ -8,7 +8,7 @@ use tonic_interop::{server, MergeTrailers};
 
 #[derive(StructOpt)]
 struct Opts {
-    #[structopt(long)]
+    #[structopt(name = "use_tls", long)]
     use_tls: bool,
 }
 

--- a/tests/included_service/Cargo.toml
+++ b/tests/included_service/Cargo.toml
@@ -10,7 +10,6 @@ license = "MIT"
 
 [dependencies]
 tonic = { path = "../../tonic" }
-bytes = "0.5"
 prost = { git = "https://github.com/danburkert/prost", branch = "master" }
 
 [build-dependencies]

--- a/tests/same_name/Cargo.toml
+++ b/tests/same_name/Cargo.toml
@@ -10,7 +10,6 @@ license = "MIT"
 
 [dependencies]
 tonic = { path = "../../tonic" }
-bytes = "0.5"
 prost = { git = "https://github.com/danburkert/prost", branch = "master" }
 
 [build-dependencies]

--- a/tests/wellknown/Cargo.toml
+++ b/tests/wellknown/Cargo.toml
@@ -10,7 +10,6 @@ license = "MIT"
 
 [dependencies]
 tonic = { path = "../../tonic" }
-bytes = "0.5"
 prost = { git = "https://github.com/danburkert/prost", branch = "master" }
 prost-types = { git = "https://github.com/danburkert/prost", branch = "master" }
 

--- a/tonic/Cargo.toml
+++ b/tonic/Cargo.toml
@@ -78,7 +78,7 @@ rustls-native-certs = { version = "0.1", optional = true }
 [dev-dependencies]
 tokio = { version = "0.2", features = ["rt-core", "macros"] }
 static_assertions = "1.0"
-rand = "0.6"
+rand = "0.7"
 bencher = "0.1.5"
 
 [package.metadata.docs.rs]


### PR DESCRIPTION
Closes #123 and #93

This removes the required bytes dependency because of the upstream change https://github.com/danburkert/prost/pull/254.

This also updates the deny config, we no longer bring in two versions of `syn/quote/proc_macro2`. Currently, the only two left duplicate dependencies is `winapi 0.2/0.3`/`autocfg 0.1/1`. 