### PR TITLE
Remove use of std::error::Error.description()

### DIFF
--- a/tonic/src/metadata/encoding.rs
+++ b/tonic/src/metadata/encoding.rs
@@ -180,15 +180,11 @@ impl InvalidMetadataValue {
 
 impl fmt::Display for InvalidMetadataValue {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        self.description().fmt(f)
+        f.write_str("failed to parse metadata value")
     }
 }
 
-impl Error for InvalidMetadataValue {
-    fn description(&self) -> &str {
-        "failed to parse metadata value"
-    }
-}
+impl Error for InvalidMetadataValue {}
 
 /// A possible error when converting a `MetadataValue` from a string or byte
 /// slice.
@@ -209,8 +205,4 @@ impl fmt::Display for InvalidMetadataValueBytes {
     }
 }
 
-impl Error for InvalidMetadataValueBytes {
-    fn description(&self) -> &str {
-        self.0.description()
-    }
-}
+impl Error for InvalidMetadataValueBytes {}

--- a/tonic/src/metadata/key.rs
+++ b/tonic/src/metadata/key.rs
@@ -271,12 +271,8 @@ impl<'a, VE: ValueEncoding> PartialEq<MetadataKey<VE>> for &'a str {
 
 impl fmt::Display for InvalidMetadataKey {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        self.description().fmt(f)
+        f.write_str("invalid gRPC metadata key name")
     }
 }
 
-impl Error for InvalidMetadataKey {
-    fn description(&self) -> &str {
-        "invalid gRPC metadata key name"
-    }
-}
+impl Error for InvalidMetadataKey {}

--- a/tonic/src/metadata/value.rs
+++ b/tonic/src/metadata/value.rs
@@ -531,15 +531,11 @@ impl ToStrError {
 
 impl fmt::Display for ToStrError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        self.description().fmt(f)
+        f.write_str("failed to convert metadata to a str")
     }
 }
 
-impl Error for ToStrError {
-    fn description(&self) -> &str {
-        "failed to convert metadata to a str"
-    }
-}
+impl Error for ToStrError {}
 
 // ===== PartialEq / PartialOrd =====
 


### PR DESCRIPTION
Rust 1.42 deprecates the `description()` method of `std::error::Error` and provides a blanket implementation suggesting implementation of `std::fmt::Display` instead. We already implemented `Display` for error types but in terms of the deprecated `description`. This commit implements `Display` directly and falls back to the blanket implementation of `description()`.