### PR TITLE
Allow non_camel_case_types on some codegen structs

### DIFF
--- a/tonic-build/src/server.rs
+++ b/tonic-build/src/server.rs
@@ -259,6 +259,7 @@ fn generate_unary<'a, T: Method<'a>>(
     let (request, response) = method.request_response_name(context);
 
     quote! {
+        #[allow(non_camel_case_types)]
         struct #service_ident<T: #server_trait >(pub Arc<T>);
 
         impl<T: #server_trait> tonic::server::UnaryService<#request> for #service_ident<T> {
@@ -310,6 +311,7 @@ fn generate_server_streaming<'a, T: Method<'a>>(
     let response_stream = quote::format_ident!("{}Stream", method.identifier());
 
     quote! {
+        #[allow(non_camel_case_types)]
         struct #service_ident<T: #server_trait >(pub Arc<T>);
 
         impl<T: #server_trait> tonic::server::ServerStreamingService<#request> for #service_ident<T> {
@@ -360,6 +362,7 @@ fn generate_client_streaming<'a, T: Method<'a>>(
     let codec_name = syn::parse_str::<syn::Path>(context.codec_name()).unwrap();
 
     quote! {
+        #[allow(non_camel_case_types)]
         struct #service_ident<T: #server_trait >(pub Arc<T>);
 
         impl<T: #server_trait> tonic::server::ClientStreamingService<#request> for #service_ident<T>
@@ -413,6 +416,7 @@ fn generate_streaming<'a, T: Method<'a>>(
     let response_stream = quote::format_ident!("{}Stream", method.identifier());
 
     quote! {
+        #[allow(non_camel_case_types)]
         struct #service_ident<T: #server_trait>(pub Arc<T>);
 
         impl<T: #server_trait> tonic::server::StreamingService<#request> for #service_ident<T>


### PR DESCRIPTION
This commit adjusts the code generation for the internal structs in the implementation of `Service<http::Request<HyperBody>>` for `*Server<T>` in order to annotate internal structs whose names are derived from gRPC method names with `[allow(non_camel_case_types)]`. This supresses compiler warnings about type names when compiling generated code. The struct names are not exposed externally, so this has no impact on types seen by library consumers.

Fixes #295.