### PR TITLE
fix(transport): Return connection error on `Channel::connect`

### DIFF
--- a/tests/integration_tests/tests/connection.rs
+++ b/tests/integration_tests/tests/connection.rs
@@ -1,0 +1,55 @@
+use futures_util::FutureExt;
+use integration_tests::pb::{test_client::TestClient, test_server, Input, Output};
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+use tokio::sync::oneshot;
+use tonic::{transport::Server, Request, Response, Status};
+
+#[tokio::test]
+async fn connect_returns_err() {
+    let res = TestClient::connect("http://thisdoesntexist").await;
+
+    assert!(res.is_err());
+}
+
+#[tokio::test]
+async fn connect_returns_err_via_call_after_connected() {
+    struct Svc(Arc<Mutex<Option<oneshot::Sender<()>>>>);
+
+    #[tonic::async_trait]
+    impl test_server::Test for Svc {
+        async fn unary_call(&self, _: Request<Input>) -> Result<Response<Output>, Status> {
+            let mut l = self.0.lock().unwrap();
+            l.take().unwrap().send(()).unwrap();
+
+            Ok(Response::new(Output {}))
+        }
+    }
+
+    let (tx, rx) = oneshot::channel();
+    let sender = Arc::new(Mutex::new(Some(tx)));
+    let svc = test_server::TestServer::new(Svc(sender));
+
+    let jh = tokio::spawn(async move {
+        Server::builder()
+            .add_service(svc)
+            .serve_with_shutdown("127.0.0.1:1338".parse().unwrap(), rx.map(drop))
+            .await
+            .unwrap();
+    });
+
+    tokio::time::delay_for(Duration::from_millis(100)).await;
+
+    let mut client = TestClient::connect("http://127.0.0.1:1338").await.unwrap();
+
+    // First call should pass, then shutdown the server
+    client.unary_call(Request::new(Input {})).await.unwrap();
+
+    tokio::time::delay_for(Duration::from_millis(100)).await;
+
+    let res = client.unary_call(Request::new(Input {})).await;
+
+    assert!(res.is_err());
+
+    jh.await.unwrap();
+}


### PR DESCRIPTION
Before this fix, if the connect phase of the transport failed before
ever establishing a connection, we would never return the error until
the first call to send a request. This PR changes that behavior to only
forward the error to the call method if we have ever made a connection
before. If we have never established a connection before then
`Reconnect` will return an error on the call to `poll_ready`.

Fixes #403
