### PR TITLE
feat(transport): Expose http2 keep-alive support

### DIFF
--- a/tonic/src/transport/channel/endpoint.rs
+++ b/tonic/src/transport/channel/endpoint.rs
@@ -30,6 +30,9 @@ pub struct Endpoint {
     pub(crate) init_connection_window_size: Option<u32>,
     pub(crate) tcp_keepalive: Option<Duration>,
     pub(crate) tcp_nodelay: bool,
+    pub(crate) http2_keep_alive_interval: Option<Duration>,
+    pub(crate) http2_keep_alive_timeout: Option<Duration>,
+    pub(crate) http2_keep_alive_while_idle: Option<bool>,
 }
 
 impl Endpoint {
@@ -167,6 +170,30 @@ impl Endpoint {
         }
     }
 
+    /// Set http2 KEEP_ALIVE_INTERVAL. Uses `hyper`'s default otherwise.
+    pub fn http2_keep_alive_interval(self, interval: Duration) -> Self {
+        Endpoint {
+            http2_keep_alive_interval: Some(interval),
+            ..self
+        }
+    }
+
+    /// Set http2 KEEP_ALIVE_TIMEOUT. Uses `hyper`'s default otherwise.
+    pub fn keep_alive_timeout(self, duration: Duration) -> Self {
+        Endpoint {
+            http2_keep_alive_timeout: Some(duration),
+            ..self
+        }
+    }
+
+    /// Set http2 KEEP_ALIVE_WHILE_IDLE. Uses `hyper`'s default otherwise.
+    pub fn keep_alive_while_idle(self, enabled: bool) -> Self {
+        Endpoint {
+            http2_keep_alive_while_idle: Some(enabled),
+            ..self
+        }
+    }
+
     /// Create a channel from this config.
     pub async fn connect(&self) -> Result<Channel, Error> {
         let mut http = hyper::client::connect::HttpConnector::new();
@@ -215,6 +242,9 @@ impl From<Uri> for Endpoint {
             init_connection_window_size: None,
             tcp_keepalive: None,
             tcp_nodelay: true,
+            http2_keep_alive_interval: None,
+            http2_keep_alive_timeout: None,
+            http2_keep_alive_while_idle: None,
         }
     }
 }

--- a/tonic/src/transport/service/connection.rs
+++ b/tonic/src/transport/service/connection.rs
@@ -36,11 +36,22 @@ impl Connection {
         C::Future: Unpin + Send,
         C::Response: AsyncRead + AsyncWrite + HyperConnection + Unpin + Send + 'static,
     {
-        let settings = Builder::new()
+        let mut settings = Builder::new()
             .http2_initial_stream_window_size(endpoint.init_stream_window_size)
             .http2_initial_connection_window_size(endpoint.init_connection_window_size)
             .http2_only(true)
+            .http2_keep_alive_interval(endpoint.http2_keep_alive_interval)
             .clone();
+
+        if let Some(val) = endpoint.http2_keep_alive_timeout {
+            settings.http2_keep_alive_timeout(val);
+        }
+
+        if let Some(val) = endpoint.http2_keep_alive_while_idle {
+            settings.http2_keep_alive_while_idle(val);
+        }
+
+        let settings = settings.clone();
 
         let stack = ServiceBuilder::new()
             .layer_fn(|s| AddOrigin::new(s, endpoint.uri.clone()))


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/hyperium/tonic/blob/master/CONTRIBUTING.md
-->

## Motivation

Expose HTTP2 keep alive support as provided by hyper.

Motivated by https://github.com/hyperium/tonic/issues/258

## Solution

Add's the config options to the `Endpoint` struct and passes them along to hyper when building a connection.
