### PR TITLE
chore: Add blocknig server example

### DIFF
--- a/examples/helloworld-tutorial.md
+++ b/examples/helloworld-tutorial.md
@@ -129,7 +129,7 @@ At the root of your crate, create a `build.rs` file and add the following code:
 
 ```rust
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    tonic_build::prost::compile_protos("proto/helloworld.proto")?;
+    tonic_build::compile_protos("proto/helloworld.proto")?;
     Ok(())
 }
 ```

--- a/examples/routeguide-tutorial.md
+++ b/examples/routeguide-tutorial.md
@@ -199,7 +199,7 @@ Create a `build.rs` file at the root of your crate:
 
 ```rust
 fn main() {
-    tonic_build::prost::compile_protos("proto/route_guide.proto")
+    tonic_build::compile_protos("proto/route_guide.proto")
         .unwrap_or_else(|e| panic!("Failed to compile protos {:?}", e));
 }
 ```

--- a/examples/src/helloworld/server_blocking.rs
+++ b/examples/src/helloworld/server_blocking.rs
@@ -1,0 +1,41 @@
+use tonic::{transport::Server, Request, Response, Status};
+
+use hello_world::greeter_server::{Greeter, GreeterServer};
+use hello_world::{HelloReply, HelloRequest};
+
+use tokio::runtime::Runtime;
+
+
+pub mod hello_world {
+    tonic::include_proto!("helloworld");
+}
+
+#[derive(Debug, Default)]
+pub struct MyGreeter {}
+
+#[tonic::async_trait]
+impl Greeter for MyGreeter {
+    async fn say_hello(
+        &self,
+        request: Request<HelloRequest>,
+    ) -> Result<Response<HelloReply>, Status> {
+        println!("Got a request: {:?}", request);
+
+        let reply = hello_world::HelloReply {
+            message: format!("Hello {}!", request.into_inner().name).into(),
+        };
+
+        Ok(Response::new(reply))
+    }
+}
+
+fn main() {
+    let addr = "[::1]:50051".parse().unwrap();
+    let greeter = MyGreeter::default();
+
+    let mut rt = Runtime::new().expect("failed to obtain a new RunTime object");
+    let server_future = Server::builder()
+                        .add_service(GreeterServer::new(greeter))
+                        .serve(addr);
+    rt.block_on(server_future).expect("failed to successfully run the future on RunTime");
+}

--- a/examples/src/helloworld/server_blocking.rs
+++ b/examples/src/helloworld/server_blocking.rs
@@ -5,7 +5,6 @@ use hello_world::{HelloReply, HelloRequest};
 
 use tokio::runtime::Runtime;
 
-
 pub mod hello_world {
     tonic::include_proto!("helloworld");
 }


### PR DESCRIPTION
## Motivation

Added a new blocking hello_world server example. 
Also corrected the way .proto file is compiled in the files https://github.com/hyperium/tonic/blob/master/examples/helloworld-tutorial.md and https://github.com/hyperium/tonic/blob/master/examples/routeguide-tutorial.md  

This is done in an attempt to close #253

## Solution
