### PR TITLE
feat: add new method get_uri for Endpoint

### DIFF
--- a/tonic/src/transport/channel/endpoint.rs
+++ b/tonic/src/transport/channel/endpoint.rs
@@ -226,6 +226,19 @@ impl Endpoint {
 
         Channel::connect(connector, self.clone()).await
     }
+
+    /// Get the endpoint uri.
+    ///
+    /// ```
+    /// # use tonic::transport::Endpoint;
+    /// # use http::Uri;
+    /// let endpoint = Endpoint::from_static("https://example.com");
+    ///
+    /// assert_eq!(endpoint.get_uri(), &Uri::from_static("https://example.com"));
+    /// ```
+    pub fn get_uri(&self) -> &Uri {
+        &self.uri
+    }
 }
 
 impl From<Uri> for Endpoint {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/hyperium/tonic/blob/master/CONTRIBUTING.md
-->

This PR adds a new method `get_uri` for `Endpoint`, to allow user to get the `&Uri` from an `Endpoint`

## Motivation

I am using `tonic` and stored the `Endpoint`, ensure I can reconnect GRPC server directly, however sometimes I need to get the uri in `Endpoint` to print some log.

One way is to create a wrapper `struct Endpoint(Uri, tonic::transport::Endpoint)`, but it will allocate a new `Uri`.

I think the better way is let `Endpoint` can return the `Uri` reference which is in the `Endpoint`, user can use it to print logs or do something else, without unnecessary allocating.

related issue is #370 
