### PR TITLE
fix(build): Match namespace code with other generated packages

### DIFF
--- a/tonic-build/src/server.rs
+++ b/tonic-build/src/server.rs
@@ -18,7 +18,16 @@ pub fn generate<T: Service>(service: &T, proto_path: &str) -> TokenStream {
     let service_doc = generate_doc_comments(service.comment());
 
     // Transport based implementations
-    let path = format!("{}.{}", service.package(), service.identifier());
+    let path = format!(
+        "{}{}{}",
+        service.package(),
+        if service.package().is_empty() {
+            ""
+        } else {
+            "."
+        },
+        service.identifier()
+    );
     let transport = generate_transport(&server_service, &server_trait, &path);
 
     quote! {


### PR DESCRIPTION
## Motivation
I submitted a pr earlier that made it so that when prost supports protobufs without a package spec that tonic will already support it. Because prost doesn't actually support the feature I can't see a way to test the functionality. I just tried spinning up a server and had an issue with the implementation of the `NamedService` trait in hyper where it wasn't respecting the package spec. This is a fix for that.

## Solution
If the package is empty then don't add a preceding `.` to the namespace.