### PR TITLE
Support deadlines with "grpc-timeout" header

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ target/
 **/*.rs.bk
 Cargo.lock
 tags
+.DS_Store

--- a/tests/integration_tests/proto/test.proto
+++ b/tests/integration_tests/proto/test.proto
@@ -7,4 +7,6 @@ service Test {
 }
 
 message Input {}
-message Output {}
+message Output {
+  string message = 1;
+}

--- a/tests/integration_tests/tests/status.rs
+++ b/tests/integration_tests/tests/status.rs
@@ -160,7 +160,6 @@ async fn cancelation_on_timeout() {
         .unary_call(Request::new(Input {}))
         .await
         .unwrap_err();
-    dbg!(&err);
 
     assert_eq!(err.message(), "request timed out!");
     assert_eq!(err.code(), Code::Cancelled);

--- a/tonic-build/src/client.rs
+++ b/tonic-build/src/client.rs
@@ -25,6 +25,7 @@ pub fn generate<T: Service>(service: &T, proto_path: &str) -> TokenStream {
 
             #service_doc
             pub struct #service_ident<T> {
+                // TODO: Don't expose the inner struct, add `set_deadline(...)` in the codegen
                 pub inner: tonic::client::Grpc<T>,
             }
 

--- a/tonic-build/src/client.rs
+++ b/tonic-build/src/client.rs
@@ -25,7 +25,7 @@ pub fn generate<T: Service>(service: &T, proto_path: &str) -> TokenStream {
 
             #service_doc
             pub struct #service_ident<T> {
-                inner: tonic::client::Grpc<T>,
+                pub inner: tonic::client::Grpc<T>,
             }
 
             #connect

--- a/tonic/Cargo.toml
+++ b/tonic/Cargo.toml
@@ -65,7 +65,7 @@ async-trait = { version = "0.1.13", optional = true }
 
 # transport
 hyper = { version = "0.13.4", features = ["stream"], optional = true }
-tokio = { version = "0.2.13", features = ["tcp"], optional = true }
+tokio = { version = "0.2.13", features = ["tcp", "time"], optional = true }
 tower = { version = "0.3", optional = true}
 tower-make = { version = "0.3", features = ["connect"] }
 tower-balance =  { version = "0.3", optional = true }

--- a/tonic/src/client/grpc.rs
+++ b/tonic/src/client/grpc.rs
@@ -188,7 +188,7 @@ impl<T> Grpc<T> {
             .insert(CONTENT_TYPE, HeaderValue::from_static("application/grpc"));
 
         // Set the timeout, if provided
-        if let Some(deadline) = self.deadline.as_ref() {
+        if let Some(deadline) = self.deadline {
             request.headers_mut().insert(
                 HeaderName::from_static(GRPC_TIMEOUT_HEADER_CODE),
                 GrpcTimeout::from(deadline).into(),

--- a/tonic/src/client/grpc.rs
+++ b/tonic/src/client/grpc.rs
@@ -58,6 +58,7 @@ impl<T> Grpc<T> {
 
     /// Sets a deadline for how long you're willing to wait for a response from the server.
     /// If this deadline is passed before a response, returns gRPC status [`tonic::Code::Cancelled`]
+    #[cfg(feature = "transport")]
     pub fn set_deadline(&mut self, deadline: Duration) {
         self.deadline = Some(deadline);
     }

--- a/tonic/src/metadata/mod.rs
+++ b/tonic/src/metadata/mod.rs
@@ -3,6 +3,7 @@
 mod encoding;
 mod key;
 mod map;
+pub(crate) mod timeout;
 mod value;
 
 pub use self::encoding::Ascii;

--- a/tonic/src/metadata/timeout.rs
+++ b/tonic/src/metadata/timeout.rs
@@ -1,4 +1,5 @@
 use crate::{metadata::map::MetadataMap, Status};
+#[cfg(feature = "transport")]
 use futures_util::{future::Either, FutureExt};
 use http::header::HeaderValue;
 use std::{future::Future, str::FromStr, string::ToString, time::Duration};
@@ -72,7 +73,9 @@ impl FromStr for GrpcTimeout {
     }
 }
 
-/// Optionally wrap a future in a Timeout, if one is provided
+/// Optionally wrap a future in a Timeout, if one is provided.
+/// `features = ["transport"]` must be enabled.
+#[cfg(feature = "transport")]
 pub(crate) fn wrap_with_timeout<R>(
     future: impl Future<Output = Result<R, Status>>,
     deadline: Option<GrpcTimeout>,
@@ -89,6 +92,14 @@ pub(crate) fn wrap_with_timeout<R>(
         }
         None => Either::Right(future),
     }
+}
+
+#[cfg(not(feature = "transport"))]
+pub(crate) fn wrap_with_timeout<R>(
+    future: impl Future<Output = Result<R, Status>>,
+    _deadline: Option<GrpcTimeout>,
+) -> impl Future<Output = Result<R, Status>> {
+    future
 }
 
 #[cfg(test)]

--- a/tonic/src/metadata/timeout.rs
+++ b/tonic/src/metadata/timeout.rs
@@ -18,7 +18,7 @@ pub(crate) enum GrpcTimeoutError {
 }
 
 impl GrpcTimeout {
-    /// Try to read a `"grp-timeout"` value from a MetadataMap. Errors if the value is not present,
+    /// Try to read a `"grpc-timeout"` value from a MetadataMap. Errors if the value is not present,
     /// or if it cannot be parsed
     pub(crate) fn try_read_from_metadata(metadata: &MetadataMap) -> Result<Self, GrpcTimeoutError> {
         let value = metadata
@@ -59,6 +59,8 @@ impl From<GrpcTimeout> for HeaderValue {
 impl FromStr for GrpcTimeout {
     type Err = GrpcTimeoutError;
 
+    /// TODO: Better parsing of the "grpc-timeout" header value, official spec
+    /// [here](https://github.com/grpc/grpc/blob/master/doc/PROTOCOL-HTTP2.md)
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         let idx = s.find("n").ok_or(GrpcTimeoutError::Parse)?;
         let (value, _unit) = s.split_at(idx);

--- a/tonic/src/metadata/timeout.rs
+++ b/tonic/src/metadata/timeout.rs
@@ -1,28 +1,60 @@
+use crate::metadata::map::MetadataMap;
 use http::header::HeaderValue;
-use std::{string::ToString, time::Duration};
+use std::{str::FromStr, string::ToString, time::Duration};
 
 /// Internal struct used to convert from a [`std::time::Duration`] to a `"grpc-timeout"` `String`
-#[derive(Debug)]
-pub(crate) struct GrpcTimeout<'a> {
-    deadline: &'a Duration,
+#[derive(Debug, Eq, PartialEq)]
+pub(crate) struct GrpcTimeout {
+    deadline: Duration,
 }
 
-impl<'a> From<&'a Duration> for GrpcTimeout<'a> {
-    fn from(deadline: &'a Duration) -> GrpcTimeout<'a> {
+impl GrpcTimeout {
+    pub(crate) fn into_inner(self) -> Duration {
+        self.deadline
+    }
+}
+
+impl From<Duration> for GrpcTimeout {
+    fn from(deadline: Duration) -> GrpcTimeout {
         GrpcTimeout { deadline }
     }
 }
 
-impl<'a> ToString for GrpcTimeout<'a> {
+impl ToString for GrpcTimeout {
     fn to_string(&self) -> String {
         format!("{}n", self.deadline.as_nanos())
     }
 }
 
-impl<'a> From<GrpcTimeout<'a>> for HeaderValue {
-    fn from(timeout: GrpcTimeout<'a>) -> HeaderValue {
+impl From<GrpcTimeout> for HeaderValue {
+    fn from(timeout: GrpcTimeout) -> HeaderValue {
         HeaderValue::from_str(&timeout.to_string())
             .expect("failed to create HeaderValue from GrpcTimeout!")
+    }
+}
+
+impl std::convert::TryFrom<&MetadataMap> for GrpcTimeout {
+    type Error = ();
+
+    fn try_from(map: &MetadataMap) -> Result<GrpcTimeout, Self::Error> {
+        map.get("grpc-timeout")
+            .map(|s| GrpcTimeout::from_str(s.to_str().unwrap()).ok())
+            .flatten()
+            .ok_or(())
+    }
+}
+
+impl FromStr for GrpcTimeout {
+    type Err = ();
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let idx = s.find("n").unwrap();
+        let (value, _unit) = s.split_at(idx);
+        let nanos: u64 = value.parse().unwrap();
+
+        Ok(GrpcTimeout {
+            deadline: Duration::from_nanos(nanos),
+        })
     }
 }
 
@@ -33,10 +65,18 @@ mod tests {
     #[test]
     fn timeout_converts_to_correct_header_value() {
         let duration = Duration::new(1, 500);
-        let timeout = GrpcTimeout::from(&duration);
+        let timeout = GrpcTimeout::from(duration);
         let header_value: HeaderValue = timeout.into();
 
         assert_eq!(HeaderValue::from_static("1000000500n"), header_value);
     }
 
+    #[test]
+    fn str_converts_to_timeout() {
+        let str_timeout = GrpcTimeout::from_str("1000000500n").unwrap();
+        let timeout = GrpcTimeout {
+            deadline: Duration::new(1, 500),
+        };
+        assert_eq!(str_timeout, timeout);
+    }
 }

--- a/tonic/src/metadata/timeout.rs
+++ b/tonic/src/metadata/timeout.rs
@@ -1,6 +1,9 @@
-use crate::metadata::map::MetadataMap;
+use crate::{metadata::map::MetadataMap, Status};
+use futures_util::{FutureExt, future::Either};
 use http::header::HeaderValue;
-use std::{str::FromStr, string::ToString, time::Duration};
+use std::{future::Future, str::FromStr, string::ToString, time::Duration};
+
+const GRPC_TIMEOUT_HEADER_CODE: &str = "grpc-timeout";
 
 /// Internal struct used to convert from a [`std::time::Duration`] to a `"grpc-timeout"` `String`
 #[derive(Debug, Eq, PartialEq)]
@@ -8,9 +11,20 @@ pub(crate) struct GrpcTimeout {
     deadline: Duration,
 }
 
+#[derive(Debug, Eq, PartialEq)]
+pub(crate) enum GrpcTimeoutError {
+    Parse,
+    NotPresent,
+}
+
 impl GrpcTimeout {
-    pub(crate) fn into_inner(self) -> Duration {
-        self.deadline
+    pub(crate) fn try_read_from_metadata(metadata: &MetadataMap) -> Result<Self, GrpcTimeoutError> {
+        let value = metadata
+            .get(GRPC_TIMEOUT_HEADER_CODE)
+            .ok_or(GrpcTimeoutError::NotPresent)?
+            .to_str()
+            .map_err(|_| GrpcTimeoutError::Parse)?;
+        GrpcTimeout::from_str(value)
     }
 }
 
@@ -20,8 +34,15 @@ impl From<Duration> for GrpcTimeout {
     }
 }
 
+impl From<GrpcTimeout> for Duration {
+    fn from(timeout: GrpcTimeout) -> Duration {
+        timeout.deadline
+    }
+}
+
 impl ToString for GrpcTimeout {
     fn to_string(&self) -> String {
+        // TODO: Smarter conversion from Duration to "grpc-timeout", don't just always convert to nanos
         format!("{}n", self.deadline.as_nanos())
     }
 }
@@ -33,28 +54,33 @@ impl From<GrpcTimeout> for HeaderValue {
     }
 }
 
-impl std::convert::TryFrom<&MetadataMap> for GrpcTimeout {
-    type Error = ();
-
-    fn try_from(map: &MetadataMap) -> Result<GrpcTimeout, Self::Error> {
-        map.get("grpc-timeout")
-            .map(|s| GrpcTimeout::from_str(s.to_str().unwrap()).ok())
-            .flatten()
-            .ok_or(())
-    }
-}
-
 impl FromStr for GrpcTimeout {
-    type Err = ();
+    type Err = GrpcTimeoutError;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        let idx = s.find("n").unwrap();
+        let idx = s.find("n").ok_or(GrpcTimeoutError::Parse)?;
         let (value, _unit) = s.split_at(idx);
-        let nanos: u64 = value.parse().unwrap();
+        let nanos: u64 = value.parse().map_err(|_| GrpcTimeoutError::Parse)?;
 
         Ok(GrpcTimeout {
             deadline: Duration::from_nanos(nanos),
         })
+    }
+}
+
+pub(crate) fn wrap_with_timeout<R>(
+    future: impl Future<Output = Result<R, Status>>,
+    deadline: Option<GrpcTimeout>,
+) -> impl Future<Output = Result<R, Status>> {
+    match deadline {
+        Some(d) => {
+            let duration = d.into();
+            Either::Left(tokio::time::timeout(duration, future).map(|timeout_result| match timeout_result {
+                Ok(resp) => resp,
+                Err(_) => Err(Status::cancelled("request timed out!")),
+            }))
+        },
+        None => Either::Right(future),
     }
 }
 

--- a/tonic/src/metadata/timeout.rs
+++ b/tonic/src/metadata/timeout.rs
@@ -1,0 +1,42 @@
+use http::header::HeaderValue;
+use std::{string::ToString, time::Duration};
+
+/// Internal struct used to convert from a [`std::time::Duration`] to a `"grpc-timeout"` `String`
+#[derive(Debug)]
+pub(crate) struct GrpcTimeout<'a> {
+    deadline: &'a Duration,
+}
+
+impl<'a> From<&'a Duration> for GrpcTimeout<'a> {
+    fn from(deadline: &'a Duration) -> GrpcTimeout<'a> {
+        GrpcTimeout { deadline }
+    }
+}
+
+impl<'a> ToString for GrpcTimeout<'a> {
+    fn to_string(&self) -> String {
+        format!("{}n", self.deadline.as_nanos())
+    }
+}
+
+impl<'a> From<GrpcTimeout<'a>> for HeaderValue {
+    fn from(timeout: GrpcTimeout<'a>) -> HeaderValue {
+        HeaderValue::from_str(&timeout.to_string())
+            .expect("failed to create HeaderValue from GrpcTimeout!")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn timeout_converts_to_correct_header_value() {
+        let duration = Duration::new(1, 500);
+        let timeout = GrpcTimeout::from(&duration);
+        let header_value: HeaderValue = timeout.into();
+
+        assert_eq!(HeaderValue::from_static("1000000500n"), header_value);
+    }
+
+}

--- a/tonic/src/server/grpc.rs
+++ b/tonic/src/server/grpc.rs
@@ -76,14 +76,11 @@ where
                     ));
             }
         };
-
         let request = t!(self.intercept_request(request));
-
         let response = service
             .call(request)
             .await
             .map(|r| r.map(|m| stream::once(future::ok(m))));
-
         self.map_response(response)
     }
 
@@ -105,11 +102,8 @@ where
                 return self.map_response::<S::ResponseStream>(Err(status));
             }
         };
-
         let request = t!(self.intercept_request(request));
-
         let response = service.call(request).await;
-
         self.map_response(response)
     }
 

--- a/tonic/src/server/grpc.rs
+++ b/tonic/src/server/grpc.rs
@@ -85,7 +85,7 @@ where
         self.map_response(response)
     }
 
-    /// Handle a server side streacming request.
+    /// Handle a server side streaming request.
     pub async fn server_streaming<S, B>(
         &mut self,
         mut service: S,


### PR DESCRIPTION
## Motivation
This PR fixes issue #75, which is to implement support for the `"grpc-timeout"` header in tonic. Setting a timeout/deadline is an official part of the gRPC spec, and is a [recommended](https://grpc.io/blog/deadlines/) practice.

#### Note
This code needs to be cleaned up a bit before merging, e.g. adding a `set_duration(...)` function to the generated client code, instead of making `client::Grpc.inner` public (and more). I put this PR up in this state to get some early feedback on the design of the timeout implementation.

## Solution
### Server
Requests are timed out by attempting to read a `"grpc-timeout"` value from the `MetadataMap` of a request. If we find a value for a timeout, then we wrap inner service call with a `tokio::time::Timeout`, using the duration we read previously.

### Client
Taking inspiration from other [gRPC clients](https://grpc.io/blog/deadlines/#c) we add a function to `client::Grpc` called `set_duration(deadline: Duration)` which sets a duration value on the inner struct. When any request is made with this client, we insert this duration value in the `"grpc-timeout"` header.

## Testing
To make sure this works, and to prevent regressions, I added a `cancelation_on_timeout` test which sets a deadline on the client of 500ms, but the handler on the server pauses for 1,000ms before returning a value. We assert this request returns with the expected message and code.

#### Note
As part of the cleanup I'd also like to add a benchmark test to assert the timely cleanup of assets on timeout. e.g. in the current test, our request should only take 10s (ideally 1s) of milliseconds longer than the deadline.
