### PR TITLE
fix(build): Server service uses generic body bound

### DIFF
--- a/tonic-build/src/server.rs
+++ b/tonic-build/src/server.rs
@@ -49,7 +49,12 @@ pub fn generate<'a, T: Service<'a>>(service: &'a T, context: &T::Context) -> Tok
                 }
             }
 
-            impl<T: #server_trait> Service<http::Request<RequestBody>> for #server_service<T> {
+            impl<T, B> Service<http::Request<B>> for #server_service<T>
+                where
+                    T: #server_trait,
+                    B: HttpBody + Send + Sync + 'static,
+                    B::Error: Into<StdError> + Send + 'static,
+            {
                 type Response = http::Response<tonic::body::BoxBody>;
                 type Error = Never;
                 type Future = BoxFuture<Self::Response, Self::Error>;
@@ -58,7 +63,7 @@ pub fn generate<'a, T: Service<'a>>(service: &'a T, context: &T::Context) -> Tok
                     Poll::Ready(Ok(()))
                 }
 
-                fn call(&mut self, req: http::Request<RequestBody>) -> Self::Future {
+                fn call(&mut self, req: http::Request<B>) -> Self::Future {
                     let inner = self.inner.clone();
 
                     match req.uri().path() {

--- a/tonic-build/src/server.rs
+++ b/tonic-build/src/server.rs
@@ -49,7 +49,7 @@ pub fn generate<'a, T: Service<'a>>(service: &'a T, context: &T::Context) -> Tok
                 }
             }
 
-            impl<T: #server_trait> Service<http::Request<HyperBody>> for #server_service<T> {
+            impl<T: #server_trait> Service<http::Request<RequestBody>> for #server_service<T> {
                 type Response = http::Response<tonic::body::BoxBody>;
                 type Error = Never;
                 type Future = BoxFuture<Self::Response, Self::Error>;
@@ -58,7 +58,7 @@ pub fn generate<'a, T: Service<'a>>(service: &'a T, context: &T::Context) -> Tok
                     Poll::Ready(Ok(()))
                 }
 
-                fn call(&mut self, req: http::Request<HyperBody>) -> Self::Future {
+                fn call(&mut self, req: http::Request<RequestBody>) -> Self::Future {
                     let inner = self.inner.clone();
 
                     match req.uri().path() {

--- a/tonic/src/codegen.rs
+++ b/tonic/src/codegen.rs
@@ -13,11 +13,6 @@ pub use tower_service::Service;
 pub type StdError = Box<dyn std::error::Error + Send + Sync + 'static>;
 pub use crate::body::Body;
 
-#[cfg(not(feature = "transport"))]
-pub use crate::body::BoxBody as RequestBody;
-#[cfg(feature = "transport")]
-pub use hyper::Body as RequestBody;
-
 pub type BoxFuture<T, E> = self::Pin<Box<dyn self::Future<Output = Result<T, E>> + Send + 'static>>;
 pub type BoxStream<T> =
     self::Pin<Box<dyn futures_core::Stream<Item = Result<T, crate::Status>> + Send + 'static>>;

--- a/tonic/src/codegen.rs
+++ b/tonic/src/codegen.rs
@@ -13,8 +13,10 @@ pub use tower_service::Service;
 pub type StdError = Box<dyn std::error::Error + Send + Sync + 'static>;
 pub use crate::body::Body;
 
+#[cfg(not(feature = "transport"))]
+pub use crate::body::BoxBody as RequestBody;
 #[cfg(feature = "transport")]
-pub use hyper::Body as HyperBody;
+pub use hyper::Body as RequestBody;
 
 pub type BoxFuture<T, E> = self::Pin<Box<dyn self::Future<Output = Result<T, E>> + Send + 'static>>;
 pub type BoxStream<T> =


### PR DESCRIPTION
## Motivation

close #281 

## Solution

I choose to use `BoxBody`as a generic body when the transport feature is disabled. Let me know if it's a good choice.