### PR TITLE
Add optional service methods

### DIFF
--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -122,6 +122,10 @@ path = "src/health/server.rs"
 name = "autoreload-server"
 path = "src/autoreload/server.rs"
 
+[[bin]]
+name = "optional-server"
+path = "src/optional/server.rs"
+
 [dependencies]
 tonic = { path = "../tonic", features = ["tls"] }
 prost = "0.6"

--- a/examples/src/optional/server.rs
+++ b/examples/src/optional/server.rs
@@ -29,7 +29,7 @@ impl Greeter for MyGreeter {
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let args: Vec<String> = env::args().collect();
-    let enabled = args.get(1) == Some(&"enabled".to_string());
+    let enabled = args.get(1) == Some(&"enable".to_string());
 
     let addr = "[::1]:50051".parse().unwrap();
     let greeter = MyGreeter::default();

--- a/examples/src/optional/server.rs
+++ b/examples/src/optional/server.rs
@@ -1,0 +1,53 @@
+use tonic::{transport::Server, Request, Response, Status};
+use std::env;
+
+use hello_world::greeter_server::{Greeter, GreeterServer};
+use hello_world::{HelloReply, HelloRequest};
+
+pub mod hello_world {
+    tonic::include_proto!("helloworld");
+}
+
+#[derive(Default)]
+pub struct MyGreeter {}
+
+#[tonic::async_trait]
+impl Greeter for MyGreeter {
+    async fn say_hello(
+        &self,
+        request: Request<HelloRequest>,
+    ) -> Result<Response<HelloReply>, Status> {
+        println!("Got a request from {:?}", request.remote_addr());
+
+        let reply = hello_world::HelloReply {
+            message: format!("Hello {}!", request.into_inner().name),
+        };
+        Ok(Response::new(reply))
+    }
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let args: Vec<String> = env::args().collect();
+    let enabled = args.get(1) == Some(&"enabled".to_string());
+
+    let addr = "[::1]:50051".parse().unwrap();
+    let greeter = MyGreeter::default();
+
+    let optional_service = if enabled {
+        println!("MyGreeter enabled");
+        Some(GreeterServer::new(greeter))
+    } else {
+        println!("MyGreeter disabled");
+        None
+    };
+
+    println!("GreeterServer listening on {}", addr);
+
+    Server::builder()
+        .add_optional_service(optional_service)
+        .serve(addr)
+        .await?;
+
+    Ok(())
+}

--- a/examples/src/optional/server.rs
+++ b/examples/src/optional/server.rs
@@ -1,5 +1,5 @@
-use tonic::{transport::Server, Request, Response, Status};
 use std::env;
+use tonic::{transport::Server, Request, Response, Status};
 
 use hello_world::greeter_server::{Greeter, GreeterServer};
 use hello_world::{HelloReply, HelloRequest};

--- a/tonic/src/transport/server/mod.rs
+++ b/tonic/src/transport/server/mod.rs
@@ -243,7 +243,7 @@ impl Server {
     pub fn add_optional_service<S>(
         &mut self,
         svc: Option<S>,
-    ) -> Router<Either<S, EmptyService>, Unimplemented>
+    ) -> Router<Either<S, Unimplemented>, Unimplemented>
     where
         S: Service<Request<Body>, Response = Response<BoxBody>>
             + NamedService
@@ -255,7 +255,7 @@ impl Server {
     {
         let svc = match svc {
             Some(some) => Either::A(some),
-            None => Either::B(EmptyService),
+            None => Either::B(Unimplemented::default()),
         };
         Router::new(self.clone(), svc)
     }
@@ -539,29 +539,6 @@ pub struct Unimplemented {
 }
 
 impl Service<Request<Body>> for Unimplemented {
-    type Response = Response<BoxBody>;
-    type Error = crate::Error;
-    type Future = future::Ready<Result<Self::Response, Self::Error>>;
-
-    fn poll_ready(&mut self, _cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
-        Ok(()).into()
-    }
-
-    fn call(&mut self, _req: Request<Body>) -> Self::Future {
-        future::ok(
-            http::Response::builder()
-                .status(200)
-                .header("grpc-status", "12")
-                .body(BoxBody::empty())
-                .unwrap(),
-        )
-    }
-}
-
-#[derive(Clone)]
-pub struct EmptyService;
-
-impl Service<Request<Body>> for EmptyService {
     type Response = Response<BoxBody>;
     type Error = crate::Error;
     type Future = future::Ready<Result<Self::Response, Self::Error>>;


### PR DESCRIPTION
## Motivation
https://github.com/hyperium/tonic/issues/265

## Solution
This is currently an incomplete solution - it is the minimum required to demonstrate this approach and allow for a decision.

It mirrors closely the way `optional_layer` method works.

## Considerations
* Is this zero-cost?
* Should `NamedService` be implemented on `Either` like this? Does this break anything?
* There's an `Unimplemented` service which seems to do the same thing as `EmptyService`, perhaps we should use that instead?

## TODO
After deciding whether this approach is feasible the following needs to be done:

- [x] Implement `add_optional_service` onto the `Router` in a similar manner
- [x] Documentation