### PR TITLE
Custom codec

### DIFF
--- a/tonic-build/src/client.rs
+++ b/tonic-build/src/client.rs
@@ -119,7 +119,7 @@ fn generate_methods<T: Service>(service: &T, proto_path: &str) -> TokenStream {
 }
 
 fn generate_unary<T: Method>(method: &T, proto_path: &str, path: String) -> TokenStream {
-    let codec_name = syn::parse_str::<syn::Path>(T::CODEC_PATH).unwrap();
+    let codec_name = syn::parse_str::<syn::Path>(method.codec_path()).unwrap();
     let ident = format_ident!("{}", method.name());
     let (request, response) = method.request_response_name(proto_path);
 
@@ -132,14 +132,14 @@ fn generate_unary<T: Method>(method: &T, proto_path: &str, path: String) -> Toke
                         tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
             })?;
             let codec = #codec_name::default();
-           let path = http::uri::PathAndQuery::from_static(#path);
-           self.inner.unary(request.into_request(), path, codec).await
+            let path = http::uri::PathAndQuery::from_static(#path);
+            self.inner.unary(request.into_request(), path, codec).await
         }
     }
 }
 
 fn generate_server_streaming<T: Method>(method: &T, proto_path: &str, path: String) -> TokenStream {
-    let codec_name = syn::parse_str::<syn::Path>(T::CODEC_PATH).unwrap();
+    let codec_name = syn::parse_str::<syn::Path>(method.codec_path()).unwrap();
     let ident = format_ident!("{}", method.name());
 
     let (request, response) = method.request_response_name(proto_path);
@@ -153,14 +153,14 @@ fn generate_server_streaming<T: Method>(method: &T, proto_path: &str, path: Stri
                         tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
             })?;
             let codec = #codec_name::default();
-           let path = http::uri::PathAndQuery::from_static(#path);
-           self.inner.server_streaming(request.into_request(), path, codec).await
+            let path = http::uri::PathAndQuery::from_static(#path);
+            self.inner.server_streaming(request.into_request(), path, codec).await
         }
     }
 }
 
 fn generate_client_streaming<T: Method>(method: &T, proto_path: &str, path: String) -> TokenStream {
-    let codec_name = syn::parse_str::<syn::Path>(T::CODEC_PATH).unwrap();
+    let codec_name = syn::parse_str::<syn::Path>(method.codec_path()).unwrap();
     let ident = format_ident!("{}", method.name());
 
     let (request, response) = method.request_response_name(proto_path);
@@ -181,7 +181,7 @@ fn generate_client_streaming<T: Method>(method: &T, proto_path: &str, path: Stri
 }
 
 fn generate_streaming<T: Method>(method: &T, proto_path: &str, path: String) -> TokenStream {
-    let codec_name = syn::parse_str::<syn::Path>(T::CODEC_PATH).unwrap();
+    let codec_name = syn::parse_str::<syn::Path>(method.codec_path()).unwrap();
     let ident = format_ident!("{}", method.name());
 
     let (request, response) = method.request_response_name(proto_path);
@@ -195,8 +195,8 @@ fn generate_streaming<T: Method>(method: &T, proto_path: &str, path: String) -> 
                         tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
             })?;
             let codec = #codec_name::default();
-           let path = http::uri::PathAndQuery::from_static(#path);
-           self.inner.streaming(request.into_streaming_request(), path, codec).await
+            let path = http::uri::PathAndQuery::from_static(#path);
+            self.inner.streaming(request.into_streaming_request(), path, codec).await
         }
     }
 }

--- a/tonic-build/src/lib.rs
+++ b/tonic-build/src/lib.rs
@@ -103,15 +103,14 @@ pub mod server;
 /// to allow any codegen module to generate service
 /// abstractions.
 pub trait Service {
-    /// Path to the codec.
-    const CODEC_PATH: &'static str;
-
     /// Comment type.
     type Comment: AsRef<str>;
 
     /// Method type.
     type Method: Method;
 
+    /// Path to the codec.
+    fn codec_path(&self) -> &str;
     /// Name of service.
     fn name(&self) -> &str;
     /// Package name of service.
@@ -131,11 +130,11 @@ pub trait Service {
 /// to generate abstraction implementations for
 /// the provided methods.
 pub trait Method {
-    /// Path to the codec.
-    const CODEC_PATH: &'static str;
     /// Comment type.
     type Comment: AsRef<str>;
 
+    /// Path to the codec.
+    fn codec_path(&self) -> &str;
     /// Name of method.
     fn name(&self) -> &str;
     /// Identifier used to generate type name.

--- a/tonic-build/src/prost.rs
+++ b/tonic-build/src/prost.rs
@@ -58,10 +58,14 @@ impl Service {
             package: service.package,
             proto_name: service.proto_name,
             comments: service.comments.leading,
-            methods: service.methods.into_iter().map(|v| Method {
-                inner: v,
-                codec_path: codec_path.clone()
-            }).collect(),
+            methods: service
+                .methods
+                .into_iter()
+                .map(|v| Method {
+                    inner: v,
+                    codec_path: codec_path.clone(),
+                })
+                .collect(),
             codec_path,
         }
     }

--- a/tonic-build/src/prost.rs
+++ b/tonic-build/src/prost.rs
@@ -42,10 +42,13 @@ pub fn compile_protos(proto: impl AsRef<Path>) -> io::Result<()> {
 const PROST_CODEC_PATH: &'static str = "tonic::codec::ProstCodec";
 
 impl crate::Service for Service {
-    const CODEC_PATH: &'static str = PROST_CODEC_PATH;
 
     type Method = Method;
     type Comment = String;
+
+    fn codec_path(&self) -> &str {
+        PROST_CODEC_PATH
+    }
 
     fn name(&self) -> &str {
         &self.name
@@ -69,8 +72,11 @@ impl crate::Service for Service {
 }
 
 impl crate::Method for Method {
-    const CODEC_PATH: &'static str = PROST_CODEC_PATH;
     type Comment = String;
+
+    fn codec_path(&self) -> &str {
+        PROST_CODEC_PATH
+    }
 
     fn name(&self) -> &str {
         &self.name

--- a/tonic-build/src/prost.rs
+++ b/tonic-build/src/prost.rs
@@ -62,7 +62,7 @@ impl Service {
                 inner: v,
                 codec_path: codec_path.clone()
             }).collect(),
-            codec_path: codec_path.clone(),
+            codec_path,
         }
     }
 }

--- a/tonic-build/src/server.rs
+++ b/tonic-build/src/server.rs
@@ -261,7 +261,7 @@ fn generate_unary<T: Method>(
     method_ident: Ident,
     server_trait: Ident,
 ) -> TokenStream {
-    let codec_name = syn::parse_str::<syn::Path>(T::CODEC_PATH).unwrap();
+    let codec_name = syn::parse_str::<syn::Path>(method.codec_path()).unwrap();
 
     let service_ident = quote::format_ident!("{}Svc", method.identifier());
 
@@ -311,7 +311,7 @@ fn generate_server_streaming<T: Method>(
     method_ident: Ident,
     server_trait: Ident,
 ) -> TokenStream {
-    let codec_name = syn::parse_str::<syn::Path>(T::CODEC_PATH).unwrap();
+    let codec_name = syn::parse_str::<syn::Path>(method.codec_path()).unwrap();
 
     let service_ident = quote::format_ident!("{}Svc", method.identifier());
 
@@ -368,7 +368,7 @@ fn generate_client_streaming<T: Method>(
     let service_ident = quote::format_ident!("{}Svc", method.identifier());
 
     let (request, response) = method.request_response_name(proto_path);
-    let codec_name = syn::parse_str::<syn::Path>(T::CODEC_PATH).unwrap();
+    let codec_name = syn::parse_str::<syn::Path>(method.codec_path()).unwrap();
 
     quote! {
         #[allow(non_camel_case_types)]
@@ -416,7 +416,7 @@ fn generate_streaming<T: Method>(
     method_ident: Ident,
     server_trait: Ident,
 ) -> TokenStream {
-    let codec_name = syn::parse_str::<syn::Path>(T::CODEC_PATH).unwrap();
+    let codec_name = syn::parse_str::<syn::Path>(method.codec_path()).unwrap();
 
     let service_ident = quote::format_ident!("{}Svc", method.identifier());
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/hyperium/tonic/blob/master/CONTRIBUTING.md
-->

## Motivation

Allow the user to specify a custom prost codec implementation.

My use-case is to provide application-layer encryption, by (en/de)crypting the messages at serialization time, before writing them to the wire. Other use-cases include serializing as JSON instead of ProtoBuf (once support for it lands in prost).

## Solution

The idea is to allow the user to specify a path to their codec implementation, e.g. 

```rust
    tonic_crypto_build::configure()
        .codec_path("crate::MyCodec")
        .compile(&protos, &["proto".into()])
        .unwrap();
```

This is technically a breaking change, as it requires moving `Method::CODEC_PATH` to be a method instead. It's probably possible to avoid the breaking change (by leaving `CODEC_PATH`, and making `codec_path` have a default implementation returning `CODEC_PATH`), but since a 0.7 version seems to be in the work, I assume a breaking change isn't a big problem.