### PR TITLE
Fix client side streaming example in the getting started guide

### DIFF
--- a/examples/routeguide-tutorial.md
+++ b/examples/routeguide-tutorial.md
@@ -453,7 +453,7 @@ async fn record_route(
     let mut last_point = None;
     let now = Instant::now();
 
-    while let Some(point) = stream.next().await {
+    while let Some(point) = stream.message().await? {
         let point = point?;
         summary.point_count += 1;
 


### PR DESCRIPTION
Thanks for the awesome library!

Unless I'm missing something, shouldn't this be `stream.message()` (i.e [this function](https://github.com/hyperium/tonic/blob/master/tonic/src/codec/decode.rs#L106))?