### PR TITLE
Propagate errors in tls_config instead of unwrap/panic

### DIFF
--- a/examples/src/gcp/client.rs
+++ b/examples/src/gcp/client.rs
@@ -32,7 +32,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .domain_name("pubsub.googleapis.com");
 
     let channel = Channel::from_static(ENDPOINT)
-        .tls_config(tls_config)
+        .tls_config(tls_config)?
         .connect()
         .await?;
 

--- a/examples/src/tls/client.rs
+++ b/examples/src/tls/client.rs
@@ -15,7 +15,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .domain_name("example.com");
 
     let channel = Channel::from_static("http://[::1]:50051")
-        .tls_config(tls)
+        .tls_config(tls)?
         .connect()
         .await?;
 

--- a/examples/src/tls/server.rs
+++ b/examples/src/tls/server.rs
@@ -60,7 +60,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let server = EchoServer::default();
 
     Server::builder()
-        .tls_config(ServerTlsConfig::new().identity(identity))
+        .tls_config(ServerTlsConfig::new().identity(identity))?
         .add_service(pb::echo_server::EchoServer::new(server))
         .serve(addr)
         .await?;

--- a/examples/src/tls_client_auth/client.rs
+++ b/examples/src/tls_client_auth/client.rs
@@ -19,7 +19,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .identity(client_identity);
 
     let channel = Channel::from_static("http://[::1]:50051")
-        .tls_config(tls)
+        .tls_config(tls)?
         .connect()
         .await?;
 

--- a/examples/src/tls_client_auth/server.rs
+++ b/examples/src/tls_client_auth/server.rs
@@ -68,7 +68,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .client_ca_root(client_ca_cert);
 
     Server::builder()
-        .tls_config(tls)
+        .tls_config(tls)?
         .add_service(pb::echo_server::EchoServer::new(server))
         .serve(addr)
         .await?;

--- a/interop/src/bin/client.rs
+++ b/interop/src/bin/client.rs
@@ -38,7 +38,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             ClientTlsConfig::new()
                 .ca_certificate(ca)
                 .domain_name("foo.test.google.fr"),
-        );
+        )?;
     }
 
     let channel = endpoint.connect().await?;

--- a/interop/src/bin/server.rs
+++ b/interop/src/bin/server.rs
@@ -24,7 +24,7 @@ async fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
         let key = tokio::fs::read("interop/data/server1.key").await?;
         let identity = Identity::from_pem(cert, key);
 
-        builder = builder.tls_config(ServerTlsConfig::new().identity(identity));
+        builder = builder.tls_config(ServerTlsConfig::new().identity(identity))?;
     }
 
     let test_service = server::TestServiceServer::new(server::TestService::default());

--- a/tonic/src/transport/channel/endpoint.rs
+++ b/tonic/src/transport/channel/endpoint.rs
@@ -155,11 +155,15 @@ impl Endpoint {
     /// Configures TLS for the endpoint.
     #[cfg(feature = "tls")]
     #[cfg_attr(docsrs, doc(cfg(feature = "tls")))]
-    pub fn tls_config(self, tls_config: ClientTlsConfig) -> Self {
-        Endpoint {
-            tls: Some(tls_config.tls_connector(self.uri.clone()).unwrap()),
+    pub fn tls_config(self, tls_config: ClientTlsConfig) -> Result<Self, Error> {
+        Ok(Endpoint {
+            tls: Some(
+                tls_config
+                    .tls_connector(self.uri.clone())
+                    .map_err(|e| Error::from_source(e))?,
+            ),
             ..self
-        }
+        })
     }
 
     /// Set the value of `TCP_NODELAY` option for accepted connections. Enabled by default.

--- a/tonic/src/transport/mod.rs
+++ b/tonic/src/transport/mod.rs
@@ -30,7 +30,7 @@
 //! let mut channel = Channel::from_static("https://example.com")
 //!     .tls_config(ClientTlsConfig::new()
 //!         .ca_certificate(Certificate::from_pem(&cert))
-//!         .domain_name("example.com".to_string()))
+//!         .domain_name("example.com".to_string()))?
 //!     .timeout(Duration::from_secs(5))
 //!     .rate_limit(5, Duration::from_secs(1))
 //!     .concurrency_limit(256)
@@ -74,7 +74,7 @@
 //!
 //! Server::builder()
 //!     .tls_config(ServerTlsConfig::new()
-//!         .identity(Identity::from_pem(&cert, &key)))
+//!         .identity(Identity::from_pem(&cert, &key)))?
 //!     .concurrency_limit_per_connection(256)
 //!     .add_service(my_svc)
 //!     .serve(addr)

--- a/tonic/src/transport/server/mod.rs
+++ b/tonic/src/transport/server/mod.rs
@@ -19,6 +19,7 @@ use incoming::TcpIncoming;
 pub(crate) use incoming::TlsStream;
 
 use super::service::{Or, Routes, ServerIo, ServiceBuilderExt};
+use crate::transport::Error;
 use crate::{body::BoxBody, request::ConnectionInfo};
 use futures_core::Stream;
 use futures_util::{
@@ -97,11 +98,15 @@ impl Server {
     /// Configure TLS for this server.
     #[cfg(feature = "tls")]
     #[cfg_attr(docsrs, doc(cfg(feature = "tls")))]
-    pub fn tls_config(self, tls_config: ServerTlsConfig) -> Self {
-        Server {
-            tls: Some(tls_config.tls_acceptor().unwrap()),
+    pub fn tls_config(self, tls_config: ServerTlsConfig) -> Result<Self, Error> {
+        Ok(Server {
+            tls: Some(
+                tls_config
+                    .tls_acceptor()
+                    .map_err(|e| Error::from_source(e))?,
+            ),
             ..self
-        }
+        })
     }
 
     /// Set the concurrency limit applied to on requests inbound per connection.

--- a/tonic/src/transport/server/mod.rs
+++ b/tonic/src/transport/server/mod.rs
@@ -18,8 +18,10 @@ use incoming::TcpIncoming;
 #[cfg(feature = "tls")]
 pub(crate) use incoming::TlsStream;
 
-use super::service::{Or, Routes, ServerIo, ServiceBuilderExt};
+#[cfg(feature = "tls")]
 use crate::transport::Error;
+
+use super::service::{Or, Routes, ServerIo, ServiceBuilderExt};
 use crate::{body::BoxBody, request::ConnectionInfo};
 use futures_core::Stream;
 use futures_util::{


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/hyperium/tonic/blob/master/CONTRIBUTING.md
-->

## Motivation

We ran into `tls_connector` failing and causing our app to panic and shutdown as it seems there wasn't any way to avoid panicking in `tls_config`.

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? If a new feature is being added, describe the intended
use case that feature fulfills.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

So after talking to @LucioFranco briefly `tls_config` now returns a `Result` instead and propagates errors to the caller, where they have to be handled. 

This is a bit of an intrusive change to the API here. could alternatively introduce an additional `tls_config` function that does the error handling and keep the existing unwrapping one, to allow it to become an additive opt-in minor semver change instead?