### PR TITLE
chore: Upgrade to prost, prost-build and prost-derive 0.6 (#230)

### DIFF
--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -88,7 +88,7 @@ path = "src/uds/server.rs"
 
 [dependencies]
 tonic = { path = "../tonic", features = ["tls"] }
-prost = { git = "https://github.com/danburkert/prost", branch = "master" }
+prost = "0.6"
 
 tokio = { version = "0.2", features = ["rt-threaded", "time", "stream", "fs", "macros", "uds"] }
 futures = { version = "0.3", default-features = false, features = ["alloc"]}
@@ -108,7 +108,7 @@ tracing-attributes = "0.1"
 tracing-futures = "0.2"
 
 # Required for wellknown types
-prost-types = { git = "https://github.com/danburkert/prost", branch = "master" }
+prost-types = "0.6"
 
 [build-dependencies]
 tonic-build = { path = "../tonic-build" }

--- a/examples/helloworld-tutorial.md
+++ b/examples/helloworld-tutorial.md
@@ -114,7 +114,7 @@ path = "src/client.rs"
 
 [dependencies]
 tonic = "0.1.0-beta.1"
-prost = { git = "https://github.com/danburkert/prost", branch = "master" }
+prost = "0.6"
 tokio = { version = "0.2", features = ["macros"] }
 
 [build-dependencies]

--- a/examples/routeguide-tutorial.md
+++ b/examples/routeguide-tutorial.md
@@ -181,7 +181,7 @@ Edit `Cargo.toml` and add all the dependencies we'll need for this example:
 ```toml
 [dependencies]
 tonic = "0.1.0-beta.1"
-prost = { git = "https://github.com/danburkert/prost", branch = "master" }
+prost = "0.6"
 futures-core = "0.3"
 futures-util = "0.3"
 tokio = { version = "0.2", features = ["macros", "sync", "stream", "time"] }

--- a/interop/Cargo.toml
+++ b/interop/Cargo.toml
@@ -17,8 +17,8 @@ path = "src/bin/server.rs"
 [dependencies]
 tokio = { version = "0.2", features = ["rt-threaded", "time", "macros", "stream", "fs"] }
 tonic = { path = "../tonic", features = ["tls"] }
-prost = { git = "https://github.com/danburkert/prost", branch = "master" }
-prost-derive = { git = "https://github.com/danburkert/prost", branch = "master" }
+prost = "0.6"
+prost-derive = "0.6"
 bytes = "0.5"
 http = "0.2"
 futures-core = "0.3"

--- a/tests/included_service/Cargo.toml
+++ b/tests/included_service/Cargo.toml
@@ -10,7 +10,7 @@ license = "MIT"
 
 [dependencies]
 tonic = { path = "../../tonic" }
-prost = { git = "https://github.com/danburkert/prost", branch = "master" }
+prost = "0.6"
 
 [build-dependencies]
 tonic-build = { path = "../../tonic-build" }

--- a/tests/same_name/Cargo.toml
+++ b/tests/same_name/Cargo.toml
@@ -10,7 +10,7 @@ license = "MIT"
 
 [dependencies]
 tonic = { path = "../../tonic" }
-prost = { git = "https://github.com/danburkert/prost", branch = "master" }
+prost = "0.6"
 
 [build-dependencies]
 tonic-build = { path = "../../tonic-build" }

--- a/tests/wellknown/Cargo.toml
+++ b/tests/wellknown/Cargo.toml
@@ -10,8 +10,8 @@ license = "MIT"
 
 [dependencies]
 tonic = { path = "../../tonic" }
-prost = { git = "https://github.com/danburkert/prost", branch = "master" }
-prost-types = { git = "https://github.com/danburkert/prost", branch = "master" }
+prost = "0.6"
+prost-types = "0.6"
 
 [build-dependencies]
 tonic-build = { path = "../../tonic-build" }

--- a/tonic-build/Cargo.toml
+++ b/tonic-build/Cargo.toml
@@ -16,7 +16,7 @@ keywords = ["rpc", "grpc", "async", "codegen", "protobuf"]
 
 
 [dependencies]
-prost-build = { git = "https://github.com/danburkert/prost", branch = "master" }
+prost-build = "0.6"
 syn = "1.0"
 quote = "1.0"
 proc-macro2 = "1.0"

--- a/tonic/Cargo.toml
+++ b/tonic/Cargo.toml
@@ -56,8 +56,8 @@ http-body = "0.3"
 pin-project = "0.4"
 
 # prost
-prost = { git = "https://github.com/danburkert/prost", branch = "master", optional = true }
-prost-derive = { git = "https://github.com/danburkert/prost", branch = "master", optional = true }
+prost = { version = "0.6", optional = true }
+prost-derive = { version = "0.6", optional = true }
 
 # codegen
 async-trait = { version = "0.1.13", optional = true }


### PR DESCRIPTION
## Motivation

As far as I remember I think this was one of the last issues that tonic 0.1.0 is not yet released ?

## Solution

Updated all occurences of prost, prost-build and prost-derive to the just released 0.6, replacing the git / master branch dependency.