### PR TITLE
fix(transport): Fix wrong doc for domain

### DIFF
--- a/tonic/src/transport/channel/tls.rs
+++ b/tonic/src/transport/channel/tls.rs
@@ -41,8 +41,6 @@ impl ClientTlsConfig {
     }
 
     /// Sets the domain name against which to verify the server's TLS certificate.
-    ///
-    /// This has no effect if `rustls_client_config` is used to configure Rustls.
     pub fn domain_name(self, domain_name: impl Into<String>) -> Self {
         ClientTlsConfig {
             domain: Some(domain_name.into()),


### PR DESCRIPTION
## Motivation

Both my test and function 'tls_connector' indicated 'domain_name' works for using `rustls_client_config` or not