### PR TITLE
chore(example): Autoreloading server example

### DIFF
--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -106,6 +106,10 @@ path = "src/hyper_warp/server.rs"
 name = "health-server"
 path = "src/health/server.rs"
 
+[[bin]]
+name = "autoreload-server"
+path = "src/autoreload/server.rs"
+
 [dependencies]
 tonic = { path = "../tonic", features = ["tls"] }
 prost = "0.6"
@@ -132,6 +136,7 @@ http-body = "0.3"
 pin-project = "0.4"
 # Health example
 tonic-health = { path = "../tonic-health" }
+listenfd = "0.3"
 
 [build-dependencies]
 tonic-build = { path = "../tonic-build", features = ["prost"] }

--- a/examples/README.md
+++ b/examples/README.md
@@ -80,6 +80,13 @@ $ cargo run --bin tls-server
 $ cargo run --bin health-server
 ```
 
+## Autoreloading Server
+
+### Server
+```bash
+systemfd --no-pid -s http::[::1]:50051 -- cargo watch -x 'run --bin autoreload-server'
+```
+
 ### Notes:
 
 If you are using the `codegen` feature, then the following dependencies are
@@ -89,3 +96,4 @@ If you are using the `codegen` feature, then the following dependencies are
 * [prost](https://crates.io/crates/prost)
 * [prost-derive](https://crates.io/crates/prost-derive)
 
+The autoload example requires [systemfd](https://crates.io/crates/systemfd)

--- a/examples/README.md
+++ b/examples/README.md
@@ -96,4 +96,7 @@ If you are using the `codegen` feature, then the following dependencies are
 * [prost](https://crates.io/crates/prost)
 * [prost-derive](https://crates.io/crates/prost-derive)
 
-The autoload example requires [systemfd](https://crates.io/crates/systemfd)
+The autoload example requires the following crates installed globally:
+
+* [systemfd](https://crates.io/crates/systemfd)
+* [cargo-watch](https://crates.io/crates/cargo-watch)

--- a/examples/src/autoreload/server.rs
+++ b/examples/src/autoreload/server.rs
@@ -32,8 +32,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     println!("GreeterServer listening on {}", addr);
 
-    let server = Server::builder()
-        .add_service(GreeterServer::new(greeter));
+    let server = Server::builder().add_service(GreeterServer::new(greeter));
 
     match listenfd::ListenFd::from_env().take_tcp_listener(0)? {
         Some(listener) => {

--- a/examples/src/autoreload/server.rs
+++ b/examples/src/autoreload/server.rs
@@ -1,0 +1,50 @@
+use tonic::{transport::Server, Request, Response, Status};
+
+use hello_world::greeter_server::{Greeter, GreeterServer};
+use hello_world::{HelloReply, HelloRequest};
+
+pub mod hello_world {
+    tonic::include_proto!("helloworld");
+}
+
+#[derive(Default)]
+pub struct MyGreeter {}
+
+#[tonic::async_trait]
+impl Greeter for MyGreeter {
+    async fn say_hello(
+        &self,
+        request: Request<HelloRequest>,
+    ) -> Result<Response<HelloReply>, Status> {
+        println!("Got a request from {:?}", request.remote_addr());
+
+        let reply = hello_world::HelloReply {
+            message: format!("Hello {}!", request.into_inner().name),
+        };
+        Ok(Response::new(reply))
+    }
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let addr = "[::1]:50051".parse().unwrap();
+    let greeter = MyGreeter::default();
+
+    println!("GreeterServer listening on {}", addr);
+
+    let server = Server::builder()
+        .add_service(GreeterServer::new(greeter));
+
+    match listenfd::ListenFd::from_env().take_tcp_listener(0)? {
+        Some(listener) => {
+            let mut listener = tokio::net::TcpListener::from_std(listener)?;
+
+            server.serve_with_incoming(listener.incoming()).await?;
+        }
+        None => {
+            server.serve(addr).await?;
+        }
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/hyperium/tonic/blob/master/CONTRIBUTING.md
-->

## Motivation
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? If a new feature is being added, describe the intended
use case that feature fulfills.
-->
I was trying to figure out whether the trick actix-web uses for [autoreloading](https://actix.rs/docs/autoreload/) the server would work with tonic. All that was needed was to add [listenfd](https://crates.io/crates/listenfd) as a dependency, install [systemfd](https://crates.io/crates/systemfd), change the following code:
```rust
Server::builder()
        .add_service(GreeterServer::new(greeter))
        .serve(addr)
        .await?;
```
to:
```rust
let server = Server::builder()
    .add_service(GreeterServer::new(greeter));

match listenfd::ListenFd::from_env().take_tcp_listener(0)? {
    Some(listener) => {
        let mut listener = tokio::net::TcpListener::from_std(listener)?;

        server.serve_with_incoming(listener.incoming()).await?;
    }
    None => {
        server.serve(addr).await?;
    }
}
```
and run:
```sh
systemfd --no-pid -s http::$ADDRESS_OR_PORT -- cargo watch -x run
```

## Solution
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
I created an example with a copy of the helloworld server with these modifications, added listenfd as a dependency of the examples repository and added notes to the examples readme
