### PR TITLE
Add Endpoint::connect_lazy method

### DIFF
--- a/tonic/src/transport/channel/mod.rs
+++ b/tonic/src/transport/channel/mod.rs
@@ -139,8 +139,7 @@ impl Channel {
     {
         let buffer_size = endpoint.buffer_size.clone().unwrap_or(DEFAULT_BUFFER_SIZE);
 
-        let svc = Connection::new(connector, endpoint)
-            .map_err(super::Error::from_source)?;
+        let svc = Connection::new(connector, endpoint).map_err(super::Error::from_source)?;
         let svc = Buffer::new(Either::A(svc), buffer_size);
 
         Ok(Channel { svc })

--- a/tonic/src/transport/channel/mod.rs
+++ b/tonic/src/transport/channel/mod.rs
@@ -130,7 +130,7 @@ impl Channel {
         (Self::balance(list, DEFAULT_BUFFER_SIZE), tx)
     }
 
-    pub(crate) async fn connect<C>(connector: C, endpoint: Endpoint) -> Result<Self, super::Error>
+    pub(crate) fn new<C>(connector: C, endpoint: Endpoint) -> Result<Self, super::Error>
     where
         C: Service<Uri> + Send + 'static,
         C::Error: Into<crate::Error> + Send,
@@ -140,9 +140,24 @@ impl Channel {
         let buffer_size = endpoint.buffer_size.clone().unwrap_or(DEFAULT_BUFFER_SIZE);
 
         let svc = Connection::new(connector, endpoint)
-            .await
-            .map_err(|e| super::Error::from_source(e))?;
+            .map_err(super::Error::from_source)?;
+        let svc = Buffer::new(Either::A(svc), buffer_size);
 
+        Ok(Channel { svc })
+    }
+
+    pub(crate) async fn connect<C>(connector: C, endpoint: Endpoint) -> Result<Self, super::Error>
+    where
+        C: Service<Uri> + Send + 'static,
+        C::Error: Into<crate::Error> + Send,
+        C::Future: Unpin + Send,
+        C::Response: AsyncRead + AsyncWrite + HyperConnection + Unpin + Send + 'static,
+    {
+        let buffer_size = endpoint.buffer_size.clone().unwrap_or(DEFAULT_BUFFER_SIZE);
+
+        let svc = Connection::connect(connector, endpoint)
+            .await
+            .map_err(super::Error::from_source)?;
         let svc = Buffer::new(Either::A(svc), buffer_size);
 
         Ok(Channel { svc })

--- a/tonic/src/transport/service/connection.rs
+++ b/tonic/src/transport/service/connection.rs
@@ -16,8 +16,7 @@ use tower::{
     limit::{concurrency::ConcurrencyLimitLayer, rate::RateLimitLayer},
     timeout::TimeoutLayer,
     util::BoxService,
-    ServiceBuilder,
-    ServiceExt,
+    ServiceBuilder, ServiceExt,
 };
 use tower_load::Load;
 use tower_service::Service;

--- a/tonic/src/transport/service/connection.rs
+++ b/tonic/src/transport/service/connection.rs
@@ -77,9 +77,7 @@ impl Connection {
         C::Future: Unpin + Send,
         C::Response: AsyncRead + AsyncWrite + HyperConnection + Unpin + Send + 'static,
     {
-        let mut connection = Self::new(connector, endpoint)?;
-        connection.ready_and().await?;
-        Ok(connection)
+        Self::new(connector, endpoint)?.ready_oneshot().await
     }
 }
 

--- a/tonic/src/transport/service/connection.rs
+++ b/tonic/src/transport/service/connection.rs
@@ -17,6 +17,7 @@ use tower::{
     timeout::TimeoutLayer,
     util::BoxService,
     ServiceBuilder,
+    ServiceExt,
 };
 use tower_load::Load;
 use tower_service::Service;
@@ -29,7 +30,7 @@ pub(crate) struct Connection {
 }
 
 impl Connection {
-    pub(crate) async fn new<C>(connector: C, endpoint: Endpoint) -> Result<Self, crate::Error>
+    pub(crate) fn new<C>(connector: C, endpoint: Endpoint) -> Result<Self, crate::Error>
     where
         C: Service<Uri> + Send + 'static,
         C::Error: Into<crate::Error> + Send,
@@ -60,15 +61,26 @@ impl Connection {
             .optional_layer(endpoint.rate_limit.map(|(l, d)| RateLimitLayer::new(l, d)))
             .into_inner();
 
-        let mut connector = HyperConnect::new(connector, settings);
-        let initial_conn = connector.call(endpoint.uri.clone()).await?;
-        let conn = Reconnect::new(initial_conn, connector, endpoint.uri.clone());
+        let connector = HyperConnect::new(connector, settings);
+        let conn = Reconnect::new(connector, endpoint.uri.clone());
 
         let inner = stack.layer(conn);
 
         Ok(Self {
             inner: BoxService::new(inner),
         })
+    }
+
+    pub(crate) async fn connect<C>(connector: C, endpoint: Endpoint) -> Result<Self, crate::Error>
+    where
+        C: Service<Uri> + Send + 'static,
+        C::Error: Into<crate::Error> + Send,
+        C::Future: Unpin + Send,
+        C::Response: AsyncRead + AsyncWrite + HyperConnection + Unpin + Send + 'static,
+    {
+        let mut connection = Self::new(connector, endpoint)?;
+        connection.ready_and().await?;
+        Ok(connection)
     }
 }
 

--- a/tonic/src/transport/service/discover.rs
+++ b/tonic/src/transport/service/discover.rs
@@ -64,7 +64,7 @@ impl<K: Hash + Eq + Clone> Discover for DynamicServiceStream<K> {
 
                         #[cfg(not(feature = "tls"))]
                         let connector = service::connector(http);
-                        let fut = Connection::new(connector, endpoint);
+                        let fut = Connection::connect(connector, endpoint);
                         self.connecting = Some((k, Box::pin(fut)));
                         continue;
                     }

--- a/tonic/src/transport/service/reconnect.rs
+++ b/tonic/src/transport/service/reconnect.rs
@@ -31,16 +31,10 @@ impl<M, Target> Reconnect<M, Target>
 where
     M: Service<Target>,
 {
-    pub(crate) fn new<S, Request>(initial_connection: S, mk_service: M, target: Target) -> Self
-    where
-        M: Service<Target, Response = S>,
-        S: Service<Request>,
-        Error: From<M::Error> + From<S::Error>,
-        Target: Clone,
-    {
+    pub(crate) fn new(mk_service: M, target: Target) -> Self {
         Reconnect {
             mk_service,
-            state: State::Connected(initial_connection),
+            state: State::Idle,
             target,
             error: None,
         }


### PR DESCRIPTION
## Motivation

Adds a 'lazy' constructor which will not attempt to connect to the
endpoint until first use. This is useful in situations where the
connection is created when the remote service may temporarily not be
responding, such as server startup.

Fixes #167