### PR TITLE
feat(health): Add tonic-health server impl

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,9 +2,12 @@
 members = [
     "tonic",
     "tonic-build",
+    "tonic-health",
+
     # Non-published crates
     "examples",
     "interop",
+
     # Tests
     "tests/included_service",
     "tests/same_name",

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -102,6 +102,10 @@ path = "src/hyper_warp/client.rs"
 name = "hyper-warp-server"
 path = "src/hyper_warp/server.rs"
 
+[[bin]]
+name = "health-server"
+path = "src/health/server.rs"
+
 [dependencies]
 tonic = { path = "../tonic", features = ["tls", "data-prost"] }
 prost = "0.6"
@@ -126,6 +130,8 @@ warp = { version = "0.2", default-features = false }
 http = "0.2"
 http-body = "0.3"
 pin-project = "0.4"
+# Health example
+tonic-health = { path = "../tonic-health" }
 
 [build-dependencies]
 tonic-build = { path = "../tonic-build", features = ["prost"] }

--- a/examples/README.md
+++ b/examples/README.md
@@ -72,6 +72,13 @@ $ cargo run --bin tls-client
 $ cargo run --bin tls-server
 ```
 
+## Health Checking
+
+### Server
+
+```bash
+$ cargo run --bin health-server
+```
 
 ### Notes:
 

--- a/examples/src/health/server.rs
+++ b/examples/src/health/server.rs
@@ -1,0 +1,68 @@
+use tonic::{transport::Server, Request, Response, Status};
+
+use hello_world::greeter_server::{Greeter, GreeterServer};
+use hello_world::{HelloReply, HelloRequest};
+use std::time::Duration;
+use tokio::time::delay_for;
+use tonic_health::server::HealthReporter;
+
+pub mod hello_world {
+    tonic::include_proto!("helloworld");
+}
+
+#[derive(Default)]
+pub struct MyGreeter {}
+
+#[tonic::async_trait]
+impl Greeter for MyGreeter {
+    async fn say_hello(
+        &self,
+        request: Request<HelloRequest>,
+    ) -> Result<Response<HelloReply>, Status> {
+        println!("Got a request from {:?}", request.remote_addr());
+
+        let reply = hello_world::HelloReply {
+            message: format!("Hello {}!", request.into_inner().name),
+        };
+        Ok(Response::new(reply))
+    }
+}
+
+/// This function (somewhat improbably) flips the status of a service every second, in order
+/// that the effect of `tonic_health::HealthReporter::watch` can be easily observed.
+async fn twiddle_service_status(mut reporter: HealthReporter) {
+    let mut iter = 0u64;
+    loop {
+        iter += 1;
+        delay_for(Duration::from_secs(1)).await;
+
+        if iter % 2 == 0 {
+            reporter.set_serving::<GreeterServer<MyGreeter>>().await;
+        } else {
+            reporter.set_not_serving::<GreeterServer<MyGreeter>>().await;
+        };
+    }
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let (mut health_reporter, health_service) = tonic_health::server::health_reporter();
+    health_reporter
+        .set_serving::<GreeterServer<MyGreeter>>()
+        .await;
+
+    tokio::spawn(twiddle_service_status(health_reporter.clone()));
+
+    let addr = "[::1]:50051".parse().unwrap();
+    let greeter = MyGreeter::default();
+
+    println!("HealthServer + GreeterServer listening on {}", addr);
+
+    Server::builder()
+        .add_service(health_service)
+        .add_service(GreeterServer::new(greeter))
+        .serve(addr)
+        .await?;
+
+    Ok(())
+}

--- a/tonic-health/Cargo.toml
+++ b/tonic-health/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "tonic-health"
+version = "0.1.0"
+authors = ["James Nugent <james@jen20.com>"]
+edition = "2018"
+
+[dependencies]
+tokio = { version = "0.2", features = ["sync"] }
+tonic = { path = "../tonic" }
+bytes = "0.5"
+prost = "0.6"
+
+[dev-dependencies]
+tokio = { version = "0.2", features = ["rt-core", "macros"]}
+
+[build-dependencies]
+tonic-build = { path = "../tonic-build" }

--- a/tonic-health/build.rs
+++ b/tonic-health/build.rs
@@ -1,0 +1,9 @@
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    tonic_build::prost::configure()
+        .build_server(true)
+        .build_client(false)
+        .format(true)
+        .compile(&["proto/health.proto"], &["proto/"])?;
+
+    Ok(())
+}

--- a/tonic-health/proto/health.proto
+++ b/tonic-health/proto/health.proto
@@ -1,0 +1,22 @@
+syntax = "proto3";
+
+package grpc.health.v1;
+
+message HealthCheckRequest {
+    string service = 1;
+}
+
+message HealthCheckResponse {
+    enum ServingStatus {
+        UNKNOWN = 0;
+        SERVING = 1;
+        NOT_SERVING = 2;
+    }
+    ServingStatus status = 1;
+}
+
+service Health {
+    rpc Check(HealthCheckRequest) returns (HealthCheckResponse);
+
+    rpc Watch(HealthCheckRequest) returns (stream HealthCheckResponse);
+}

--- a/tonic-health/src/lib.rs
+++ b/tonic-health/src/lib.rs
@@ -1,0 +1,35 @@
+use std::fmt::{Display, Formatter};
+
+mod proto {
+    tonic::include_proto!("grpc.health.v1");
+}
+
+pub mod server;
+
+/// An enumeration of values representing gRPC service health.
+#[derive(Copy, Clone, Debug, PartialEq)]
+pub enum ServingStatus {
+    Unknown,
+    Serving,
+    NotServing,
+}
+
+impl Display for ServingStatus {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ServingStatus::Unknown => f.write_str("Unknown"),
+            ServingStatus::Serving => f.write_str("Serving"),
+            ServingStatus::NotServing => f.write_str("NotServing"),
+        }
+    }
+}
+
+impl From<ServingStatus> for proto::health_check_response::ServingStatus {
+    fn from(s: ServingStatus) -> Self {
+        match s {
+            ServingStatus::Unknown => proto::health_check_response::ServingStatus::Unknown,
+            ServingStatus::Serving => proto::health_check_response::ServingStatus::Serving,
+            ServingStatus::NotServing => proto::health_check_response::ServingStatus::NotServing,
+        }
+    }
+}

--- a/tonic-health/src/server.rs
+++ b/tonic-health/src/server.rs
@@ -1,0 +1,166 @@
+use crate::proto::health_server::{Health, HealthServer};
+use crate::proto::{HealthCheckRequest, HealthCheckResponse};
+use crate::ServingStatus;
+use std::collections::HashMap;
+use std::sync::Arc;
+use tokio::sync::{mpsc, watch, RwLock};
+use tonic::{transport::NamedService, Request, Response, Status};
+
+/// Creates a `HealthReporter` and a linked `HealthServer` pair. Together,
+/// these types can be used to serve the gRPC Health Checking service.
+///
+/// A `HealthReporter` is used to update the state of gRPC services.
+///
+/// A `HealthServer` is a Tonic gRPC server for the `grpc.health.v1.Health`,
+/// which can be added to a Tonic runtime using `add_service` on the runtime
+/// builder.
+pub fn health_reporter() -> (HealthReporter, HealthServer<impl Health>) {
+    let reporter = HealthReporter::new();
+    let service = HealthService::new(reporter.statuses.clone());
+    let server = HealthServer::new(service);
+
+    (reporter, server)
+}
+
+type StatusPair = (watch::Sender<ServingStatus>, watch::Receiver<ServingStatus>);
+
+/// A handle providing methods to update the health status of gRPC services. A
+/// `HealthReporter` is connected to a `HealthServer` which serves the statuses
+/// over the `grpc.health.v1.Health` service.
+#[derive(Clone, Debug)]
+pub struct HealthReporter {
+    statuses: Arc<RwLock<HashMap<String, StatusPair>>>,
+}
+
+impl HealthReporter {
+    fn new() -> Self {
+        let statuses = Arc::new(RwLock::new(HashMap::new()));
+
+        HealthReporter { statuses }
+    }
+
+    /// Sets the status of the service implemented by `S` to `Serving`. This notifies any watchers
+    /// if there is a change in status.
+    pub async fn set_serving<S>(&mut self)
+    where
+        S: NamedService,
+    {
+        let service_name = <S as NamedService>::NAME;
+        self.set_service_status(service_name, ServingStatus::Serving)
+            .await;
+    }
+
+    /// Sets the status of the service implemented by `S` to `NotServing`. This notifies any watchers
+    /// if there is a change in status.
+    pub async fn set_not_serving<S>(&mut self)
+    where
+        S: NamedService,
+    {
+        let service_name = <S as NamedService>::NAME;
+        self.set_service_status(service_name, ServingStatus::NotServing)
+            .await;
+    }
+
+    /// Sets the status of the service with `service_name` to `status`. This notifies any watchers
+    /// if there is a change in status.
+    pub async fn set_service_status<S>(&mut self, service_name: S, status: ServingStatus)
+    where
+        S: AsRef<str>,
+    {
+        let service_name = service_name.as_ref();
+        let mut writer = self.statuses.write().await;
+        match writer.get(service_name) {
+            None => {
+                let _ = writer.insert(service_name.to_string(), watch::channel(status));
+            }
+            Some((tx, rx)) => {
+                let mut rx = rx.clone();
+                if rx.recv().await == Some(status) {
+                    return;
+                }
+
+                // We only ever hand out clones of the receiver, so the originally-created
+                // receiver should always be present, only being dropped when clearing the
+                // service status. Consequently, `tx.broadcast` should not fail, making use
+                // of `expect` here safe.
+                tx.broadcast(status).expect("channel should not be closed");
+            }
+        };
+    }
+
+    /// Clear the status of the given service.
+    pub async fn clear_service_status(&mut self, service_name: &str) {
+        let mut writer = self.statuses.write().await;
+        let _ = writer.remove(service_name);
+    }
+}
+
+struct HealthService {
+    statuses: Arc<RwLock<HashMap<String, StatusPair>>>,
+}
+
+impl HealthService {
+    fn new(services: Arc<RwLock<HashMap<String, StatusPair>>>) -> Self {
+        HealthService { statuses: services }
+    }
+
+    async fn service_health(&self, service_name: &str) -> Option<ServingStatus> {
+        let reader = self.statuses.read().await;
+        match reader.get(service_name).map(|p| p.1.clone()) {
+            None => None,
+            Some(mut receiver) => receiver.recv().await,
+        }
+    }
+}
+
+#[tonic::async_trait]
+impl Health for HealthService {
+    async fn check(
+        &self,
+        request: Request<HealthCheckRequest>,
+    ) -> Result<Response<HealthCheckResponse>, Status> {
+        let service_name = request.get_ref().service.as_str();
+        let status = self.service_health(service_name).await;
+
+        match status {
+            None => Err(Status::not_found("service not registered")),
+            Some(status) => Ok(Response::new(HealthCheckResponse {
+                status: crate::proto::health_check_response::ServingStatus::from(status.clone())
+                    as i32,
+            })),
+        }
+    }
+
+    type WatchStream = mpsc::Receiver<Result<HealthCheckResponse, Status>>;
+
+    async fn watch(
+        &self,
+        request: Request<HealthCheckRequest>,
+    ) -> Result<Response<Self::WatchStream>, Status> {
+        let service_name = request.get_ref().service.as_str();
+
+        let (mut grpc_tx, grpc_rx) = mpsc::channel(10);
+
+        let mut status_rx = match self.statuses.read().await.get(service_name) {
+            None => return Err(Status::not_found("service not registered")),
+            Some(pair) => pair.1.clone(),
+        };
+
+        tokio::spawn(async move {
+            while let Some(status) = status_rx.recv().await {
+                match grpc_tx
+                    .send(Ok(HealthCheckResponse {
+                        status: crate::proto::health_check_response::ServingStatus::from(status)
+                            as i32,
+                    }))
+                    .await
+                {
+                    Ok(_) => {}
+                    Err(_) => break,
+                }
+            }
+        });
+
+        Ok(Response::new(grpc_rx))
+    }
+}


### PR DESCRIPTION
This commit adds a new crate `tonic-health` which implements the [standard GRPC Health Checking][checking] protocol, as per #135.

Currently there is only a server implementation, though others have alluded in the discussion in #135 that client implementations exist which could also be imported as necessary.

A example server has also been added - once the client work is done a client for this should be added also.

Some further work that needs doing:

- [ ] Clean up `Cargo.toml` metadata
- [ ] Add a `transport` feature which unlocks the various methods which use `NamedService`
- [ ] Add some tests of both `Check` and `Watch`
- [ ] Consider whether to write or import a client as part of this PR or separately.

[checking]: https://github.com/grpc/grpc/blob/master/doc/health-checking.md