### PR TITLE
Add some info about concurrent usage to client mod

### DIFF
--- a/tonic/src/client/mod.rs
+++ b/tonic/src/client/mod.rs
@@ -11,8 +11,8 @@
 //! Upon using the your generated client, you will discover all the functions
 //! corresponding to your rpc methods take `&mut self`, making concurrent
 //! usage of the client difficult. The answer is simply to clone the client,
-//! which is cheap as all client instances will share the same channel for 
-//! communication. For more details, see 
+//! which is cheap as all client instances will share the same channel for
+//! communication. For more details, see
 //! [transport::Channel](../transport/struct.Channel.html#multiplexing-requests).
 
 mod grpc;

--- a/tonic/src/client/mod.rs
+++ b/tonic/src/client/mod.rs
@@ -8,6 +8,7 @@
 //! for the gRPC service. Thusly, they are a bit cumbersome to use by hand.
 //!
 //! ## Concurrent usage
+//!
 //! Upon using the your generated client, you will discover all the functions
 //! corresponding to your rpc methods take `&mut self`, making concurrent
 //! usage of the client difficult. The answer is simply to clone the client,

--- a/tonic/src/client/mod.rs
+++ b/tonic/src/client/mod.rs
@@ -6,6 +6,14 @@
 //!
 //! This client is generally used by some code generation tool to provide stubs
 //! for the gRPC service. Thusly, they are a bit cumbersome to use by hand.
+//!
+//! ## Concurrent usage
+//! Upon using the your generated client, you will discover all the functions
+//! corresponding to your rpc methods take `&mut self`, making concurrent
+//! usage of the client difficult. The answer is simply to clone the client,
+//! which is cheap as all client instances will share the same channel for 
+//! communication. For more details, see 
+//! [transport::Channel](../transport/struct.Channel.html#multiplexing-requests).
 
 mod grpc;
 mod service;


### PR DESCRIPTION
## Motivation
Help users better discover cloning the client is the simple way to use it concurrently

Relates to https://github.com/hyperium/tonic/issues/285

## Solution
Expand on `client` module docs

I considered added docstrings to the generated client implementations, but it was gonna take me a little bit to grok that and I don't have a ton of extra time right now unfortunately. Plus, the generated stuff rarely works in IDE doc help anyway. Putting it in the module docs should make it more discoverable.

Hope this helps! Thanks!