### PR TITLE
Use direction in error reporting during decode

### DIFF
--- a/tonic/src/codec/decode.rs
+++ b/tonic/src/codec/decode.rs
@@ -168,10 +168,15 @@ impl<T> Streaming<T> {
                 }
                 f => {
                     trace!("unexpected compression flag");
-                    return Err(Status::new(
-                        Code::Internal,
-                        format!("Unexpected compression flag: {}", f),
-                    ));
+                    let message = if let Direction::Response(status) = self.direction {
+                        format!(
+                            "Unexpected compression flag: {}, while receiving response with status: {}",
+                            f, status
+                        )
+                    } else {
+                        format!("Unexpected compression flag: {}, while sending request", f)
+                    };
+                    return Err(Status::new(Code::Internal, message));
                 }
             };
             let len = self.buf.get_u32() as usize;


### PR DESCRIPTION
It is not a bug-fix or a new feature as such. Just being more explicit and loud in reporting error using the communication direction. 

## Motivation

We encountered this error message today:

```rust
(Status { code: Internal, message: "Unexpected compression flag: 123" }
```
It's not immediately obvious as to whether this error-scenario was encountered while _sending_ the request or while _receiving_ the response. I think adding that information in the message would be highly helpful to figure out the actual source causing the error. 

## Solution

It's pretty simple. I used `self.direction` to detect the error-scenario (as in, sending or receiving?) and created an error message accordingly.

Please let me know if this little improvement is acceptable in this form, or I missed out anything important. I'd like to make changes as required.
