### PR TITLE
chore: Upgrade cargo-deny-action v0 -> v1

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -38,7 +38,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v1
-    - uses: EmbarkStudios/cargo-deny-action@v0
+    - uses: EmbarkStudios/cargo-deny-action@v1
 
   test:
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
[v1 release notes](https://github.com/EmbarkStudios/cargo-deny-action/releases/tag/v1.0.0)

Only changes from cargo-deny 0.6.4 -> 0.6.6 so should just work
