### PR TITLE
fix(build): Add content-type for generated unimplemented service

### DIFF
--- a/tonic-build/src/server.rs
+++ b/tonic-build/src/server.rs
@@ -75,6 +75,7 @@ pub fn generate<T: Service>(service: &T, proto_path: &str) -> TokenStream {
                             Ok(http::Response::builder()
                                .status(200)
                                .header("grpc-status", "12")
+                               .header("content-type", "application/grpc")
                                .body(tonic::body::BoxBody::empty())
                                .unwrap())
                         }),


### PR DESCRIPTION
## Motivation

According to the spec content-type should be set. Related to https://github.com/hyperium/tonic/pull/434

## Solution

Add the application/grpc content-type header.
