### PR TITLE
chore: upgrade `percent-encoding` 1.0.1 -> 2.0

### DIFF
--- a/tonic/Cargo.toml
+++ b/tonic/Cargo.toml
@@ -48,7 +48,7 @@ tracing = "0.1"
 http = "0.2"
 base64 = "0.10"
 
-percent-encoding = "1.0.1"
+percent-encoding = "2.0"
 tower-service = "0.3"
 tokio-util = { version = "0.2", features = ["codec"] }
 async-stream = "0.2"


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/hyperium/tonic/blob/master/CONTRIBUTING.md
-->

## Motivation

Many crates in the Rust ecosystem are now moving to `percent-encoding` 2.0, and it'd be great to have `tonic` stay up-to-date 

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? If a new feature is being added, describe the intended
use case that feature fulfills.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

Upgrade `percent-encoding`. Because the API breaks with the new release, some minor changes are necessary to get the same behavior as before.