### PR TITLE
chore(docs): Remove unecessary pinning

### DIFF
--- a/examples/routeguide-tutorial.md
+++ b/examples/routeguide-tutorial.md
@@ -447,8 +447,7 @@ async fn record_route(
     &self,
     request: Request<tonic::Streaming<Point>>,
 ) -> Result<Response<RouteSummary>, Status> {
-    let stream = request.into_inner();
-    futures_util::pin_mut!(stream);
+    let mut stream = request.into_inner();
 
     let mut summary = RouteSummary::default();
     let mut last_point = None;
@@ -500,11 +499,9 @@ async fn route_chat(
     request: Request<tonic::Streaming<RouteNote>>,
 ) -> Result<Response<Self::RouteChatStream>, Status> {
     let mut notes = HashMap::new();
-    let stream = request.into_inner();
+    let mut stream = request.into_inner();
 
     let output = async_stream::try_stream! {
-        futures_util::pin_mut!(stream);
-
         while let Some(note) = stream.next().await {
             let note = note?;
 

--- a/examples/src/routeguide/server.rs
+++ b/examples/src/routeguide/server.rs
@@ -68,10 +68,7 @@ impl RouteGuide for RouteGuideService {
     ) -> Result<Response<RouteSummary>, Status> {
         println!("RecordRoute");
 
-        let stream = request.into_inner();
-
-        // Pin the inbound stream to the stack so that we can call next on it
-        futures::pin_mut!(stream);
+        let mut stream = request.into_inner();
 
         let mut summary = RouteSummary::default();
         let mut last_point = None;
@@ -115,11 +112,9 @@ impl RouteGuide for RouteGuideService {
         println!("RouteChat");
 
         let mut notes = HashMap::new();
-        let stream = request.into_inner();
+        let mut stream = request.into_inner();
 
         let output = async_stream::try_stream! {
-            futures::pin_mut!(stream);
-
             while let Some(note) = stream.next().await {
                 let note = note?;
 

--- a/examples/src/routeguide/server.rs
+++ b/examples/src/routeguide/server.rs
@@ -129,10 +129,7 @@ impl RouteGuide for RouteGuideService {
             }
         };
 
-        Ok(Response::new(Box::pin(output)
-            as Pin<
-                Box<dyn Stream<Item = Result<RouteNote, Status>> + Send + Sync + 'static>,
-            >))
+        Ok(Response::new(Box::pin(output) as Self::RouteChatStream))
     }
 }
 


### PR DESCRIPTION
## Motivation

Keep the example code simple.

## Solution

1. Remove `pin_mut!` macro in the example code because `Streaming` is `Unpin` for any `T`.
2. Update the corresponding doc.
3. Change the return type to `Self::RouteChatStream`, it is already well defined above.
