### PR TITLE
fix(interop) fix failing interop test with go client

### DIFF
--- a/interop/src/server.rs
+++ b/interop/src/server.rs
@@ -215,11 +215,12 @@ where
             if let Some(echo_header) = echo_header {
                 res.headers_mut()
                     .insert("x-grpc-test-echo-initial", echo_header);
+                Ok(res
+                    .map(|b| MergeTrailers::new(b, echo_trailer))
+                    .map(BoxBody::new))
+            } else {
+                Ok(res)
             }
-
-            Ok(res
-                .map(|b| MergeTrailers::new(b, echo_trailer))
-                .map(BoxBody::new))
         })
     }
 }

--- a/interop/test.sh
+++ b/interop/test.sh
@@ -57,3 +57,9 @@ sleep 1
 --test_case=empty_unary,large_unary,client_streaming,server_streaming,ping_pong,\
 empty_stream,status_code_and_message,special_status_message,unimplemented_method,\
 unimplemented_service,custom_metadata ${ARG}
+
+# TODO: run all other test cases w/wo tls
+GO_CLIENT="interop/bin/client_${OS}_amd64${EXT}"
+
+$GO_CLIENT --test_case="status_code_and_message"
+$GO_CLIENT --test_case="custom_metadata"

--- a/interop/test.sh
+++ b/interop/test.sh
@@ -16,6 +16,7 @@ esac
 
 ARG="${1:-""}"
 
+
 (cd interop && cargo build --bins)
 
 SERVER="interop/bin/server_${OS}_amd64${EXT}"
@@ -58,8 +59,10 @@ sleep 1
 empty_stream,status_code_and_message,special_status_message,unimplemented_method,\
 unimplemented_service,custom_metadata ${ARG}
 
-# TODO: run all other test cases w/wo tls
-GO_CLIENT="interop/bin/client_${OS}_amd64${EXT}"
+if [ -z "${ARG}" ]; then
+  # TODO: run all other test cases w/wo tls
+  GO_CLIENT="interop/bin/client_${OS}_amd64${EXT}"
 
-$GO_CLIENT --test_case="status_code_and_message"
-$GO_CLIENT --test_case="custom_metadata"
+  $GO_CLIENT --test_case="status_code_and_message"
+  $GO_CLIENT --test_case="custom_metadata"
+fi


### PR DESCRIPTION
Fixes https://github.com/hyperium/tonic/issues/414.

As part of the fix, two interop test cases `go client -> rust server` were added. I will include the rest once https://github.com/hyperium/tonic/pull/440 gets merged.
