### PR TITLE
Add tower server example

### DIFF
--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -67,6 +67,10 @@ name = "tls-client-auth-client"
 path = "src/tls_client_auth/client.rs"
 
 [[bin]]
+name = "tower-server"
+path = "src/tower/server.rs"
+
+[[bin]]
 name = "multiplex-server"
 path = "src/multiplex/server.rs"
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -94,6 +94,14 @@ $ cargo run --bin tls-server
 $ cargo run --bin health-server
 ```
 
+## Tower Middleware
+
+### Server
+
+```bash
+$ cargo run --bin tower-server
+```
+
 ## Autoreloading Server
 
 ### Server

--- a/examples/src/tower/server.rs
+++ b/examples/src/tower/server.rs
@@ -1,0 +1,86 @@
+use hyper::{Body, Request as HyperRequest, Response as HyperResponse};
+use std::task::{Context, Poll};
+use tonic::{
+    body::BoxBody,
+    transport::{NamedService, Server},
+    Request, Response, Status,
+};
+use tower::Service;
+
+use hello_world::greeter_server::{Greeter, GreeterServer};
+use hello_world::{HelloReply, HelloRequest};
+
+pub mod hello_world {
+    tonic::include_proto!("helloworld");
+}
+
+#[derive(Default)]
+pub struct MyGreeter {}
+
+#[tonic::async_trait]
+impl Greeter for MyGreeter {
+    async fn say_hello(
+        &self,
+        request: Request<HelloRequest>,
+    ) -> Result<Response<HelloReply>, Status> {
+        println!("Got a request from {:?}", request.remote_addr());
+
+        let reply = hello_world::HelloReply {
+            message: format!("Hello {}!", request.into_inner().name),
+        };
+        Ok(Response::new(reply))
+    }
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let addr = "[::1]:50051".parse().unwrap();
+    let greeter = MyGreeter::default();
+
+    println!("GreeterServer listening on {}", addr);
+
+    let svc = InterceptedService {
+        inner: GreeterServer::new(greeter),
+    };
+
+    Server::builder().add_service(svc).serve(addr).await?;
+
+    Ok(())
+}
+
+#[derive(Debug, Clone)]
+struct InterceptedService<S> {
+    inner: S,
+}
+
+impl<S> Service<HyperRequest<Body>> for InterceptedService<S>
+where
+    S: Service<HyperRequest<Body>, Response = HyperResponse<BoxBody>>
+        + NamedService
+        + Clone
+        + Send
+        + 'static,
+    S::Future: Send + 'static,
+{
+    type Response = S::Response;
+    type Error = S::Error;
+    type Future = futures::future::BoxFuture<'static, Result<Self::Response, Self::Error>>;
+
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.inner.poll_ready(cx)
+    }
+
+    fn call(&mut self, req: HyperRequest<Body>) -> Self::Future {
+        let mut svc = self.inner.clone();
+
+        Box::pin(async move {
+            // Do async work here....
+
+            svc.call(req).await
+        })
+    }
+}
+
+impl<S: NamedService> NamedService for InterceptedService<S> {
+    const NAME: &'static str = S::NAME;
+}


### PR DESCRIPTION
Note that this also adds `impl From<Status> for http::Response<BoxBody>`
in order to make writing middleware which can return an error much
easier.

## Motivation

This is based off the example from https://gist.github.com/LucioFranco/9d5cab419797f54fc7b96bc409d8c6e8. It has been expanded into something a little more complex which requires specifying the Request/Response types but allows for intercepting metadata values with an async context. This allows lookups to happen to verify things like auth tokens.

## Solution

Most of the code here is the example, but it also replaces `Grpc::map_status` with an `impl From<Status> for http::Response<tonic::body::BoxBody>` in order to make it easier to write middleware which can return an error.
