### PR TITLE
doc(transport): improve connect_with_connector doc

### DIFF
--- a/tonic/src/transport/channel/endpoint.rs
+++ b/tonic/src/transport/channel/endpoint.rs
@@ -236,7 +236,7 @@ impl Endpoint {
     /// Connect with a custom connector.
     ///
     /// This allows you to build a [Channel](struct.Channel.html) that uses a non-HTTP transport.
-    /// See `/examples/src/uds/` for an example of how to use this function to build channel that
+    /// See the `uds` example for an example on how to use this function to build channel that
     /// uses a Unix socket transport.
     pub async fn connect_with_connector<C>(&self, connector: C) -> Result<Channel, Error>
     where

--- a/tonic/src/transport/channel/endpoint.rs
+++ b/tonic/src/transport/channel/endpoint.rs
@@ -234,6 +234,10 @@ impl Endpoint {
     }
 
     /// Connect with a custom connector.
+    ///
+    /// This allows you to build a [Channel](struct.Channel.html) that uses a non-HTTP transport.
+    /// See `/examples/src/uds/` for an example of how to use this function to build channel that
+    /// uses a Unix socket transport.
     pub async fn connect_with_connector<C>(&self, connector: C) -> Result<Channel, Error>
     where
         C: MakeConnection<Uri> + Send + 'static,


### PR DESCRIPTION
## Motivation

I was trying to understand a project that uses tonic and it was hard to understand exactly what connect_with_connector  (especially since you need to provide a bogus URL to use it). It wasn't until I landed on https://github.com/hyperium/tonic/pull/184 that I understood what was going on. I think the documentation is lacking a bit of context for that function.

## Solution

Added a bit of context to that function's documentation
