### PR TITLE
Make the cast in Bidirectional stream smaller

### DIFF
--- a/examples/routeguide-tutorial.md
+++ b/examples/routeguide-tutorial.md
@@ -517,9 +517,7 @@ async fn route_chat(
     };
 
     Ok(Response::new(Box::pin(output)
-        as Pin<
-            Box<dyn Stream<Item = Result<RouteNote, Status>> + Send + Sync + 'static>,
-        >))
+        as Self::RouteChatStream))
 
 }
 ```


### PR DESCRIPTION
Since we already define the type we can just use it instead of writing it again

## Motivation

The example on the bidirectional streaming is confusing since we are casting the output 
of `Box::pin()` to a type. However it is the same type as the associated type `RouteChatStream`.
It makes the code more clean and understandable.

## Solution

Use the associated type instead of writing the type again.