### PR TITLE
fix(build): Don't replace extern_paths

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,4 +9,6 @@ members = [
     "tests/included_service",
     "tests/same_name",
     "tests/wellknown",
+    "tests/extern_path/uuid",
+    "tests/extern_path/my_application"
 ]

--- a/tests/extern_path/my_application/Cargo.toml
+++ b/tests/extern_path/my_application/Cargo.toml
@@ -3,6 +3,8 @@ name = "my_application"
 version = "0.1.0"
 authors = ["Danny Hua <danny@42layers.io>"]
 edition = "2018"
+publish = false
+license = "MIT"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/tests/extern_path/my_application/Cargo.toml
+++ b/tests/extern_path/my_application/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "my_application"
+version = "0.1.0"
+authors = ["Danny Hua <danny@42layers.io>"]
+edition = "2018"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+tonic = { path= "../../../tonic" }
+prost = "0.6"
+prost-types = "0.6"
+uuid = { path= "../uuid" }
+
+[build-dependencies]
+tonic-build = { path= "../../../tonic-build" }

--- a/tests/extern_path/my_application/build.rs
+++ b/tests/extern_path/my_application/build.rs
@@ -1,0 +1,11 @@
+fn main() -> Result<(), std::io::Error> {
+    tonic_build::configure()
+        .build_server(false)
+        .build_client(true)
+        .extern_path(".uuid", "::uuid")
+        .compile(
+            &["service.proto", "uuid.proto"],
+            &["../proto/my_application", "../proto/uuid"],
+        )?;
+    Ok(())
+}

--- a/tests/extern_path/my_application/src/main.rs
+++ b/tests/extern_path/my_application/src/main.rs
@@ -1,0 +1,26 @@
+use uuid::DoSomething;
+mod pb {
+    tonic::include_proto!("my_application");
+}
+fn main() {
+    // verify that extern_path to replace proto's with impl's from other crates works.
+    let message = pb::MyMessage {
+        message_id: Some(::uuid::Uuid {
+            uuid_str: "".to_string(),
+        }),
+        some_payload: "".to_string(),
+    };
+    dbg!(message.message_id.unwrap().do_it());
+}
+#[cfg(test)]
+#[test]
+fn service_types_have_extern_types() {
+    // verify that extern_path to replace proto's with impl's from other crates works.
+    let message = pb::MyMessage {
+        message_id: Some(::uuid::Uuid {
+            uuid_str: "not really a uuid".to_string(),
+        }),
+        some_payload: "payload".to_string(),
+    };
+    assert_eq!(message.message_id.unwrap().do_it(), "Done");
+}

--- a/tests/extern_path/proto/my_application/service.proto
+++ b/tests/extern_path/proto/my_application/service.proto
@@ -1,0 +1,25 @@
+syntax = "proto3";
+
+package my_application;
+
+option go_package = "my_applicationpb";
+option java_multiple_files = true;
+option java_outer_classname = "ServiceProto";
+option java_package = "com.my_application";
+
+
+import "uuid.proto";
+
+message MyMessage {
+    uuid.Uuid message_id = 1;
+    string some_payload = 2;
+}
+
+service MyService {
+    rpc GetUuid(MyMessage) returns (uuid.Uuid){
+
+    }
+    rpc GetMyMessage(uuid.Uuid) returns (MyMessage){
+
+    }
+}

--- a/tests/extern_path/proto/uuid/uuid.proto
+++ b/tests/extern_path/proto/uuid/uuid.proto
@@ -1,0 +1,13 @@
+syntax = "proto3";
+
+package uuid;
+
+option go_package = "uuidpb";
+option java_multiple_files = true;
+option java_outer_classname = "UuidProto";
+option java_package = "com.uuid";
+
+
+message Uuid {
+    string uuid_str = 1;
+}

--- a/tests/extern_path/uuid/Cargo.toml
+++ b/tests/extern_path/uuid/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "uuid"
+version = "0.1.0"
+authors = ["Danny Hua <danny@42layers.io>"]
+edition = "2018"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+prost = "0.6"
+bytes = "0.5"
+[build-dependencies]
+prost-build = "0.6"

--- a/tests/extern_path/uuid/Cargo.toml
+++ b/tests/extern_path/uuid/Cargo.toml
@@ -3,6 +3,8 @@ name = "uuid"
 version = "0.1.0"
 authors = ["Danny Hua <danny@42layers.io>"]
 edition = "2018"
+publish = false
+license = "MIT"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/tests/extern_path/uuid/build.rs
+++ b/tests/extern_path/uuid/build.rs
@@ -1,0 +1,3 @@
+fn main() {
+    prost_build::compile_protos(&["uuid/uuid.proto"], &["../proto/"]).unwrap();
+}

--- a/tests/extern_path/uuid/src/lib.rs
+++ b/tests/extern_path/uuid/src/lib.rs
@@ -1,0 +1,11 @@
+include!(concat!(env!("OUT_DIR"), "/uuid.rs"));
+
+pub trait DoSomething {
+    fn do_it(&self) -> String;
+}
+
+impl DoSomething for Uuid {
+    fn do_it(&self) -> String {
+        "Done".to_string()
+    }
+}

--- a/tonic-build/src/lib.rs
+++ b/tonic-build/src/lib.rs
@@ -318,7 +318,9 @@ fn generate_doc_comments<T: AsRef<str>>(comments: &[T]) -> TokenStream {
 }
 
 fn replace_wellknown(proto_path: &str, method: &Method) -> (TokenStream, TokenStream) {
-    let request = if method.input_proto_type.starts_with(".google.protobuf") {
+    let request = if method.input_proto_type.starts_with(".google.protobuf")
+        || method.input_type.starts_with("::")
+    {
         method.input_type.parse::<TokenStream>().unwrap()
     } else {
         syn::parse_str::<syn::Path>(&format!("{}::{}", proto_path, method.input_type))
@@ -326,7 +328,9 @@ fn replace_wellknown(proto_path: &str, method: &Method) -> (TokenStream, TokenSt
             .to_token_stream()
     };
 
-    let response = if method.output_proto_type.starts_with(".google.protobuf") {
+    let response = if method.output_proto_type.starts_with(".google.protobuf")
+        || method.output_type.starts_with("::")
+    {
         method.output_type.parse::<TokenStream>().unwrap()
     } else {
         syn::parse_str::<syn::Path>(&format!("{}::{}", proto_path, method.output_type))

--- a/tonic-build/src/lib.rs
+++ b/tonic-build/src/lib.rs
@@ -114,6 +114,8 @@ impl Builder {
     /// Declare externally provided Protobuf package or type.
     ///
     /// Passed directly to `prost_build::Config.extern_path`.
+    /// Note that both the Protobuf path and the rust package paths should both be fully qualified.
+    /// i.e. Protobuf paths should start with "." and rust paths should start with "::"
     pub fn extern_path(mut self, proto_path: impl AsRef<str>, rust_path: impl AsRef<str>) -> Self {
         self.extern_path.push((
             proto_path.as_ref().to_string(),


### PR DESCRIPTION
tonic-build will replace all paths except for google well known types
with one rooted at the super module. For paths that have already been
replaced with a fully qualified path via the extern_path config option,
(e.g. "::uuid::Uuid"), this results in an invalid path
(e.g. "super::::uuid::Uuid"), and a build failure. These paths should
also be excluded when prefixing relative modules with super.

## Motivation

See commit message, and #260 

When extern_path'd are used in service method definitions, prost-build panics.

See https://github.com/cthulhua/tonic_extern_path/tree/master for a repro of the issue (it works when build against this branch).

## Solution

Similar to how google well known types are handled, in the event an absolute path would be made relative, leave it absolute.
