### PR TITLE
fix: Remove uses of pin_project::project attribute

### DIFF
--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -141,7 +141,7 @@ hyper = "0.13"
 warp = { version = "0.2", default-features = false }
 http = "0.2"
 http-body = "0.3"
-pin-project = "0.4"
+pin-project = "0.4.17"
 # Health example
 tonic-health = { path = "../tonic-health" }
 listenfd = "0.3"

--- a/tonic/Cargo.toml
+++ b/tonic/Cargo.toml
@@ -54,7 +54,7 @@ tower-service = "0.3"
 tokio-util = { version = "0.3", features = ["codec"] }
 async-stream = "0.2"
 http-body = "0.3"
-pin-project = "0.4"
+pin-project = "0.4.17"
 
 # prost
 prost1 = { package = "prost", version = "0.6", optional = true }


### PR DESCRIPTION
pin-project will deprecate the project attribute due to some unfixable
limitations.

Refs: https://github.com/taiki-e/pin-project/issues/225

*Although the deprecation of the project attribute has not been released yet, this PR is submitted in advance to avoid the CI from being broken by deprecated warnings.*
