### PR TITLE
Allow user to disable server certificate validation.

### DIFF
--- a/tonic/Cargo.toml
+++ b/tonic/Cargo.toml
@@ -75,8 +75,8 @@ tracing-futures = { version = "0.2", optional = true }
 # rustls
 tokio-rustls = { version = "0.12", optional = true }
 rustls-native-certs = { version = "0.1", optional = true }
-rustls = { version = "^0.16", features = ["dangerous_configuration"], optional = true }
-webpki = { version = "^0.21", optional = true }
+rustls = { version = "0.16", features = ["dangerous_configuration"], optional = true }
+webpki = { version = "0.21", optional = true }
 
 [dev-dependencies]
 tokio = { version = "0.2", features = ["rt-core", "macros"] }

--- a/tonic/Cargo.toml
+++ b/tonic/Cargo.toml
@@ -35,6 +35,7 @@ transport = [
 ]
 tls = ["transport", "tokio-rustls"]
 tls-roots = ["tls", "rustls-native-certs"]
+tls-dangerous = ["rustls", "webpki"]
 
 # [[bench]]
 # name = "bench_main"
@@ -42,7 +43,7 @@ tls-roots = ["tls", "rustls-native-certs"]
 
 [dependencies]
 bytes = "0.5"
-futures-core = { version = "0.3", default-features = false } 
+futures-core = { version = "0.3", default-features = false }
 futures-util = { version = "0.3", default-features = false }
 tracing = "0.1"
 http = "0.2"
@@ -74,6 +75,8 @@ tracing-futures = { version = "0.2", optional = true }
 # rustls
 tokio-rustls = { version = "0.12", optional = true }
 rustls-native-certs = { version = "0.1", optional = true }
+rustls = { version = "^0.16", features = ["dangerous_configuration"], optional = true }
+webpki = { version = "^0.21", optional = true }
 
 [dev-dependencies]
 tokio = { version = "0.2", features = ["rt-core", "macros"] }
@@ -88,4 +91,3 @@ rustdoc-args = ["--cfg", "docsrs"]
 [[bench]]
 name = "decode"
 harness = false
-

--- a/tonic/src/transport/channel/tls.rs
+++ b/tonic/src/transport/channel/tls.rs
@@ -101,7 +101,7 @@ impl ClientTlsConfig {
     #[cfg_attr(docsrs, doc(cfg(feature = "tls-dangerous")))]
     pub fn danger_accept_invalid_certs(self) -> Self {
         ClientTlsConfig {
-            certs_validation: true,
+            certs_validation: false,
             ..self
         }
     }

--- a/tonic/src/transport/channel/tls.rs
+++ b/tonic/src/transport/channel/tls.rs
@@ -1,5 +1,5 @@
 use crate::transport::{
-    service::{CertsValidation, TlsConnector},
+    service::TlsConnector,
     tls::{Certificate, Identity},
     Error,
 };
@@ -15,7 +15,7 @@ pub struct ClientTlsConfig {
     cert: Option<Certificate>,
     identity: Option<Identity>,
     rustls_raw: Option<tokio_rustls::rustls::ClientConfig>,
-    _certs_validation: CertsValidation,
+    _certs_validation: bool,
 }
 
 #[cfg(feature = "tls")]
@@ -38,7 +38,7 @@ impl ClientTlsConfig {
             cert: None,
             identity: None,
             rustls_raw: None,
-            _certs_validation: CertsValidation::Enable,
+            _certs_validation: true,
         }
     }
 
@@ -99,7 +99,7 @@ impl ClientTlsConfig {
     #[cfg_attr(docsrs, doc(cfg(feature = "tls-dangerous")))]
     pub fn danger_accept_invalid_certs(self) -> Self {
         ClientTlsConfig {
-            _certs_validation: CertsValidation::Disable,
+            _certs_validation: true,
             ..self
         }
     }

--- a/tonic/src/transport/service/mod.rs
+++ b/tonic/src/transport/service/mod.rs
@@ -17,4 +17,4 @@ pub(crate) use self::io::ServerIo;
 pub(crate) use self::layer::ServiceBuilderExt;
 pub(crate) use self::router::{Or, Routes};
 #[cfg(feature = "tls")]
-pub(crate) use self::tls::{TlsAcceptor, TlsConnector};
+pub(crate) use self::tls::{CertsValidation, TlsAcceptor, TlsConnector};

--- a/tonic/src/transport/service/mod.rs
+++ b/tonic/src/transport/service/mod.rs
@@ -17,4 +17,4 @@ pub(crate) use self::io::ServerIo;
 pub(crate) use self::layer::ServiceBuilderExt;
 pub(crate) use self::router::{Or, Routes};
 #[cfg(feature = "tls")]
-pub(crate) use self::tls::{CertsValidation, TlsAcceptor, TlsConnector};
+pub(crate) use self::tls::{TlsAcceptor, TlsConnector};

--- a/tonic/src/transport/service/tls.rs
+++ b/tonic/src/transport/service/tls.rs
@@ -66,7 +66,7 @@ impl TlsConnector {
 
         #[cfg(feature = "tls-dangerous")]
         {
-            if _certs_validation {
+            if !_certs_validation {
                 config.dangerous()
                     .set_certificate_verifier(std::sync::Arc::new(NoCertsValidation));
             }

--- a/tonic/src/transport/service/tls.rs
+++ b/tonic/src/transport/service/tls.rs
@@ -32,14 +32,6 @@ enum TlsError {
     PrivateKeyParseError,
 }
 
-/// If we do certificats validation.
-#[derive(Copy, Clone, Debug)]
-pub(crate) enum CertsValidation {
-    Enable,
-    #[cfg(feature = "tls-dangerous")]
-    Disable,
-}
-
 #[derive(Clone)]
 pub(crate) struct TlsConnector {
     config: Arc<ClientConfig>,
@@ -51,7 +43,7 @@ impl TlsConnector {
     pub(crate) fn new_with_rustls_cert(
         ca_cert: Option<Certificate>,
         identity: Option<Identity>,
-        _certs_validation: CertsValidation,
+        _certs_validation: bool,
         domain: String,
     ) -> Result<Self, crate::Error> {
         let mut config = ClientConfig::new();
@@ -74,7 +66,7 @@ impl TlsConnector {
 
         #[cfg(feature = "tls-dangerous")]
         {
-            if let CertsValidation::Disable = _certs_validation {
+            if _certs_validation {
                 config.dangerous()
                     .set_certificate_verifier(std::sync::Arc::new(NoCertsValidation));
             }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/hyperium/tonic/blob/master/CONTRIBUTING.md
-->
## Motivation
Currently, if you want to disable server certificate validation, you have to manually set a `rustls` configuration. Unfortunately, it also overrides default tonic configuration like ALPN protocols.
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? If a new feature is being added, describe the intended
use case that feature fulfills.
-->

## Solution
This PR exposes `danger_accept_invalid_certs` in `ClientTlsConfig`. That function while still preserving `tonic` default `tls` configuration, disables server certificate validation. Because it introduces a security vulnerability, we gated that function behind `tls-dangerous` feature flag.
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
