### PR TITLE
feat: Add gRPC interceptors

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,11 +2,9 @@
 members = [
     "tonic",
     "tonic-build",
-
     # Non-published crates
     "examples",
     "interop",
-
     # Tests
     "tests/included_service",
     "tests/same_name",

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -86,27 +86,37 @@ path = "src/uds/client.rs"
 name = "uds-server"
 path = "src/uds/server.rs"
 
+[[bin]]
+name = "interceptor-client"
+path = "src/interceptor/client.rs"
+
+[[bin]]
+name = "interceptor-server"
+path = "src/interceptor/server.rs"
+
 [dependencies]
 tonic = { path = "../tonic", features = ["tls"] }
 prost = "0.6"
-
-tokio = { version = "0.2", features = ["rt-threaded", "time", "stream", "fs", "macros", "uds"] }
-futures = { version = "0.3", default-features = false, features = ["alloc"]}
+tokio = { version = "0.2", features = [
+    "rt-threaded",
+    "time",
+    "stream",
+    "fs",
+    "macros",
+    "uds"
+] }
+futures = { version = "0.3", default-features = false, features = ["alloc"] }
 async-stream = "0.2"
-http = "0.2"
-tower = "0.3" 
-
+tower = "0.3"
 # Required for routeguide
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 rand = "0.7"
-
 # Tracing
 tracing = "0.1"
-tracing-subscriber =  { version = "0.2.0-alpha", features = ["tracing-log"] }
+tracing-subscriber = { version = "0.2.0-alpha", features = ["tracing-log"] }
 tracing-attributes = "0.1"
 tracing-futures = "0.2"
-
 # Required for wellknown types
 prost-types = "0.6"
 

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -97,14 +97,7 @@ path = "src/interceptor/server.rs"
 [dependencies]
 tonic = { path = "../tonic", features = ["tls"] }
 prost = "0.6"
-tokio = { version = "0.2", features = [
-    "rt-threaded",
-    "time",
-    "stream",
-    "fs",
-    "macros",
-    "uds"
-] }
+tokio = { version = "0.2", features = ["rt-threaded", "time", "stream", "fs", "macros", "uds"] }
 futures = { version = "0.3", default-features = false, features = ["alloc"] }
 async-stream = "0.2"
 tower = "0.3"

--- a/examples/src/gcp/client.rs
+++ b/examples/src/gcp/client.rs
@@ -4,8 +4,9 @@ pub mod api {
 
 use api::{publisher_client::PublisherClient, ListTopicsRequest};
 use tonic::{
+    metadata::MetadataValue,
     transport::{Certificate, Channel, ClientTlsConfig},
-    Request, metadata::MetadataValue
+    Request,
 };
 
 const ENDPOINT: &str = "https://pubsub.googleapis.com";
@@ -36,7 +37,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .await?;
 
     let mut service = PublisherClient::with_interceptor(channel, move |mut req: Request<()>| {
-        req.metadata_mut().insert("authorization", header_value.clone());
+        req.metadata_mut()
+            .insert("authorization", header_value.clone());
         Ok(req)
     });
 

--- a/examples/src/gcp/client.rs
+++ b/examples/src/gcp/client.rs
@@ -3,10 +3,9 @@ pub mod api {
 }
 
 use api::{publisher_client::PublisherClient, ListTopicsRequest};
-use http::header::HeaderValue;
 use tonic::{
     transport::{Certificate, Channel, ClientTlsConfig},
-    Request,
+    Request, metadata::MetadataValue
 };
 
 const ENDPOINT: &str = "https://pubsub.googleapis.com";
@@ -23,7 +22,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .ok_or("Expected a project name as the first argument.".to_string())?;
 
     let bearer_token = format!("Bearer {}", token);
-    let header_value = HeaderValue::from_str(&bearer_token)?;
+    let header_value = MetadataValue::from_str(&bearer_token)?;
 
     let certs = tokio::fs::read("examples/data/gcp/roots.pem").await?;
 
@@ -32,14 +31,14 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .domain_name("pubsub.googleapis.com");
 
     let channel = Channel::from_static(ENDPOINT)
-        .intercept_headers(move |headers| {
-            headers.insert("authorization", header_value.clone());
-        })
         .tls_config(tls_config)
         .connect()
         .await?;
 
-    let mut service = PublisherClient::new(channel);
+    let mut service = PublisherClient::with_interceptor(channel, move |mut req: Request<()>| {
+        req.metadata_mut().insert("authorization", header_value.clone());
+        Ok(req)
+    });
 
     let response = service
         .list_topics(Request::new(ListTopicsRequest {

--- a/examples/src/interceptor/client.rs
+++ b/examples/src/interceptor/client.rs
@@ -1,0 +1,34 @@
+use hello_world::greeter_client::GreeterClient;
+use hello_world::HelloRequest;
+use tonic::{transport::Endpoint, Request, Status};
+
+pub mod hello_world {
+    tonic::include_proto!("helloworld");
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let channel = Endpoint::from_static("http://[::1]:50051")
+        .connect()
+        .await?;
+
+    let mut client = GreeterClient::with_interceptor(channel, intercept);
+
+    let request = tonic::Request::new(HelloRequest {
+        name: "Tonic".into(),
+    });
+
+    let response = client.say_hello(request).await?;
+
+    println!("RESPONSE={:?}", response);
+
+    Ok(())
+}
+
+/// This function will get called on each outbound request. Returning a
+/// `Status` here will cancel the request and have that status returned to
+/// the client.
+fn intercept(req: Request<()>) -> Result<Request<()>, Status> {
+    println!("Intercepting request: {:?}", req);
+    Ok(req)
+}

--- a/examples/src/interceptor/client.rs
+++ b/examples/src/interceptor/client.rs
@@ -27,7 +27,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
 /// This function will get called on each outbound request. Returning a
 /// `Status` here will cancel the request and have that status returned to
-/// the client.
+/// the caller.
 fn intercept(req: Request<()>) -> Result<Request<()>, Status> {
     println!("Intercepting request: {:?}", req);
     Ok(req)

--- a/examples/src/interceptor/server.rs
+++ b/examples/src/interceptor/server.rs
@@ -1,0 +1,45 @@
+use tonic::{transport::Server, Request, Response, Status};
+
+use hello_world::greeter_server::{Greeter, GreeterServer};
+use hello_world::{HelloReply, HelloRequest};
+
+pub mod hello_world {
+    tonic::include_proto!("helloworld");
+}
+
+#[derive(Default)]
+pub struct MyGreeter {}
+
+#[tonic::async_trait]
+impl Greeter for MyGreeter {
+    async fn say_hello(
+        &self,
+        request: Request<HelloRequest>,
+    ) -> Result<Response<HelloReply>, Status> {
+        let reply = hello_world::HelloReply {
+            message: format!("Hello {}!", request.into_inner().name),
+        };
+        Ok(Response::new(reply))
+    }
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let addr = "[::1]:50051".parse().unwrap();
+    let greeter = MyGreeter::default();
+
+    let svc = GreeterServer::with_interceptor(greeter, intercept);
+
+    println!("GreeterServer listening on {}", addr);
+
+    Server::builder().add_service(svc).serve(addr).await?;
+
+    Ok(())
+}
+
+/// This function will get called on each inbound request, if a `Status`
+/// is returned, it will cancel the request and return that status.
+fn intercept(req: Request<()>) -> Result<Request<()>, Status> {
+    println!("Intercepting request: {:?}", req);
+    Ok(req)
+}

--- a/examples/src/interceptor/server.rs
+++ b/examples/src/interceptor/server.rs
@@ -38,7 +38,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 }
 
 /// This function will get called on each inbound request, if a `Status`
-/// is returned, it will cancel the request and return that status.
+/// is returned, it will cancel the request and return that status to the
+/// client.
 fn intercept(req: Request<()>) -> Result<Request<()>, Status> {
     println!("Intercepting request: {:?}", req);
     Ok(req)

--- a/examples/src/uds/client.rs
+++ b/examples/src/uds/client.rs
@@ -5,11 +5,10 @@ pub mod hello_world {
 }
 
 use hello_world::{greeter_client::GreeterClient, HelloRequest};
-use http::Uri;
 use std::convert::TryFrom;
 #[cfg(unix)]
 use tokio::net::UnixStream;
-use tonic::transport::Endpoint;
+use tonic::transport::{Endpoint, Uri};
 use tower::service_fn;
 
 #[cfg(unix)]

--- a/interop/Cargo.toml
+++ b/interop/Cargo.toml
@@ -15,7 +15,13 @@ name = "server"
 path = "src/bin/server.rs"
 
 [dependencies]
-tokio = { version = "0.2", features = ["rt-threaded", "time", "macros", "stream", "fs"] }
+tokio = { version = "0.2", features = [
+    "rt-threaded",
+    "time",
+    "macros",
+    "stream",
+    "fs"
+] }
 tonic = { path = "../tonic", features = ["tls"] }
 prost = "0.6"
 prost-derive = "0.6"
@@ -26,10 +32,9 @@ futures-util = "0.3"
 async-stream = "0.2"
 tower = "0.3"
 http-body = "0.3"
-
+hyper = "0.13"
 console = "0.9"
 structopt = "0.3"
-
 tracing = "0.1"
 tracing-subscriber = "0.2.0-alpha"
 tracing-log = "0.1.0"

--- a/interop/Cargo.toml
+++ b/interop/Cargo.toml
@@ -15,13 +15,7 @@ name = "server"
 path = "src/bin/server.rs"
 
 [dependencies]
-tokio = { version = "0.2", features = [
-    "rt-threaded",
-    "time",
-    "macros",
-    "stream",
-    "fs"
-] }
+tokio = { version = "0.2", features = ["rt-threaded", "time", "macros", "stream", "fs"] }
 tonic = { path = "../tonic", features = ["tls"] }
 prost = "0.6"
 prost-derive = "0.6"

--- a/interop/src/lib.rs
+++ b/interop/src/lib.rs
@@ -9,9 +9,7 @@ pub mod pb {
     include!(concat!(env!("OUT_DIR"), "/grpc.testing.rs"));
 }
 
-use std::{
-    default, fmt, iter,
-};
+use std::{default, fmt, iter};
 
 pub fn trace_init() {
     let sub = tracing_subscriber::FmtSubscriber::builder()
@@ -143,4 +141,3 @@ macro_rules! test_assert {
         }
     };
 }
-

--- a/tonic-build/src/client.rs
+++ b/tonic-build/src/client.rs
@@ -34,6 +34,11 @@ pub(crate) fn generate(service: &Service, proto: &str) -> TokenStream {
                     Self { inner }
                 }
 
+                pub fn with_interceptor(inner: T, interceptor: impl Into<tonic::Interceptor>) -> Self {
+                    let inner = tonic::client::Grpc::with_interceptor(inner, interceptor);
+                    Self { inner }
+                }
+
                 #methods
             }
 

--- a/tonic/src/interceptor.rs
+++ b/tonic/src/interceptor.rs
@@ -1,0 +1,54 @@
+use crate::{Request, Status};
+use std::{fmt, sync::Arc};
+
+/// Represents a gRPC interceptor.
+///
+/// gRPC interceptors are similar to middleware but have much less
+/// flexibility. This interceptor allows you to do two main things,
+/// one is to add/remove/check items in the `MetadataMap` of each
+/// request. Two, cancel a request with any `Status`.
+///
+/// An interceptor can be used on both the server and client side through
+/// the `tonic-build` crate's generated structs.
+///
+/// These interceptors do not allow you to modify the `Message` of the request
+/// but allow you to check for metadata. If you would like to apply middleware like
+/// features to the body of the request, going through the `tower` abstraction is recommended.
+#[derive(Clone)]
+pub struct Interceptor {
+    f: Arc<dyn Fn(Request<()>) -> Result<Request<()>, Status> + Send + Sync + 'static>,
+}
+
+impl Interceptor {
+    /// Create a new `Interceptor` from the provided function.
+    pub fn new(
+        f: impl Fn(Request<()>) -> Result<Request<()>, Status> + Send + Sync + 'static,
+    ) -> Self {
+        Interceptor { f: Arc::new(f) }
+    }
+
+    pub(crate) fn call<T>(&self, req: Request<T>) -> Result<Request<T>, Status> {
+        let (metadata, ext, message) = req.into_parts();
+
+        let temp_req = Request::from_parts(metadata, ext, ());
+
+        let (metadata, ext, _) = (self.f)(temp_req)?.into_parts();
+
+        Ok(Request::from_parts(metadata, ext, message))
+    }
+}
+
+impl<F> From<F> for Interceptor
+where
+    F: Fn(Request<()>) -> Result<Request<()>, Status> + Send + Sync + 'static,
+{
+    fn from(f: F) -> Self {
+        Interceptor::new(f)
+    }
+}
+
+impl fmt::Debug for Interceptor {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Interceptor").finish()
+    }
+}

--- a/tonic/src/lib.rs
+++ b/tonic/src/lib.rs
@@ -86,6 +86,7 @@ pub mod server;
 #[cfg_attr(docsrs, doc(cfg(feature = "transport")))]
 pub mod transport;
 
+mod interceptor;
 mod macros;
 mod request;
 mod response;
@@ -98,6 +99,7 @@ pub use async_trait::async_trait;
 
 #[doc(inline)]
 pub use codec::Streaming;
+pub use interceptor::Interceptor;
 pub use request::{IntoRequest, IntoStreamingRequest, Request};
 pub use response::Response;
 pub use status::{Code, Status};

--- a/tonic/src/request.rs
+++ b/tonic/src/request.rs
@@ -145,6 +145,18 @@ impl<T> Request<T> {
         self.message
     }
 
+    pub(crate) fn into_parts(self) -> (MetadataMap, Extensions, T) {
+        (self.metadata, self.extensions, self.message)
+    }
+
+    pub(crate) fn from_parts(metadata: MetadataMap, extensions: Extensions, message: T) -> Self {
+        Self {
+            metadata,
+            extensions,
+            message,
+        }
+    }
+
     pub(crate) fn from_http_parts(parts: http::request::Parts, message: T) -> Self {
         Request {
             metadata: MetadataMap::from_headers(parts.headers),

--- a/tonic/src/transport/channel/mod.rs
+++ b/tonic/src/transport/channel/mod.rs
@@ -132,15 +132,10 @@ impl Channel {
 
         let svc = Buffer::new(Either::A(svc), buffer_size);
 
-        Ok(Channel {
-            svc,
-        })
+        Ok(Channel { svc })
     }
 
-    pub(crate) fn balance<D>(
-        discover: D,
-        buffer_size: usize,
-    ) -> Self
+    pub(crate) fn balance<D>(discover: D, buffer_size: usize) -> Self
     where
         D: Discover<Service = Connection> + Unpin + Send + 'static,
         D::Error: Into<crate::Error>,
@@ -151,9 +146,7 @@ impl Channel {
         let svc = BoxService::new(svc);
         let svc = Buffer::new(Either::B(svc), buffer_size);
 
-        Channel {
-            svc,
-        }
+        Channel { svc }
     }
 }
 

--- a/tonic/src/transport/mod.rs
+++ b/tonic/src/transport/mod.rs
@@ -12,7 +12,6 @@
 //! - Timeouts
 //! - Concurrency Limits
 //! - Rate limiting
-//! - gRPC Interceptors
 //!
 //! # Examples
 //!
@@ -77,10 +76,6 @@
 //!     .tls_config(ServerTlsConfig::with_rustls()
 //!         .identity(Identity::from_pem(&cert, &key)))
 //!     .concurrency_limit_per_connection(256)
-//!     .interceptor_fn(|svc, req| {
-//!         println!("Request: {:?}", req);
-//!         svc.call(req)
-//!     })
 //!     .add_service(my_svc)
 //!     .serve(addr)
 //!     .await?;
@@ -104,7 +99,7 @@ pub use self::error::Error;
 #[doc(inline)]
 pub use self::server::{Server, ServiceName};
 pub use self::tls::{Certificate, Identity};
-pub use hyper::Body;
+pub use hyper::{Body, Uri};
 
 #[cfg(feature = "tls")]
 #[cfg_attr(docsrs, doc(cfg(feature = "tls")))]

--- a/tonic/src/transport/service/layer.rs
+++ b/tonic/src/transport/service/layer.rs
@@ -42,6 +42,8 @@ impl<L> ServiceBuilderExt<L> for ServiceBuilder<L> {
     }
 }
 
+// TODO: figure out why this is causing a warning even though its used in optional_layer_fn
+#[allow(dead_code)]
 pub(crate) fn layer_fn<F>(f: F) -> LayerFn<F> {
     LayerFn(f)
 }

--- a/tonic/src/transport/service/mod.rs
+++ b/tonic/src/transport/service/mod.rs
@@ -14,7 +14,7 @@ pub(crate) use self::connection::Connection;
 pub(crate) use self::connector::connector;
 pub(crate) use self::discover::ServiceList;
 pub(crate) use self::io::ServerIo;
-pub(crate) use self::layer::{layer_fn, ServiceBuilderExt};
+pub(crate) use self::layer::ServiceBuilderExt;
 pub(crate) use self::router::{Or, Routes};
 #[cfg(feature = "tls")]
 pub(crate) use self::tls::{TlsAcceptor, TlsConnector};


### PR DESCRIPTION
This change introduces proper gRPC interceptors that are avilable
regardless of the transport used. Each codegen service now produces an
additional method called `with_interceptor` that accepts a
`Interceptor`.

All examples have been updated to use this new style and interop has a
custom `tower::Service` middleware to echo the headers. There is also a
new `interceptor` example that shows basic usage.