### PR TITLE
fix(build): Remove ambiguity in service method call

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,5 +13,6 @@ members = [
     "tests/same_name",
     "tests/wellknown",
     "tests/extern_path/uuid",
+    "tests/ambiguous_methods",
     "tests/extern_path/my_application"
 ]

--- a/tests/ambiguous_methods/Cargo.toml
+++ b/tests/ambiguous_methods/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "ambiguous_methods"
+version = "0.1.0"
+authors = ["Yonathan Randolph <yonathan@gmail.com>"]
+edition = "2018"
+publish = false
+license = "MIT"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+tonic = { path= "../../tonic" }
+prost = "0.6"
+
+[build-dependencies]
+tonic-build = { path= "../../tonic-build" }

--- a/tests/ambiguous_methods/build.rs
+++ b/tests/ambiguous_methods/build.rs
@@ -1,0 +1,3 @@
+fn main() {
+    tonic_build::compile_protos("proto/ambiguous_methods.proto").unwrap();
+}

--- a/tests/ambiguous_methods/proto/ambiguous_methods.proto
+++ b/tests/ambiguous_methods/proto/ambiguous_methods.proto
@@ -1,0 +1,19 @@
+syntax = "proto3";
+
+package ambiguous_methods;
+
+message DropReq {}
+message DropResp {}
+
+// The generated stubs can confuse drop and clone
+// with the same method names from Arc,
+// resulting in a compile error.
+service HelloService {
+    rpc Drop (DropReq) returns (DropResp);
+    rpc Clone (DropReq) returns (DropResp);
+}
+
+service HelloStreamingService {
+    rpc Drop (DropReq) returns (stream DropResp);
+    rpc Clone (DropReq) returns (stream DropResp);
+}

--- a/tests/ambiguous_methods/src/main.rs
+++ b/tests/ambiguous_methods/src/main.rs
@@ -1,0 +1,8 @@
+#[macro_use]
+extern crate tonic;
+
+tonic::include_proto!("ambiguous_methods");
+
+fn main() {
+    println!("Hello, world!");
+}

--- a/tonic-build/src/server.rs
+++ b/tonic-build/src/server.rs
@@ -273,7 +273,7 @@ fn generate_unary<T: Method>(
             fn call(&mut self, request: tonic::Request<#request>) -> Self::Future {
                 let inner = self.0.clone();
                 let fut = async move {
-                    inner.#method_ident(request).await
+                    (*inner).#method_ident(request).await
                 };
                 Box::pin(fut)
             }
@@ -326,7 +326,7 @@ fn generate_server_streaming<T: Method>(
             fn call(&mut self, request: tonic::Request<#request>) -> Self::Future {
                 let inner = self.0.clone();
                 let fut = async move {
-                    inner.#method_ident(request).await
+                    (*inner).#method_ident(request).await
 
                 };
                 Box::pin(fut)
@@ -377,7 +377,7 @@ fn generate_client_streaming<T: Method>(
             fn call(&mut self, request: tonic::Request<tonic::Streaming<#request>>) -> Self::Future {
                 let inner = self.0.clone();
                 let fut = async move {
-                    inner.#method_ident(request).await
+                    (*inner).#method_ident(request).await
 
                 };
                 Box::pin(fut)
@@ -432,7 +432,7 @@ fn generate_streaming<T: Method>(
             fn call(&mut self, request: tonic::Request<tonic::Streaming<#request>>) -> Self::Future {
                 let inner = self.0.clone();
                 let fut = async move {
-                    inner.#method_ident(request).await
+                    (*inner).#method_ident(request).await
                 };
                 Box::pin(fut)
             }


### PR DESCRIPTION

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/hyperium/tonic/blob/master/CONTRIBUTING.md
-->

## Motivation

I have an existing proto with a method that was unfortunately named `Drop`, and the tonic stub did not compile. When calling methods on Arc<MyService> where the method is also defined on `Arc` (e.g. `drop` and `clone`), calling `inner.#method_ident(request)` will actually attempt to call the `Arc` method instead of the method on the service, resulting in a compile error when building the generated rust file. 

Here is an excerpt from a test proto, which I have added as [tests/ambiguous_methods/proto/ambiguous_methods.proto](https://github.com/hyperium/tonic/pull/327/files#diff-208d3daf20d818dcfca5ffc390bfb0ee):

```proto
service HelloService {
    rpc Drop (DropReq) returns (DropResp);
    rpc Clone (DropReq) returns (DropResp);
}
```

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? If a new feature is being added, describe the intended
use case that feature fulfills.
-->

## Solution

This change removes the ambiguity by dereferencing the inner `Arc`.

An alternative fix would be to use the [fully qualified syntax for method calls](https://doc.rust-lang.org/book/ch19-03-advanced-traits.html#fully-qualified-syntax-for-disambiguation-calling-methods-with-the-same-name). I believe that this change should be good enough because `#server_trait` is only known to be `#server_trait : Send + Sync + 'static`, and `Sync` and `Send` define no other methods.

See also: my PR to grpc-rust for the exact same issue a year ago stepancheg/grpc-rust#142