### PR TITLE
tonic-build: (docs) adds NixOS related hints

### DIFF
--- a/tonic-build/src/lib.rs
+++ b/tonic-build/src/lib.rs
@@ -40,6 +40,21 @@
 //!         )?;
 //!    Ok(())
 //! }
+//!
+//! ### NixOS related hints
+//!
+//! On NixOS, it is better to specify the location of `PROTOC` and `PROTOC_INCLUDE` explicitly.
+//!
+//! ```bash
+//! $ export PROTOBUF_LOCATION=$(nix-env -q protobuf --out-path --no-name)
+//! $ export PROTOC=$(PROTOBUF_LOCATION)/bin/protoc
+//! $ export PROTOC_INCLUDE=$(PROTOBUF_LOCATION)/include
+//! $ cargo build
+//! ```
+//!
+//! The reason being that if `prost_build::compile_protos` fails to generate the resultant package,
+//! the failure is not obvious until the `include!(concat!(env!("OUT_DIR"), "/resultant.rs"));`
+//! fails with `No such file or directory` error.
 //! ```
 
 #![recursion_limit = "256"]

--- a/tonic-build/src/lib.rs
+++ b/tonic-build/src/lib.rs
@@ -40,22 +40,22 @@
 //!         )?;
 //!    Ok(())
 //! }
+//!```
 //!
-//! ### NixOS related hints
+//! ## NixOS related hints
 //!
 //! On NixOS, it is better to specify the location of `PROTOC` and `PROTOC_INCLUDE` explicitly.
 //!
 //! ```bash
 //! $ export PROTOBUF_LOCATION=$(nix-env -q protobuf --out-path --no-name)
-//! $ export PROTOC=$(PROTOBUF_LOCATION)/bin/protoc
-//! $ export PROTOC_INCLUDE=$(PROTOBUF_LOCATION)/include
+//! $ export PROTOC=$PROTOBUF_LOCATION/bin/protoc
+//! $ export PROTOC_INCLUDE=$PROTOBUF_LOCATION/include
 //! $ cargo build
 //! ```
 //!
 //! The reason being that if `prost_build::compile_protos` fails to generate the resultant package,
 //! the failure is not obvious until the `include!(concat!(env!("OUT_DIR"), "/resultant.rs"));`
 //! fails with `No such file or directory` error.
-//! ```
 
 #![recursion_limit = "256"]
 #![warn(


### PR DESCRIPTION
For `prost`, on NixOS, it is better to explicitly define Protobuf related
environment variables `PROTOC` and `PROTOC_INCLUDE`.

## Motivation

On NixOS, `prost` will require explicit setting of environment variables 

- `PROTOC` 
- `PROTOC_INCLUDE`

## Solution

Documentation instructions are added in `tonic-build` crate per request of @LucioFranco. 