### PR TITLE
chore: wrong path for call to `compile_protos`

### DIFF
--- a/examples/helloworld-tutorial.md
+++ b/examples/helloworld-tutorial.md
@@ -129,7 +129,7 @@ At the root of your crate, create a `build.rs` file and add the following code:
 
 ```rust
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    tonic_build::compile_protos("proto/helloworld.proto")?;
+    tonic_build::compile_protos("src/proto/helloworld.proto")?;
     Ok(())
 }
 ```


### PR DESCRIPTION
Fixed wrong path "proto/helloworld.proto" for `compile_protos` first argument. `build.rs` being in the project root, means the correct path should be "src/proto/helloworld.proto".