### PR TITLE
fix(build): Remove debug println!

### DIFF
--- a/tonic-build/src/lib.rs
+++ b/tonic-build/src/lib.rs
@@ -92,7 +92,6 @@ pub fn fmt(out_dir: &str) {
             .output()
             .unwrap();
 
-        println!("out: {:?}", out);
         assert!(out.status.success());
     }
 }

--- a/tonic-build/src/lib.rs
+++ b/tonic-build/src/lib.rs
@@ -66,7 +66,9 @@ pub mod prost;
 pub mod schema;
 
 #[cfg(feature = "rustfmt")]
-use std::process::Command;
+use std::io::{self, Write};
+#[cfg(feature = "rustfmt")]
+use std::process::{exit, Command};
 
 /// Service code generation for client
 pub mod client;
@@ -92,8 +94,16 @@ pub fn fmt(out_dir: &str) {
             .output();
 
         match result {
-            Err(e) => println!("error running rustfmt: {:?}", e),
-            Ok(out) => assert!(out.status.success()),
+            Err(e) => {
+                eprintln!("error running rustfmt: {:?}", e);
+                exit(1)
+            }
+            Ok(output) => {
+                if !output.status.success() {
+                    io::stderr().write_all(&output.stderr).unwrap();
+                    exit(output.status.code().unwrap_or(1))
+                }
+            }
         }
     }
 }

--- a/tonic-build/src/lib.rs
+++ b/tonic-build/src/lib.rs
@@ -83,16 +83,18 @@ pub fn fmt(out_dir: &str) {
         if !file.ends_with(".rs") {
             continue;
         }
-        let out = Command::new("rustfmt")
+        let result = Command::new("rustfmt")
             .arg("--emit")
             .arg("files")
             .arg("--edition")
             .arg("2018")
             .arg(format!("{}/{}", out_dir, file))
-            .output()
-            .unwrap();
+            .output();
 
-        assert!(out.status.success());
+        match result {
+            Err(e) => println!("error running rustfmt: {:?}", e),
+            Ok(out) => assert!(out.status.success()),
+        }
     }
 }
 

--- a/tonic-build/src/lib.rs
+++ b/tonic-build/src/lib.rs
@@ -68,9 +68,9 @@ pub mod schema;
 #[cfg(feature = "rustfmt")]
 use std::process::Command;
 
-/// Serivce code generation for client
+/// Service code generation for client
 pub mod client;
-/// Serivce code generation for Server
+/// Service code generation for Server
 pub mod server;
 
 /// Format files under the out_dir with rustfmt


### PR DESCRIPTION
Remove unnecessary println! from tonic-build:

`out: Output { status: ExitStatus(ExitStatus(0)), stdout: "", stderr: "" }`

can get a bit noisy and I think it serves no purpose.

Also, fixed a couple of typos, sorry to mix things up but such small edits...hope you don't mind.
