### PR TITLE
Allow empty packages - fixes #381

### DIFF
--- a/tonic-build/src/client.rs
+++ b/tonic-build/src/client.rs
@@ -92,8 +92,9 @@ fn generate_methods<T: Service>(service: &T, proto_path: &str) -> TokenStream {
 
     for method in service.methods() {
         let path = format!(
-            "/{}.{}/{}",
+            "/{}{}{}/{}",
             service.package(),
+            if service.package().is_empty() {""} else {"."},
             service.identifier(),
             method.identifier()
         );

--- a/tonic-build/src/client.rs
+++ b/tonic-build/src/client.rs
@@ -94,7 +94,11 @@ fn generate_methods<T: Service>(service: &T, proto_path: &str) -> TokenStream {
         let path = format!(
             "/{}{}{}/{}",
             service.package(),
-            if service.package().is_empty() {""} else {"."},
+            if service.package().is_empty() {
+                ""
+            } else {
+                "."
+            },
             service.identifier(),
             method.identifier()
         );

--- a/tonic-build/src/server.rs
+++ b/tonic-build/src/server.rs
@@ -218,7 +218,11 @@ fn generate_methods<T: Service>(service: &T, proto_path: &str) -> TokenStream {
         let path = format!(
             "/{}{}{}/{}",
             service.package(),
-            if service.package().is_empty() {""} else {"."},
+            if service.package().is_empty() {
+                ""
+            } else {
+                "."
+            },
             service.identifier(),
             method.identifier()
         );

--- a/tonic-build/src/server.rs
+++ b/tonic-build/src/server.rs
@@ -216,8 +216,9 @@ fn generate_methods<T: Service>(service: &T, proto_path: &str) -> TokenStream {
 
     for method in service.methods() {
         let path = format!(
-            "/{}.{}/{}",
+            "/{}{}{}/{}",
             service.package(),
+            if service.package().is_empty() {""} else {"."},
             service.identifier(),
             method.identifier()
         );


### PR DESCRIPTION
## Motivation

If prost allows for no packages then tonic generates bad endpoints for both clients and servers. See https://github.com/hyperium/tonic/issues/381.

## Solution

The solution is to make the `.` between the package name and service name dependent on whether or not the package is empty.
