### PR TITLE
feat(tonic): Configure tls automatically when possible

### DIFF
--- a/tonic/src/transport/service/connector.rs
+++ b/tonic/src/transport/service/connector.rs
@@ -37,6 +37,26 @@ impl<C> Connector<C> {
     fn new(inner: C, tls: Option<TlsConnector>) -> Self {
         Self { inner, tls }
     }
+
+    #[cfg(feature = "tls-roots")]
+    fn tls_or_default(&self, scheme: Option<&str>, host: Option<&str>) -> Option<TlsConnector> {
+        use tokio_rustls::webpki::DNSNameRef;
+
+        if self.tls.is_some() {
+            return self.tls.clone();
+        }
+
+        match (scheme, host) {
+            (Some("https"), Some(host)) => {
+                if DNSNameRef::try_from_ascii(host.as_bytes()).is_ok() {
+                    TlsConnector::new_with_rustls_cert(None, None, host.to_owned()).ok()
+                } else {
+                    None
+                }
+            }
+            _ => None,
+        }
+    }
 }
 
 impl<C> Service<Uri> for Connector<C>
@@ -57,10 +77,13 @@ where
     }
 
     fn call(&mut self, uri: Uri) -> Self::Future {
-        let connect = self.inner.make_connection(uri);
-
-        #[cfg(feature = "tls")]
+        #[cfg(all(feature = "tls", not(feature = "tls-roots")))]
         let tls = self.tls.clone();
+
+        #[cfg(feature = "tls-roots")]
+        let tls = self.tls_or_default(uri.scheme_str(), uri.host());
+
+        let connect = self.inner.make_connection(uri);
 
         Box::pin(async move {
             let io = connect.await?;


### PR DESCRIPTION
This pr enables automatic tls configuration for clients, when certain conditions are met. It enables clients to connect to a tls server without explicitly creating a `ClientTlsConfig` struct and a `Channel`:

```rust
let mut client = GreeterClient::connect("https://example.com").await?;
// client is now usable
```
For the connector to attempt to add a default tls configuration:

* the `tls-roots` feature must be enabled
* the url passed to `connect` must have the https scheme
* the url passed to `connect` must have a valid domain name (ips are not supported)
* if the client is created with an explicit channel, the channel must not have tls configured.

If any of these conditions is not met,  then the behavior should be exactly as before.
There is some additional work needed to improve errors when connections fail. 

closes https://github.com/hyperium/tonic/issues/418
