### PR TITLE
chore: Update blocking example drop order

### DIFF
--- a/examples/src/blocking/client.rs
+++ b/examples/src/blocking/client.rs
@@ -9,12 +9,13 @@ use hello_world::{greeter_client::GreeterClient, HelloReply, HelloRequest};
 type StdError = Box<dyn std::error::Error + Send + Sync + 'static>;
 type Result<T, E = StdError> = ::std::result::Result<T, E>;
 
-// The order of the fields in this struct is important. The runtime must be the first field and the
-// client must be the last field so that when `BlockingClient` is dropped the client is dropped
+// The order of the fields in this struct is important. They must be ordered 
+// such that when `BlockingClient` is dropped the client is dropped
 // before the runtime. Not doing this will result in a deadlock when dropped.
+// Rust drops struct fields in declaration order.
 struct BlockingClient {
-    rt: Runtime,
     client: GreeterClient<tonic::transport::Channel>,
+    rt: Runtime,
 }
 
 impl BlockingClient {

--- a/examples/src/blocking/client.rs
+++ b/examples/src/blocking/client.rs
@@ -9,7 +9,7 @@ use hello_world::{greeter_client::GreeterClient, HelloReply, HelloRequest};
 type StdError = Box<dyn std::error::Error + Send + Sync + 'static>;
 type Result<T, E = StdError> = ::std::result::Result<T, E>;
 
-// The order of the fields in this struct is important. They must be ordered 
+// The order of the fields in this struct is important. They must be ordered
 // such that when `BlockingClient` is dropped the client is dropped
 // before the runtime. Not doing this will result in a deadlock when dropped.
 // Rust drops struct fields in declaration order.


### PR DESCRIPTION
## Motivation
Drop order in blocking example is actually the opposite of what the comment mentions

## Solution
Switch the order. According to https://github.com/rust-lang/rfcs/blob/master/text/1857-stabilize-drop-order.md#tuples-structs-and-enum-variants Rust structs drop their fields in decl order (unlike C++ which is I imagine what tripped things up here). I just learned this recently myself!
