### PR TITLE
feat(transport): add user-agent header to client requests.

### DIFF
--- a/tests/integration_tests/tests/user_agent.rs
+++ b/tests/integration_tests/tests/user_agent.rs
@@ -2,8 +2,7 @@ use futures_util::FutureExt;
 use integration_tests::pb::{test_client, test_server, Input, Output};
 use std::time::Duration;
 use tokio::sync::oneshot;
-use tonic::transport::Endpoint;
-use tonic::{transport::Server, Request, Response, Status};
+use tonic::{transport::Endpoint, transport::Server, Request, Response, Status};
 
 #[tokio::test]
 async fn writes_user_agent_header() {

--- a/tests/integration_tests/tests/user_agent.rs
+++ b/tests/integration_tests/tests/user_agent.rs
@@ -1,0 +1,53 @@
+use futures_util::FutureExt;
+use integration_tests::pb::{test_client, test_server, Input, Output};
+use std::time::Duration;
+use tokio::sync::oneshot;
+use tonic::transport::Endpoint;
+use tonic::{transport::Server, Request, Response, Status};
+
+#[tokio::test]
+async fn writes_user_agent_header() {
+    struct Svc;
+
+    #[tonic::async_trait]
+    impl test_server::Test for Svc {
+        async fn unary_call(&self, req: Request<Input>) -> Result<Response<Output>, Status> {
+            match req.metadata().get("user-agent") {
+                Some(_) => Ok(Response::new(Output {})),
+                None => Err(Status::internal("user-agent header is missing")),
+            }
+        }
+    }
+
+    let svc = test_server::TestServer::new(Svc);
+
+    let (tx, rx) = oneshot::channel::<()>();
+
+    let jh = tokio::spawn(async move {
+        Server::builder()
+            .add_service(svc)
+            .serve_with_shutdown("127.0.0.1:1322".parse().unwrap(), rx.map(drop))
+            .await
+            .unwrap();
+    });
+
+    tokio::time::delay_for(Duration::from_millis(100)).await;
+
+    let channel = Endpoint::from_static("http://127.0.0.1:1322")
+        .user_agent("my-client")
+        .expect("valid user agent")
+        .connect()
+        .await
+        .unwrap();
+
+    let mut client = test_client::TestClient::new(channel);
+
+    match client.unary_call(Input {}).await {
+        Ok(_) => {}
+        Err(status) => panic!("{}", status.message()),
+    }
+
+    tx.send(()).unwrap();
+
+    jh.await.unwrap();
+}

--- a/tests/integration_tests/tests/user_agent.rs
+++ b/tests/integration_tests/tests/user_agent.rs
@@ -2,7 +2,10 @@ use futures_util::FutureExt;
 use integration_tests::pb::{test_client, test_server, Input, Output};
 use std::time::Duration;
 use tokio::sync::oneshot;
-use tonic::{transport::Endpoint, transport::Server, Request, Response, Status};
+use tonic::{
+    transport::{Endpoint, Server},
+    Request, Response, Status,
+};
 
 #[tokio::test]
 async fn writes_user_agent_header() {

--- a/tonic/src/transport/channel/endpoint.rs
+++ b/tonic/src/transport/channel/endpoint.rs
@@ -6,8 +6,10 @@ use super::ClientTlsConfig;
 use crate::transport::service::TlsConnector;
 use crate::transport::Error;
 use bytes::Bytes;
-use http::uri::{InvalidUri, Uri};
-use http::HeaderValue;
+use http::{
+    uri::{InvalidUri, Uri},
+    HeaderValue,
+};
 use std::{
     convert::{TryFrom, TryInto},
     fmt,

--- a/tonic/src/transport/error.rs
+++ b/tonic/src/transport/error.rs
@@ -21,6 +21,7 @@ struct ErrorImpl {
 pub(crate) enum Kind {
     Transport,
     InvalidUri,
+    InvalidUserAgent,
 }
 
 impl Error {
@@ -43,10 +44,15 @@ impl Error {
         Error::new(Kind::InvalidUri)
     }
 
+    pub(crate) fn new_invalid_user_agent() -> Self {
+        Error::new(Kind::InvalidUserAgent)
+    }
+
     fn description(&self) -> &str {
         match &self.inner.kind {
             Kind::Transport => "transport error",
             Kind::InvalidUri => "invalid URI",
+            Kind::InvalidUserAgent => "user agent is not a valid header value",
         }
     }
 }

--- a/tonic/src/transport/service/connection.rs
+++ b/tonic/src/transport/service/connection.rs
@@ -1,4 +1,4 @@
-use super::{layer::ServiceBuilderExt, reconnect::Reconnect, AddOrigin};
+use super::{layer::ServiceBuilderExt, reconnect::Reconnect, AddOrigin, UserAgent};
 use crate::{body::BoxBody, transport::Endpoint};
 use http::Uri;
 use hyper::client::conn::Builder;
@@ -55,6 +55,7 @@ impl Connection {
 
         let stack = ServiceBuilder::new()
             .layer_fn(|s| AddOrigin::new(s, endpoint.uri.clone()))
+            .layer_fn(|s| UserAgent::new(s, endpoint.user_agent.clone()))
             .optional_layer(endpoint.timeout.map(TimeoutLayer::new))
             .optional_layer(endpoint.concurrency_limit.map(ConcurrencyLimitLayer::new))
             .optional_layer(endpoint.rate_limit.map(|(l, d)| RateLimitLayer::new(l, d)))

--- a/tonic/src/transport/service/mod.rs
+++ b/tonic/src/transport/service/mod.rs
@@ -8,6 +8,7 @@ mod reconnect;
 mod router;
 #[cfg(feature = "tls")]
 mod tls;
+mod user_agent;
 
 pub(crate) use self::add_origin::AddOrigin;
 pub(crate) use self::connection::Connection;
@@ -18,3 +19,4 @@ pub(crate) use self::layer::ServiceBuilderExt;
 pub(crate) use self::router::{Or, Routes};
 #[cfg(feature = "tls")]
 pub(crate) use self::tls::{TlsAcceptor, TlsConnector};
+pub(crate) use self::user_agent::UserAgent;

--- a/tonic/src/transport/service/user_agent.rs
+++ b/tonic/src/transport/service/user_agent.rs
@@ -1,0 +1,47 @@
+use http::{header::USER_AGENT, HeaderValue, Request};
+use std::task::{Context, Poll};
+use tower_service::Service;
+
+const TONIC_USER_AGENT: &str = concat!("tonic/", env!("CARGO_PKG_VERSION"));
+
+#[derive(Debug)]
+pub(crate) struct UserAgent<T> {
+    inner: T,
+    user_agent: Option<HeaderValue>,
+}
+
+impl<T> UserAgent<T> {
+    pub(crate) fn new(inner: T, user_agent: Option<HeaderValue>) -> Self {
+        Self { inner, user_agent }
+    }
+}
+
+impl<T, ReqBody> Service<Request<ReqBody>> for UserAgent<T>
+where
+    T: Service<Request<ReqBody>>,
+{
+    type Response = T::Response;
+    type Error = T::Error;
+    type Future = T::Future;
+
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.inner.poll_ready(cx)
+    }
+
+    fn call(&mut self, mut req: Request<ReqBody>) -> Self::Future {
+        let value = match self.user_agent.as_ref() {
+            Some(custom_ua) => {
+                let mut buf = Vec::new();
+                buf.extend(custom_ua.as_bytes());
+                buf.push(b' ');
+                buf.extend(TONIC_USER_AGENT.as_bytes());
+                HeaderValue::from_bytes(&buf).expect("user-agent should be valid")
+            }
+            None => HeaderValue::from_static(TONIC_USER_AGENT),
+        };
+
+        req.headers_mut().insert(USER_AGENT, value);
+
+        self.inner.call(req)
+    }
+}

--- a/tonic/src/transport/service/user_agent.rs
+++ b/tonic/src/transport/service/user_agent.rs
@@ -7,11 +7,21 @@ const TONIC_USER_AGENT: &str = concat!("tonic/", env!("CARGO_PKG_VERSION"));
 #[derive(Debug)]
 pub(crate) struct UserAgent<T> {
     inner: T,
-    user_agent: Option<HeaderValue>,
+    user_agent: HeaderValue,
 }
 
 impl<T> UserAgent<T> {
     pub(crate) fn new(inner: T, user_agent: Option<HeaderValue>) -> Self {
+        let user_agent = user_agent
+            .map(|value| {
+                let mut buf = Vec::new();
+                buf.extend(value.as_bytes());
+                buf.push(b' ');
+                buf.extend(TONIC_USER_AGENT.as_bytes());
+                HeaderValue::from_bytes(&buf).expect("user-agent should be valid")
+            })
+            .unwrap_or(HeaderValue::from_static(TONIC_USER_AGENT));
+
         Self { inner, user_agent }
     }
 }
@@ -29,18 +39,8 @@ where
     }
 
     fn call(&mut self, mut req: Request<ReqBody>) -> Self::Future {
-        let value = match self.user_agent.as_ref() {
-            Some(custom_ua) => {
-                let mut buf = Vec::new();
-                buf.extend(custom_ua.as_bytes());
-                buf.push(b' ');
-                buf.extend(TONIC_USER_AGENT.as_bytes());
-                HeaderValue::from_bytes(&buf).expect("user-agent should be valid")
-            }
-            None => HeaderValue::from_static(TONIC_USER_AGENT),
-        };
-
-        req.headers_mut().insert(USER_AGENT, value);
+        req.headers_mut()
+            .insert(USER_AGENT, self.user_agent.clone());
 
         self.inner.call(req)
     }

--- a/tonic/src/transport/service/user_agent.rs
+++ b/tonic/src/transport/service/user_agent.rs
@@ -45,3 +45,26 @@ where
         self.inner.call(req)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    struct Svc;
+
+    #[test]
+    fn sets_default_if_no_custom_user_agent() {
+        assert_eq!(
+            UserAgent::new(Svc, None).user_agent,
+            HeaderValue::from_static(TONIC_USER_AGENT)
+        )
+    }
+
+    #[test]
+    fn prepends_custom_user_agent_to_default() {
+        assert_eq!(
+            UserAgent::new(Svc, Some(HeaderValue::from_static("Greeter 1.1"))).user_agent,
+            HeaderValue::from_str(&format!("Greeter 1.1 {}", TONIC_USER_AGENT)).unwrap()
+        )
+    }
+}


### PR DESCRIPTION
This PR adds a  user-agent header to client requests. The default value is `tonic/x.x.x`. The value can be configured through the `Channel` builder.

```rust
Endpoint::from_static("...").user_agent("Greeter 1.1")?.connect();
```

The value passed to the `user_agent` method will be prepended to the default, in this case the full value will be: `Greeter 1.1 tonic/0.3.1`.

The header is added by a new `UserAgent` layer in the client's service stack. While this is not the most straight forward implementation, it seemed to be the cleanest and safest one. It also aligns better with other client implementations (grpc-go clients, in particular).

**Alternatives**
* Remove `user-agent` from the list of grpc reserved headers.
* Do not filter out the `user-agent` header in tonic <-> http request conversions.
* Sniff the request after passing it to the interceptor fn to see if user-agent was set, pluck it out and add it manually after mapping the request.
* Move the optional header  from the `Endpoint` to the `client::Grpc` struct and set the header after converting the request.
* Don't set user-agent headers at all.

...and maybe others. 
  
fixes #453

