### PR TITLE
Endpoint::lazy_connect always tries to reconnect

### DIFF
--- a/tonic/src/transport/channel/endpoint.rs
+++ b/tonic/src/transport/channel/endpoint.rs
@@ -215,7 +215,8 @@ impl Endpoint {
         #[cfg(not(feature = "tls"))]
         let connector = service::connector(http);
 
-        Channel::connect(connector, self.clone()).await
+        let always_reconnect = false;
+        Channel::connect(connector, self.clone(), always_reconnect).await
     }
 
     /// Create a channel from this config.
@@ -234,7 +235,8 @@ impl Endpoint {
         #[cfg(not(feature = "tls"))]
         let connector = service::connector(http);
 
-        Channel::new(connector, self.clone())
+        let always_reconnect = true;
+        Channel::new(connector, self.clone(), always_reconnect)
     }
 
     /// Connect with a custom connector.
@@ -255,7 +257,8 @@ impl Endpoint {
         #[cfg(not(feature = "tls"))]
         let connector = service::connector(connector);
 
-        Channel::connect(connector, self.clone()).await
+        let always_reconnect = false;
+        Channel::connect(connector, self.clone(), always_reconnect).await
     }
 
     /// Get the endpoint uri.

--- a/tonic/src/transport/service/discover.rs
+++ b/tonic/src/transport/service/discover.rs
@@ -64,7 +64,8 @@ impl<K: Hash + Eq + Clone> Discover for DynamicServiceStream<K> {
 
                         #[cfg(not(feature = "tls"))]
                         let connector = service::connector(http);
-                        let fut = Connection::connect(connector, endpoint);
+                        let always_reconnect = false;
+                        let fut = Connection::connect(connector, endpoint, always_reconnect);
                         self.connecting = Some((k, Box::pin(fut)));
                         continue;
                     }

--- a/tonic/src/transport/service/reconnect.rs
+++ b/tonic/src/transport/service/reconnect.rs
@@ -32,13 +32,15 @@ impl<M, Target> Reconnect<M, Target>
 where
     M: Service<Target>,
 {
-    pub(crate) fn new(mk_service: M, target: Target) -> Self {
+    pub(crate) fn new(mk_service: M, target: Target, always_reconnect: bool) -> Self {
         Reconnect {
             mk_service,
             state: State::Idle,
             target,
             error: None,
-            has_been_connected: false,
+            // If true, it makes sure that a failure (if any) on the first connection attempt
+            // will not result in an error, and we will keep trying reconnecting.
+            has_been_connected: always_reconnect,
         }
     }
 }


### PR DESCRIPTION
When a connection could not be established on first connection
attempt, an error was reported and the connection never tried to  reconnect.
This behaviour is kept for `Endpoint::connect` and changed for
`Endpoint::lazy_connect`.

## Motivation

The behaviour to fail on the first attempt was introduced in #413.
This makes tonic clients behave two-fold:

1. If a client fails at the first connection attempt, the connection is broken
and it will never try to reconnect.
2. If a client connected successfully at the first attempt, but later the connection
breaks, the client will resiliently try to reconnect.

As explained in #413 and #403, the behaviour in 1 is sometimes needed, however
there is another use case where the server we are connecting to is not yet up. 
When connecting lazily, we expect the connection to
be always resilient, since we move the actual connection attempt to a later
point in time.

## Solution

* Keep the error reporting behaviour in `Endpoint::connect`.
* Keep the resilient behaviour in `Endpoint::connect_lazy`.

## Note

I would appreciate a proposal if there is a better way to achieve resilient initial reconnect. Also, I am not very happy to propagate the `always_reconnect` flag through several layers, but do not see a better way to do it.