### PR TITLE
feat: Add Status with Details Constructor

### DIFF
--- a/tonic/src/status.rs
+++ b/tonic/src/status.rs
@@ -1,6 +1,7 @@
 use bytes::Bytes;
 use http::header::{HeaderMap, HeaderValue};
 use percent_encoding::{percent_decode, percent_encode, AsciiSet, CONTROLS};
+use prost::Message;
 use std::{borrow::Cow, error::Error, fmt};
 use tracing::{debug, trace, warn};
 
@@ -401,6 +402,25 @@ impl Status {
 
         Ok(())
     }
+
+    /// Create a new `Status` with the associated code, message, and binary details field.
+    pub fn with_raw_details(code: Code, message: impl Into<String>, details: Bytes) -> Status {
+        Status {
+            code,
+            message: message.into(),
+            details: details,
+        }
+    }
+
+    /// Create a new `Status` with the associated code, message, and protobuf details field.
+    pub fn with_details(code: Code, message: impl Into<String>, details: impl Message) -> Status {
+        let mut bytes = vec![];
+        details
+            .encode(&mut bytes)
+            .expect("Message only errors if not enough space");
+        Status::with_raw_details(code, message, bytes.into())
+    }
+
 }
 
 impl fmt::Debug for Status {

--- a/tonic/src/status.rs
+++ b/tonic/src/status.rs
@@ -1,7 +1,6 @@
 use bytes::Bytes;
 use http::header::{HeaderMap, HeaderValue};
 use percent_encoding::{percent_decode, percent_encode, AsciiSet, CONTROLS};
-use prost::Message;
 use std::{borrow::Cow, error::Error, fmt};
 use tracing::{debug, trace, warn};
 
@@ -404,21 +403,12 @@ impl Status {
     }
 
     /// Create a new `Status` with the associated code, message, and binary details field.
-    pub fn with_raw_details(code: Code, message: impl Into<String>, details: Bytes) -> Status {
+    pub fn with_details(code: Code, message: impl Into<String>, details: Bytes) -> Status {
         Status {
             code,
             message: message.into(),
             details: details,
         }
-    }
-
-    /// Create a new `Status` with the associated code, message, and protobuf details field.
-    pub fn with_details(code: Code, message: impl Into<String>, details: impl Message) -> Status {
-        let mut bytes = vec![];
-        details
-            .encode(&mut bytes)
-            .expect("Message only errors if not enough space");
-        Status::with_raw_details(code, message, bytes.into())
     }
 }
 

--- a/tonic/src/status.rs
+++ b/tonic/src/status.rs
@@ -420,7 +420,6 @@ impl Status {
             .expect("Message only errors if not enough space");
         Status::with_raw_details(code, message, bytes.into())
     }
-
 }
 
 impl fmt::Debug for Status {


### PR DESCRIPTION
Changes are just a Copy pasta of [this pr](https://github.com/tower-rs/tower-grpc/pull/191) in tower-rs.
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.


Bug fixes and new features should include tests.

Contributors guide: https://github.com/hyperium/tonic/blob/master/CONTRIBUTING.md
-->

## Motivation
Reference #292 for motivation. 
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? If a new feature is being added, describe the intended
use case that feature fulfills.
-->

## Solution
The prescribed solution exposes two constructors with `Status::with_details` and `Status::with_raw_details` that allow the caller to construct a Status with a `Code`, `String`, and `Bytes` or a `Message` to be converted into bytes.

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
