### PR TITLE
tonic-health: define explicit tonic-build features

### DIFF
--- a/tonic-health/Cargo.toml
+++ b/tonic-health/Cargo.toml
@@ -28,4 +28,4 @@ prost = "0.6"
 tokio = { version = "0.2", features = ["rt-core", "macros"]}
 
 [build-dependencies]
-tonic-build = { version = "0.3", path = "../tonic-build" }
+tonic-build = { version = "0.3", path = "../tonic-build", default-features = false, features = ["transport", "prost"] }


### PR DESCRIPTION
Explicitly defining tonic-health, tonic-build features, note that rustfmt got removed. The reason for removal is an unnecessary build dependency in musl nightly environments. 