### PR TITLE
Gzip decompression

### DIFF
--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -139,7 +139,7 @@ name = "hyper-warp-multiplex-server"
 path = "src/hyper_warp_multiplex/server.rs"
 
 [dependencies]
-tonic = { path = "../tonic", features = ["tls"] }
+tonic = { path = "../tonic", features = ["tls", "gzip"] }
 prost = "0.6"
 tokio = { version = "0.2", features = ["rt-threaded", "time", "stream", "fs", "macros", "uds"] }
 futures = { version = "0.3", default-features = false, features = ["alloc"] }

--- a/tonic/Cargo.toml
+++ b/tonic/Cargo.toml
@@ -36,6 +36,7 @@ transport = [
 tls = ["transport", "tokio-rustls"]
 tls-roots = ["tls", "rustls-native-certs"]
 prost = ["prost1", "prost-derive"]
+gzip = ["flate2"]
 
 # [[bench]]
 # name = "bench_main"
@@ -48,6 +49,8 @@ futures-util = { version = "0.3", default-features = false }
 tracing = "0.1"
 http = "0.2"
 base64 = "0.12"
+flate2 = { version = "1.0", optional = true }
+once_cell = "1.0"
 
 percent-encoding = "2.0"
 tower-service = "0.3"

--- a/tonic/Cargo.toml
+++ b/tonic/Cargo.toml
@@ -92,4 +92,3 @@ rustdoc-args = ["--cfg", "docsrs"]
 [[bench]]
 name = "decode"
 harness = false
-

--- a/tonic/benches/decode.rs
+++ b/tonic/benches/decode.rs
@@ -19,7 +19,7 @@ macro_rules! bench {
                 .build()
                 .expect("runtime");
 
-            let payload = make_payload($message_size, $message_count, &$encoding);
+            let payload = make_payload($message_size, $message_count, $encoding);
             let body = MockBody::new(payload, $chunk_size);
             b.bytes = body.len() as u64;
 
@@ -27,7 +27,7 @@ macro_rules! bench {
                 rt.block_on(async {
                     let decoder = MockDecoder::new($message_size);
 
-                    let decompression = Decompression::new($encoding);
+                    let decompression = Decompression::from_encoding($encoding);
                     let mut stream = Streaming::new_request(decoder, body.clone(), decompression);
 
                     let mut count = 0;
@@ -113,7 +113,7 @@ impl Decoder for MockDecoder {
     }
 }
 
-fn make_payload(message_length: usize, message_count: usize, encoding: &Option<String>) -> Bytes {
+fn make_payload(message_length: usize, message_count: usize, encoding: Option<&str>) -> Bytes {
     let mut buf = BytesMut::new();
 
     let raw_msg = vec![97u8; message_length];
@@ -166,14 +166,14 @@ bench!(message_count_10, 500, 505, 10);
 bench!(message_count_20, 500, 505, 20);
 
 // gzip change body chunk size only
-bench!(chunk_size_100_gzip, 1_000, 100, 1, Some("gzip".to_string()));
-bench!(chunk_size_500_gzip, 1_000, 500, 1, Some("gzip".to_string()));
+bench!(chunk_size_100_gzip, 1_000, 100, 1, Some("gzip"));
+bench!(chunk_size_500_gzip, 1_000, 500, 1, Some("gzip"));
 bench!(
     chunk_size_1005_gzip,
     1_000,
     1_005,
     1,
-    Some("gzip".to_string())
+    Some("gzip")
 );
 
 // gzip change message size only
@@ -182,38 +182,38 @@ bench!(
     1_000,
     1_005,
     2,
-    Some("gzip".to_string())
+    Some("gzip")
 );
 bench!(
     message_size_5k_gzip,
     5_000,
     1_005,
     2,
-    Some("gzip".to_string())
+    Some("gzip")
 );
 bench!(
     message_size_10k_gzip,
     10_000,
     1_005,
     2,
-    Some("gzip".to_string())
+    Some("gzip")
 );
 
 // gzip change message count only
-bench!(message_count_1_gzip, 500, 505, 1, Some("gzip".to_string()));
+bench!(message_count_1_gzip, 500, 505, 1, Some("gzip"));
 bench!(
     message_count_10_gzip,
     500,
     505,
     10,
-    Some("gzip".to_string())
+    Some("gzip")
 );
 bench!(
     message_count_20_gzip,
     500,
     505,
     20,
-    Some("gzip".to_string())
+    Some("gzip")
 );
 
 benchmark_group!(chunk_size, chunk_size_100, chunk_size_500, chunk_size_1005);

--- a/tonic/benches/decode.rs
+++ b/tonic/benches/decode.rs
@@ -168,53 +168,17 @@ bench!(message_count_20, 500, 505, 20);
 // gzip change body chunk size only
 bench!(chunk_size_100_gzip, 1_000, 100, 1, Some("gzip"));
 bench!(chunk_size_500_gzip, 1_000, 500, 1, Some("gzip"));
-bench!(
-    chunk_size_1005_gzip,
-    1_000,
-    1_005,
-    1,
-    Some("gzip")
-);
+bench!(chunk_size_1005_gzip, 1_000, 1_005, 1, Some("gzip"));
 
 // gzip change message size only
-bench!(
-    message_size_1k_gzip,
-    1_000,
-    1_005,
-    2,
-    Some("gzip")
-);
-bench!(
-    message_size_5k_gzip,
-    5_000,
-    1_005,
-    2,
-    Some("gzip")
-);
-bench!(
-    message_size_10k_gzip,
-    10_000,
-    1_005,
-    2,
-    Some("gzip")
-);
+bench!(message_size_1k_gzip, 1_000, 1_005, 2, Some("gzip"));
+bench!(message_size_5k_gzip, 5_000, 1_005, 2, Some("gzip"));
+bench!(message_size_10k_gzip, 10_000, 1_005, 2, Some("gzip"));
 
 // gzip change message count only
 bench!(message_count_1_gzip, 500, 505, 1, Some("gzip"));
-bench!(
-    message_count_10_gzip,
-    500,
-    505,
-    10,
-    Some("gzip")
-);
-bench!(
-    message_count_20_gzip,
-    500,
-    505,
-    20,
-    Some("gzip")
-);
+bench!(message_count_10_gzip, 500, 505, 10, Some("gzip"));
+bench!(message_count_20_gzip, 500, 505, 20, Some("gzip"));
 
 benchmark_group!(chunk_size, chunk_size_100, chunk_size_500, chunk_size_1005);
 

--- a/tonic/benches/decode.rs
+++ b/tonic/benches/decode.rs
@@ -19,7 +19,7 @@ macro_rules! bench {
                 .build()
                 .expect("runtime");
 
-            let payload = make_payload($message_size, $message_count);
+            let payload = make_payload($message_size, $message_count, $encoding);
             let body = MockBody::new(payload, $chunk_size);
             b.bytes = body.len() as u64;
 
@@ -113,13 +113,16 @@ impl Decoder for MockDecoder {
     }
 }
 
-fn make_payload(message_length: usize, message_count: usize) -> Bytes {
+fn make_payload(message_length: usize, message_count: usize, encoding: Option<String>) -> Bytes {
     let mut buf = BytesMut::new();
 
     for _ in 0..message_count {
         let msg = vec![97u8; message_length];
         buf.reserve(msg.len() + 5);
-        buf.put_u8(0);
+        buf.put_u8(match encoding {
+            Some(_) => 1,
+            None => 0,
+        });
         buf.put_u32(msg.len() as u32);
         buf.put(&msg[..]);
     }

--- a/tonic/benches/decode.rs
+++ b/tonic/benches/decode.rs
@@ -122,7 +122,8 @@ fn make_payload(message_length: usize, message_count: usize, encoding: &Option<S
         #[cfg(feature = "gzip")]
         Some(encoding) if encoding == "gzip" => {
             use bytes::buf::BufMutExt;
-            let mut reader = flate2::read::GzEncoder::new(&raw_msg[..], flate2::Compression::best());
+            let mut reader =
+                flate2::read::GzEncoder::new(&raw_msg[..], flate2::Compression::best());
             let mut writer = BytesMut::new().writer();
 
             std::io::copy(&mut reader, &mut writer).expect("copy");
@@ -133,14 +134,15 @@ fn make_payload(message_length: usize, message_count: usize, encoding: &Option<S
             msg_buf.put(&raw_msg[..]);
             msg_buf
         }
-        Some(encoding) => {
-            panic!("Encoding {} isn't supported", encoding)
-        }
+        Some(encoding) => panic!("Encoding {} isn't supported", encoding),
     };
 
     for _ in 0..message_count {
         buf.reserve(msg_buf.len() + 5);
-        buf.put_u8(match encoding { Some(_) => 1, None => 0});
+        buf.put_u8(match encoding {
+            Some(_) => 1,
+            None => 0,
+        });
         buf.put_u32(msg_buf.len() as u32);
         buf.put(&msg_buf[..]);
     }
@@ -262,8 +264,4 @@ benchmark_main!(
 );
 
 #[cfg(not(feature = "gzip"))]
-benchmark_main!(
-    chunk_size,
-    message_size,
-    message_count
-);
+benchmark_main!(chunk_size, message_size, message_count);

--- a/tonic/src/client/grpc.rs
+++ b/tonic/src/client/grpc.rs
@@ -165,7 +165,7 @@ impl<T> Grpc<T> {
             .map(BoxBody::new);
 
         let mut request = request.into_http(uri);
-        compression.set_headers(request.headers_mut());
+        compression.set_headers(request.headers_mut(), true);
 
         // Add the gRPC related HTTP headers
         request

--- a/tonic/src/client/grpc.rs
+++ b/tonic/src/client/grpc.rs
@@ -1,7 +1,7 @@
 use crate::{
     body::{Body, BoxBody},
     client::GrpcService,
-    codec::{encode_client, Codec, Streaming},
+    codec::{encode_client, Codec, Decompression, Streaming},
     interceptor::Interceptor,
     Code, Request, Response, Status,
 };
@@ -196,9 +196,10 @@ impl<T> Grpc<T> {
             true
         };
 
+        let decompression = Decompression::from_headers(response.headers());
         let response = response.map(|body| {
             if expect_additional_trailers {
-                Streaming::new_response(codec.decoder(), body, status_code)
+                Streaming::new_response(codec.decoder(), body, status_code, decompression)
             } else {
                 Streaming::new_empty(codec.decoder(), body)
             }

--- a/tonic/src/client/grpc.rs
+++ b/tonic/src/client/grpc.rs
@@ -159,11 +159,13 @@ impl<T> Grpc<T> {
 
         let uri = Uri::from_parts(parts).expect("path_and_query only is valid Uri");
 
+        let compression = Compression::disabled();
         let request = request
-            .map(|s| encode_client(codec.encoder(), s, Compression::new_request()))
+            .map(|s| encode_client(codec.encoder(), s, compression.clone()))
             .map(BoxBody::new);
 
         let mut request = request.into_http(uri);
+        compression.set_headers(request.headers_mut());
 
         // Add the gRPC related HTTP headers
         request

--- a/tonic/src/client/grpc.rs
+++ b/tonic/src/client/grpc.rs
@@ -1,7 +1,7 @@
 use crate::{
     body::{Body, BoxBody},
     client::GrpcService,
-    codec::{encode_client, Codec, Decompression, Streaming},
+    codec::{encode_client, Codec, Compression, Decompression, Streaming},
     interceptor::Interceptor,
     Code, Request, Response, Status,
 };
@@ -160,7 +160,7 @@ impl<T> Grpc<T> {
         let uri = Uri::from_parts(parts).expect("path_and_query only is valid Uri");
 
         let request = request
-            .map(|s| encode_client(codec.encoder(), s))
+            .map(|s| encode_client(codec.encoder(), s, Compression::new_request()))
             .map(BoxBody::new);
 
         let mut request = request.into_http(uri);

--- a/tonic/src/codec/compression/bufwriter.rs
+++ b/tonic/src/codec/compression/bufwriter.rs
@@ -8,6 +8,7 @@ pub(crate) struct Writer<'a, B> {
     buf: &'a mut B,
 }
 
+#[cfg(feature = "gzip")]
 pub(crate) fn new<'a, B>(buf: &'a mut B) -> Writer<'a, B> {
     Writer { buf }
 }

--- a/tonic/src/codec/compression/bufwriter.rs
+++ b/tonic/src/codec/compression/bufwriter.rs
@@ -1,0 +1,26 @@
+use bytes::BufMut;
+
+use std::{cmp, io};
+
+/// A `BufMut` adapter which implements `io::Write` for the inner value.
+#[derive(Debug)]
+pub(crate) struct Writer<'a, B> {
+    buf: &'a mut B,
+}
+
+pub(crate) fn new<'a, B>(buf: &'a mut B) -> Writer<'a, B> {
+    Writer { buf }
+}
+
+impl<'a, B: BufMut + Sized> io::Write for Writer<'a, B> {
+    fn write(&mut self, src: &[u8]) -> io::Result<usize> {
+        let n = cmp::min(self.buf.remaining_mut(), src.len());
+
+        self.buf.put(&src[0..n]);
+        Ok(n)
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        Ok(())
+    }
+}

--- a/tonic/src/codec/compression/compression.rs
+++ b/tonic/src/codec/compression/compression.rs
@@ -61,18 +61,6 @@ impl Compression {
         Compression { compressor }
     }
 
-    /// Create an instance of compression from HTTP headers
-    pub(crate) fn response_from_headers(request_headers: &http::HeaderMap) -> Compression {
-        let accept_encoding_header = request_headers
-            .get(ACCEPT_ENCODING_HEADER)
-            .and_then(|v| v.to_str().ok())
-            .unwrap_or("");
-
-        let parsed = parse_accept_encoding_header(accept_encoding_header);
-        let compressor = first_supported_compressor(&parsed);
-        Compression { compressor }
-    }
-
     /// Get if compression is enabled
     pub(crate) fn is_enabled(&self) -> bool {
         self.compressor.is_some()

--- a/tonic/src/codec/compression/compression.rs
+++ b/tonic/src/codec/compression/compression.rs
@@ -6,7 +6,10 @@ use tracing::debug;
 
 use crate::metadata::MetadataMap;
 
-use super::{ACCEPT_ENCODING_HEADER, Compressor, ENCODING_HEADER, compressors::{self, IDENTITY}};
+use super::{
+    compressors::{self, IDENTITY},
+    Compressor, ACCEPT_ENCODING_HEADER, ENCODING_HEADER,
+};
 
 pub(crate) const BUFFER_SIZE: usize = 8 * 1024;
 
@@ -103,11 +106,14 @@ impl Compression {
     /// Set the `grpc-encoding` header with the compressor name
     pub(crate) fn set_headers(&self, headers: &mut http::HeaderMap, set_accept_encoding: bool) {
         if set_accept_encoding {
-            headers.insert(ACCEPT_ENCODING_HEADER, HeaderValue::from_str(&compressors::get_accept_encoding_header()).unwrap());
+            headers.insert(
+                ACCEPT_ENCODING_HEADER,
+                HeaderValue::from_str(&compressors::get_accept_encoding_header()).unwrap(),
+            );
         }
 
         match self.compressor {
-            None => {},
+            None => {}
             Some(compressor) => {
                 headers.insert(ENCODING_HEADER, HeaderValue::from_static(compressor.name()));
             }

--- a/tonic/src/codec/compression/compression.rs
+++ b/tonic/src/codec/compression/compression.rs
@@ -5,7 +5,10 @@ use tracing::debug;
 
 use crate::metadata::MetadataMap;
 
-use super::{Compressor, compressors::{self, IDENTITY}};
+use super::{
+    compressors::{self, IDENTITY},
+    Compressor,
+};
 
 pub(crate) const BUFFER_SIZE: usize = 8 * 1024;
 pub(crate) const ACCEPT_ENCODING_HEADER: &str = "grpc-accept-encoding";
@@ -17,19 +20,27 @@ pub(crate) struct Compression {
 impl Debug for Compression {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("Compression")
-        .field("compressor", &self.compressor.map(|c| c.name()).unwrap_or(IDENTITY))
-        .finish()
+            .field(
+                "compressor",
+                &self.compressor.map(|c| c.name()).unwrap_or(IDENTITY),
+            )
+            .finish()
     }
 }
 
 fn parse_accept_encoding_header(value: &str) -> Vec<&str> {
-    value.split(",").map(|v| v.trim()).filter(|v| !v.is_empty()).collect::<Vec<_>>()
+    value
+        .split(",")
+        .map(|v| v.trim())
+        .filter(|v| !v.is_empty())
+        .collect::<Vec<_>>()
 }
 
 fn first_supported_compressor(accepted: &Vec<&str>) -> Option<&'static Box<dyn Compressor>> {
-    accepted.iter()
+    accepted
+        .iter()
         .filter(|name| **name != IDENTITY)
-        .filter_map(|name|compressors::get(name))
+        .filter_map(|name| compressors::get(name))
         .next()
 }
 

--- a/tonic/src/codec/compression/compression.rs
+++ b/tonic/src/codec/compression/compression.rs
@@ -107,7 +107,8 @@ impl Compression {
         if set_accept_encoding {
             headers.insert(
                 ACCEPT_ENCODING_HEADER,
-                HeaderValue::from_str(&compressors::get_accept_encoding_header()).expect("All encoding names should be ASCII"),
+                HeaderValue::from_str(&compressors::get_accept_encoding_header())
+                    .expect("All encoding names should be ASCII"),
             );
         }
 

--- a/tonic/src/codec/compression/compression.rs
+++ b/tonic/src/codec/compression/compression.rs
@@ -6,10 +6,9 @@ use tracing::debug;
 
 use crate::metadata::MetadataMap;
 
-use super::{Compressor, ENCODING_HEADER, compressors::{self, IDENTITY}};
+use super::{ACCEPT_ENCODING_HEADER, Compressor, ENCODING_HEADER, compressors::{self, IDENTITY}};
 
 pub(crate) const BUFFER_SIZE: usize = 8 * 1024;
-pub(crate) const ACCEPT_ENCODING_HEADER: &str = "grpc-accept-encoding";
 
 #[derive(Clone)]
 pub(crate) struct Compression {
@@ -102,7 +101,11 @@ impl Compression {
     }
 
     /// Set the `grpc-encoding` header with the compressor name
-    pub(crate) fn set_headers(&self, headers: &mut http::HeaderMap) {
+    pub(crate) fn set_headers(&self, headers: &mut http::HeaderMap, set_accept_encoding: bool) {
+        if set_accept_encoding {
+            headers.insert(ACCEPT_ENCODING_HEADER, HeaderValue::from_str(&compressors::get_accept_encoding_header()).unwrap());
+        }
+
         match self.compressor {
             None => {},
             Some(compressor) => {

--- a/tonic/src/codec/compression/compression.rs
+++ b/tonic/src/codec/compression/compression.rs
@@ -1,0 +1,88 @@
+use std::{fmt::Debug, io};
+
+use bytes::{Buf, BytesMut};
+use tracing::debug;
+
+use crate::metadata::MetadataMap;
+
+use super::{Compressor, compressors::{self, IDENTITY}};
+
+pub(crate) const BUFFER_SIZE: usize = 8 * 1024;
+pub(crate) const ACCEPT_ENCODING_HEADER: &str = "grpc-accept-encoding";
+
+pub(crate) struct Compression {
+    compressor: Option<&'static Box<dyn Compressor>>,
+}
+
+impl Debug for Compression {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Compression")
+        .field("compressor", &self.compressor.map(|c| c.name()).unwrap_or(IDENTITY))
+        .finish()
+    }
+}
+
+fn parse_accept_encoding_header(value: &str) -> Vec<&str> {
+    value.split(",").map(|v| v.trim()).filter(|v| !v.is_empty()).collect::<Vec<_>>()
+}
+
+fn first_supported_compressor(accepted: &Vec<&str>) -> Option<&'static Box<dyn Compressor>> {
+    accepted.iter()
+        .filter(|name| **name != IDENTITY)
+        .filter_map(|name|compressors::get(name))
+        .next()
+}
+
+impl Compression {
+    pub(crate) fn new_request() -> Compression {
+        Compression { compressor: None }
+    }
+
+    pub(crate) fn response_from_metadata(request_metadata: &MetadataMap) -> Compression {
+        let accept_encoding_header = request_metadata
+            .get(ACCEPT_ENCODING_HEADER)
+            .and_then(|v| v.to_str().ok())
+            .unwrap_or("");
+
+        let parsed = parse_accept_encoding_header(accept_encoding_header);
+        let compressor = first_supported_compressor(&parsed);
+        Compression { compressor }
+    }
+
+    pub(crate) fn response_from_headers(request_headers: &http::HeaderMap) -> Compression {
+        let accept_encoding_header = request_headers
+            .get(ACCEPT_ENCODING_HEADER)
+            .and_then(|v| v.to_str().ok())
+            .unwrap_or("");
+
+        let parsed = parse_accept_encoding_header(accept_encoding_header);
+        let compressor = first_supported_compressor(&parsed);
+        Compression { compressor }
+    }
+
+    pub(crate) fn is_enabled(&self) -> bool {
+        self.compressor.is_some()
+    }
+
+    /// Decompress `len` bytes from `in_buffer` into `out_buffer`
+    pub(crate) fn compress(
+        &self,
+        in_buffer: &mut BytesMut,
+        out_buffer: &mut BytesMut,
+        len: usize,
+    ) -> Result<(), io::Error> {
+        out_buffer.reserve(((len / BUFFER_SIZE) + 1) * BUFFER_SIZE);
+
+        let compressor = self.compressor.unwrap_or_else(compressors::identity);
+        compressor.compress(in_buffer, out_buffer, len)?;
+        in_buffer.advance(len);
+
+        debug!(
+            "Decompressed {} bytes into {} bytes using {:?}",
+            len,
+            out_buffer.len(),
+            compressor.name()
+        );
+        Ok(())
+    }
+}

--- a/tonic/src/codec/compression/compressors.rs
+++ b/tonic/src/codec/compression/compressors.rs
@@ -1,7 +1,7 @@
 use std::{collections::HashMap, io};
 
 use super::bufwriter;
-use bytes::{Buf, BytesMut};
+use bytes::BytesMut;
 use once_cell::sync::Lazy;
 
 pub(crate) const IDENTITY: &str = "identity";
@@ -40,7 +40,7 @@ pub(crate) trait Compressor: Sync + Send {
     /// Decompress `len` bytes from `in_buffer` into `out_buffer`
     fn decompress(
         &self,
-        in_buffer: &mut BytesMut,
+        in_buffer: &BytesMut,
         out_buffer: &mut BytesMut,
         len: usize,
     ) -> io::Result<()>;
@@ -48,7 +48,7 @@ pub(crate) trait Compressor: Sync + Send {
     /// Compress `len` bytes from `in_buffer` into `out_buffer`
     fn compress(
         &self,
-        in_buffer: &mut BytesMut,
+        in_buffer: &BytesMut,
         out_buffer: &mut BytesMut,
         len: usize,
     ) -> io::Result<()>;
@@ -76,7 +76,7 @@ impl Compressor for IdentityCompressor {
 
     fn decompress(
         &self,
-        in_buffer: &mut BytesMut,
+        in_buffer: &BytesMut,
         out_buffer: &mut BytesMut,
         len: usize,
     ) -> io::Result<()> {
@@ -84,14 +84,13 @@ impl Compressor for IdentityCompressor {
         let mut out_writer = bufwriter::new(out_buffer);
 
         std::io::copy(&mut in_reader, &mut out_writer)?;
-        in_buffer.advance(len);
 
         Ok(())
     }
 
     fn compress(
         &self,
-        in_buffer: &mut BytesMut,
+        in_buffer: &BytesMut,
         out_buffer: &mut BytesMut,
         len: usize,
     ) -> io::Result<()> {
@@ -99,7 +98,6 @@ impl Compressor for IdentityCompressor {
         let mut out_writer = bufwriter::new(out_buffer);
 
         std::io::copy(&mut in_reader, &mut out_writer)?;
-        in_buffer.advance(len);
 
         Ok(())
     }

--- a/tonic/src/codec/compression/compressors.rs
+++ b/tonic/src/codec/compression/compressors.rs
@@ -1,0 +1,81 @@
+use std::{collections::HashMap, io};
+
+use super::bufwriter;
+use bytes::{Buf, BytesMut};
+use once_cell::sync::Lazy;
+
+pub(crate) const IDENTITY: &str = "identity";
+
+/// List of known compressors
+static COMPRESSORS: Lazy<HashMap<String, Box<dyn Compressor>>> = Lazy::new(|| {
+    let mut m = HashMap::new();
+
+    let mut add = |compressor: Box<dyn Compressor>| {
+        m.insert(compressor.name().to_string(), compressor);
+    };
+
+    add(Box::new(IdentityCompressor {}));
+
+    #[cfg(feature = "gzip")]
+    add(Box::new(super::gzip::GZipCompressor {}));
+
+    m
+});
+
+/// Get a compressor from it's name
+pub(crate) fn get(name: impl AsRef<str>) -> Option<&'static Box<dyn Compressor>> {
+    COMPRESSORS.get(name.as_ref())
+}
+
+/// Get all the known compressors
+pub(crate) fn names() -> Vec<String> {
+    COMPRESSORS.keys().map(|n| n.clone()).collect()
+}
+
+/// A compressor implement compression and decompression of GRPC frames
+pub(crate) trait Compressor: Sync + Send {
+    /// Get the name of this compressor as present in http headers
+    fn name(&self) -> &'static str;
+
+    /// Decompress `len` bytes from `in_buffer` into `out_buffer`
+    fn decompress(
+        &self,
+        in_buffer: &mut BytesMut,
+        out_buffer: &mut BytesMut,
+        len: usize,
+    ) -> io::Result<()>;
+
+    /// Estimate the space necessary to decompress `compressed_len` bytes of compressed data
+    fn estimate_decompressed_len(&self, compressed_len: usize) -> usize {
+        compressed_len * 2
+    }
+}
+
+/// The identity compressor doesn't compress
+#[derive(Debug)]
+struct IdentityCompressor {}
+
+impl Compressor for IdentityCompressor {
+    fn name(&self) -> &'static str {
+        IDENTITY
+    }
+
+    fn decompress(
+        &self,
+        in_buffer: &mut BytesMut,
+        out_buffer: &mut BytesMut,
+        len: usize,
+    ) -> io::Result<()> {
+        let mut in_reader = &in_buffer[0..len];
+        let mut out_writer = bufwriter::new(out_buffer);
+
+        std::io::copy(&mut in_reader, &mut out_writer)?;
+        in_buffer.advance(len);
+
+        Ok(())
+    }
+
+    fn estimate_decompressed_len(&self, compressed_len: usize) -> usize {
+        compressed_len
+    }
+}

--- a/tonic/src/codec/compression/compressors.rs
+++ b/tonic/src/codec/compression/compressors.rs
@@ -106,3 +106,9 @@ impl Compressor for IdentityCompressor {
         compressed_len
     }
 }
+
+static BOXED_IDENTITY_COMPRESSOR: Lazy<Box<dyn Compressor>> = Lazy::new(|| Box::new(IdentityCompressor::default()));
+
+pub(crate) fn identity() -> &'static Box<dyn Compressor> {
+    &BOXED_IDENTITY_COMPRESSOR
+}

--- a/tonic/src/codec/compression/compressors.rs
+++ b/tonic/src/codec/compression/compressors.rs
@@ -60,7 +60,12 @@ pub(crate) trait Compressor: Sync + Send {
 }
 
 pub(crate) fn get_accept_encoding_header() -> String {
-    COMPRESSORS.keys().map(|s| &**s).filter(|name| *name != IDENTITY).collect::<Vec<_>>().join(",")
+    COMPRESSORS
+        .keys()
+        .map(|s| &**s)
+        .filter(|name| *name != IDENTITY)
+        .collect::<Vec<_>>()
+        .join(",")
 }
 
 /// The identity compressor doesn't compress

--- a/tonic/src/codec/compression/compressors.rs
+++ b/tonic/src/codec/compression/compressors.rs
@@ -107,7 +107,8 @@ impl Compressor for IdentityCompressor {
     }
 }
 
-static BOXED_IDENTITY_COMPRESSOR: Lazy<Box<dyn Compressor>> = Lazy::new(|| Box::new(IdentityCompressor::default()));
+static BOXED_IDENTITY_COMPRESSOR: Lazy<Box<dyn Compressor>> =
+    Lazy::new(|| Box::new(IdentityCompressor::default()));
 
 pub(crate) fn identity() -> &'static Box<dyn Compressor> {
     &BOXED_IDENTITY_COMPRESSOR

--- a/tonic/src/codec/compression/compressors.rs
+++ b/tonic/src/codec/compression/compressors.rs
@@ -59,6 +59,10 @@ pub(crate) trait Compressor: Sync + Send {
     }
 }
 
+pub(crate) fn get_accept_encoding_header() -> String {
+    COMPRESSORS.keys().map(|s| &**s).filter(|name| *name != IDENTITY).collect::<Vec<_>>().join(",")
+}
+
 /// The identity compressor doesn't compress
 #[derive(Debug)]
 struct IdentityCompressor {}

--- a/tonic/src/codec/compression/decompression.rs
+++ b/tonic/src/codec/compression/decompression.rs
@@ -29,18 +29,24 @@ impl Debug for Decompression {
 }
 
 impl Decompression {
-    /// Create a `Decompression` structure from http headers
-    pub fn from_headers(metadata: &http::HeaderMap) -> Decompression {
-        let encoding = metadata
-            .get(ENCODING_HEADER)
-            .and_then(|v| v.to_str().ok())
-            .and_then(|v| if v == IDENTITY { None } else { Some(v) });
+    /// Create a `Decompression` structure from an encoding name
+    pub fn from_encoding(encoding: Option<&str>) -> Decompression {
         let compressor = encoding.and_then(compressors::get);
 
         Decompression {
             encoding: encoding.map(|v| v.to_string()),
             compressor,
         }
+    }
+
+    /// Create a `Decompression` structure from http headers
+    pub fn from_headers(metadata: &http::HeaderMap) -> Decompression {
+        let encoding = metadata
+            .get(ENCODING_HEADER)
+            .and_then(|v| v.to_str().ok())
+            .and_then(|v| if v == IDENTITY { None } else { Some(v) });
+
+        Decompression::from_encoding(encoding)
     }
 
     /// Decompress `len` bytes from `in_buffer` into `out_buffer`

--- a/tonic/src/codec/compression/decompression.rs
+++ b/tonic/src/codec/compression/decompression.rs
@@ -1,7 +1,7 @@
 use bytes::{Buf, BytesMut};
 use tracing::debug;
 
-use super::{Compressor, DecompressionError, ENCODING_HEADER, compressors};
+use super::{compressors, Compressor, DecompressionError, ENCODING_HEADER};
 
 const BUFFER_SIZE: usize = 8 * 1024;
 

--- a/tonic/src/codec/compression/decompression.rs
+++ b/tonic/src/codec/compression/decompression.rs
@@ -36,16 +36,6 @@ impl Decompression {
         }
     }
 
-    /// Clear the buffer and reserve an estimated number of bytes
-    fn prepare_decompress_buf(buffer: &mut BytesMut, estimated_len: usize) {
-        buffer.clear();
-
-        if buffer.capacity() < estimated_len {
-            let capacity = ((estimated_len / BUFFER_SIZE) + 1) * BUFFER_SIZE;
-            buffer.reserve(capacity)
-        }
-    }
-
     /// Find a compressor in the registry for the current encoding
     fn get_compressor(&self) -> Result<&Box<dyn Compressor>, DecompressionError> {
         match &self.encoding {
@@ -71,7 +61,8 @@ impl Decompression {
     ) -> Result<(), DecompressionError> {
         let compressor = self.get_compressor()?;
 
-        out_buffer.reserve(((compressor.estimate_decompressed_len(len) / BUFFER_SIZE) + 1) * BUFFER_SIZE);
+        out_buffer
+            .reserve(((compressor.estimate_decompressed_len(len) / BUFFER_SIZE) + 1) * BUFFER_SIZE);
         compressor.decompress(in_buffer, out_buffer, len)?;
         in_buffer.advance(len);
 

--- a/tonic/src/codec/compression/decompression.rs
+++ b/tonic/src/codec/compression/decompression.rs
@@ -1,53 +1,45 @@
 use bytes::{Buf, BytesMut};
+use std::fmt::Debug;
 use tracing::debug;
 
-use super::{compressors, Compressor, DecompressionError, ENCODING_HEADER};
+use super::{
+    compressors::{self, IDENTITY},
+    Compressor, DecompressionError, ENCODING_HEADER,
+};
 
 const BUFFER_SIZE: usize = 8 * 1024;
 
 /// Information related to the decompression of a request or response
-#[derive(Debug)]
 pub struct Decompression {
     encoding: Option<String>,
+    compressor: Option<&'static Box<dyn Compressor>>,
+}
+
+impl Debug for Decompression {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let encoding = self.encoding.as_ref().map(|e| &e[..]).unwrap_or("");
+        f.debug_struct("Compression")
+            .field("encoding", &encoding)
+            .field(
+                "compressor",
+                &self.compressor.map(|c| c.name()).unwrap_or(""),
+            )
+            .finish()
+    }
 }
 
 impl Decompression {
-    /// Create a `Decompression` structure
-    pub fn new(encoding: Option<String>) -> Decompression {
-        Decompression { encoding }
-    }
-
     /// Create a `Decompression` structure from http headers
     pub fn from_headers(metadata: &http::HeaderMap) -> Decompression {
         let encoding = metadata
             .get(ENCODING_HEADER)
             .and_then(|v| v.to_str().ok())
-            .map(|s| s.to_string());
+            .and_then(|v| if v == IDENTITY { None } else { Some(v) });
+        let compressor = encoding.and_then(compressors::get);
 
-        Decompression::new(encoding)
-    }
-
-    /// Get if the current encoding is the no-op "identity" one or no decompression is configured
-    pub fn is_identity_or_none(&self) -> bool {
-        match &self.encoding {
-            Some(encoding) => encoding == compressors::IDENTITY,
-            None => true,
-        }
-    }
-
-    /// Find a compressor in the registry for the current encoding
-    fn get_compressor(&self) -> Result<&Box<dyn Compressor>, DecompressionError> {
-        match &self.encoding {
-            None => {
-                Ok(compressors::get(compressors::IDENTITY).expect("Identity is always present"))
-            }
-            Some(encoding) => match compressors::get(encoding) {
-                Some(compressor) => Ok(compressor),
-                None => Err(DecompressionError::NotFound {
-                    requested: encoding.clone(),
-                    known: compressors::names(),
-                }),
-            },
+        Decompression {
+            encoding: encoding.map(|v| v.to_string()),
+            compressor,
         }
     }
 
@@ -58,10 +50,21 @@ impl Decompression {
         out_buffer: &mut BytesMut,
         len: usize,
     ) -> Result<(), DecompressionError> {
-        let compressor = self.get_compressor()?;
+        let compressor = self.compressor.ok_or_else(|| {
+            match &self.encoding {
+                // Asked to decompress but not compression was specified
+                None => DecompressionError::NoCompression,
+                // Asked to decompress but the decompressor wasn't found
+                Some(encoding) => DecompressionError::NotFound {
+                    requested: encoding.clone(),
+                    known: compressors::names(),
+                },
+            }
+        })?;
 
-        out_buffer
-            .reserve(((compressor.estimate_decompressed_len(len) / BUFFER_SIZE) + 1) * BUFFER_SIZE);
+        let capacity =
+            ((compressor.estimate_decompressed_len(len) / BUFFER_SIZE) + 1) * BUFFER_SIZE;
+        out_buffer.reserve(capacity);
         compressor.decompress(in_buffer, out_buffer, len)?;
         in_buffer.advance(len);
 
@@ -69,7 +72,7 @@ impl Decompression {
             "Decompressed {} bytes into {} bytes using {:?}",
             len,
             out_buffer.len(),
-            self.encoding
+            compressor.name()
         );
         Ok(())
     }
@@ -77,6 +80,9 @@ impl Decompression {
 
 impl Default for Decompression {
     fn default() -> Self {
-        Decompression { encoding: None }
+        Decompression {
+            encoding: None,
+            compressor: None,
+        }
     }
 }

--- a/tonic/src/codec/compression/decompression.rs
+++ b/tonic/src/codec/compression/decompression.rs
@@ -1,0 +1,94 @@
+use bytes::BytesMut;
+use tracing::debug;
+
+use super::{compressors, Compressor, DecompressionError};
+
+const BUFFER_SIZE: usize = 8 * 1024;
+const ENCODING_HEADER: &str = "grpc-encoding";
+
+/// Information related to the decompression of a request or response
+#[derive(Debug)]
+pub struct Decompression {
+    encoding: Option<String>,
+}
+
+impl Decompression {
+    /// Create a `Decompression` structure
+    pub fn new(encoding: Option<String>) -> Decompression {
+        Decompression { encoding }
+    }
+
+    /// Create a `Decompression` structure from http headers
+    pub fn from_headers(metadata: &http::HeaderMap) -> Decompression {
+        let encoding = metadata
+            .get(ENCODING_HEADER)
+            .and_then(|v| v.to_str().ok())
+            .map(|s| s.to_string());
+
+        Decompression::new(encoding)
+    }
+
+    /// Get if the current encoding is the no-op "identity" one
+    pub fn is_identity(&self) -> bool {
+        match &self.encoding {
+            Some(encoding) => encoding == compressors::IDENTITY,
+            None => false,
+        }
+    }
+
+    /// Clear the buffer and reserve an estimated number of bytes
+    fn prepare_decompress_buf(buffer: &mut BytesMut, estimated_len: usize) {
+        buffer.clear();
+
+        if buffer.capacity() < estimated_len {
+            let capacity = ((estimated_len / BUFFER_SIZE) + 1) * BUFFER_SIZE;
+            buffer.reserve(capacity)
+        }
+    }
+
+    /// Find a compressor in the registry for the current encoding
+    fn get_compressor(&self) -> Result<&Box<dyn Compressor>, DecompressionError> {
+        match &self.encoding {
+            None => {
+                Ok(compressors::get(compressors::IDENTITY).expect("Identity is always present"))
+            }
+            Some(encoding) => match compressors::get(encoding) {
+                Some(compressor) => Ok(compressor),
+                None => Err(DecompressionError::NotFound {
+                    requested: encoding.clone(),
+                    known: compressors::names(),
+                }),
+            },
+        }
+    }
+
+    /// Decompress `len` bytes from `in_buffer` into `out_buffer`
+    pub fn decompress(
+        &self,
+        in_buffer: &mut BytesMut,
+        out_buffer: &mut BytesMut,
+        len: usize,
+    ) -> Result<(), DecompressionError> {
+        let compressor = self.get_compressor()?;
+
+        Decompression::prepare_decompress_buf(
+            out_buffer,
+            compressor.estimate_decompressed_len(len),
+        );
+        compressor.decompress(in_buffer, out_buffer, len)?;
+
+        debug!(
+            "Decompressed {} bytes into {} bytes using {:?}",
+            len,
+            out_buffer.len(),
+            self.encoding
+        );
+        Ok(())
+    }
+}
+
+impl Default for Decompression {
+    fn default() -> Self {
+        Decompression { encoding: None }
+    }
+}

--- a/tonic/src/codec/compression/decompression.rs
+++ b/tonic/src/codec/compression/decompression.rs
@@ -27,11 +27,11 @@ impl Decompression {
         Decompression::new(encoding)
     }
 
-    /// Get if the current encoding is the no-op "identity" one
-    pub fn is_identity(&self) -> bool {
+    /// Get if the current encoding is the no-op "identity" one or no decompression is configured
+    pub fn is_identity_or_none(&self) -> bool {
         match &self.encoding {
             Some(encoding) => encoding == compressors::IDENTITY,
-            None => false,
+            None => true,
         }
     }
 

--- a/tonic/src/codec/compression/decompression.rs
+++ b/tonic/src/codec/compression/decompression.rs
@@ -71,10 +71,7 @@ impl Decompression {
     ) -> Result<(), DecompressionError> {
         let compressor = self.get_compressor()?;
 
-        Decompression::prepare_decompress_buf(
-            out_buffer,
-            compressor.estimate_decompressed_len(len),
-        );
+        out_buffer.reserve(((compressor.estimate_decompressed_len(len) / BUFFER_SIZE) + 1) * BUFFER_SIZE);
         compressor.decompress(in_buffer, out_buffer, len)?;
         in_buffer.advance(len);
 

--- a/tonic/src/codec/compression/decompression.rs
+++ b/tonic/src/codec/compression/decompression.rs
@@ -1,4 +1,4 @@
-use bytes::BytesMut;
+use bytes::{Buf, BytesMut};
 use tracing::debug;
 
 use super::{compressors, Compressor, DecompressionError};
@@ -76,6 +76,7 @@ impl Decompression {
             compressor.estimate_decompressed_len(len),
         );
         compressor.decompress(in_buffer, out_buffer, len)?;
+        in_buffer.advance(len);
 
         debug!(
             "Decompressed {} bytes into {} bytes using {:?}",

--- a/tonic/src/codec/compression/decompression.rs
+++ b/tonic/src/codec/compression/decompression.rs
@@ -1,10 +1,9 @@
 use bytes::{Buf, BytesMut};
 use tracing::debug;
 
-use super::{compressors, Compressor, DecompressionError};
+use super::{Compressor, DecompressionError, ENCODING_HEADER, compressors};
 
 const BUFFER_SIZE: usize = 8 * 1024;
-const ENCODING_HEADER: &str = "grpc-encoding";
 
 /// Information related to the decompression of a request or response
 #[derive(Debug)]

--- a/tonic/src/codec/compression/errors.rs
+++ b/tonic/src/codec/compression/errors.rs
@@ -1,0 +1,39 @@
+#[derive(Debug)]
+pub enum DecompressionError {
+    NotFound {
+        requested: String,
+        known: Vec<String>,
+    },
+    Failed(std::io::Error),
+}
+
+impl std::fmt::Display for DecompressionError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match &self {
+            DecompressionError::NotFound { requested, known } => {
+                let known_joined = known.join(", ");
+                write!(
+                    f,
+                    "Compressor for '{}' not found. Known compressors: {}",
+                    requested, known_joined
+                )
+            }
+            DecompressionError::Failed(error) => write!(f, "Decompression failed: {}", error),
+        }
+    }
+}
+
+impl std::error::Error for DecompressionError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match &self {
+            DecompressionError::NotFound { .. } => None,
+            DecompressionError::Failed(err) => Some(err),
+        }
+    }
+}
+
+impl From<std::io::Error> for DecompressionError {
+    fn from(error: std::io::Error) -> Self {
+        DecompressionError::Failed(error)
+    }
+}

--- a/tonic/src/codec/compression/errors.rs
+++ b/tonic/src/codec/compression/errors.rs
@@ -4,6 +4,7 @@ pub enum DecompressionError {
         requested: String,
         known: Vec<String>,
     },
+    NoCompression,
     Failed(std::io::Error),
 }
 
@@ -19,6 +20,9 @@ impl std::fmt::Display for DecompressionError {
                 )
             }
             DecompressionError::Failed(error) => write!(f, "Decompression failed: {}", error),
+            DecompressionError::NoCompression => {
+                write!(f, "Compressed flag set with identity or empty encoding")
+            }
         }
     }
 }
@@ -26,6 +30,7 @@ impl std::fmt::Display for DecompressionError {
 impl std::error::Error for DecompressionError {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         match &self {
+            DecompressionError::NoCompression => None,
             DecompressionError::NotFound { .. } => None,
             DecompressionError::Failed(err) => Some(err),
         }
@@ -35,5 +40,37 @@ impl std::error::Error for DecompressionError {
 impl From<std::io::Error> for DecompressionError {
     fn from(error: std::io::Error) -> Self {
         DecompressionError::Failed(error)
+    }
+}
+
+#[derive(Debug)]
+pub(crate) enum CompressionError {
+    NoCompression,
+    Failed(std::io::Error),
+}
+
+impl std::fmt::Display for CompressionError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match &self {
+            CompressionError::Failed(error) => write!(f, "Compression failed: {}", error),
+            CompressionError::NoCompression => {
+                write!(f, "Compression attempted without being configured")
+            }
+        }
+    }
+}
+
+impl std::error::Error for CompressionError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match &self {
+            CompressionError::NoCompression { .. } => None,
+            CompressionError::Failed(err) => Some(err),
+        }
+    }
+}
+
+impl From<std::io::Error> for CompressionError {
+    fn from(error: std::io::Error) -> Self {
+        CompressionError::Failed(error)
     }
 }

--- a/tonic/src/codec/compression/gzip.rs
+++ b/tonic/src/codec/compression/gzip.rs
@@ -1,6 +1,6 @@
 use std::io;
 
-use super::{Compressor, bufwriter};
+use super::{bufwriter, Compressor};
 use bytes::{Buf, BytesMut};
 use flate2::read::GzDecoder;
 

--- a/tonic/src/codec/compression/gzip.rs
+++ b/tonic/src/codec/compression/gzip.rs
@@ -1,0 +1,30 @@
+use std::io;
+
+use super::{Compressor, bufwriter};
+use bytes::{Buf, BytesMut};
+use flate2::read::GzDecoder;
+
+/// Compress using GZIP
+#[derive(Debug)]
+pub(crate) struct GZipCompressor {}
+
+impl Compressor for GZipCompressor {
+    fn name(&self) -> &'static str {
+        "gzip"
+    }
+
+    fn decompress(
+        &self,
+        in_buffer: &mut BytesMut,
+        out_buffer: &mut BytesMut,
+        len: usize,
+    ) -> io::Result<()> {
+        let mut gzip_decoder = GzDecoder::new(&in_buffer[0..len]);
+        let mut out_writer = bufwriter::new(out_buffer);
+
+        std::io::copy(&mut gzip_decoder, &mut out_writer)?;
+        in_buffer.advance(len);
+
+        Ok(())
+    }
+}

--- a/tonic/src/codec/compression/gzip.rs
+++ b/tonic/src/codec/compression/gzip.rs
@@ -7,7 +7,7 @@ use flate2::read::{GzDecoder, GzEncoder};
 /// Compress using GZIP
 #[derive(Debug)]
 pub(crate) struct GZipCompressor {
-    compression_level: flate2::Compression
+    compression_level: flate2::Compression,
 }
 
 impl GZipCompressor {

--- a/tonic/src/codec/compression/gzip.rs
+++ b/tonic/src/codec/compression/gzip.rs
@@ -1,7 +1,7 @@
 use std::io;
 
 use super::{bufwriter, Compressor};
-use bytes::{Buf, BytesMut};
+use bytes::BytesMut;
 use flate2::read::{GzDecoder, GzEncoder};
 
 /// Compress using GZIP
@@ -29,7 +29,7 @@ impl Compressor for GZipCompressor {
 
     fn decompress(
         &self,
-        in_buffer: &mut BytesMut,
+        in_buffer: &BytesMut,
         out_buffer: &mut BytesMut,
         len: usize,
     ) -> io::Result<()> {
@@ -37,14 +37,13 @@ impl Compressor for GZipCompressor {
         let mut out_writer = bufwriter::new(out_buffer);
 
         std::io::copy(&mut gzip_decoder, &mut out_writer)?;
-        in_buffer.advance(len);
 
         Ok(())
     }
 
     fn compress(
         &self,
-        in_buffer: &mut BytesMut,
+        in_buffer: &BytesMut,
         out_buffer: &mut BytesMut,
         len: usize,
     ) -> io::Result<()> {
@@ -52,7 +51,6 @@ impl Compressor for GZipCompressor {
         let mut out_writer = bufwriter::new(out_buffer);
 
         std::io::copy(&mut gzip_decoder, &mut out_writer)?;
-        in_buffer.advance(len);
 
         Ok(())
     }

--- a/tonic/src/codec/compression/mod.rs
+++ b/tonic/src/codec/compression/mod.rs
@@ -1,13 +1,11 @@
 mod bufwriter;
-mod compressors;
 mod compression;
+mod compressors;
 mod decompression;
 mod errors;
 
 #[cfg(feature = "gzip")]
 mod gzip;
-
-use bytes::BytesMut;
 
 pub(crate) use self::compressors::Compressor;
 

--- a/tonic/src/codec/compression/mod.rs
+++ b/tonic/src/codec/compression/mod.rs
@@ -5,6 +5,7 @@ mod decompression;
 mod errors;
 
 pub(crate) const ENCODING_HEADER: &str = "grpc-encoding";
+pub(crate) const ACCEPT_ENCODING_HEADER: &str = "grpc-accept-encoding";
 
 #[cfg(feature = "gzip")]
 mod gzip;

--- a/tonic/src/codec/compression/mod.rs
+++ b/tonic/src/codec/compression/mod.rs
@@ -1,0 +1,12 @@
+mod bufwriter;
+mod compressors;
+mod decompression;
+mod errors;
+
+#[cfg(feature = "gzip")]
+mod gzip;
+
+pub(crate) use self::compressors::Compressor;
+#[doc(hidden)]
+pub use self::decompression::Decompression;
+pub(crate) use self::errors::DecompressionError;

--- a/tonic/src/codec/compression/mod.rs
+++ b/tonic/src/codec/compression/mod.rs
@@ -1,12 +1,18 @@
 mod bufwriter;
 mod compressors;
+mod compression;
 mod decompression;
 mod errors;
 
 #[cfg(feature = "gzip")]
 mod gzip;
 
+use bytes::BytesMut;
+
 pub(crate) use self::compressors::Compressor;
+
 #[doc(hidden)]
 pub use self::decompression::Decompression;
 pub(crate) use self::errors::DecompressionError;
+
+pub(crate) use self::compression::Compression;

--- a/tonic/src/codec/compression/mod.rs
+++ b/tonic/src/codec/compression/mod.rs
@@ -4,6 +4,8 @@ mod compressors;
 mod decompression;
 mod errors;
 
+pub(crate) const ENCODING_HEADER: &str = "grpc-encoding";
+
 #[cfg(feature = "gzip")]
 mod gzip;
 

--- a/tonic/src/codec/decode.rs
+++ b/tonic/src/codec/decode.rs
@@ -208,13 +208,6 @@ impl<T> Streaming<T> {
             }
 
             let decode_result = if *compression {
-                if self.decompression.is_identity_or_none() {
-                    return Err(Status::new(
-                        Code::Internal,
-                        "compressed flag set with identity or empty encoding",
-                    ));
-                }
-
                 if let Err(err) =
                     self.decompression
                         .decompress(&mut self.buf, &mut self.decompress_buf, *len)

--- a/tonic/src/codec/decode.rs
+++ b/tonic/src/codec/decode.rs
@@ -207,7 +207,14 @@ impl<T> Streaming<T> {
                 return Ok(None);
             }
 
-            let decode_result = if *compression && !self.decompression.is_identity() {
+            let decode_result = if *compression {
+                if self.decompression.is_identity_or_none() {
+                    return Err(Status::new(
+                        Code::Internal,
+                        "compressed flag set with identity or empty encoding",
+                    ));
+                }
+
                 if let Err(err) =
                     self.decompression
                         .decompress(&mut self.buf, &mut self.decompress_buf, *len)

--- a/tonic/src/codec/encode.rs
+++ b/tonic/src/codec/encode.rs
@@ -1,4 +1,4 @@
-use super::{EncodeBuf, Encoder, compression::Compression};
+use super::{compression::Compression, EncodeBuf, Encoder};
 use crate::{Code, Status};
 use bytes::{BufMut, Bytes, BytesMut};
 use futures_core::{Stream, TryStream};
@@ -41,7 +41,11 @@ where
     EncodeBody::new_client(stream)
 }
 
-fn encode<T, U>(mut encoder: T, source: U, compression: Compression) -> impl TryStream<Ok = Bytes, Error = Status>
+fn encode<T, U>(
+    mut encoder: T,
+    source: U,
+    compression: Compression,
+) -> impl TryStream<Ok = Bytes, Error = Status>
 where
     T: Encoder<Error = Status>,
     U: Stream<Item = Result<T::Item, Status>>,

--- a/tonic/src/codec/mod.rs
+++ b/tonic/src/codec/mod.rs
@@ -14,6 +14,7 @@ use std::io;
 
 #[doc(hidden)]
 pub use self::compression::Decompression;
+pub(crate) use self::compression::Compression;
 pub use self::decode::Streaming;
 pub(crate) use self::encode::{encode_client, encode_server};
 #[cfg(feature = "prost")]

--- a/tonic/src/codec/mod.rs
+++ b/tonic/src/codec/mod.rs
@@ -12,9 +12,9 @@ mod prost;
 
 use std::io;
 
+pub(crate) use self::compression::Compression;
 #[doc(hidden)]
 pub use self::compression::Decompression;
-pub(crate) use self::compression::Compression;
 pub use self::decode::Streaming;
 pub(crate) use self::encode::{encode_client, encode_server};
 #[cfg(feature = "prost")]

--- a/tonic/src/codec/mod.rs
+++ b/tonic/src/codec/mod.rs
@@ -4,6 +4,7 @@
 //! and a protobuf codec based on prost.
 
 mod buffer;
+mod compression;
 mod decode;
 mod encode;
 #[cfg(feature = "prost")]
@@ -11,6 +12,8 @@ mod prost;
 
 use std::io;
 
+#[doc(hidden)]
+pub use self::compression::Decompression;
 pub use self::decode::Streaming;
 pub(crate) use self::encode::{encode_client, encode_server};
 #[cfg(feature = "prost")]

--- a/tonic/src/codec/prost.rs
+++ b/tonic/src/codec/prost.rs
@@ -121,7 +121,7 @@ mod tests {
         let messages = std::iter::repeat(Ok::<_, Status>(msg)).take(10000);
         let source = futures_util::stream::iter(messages);
 
-        let body = encode_server(encoder, source);
+        let body = encode_server(encoder, source, Compression::disabled());
 
         futures_util::pin_mut!(body);
 

--- a/tonic/src/server/grpc.rs
+++ b/tonic/src/server/grpc.rs
@@ -1,4 +1,10 @@
-use crate::{Code, Request, Status, body::BoxBody, codec::{Codec, Compression, Decompression, Streaming, encode_server}, interceptor::Interceptor, server::{ClientStreamingService, ServerStreamingService, StreamingService, UnaryService}};
+use crate::{
+    body::BoxBody,
+    codec::{encode_server, Codec, Compression, Decompression, Streaming},
+    interceptor::Interceptor,
+    server::{ClientStreamingService, ServerStreamingService, StreamingService, UnaryService},
+    Code, Request, Status,
+};
 use futures_core::TryStream;
 use futures_util::{future, stream, TryStreamExt};
 use http_body::Body;
@@ -66,9 +72,10 @@ where
             Ok(r) => r,
             Err(status) => {
                 return self
-                    .map_response::<stream::Once<future::Ready<Result<T::Encode, Status>>>>(Err(
-                        status,
-                    ), compression);
+                    .map_response::<stream::Once<future::Ready<Result<T::Encode, Status>>>>(
+                        Err(status),
+                        compression,
+                    );
             }
         };
 
@@ -99,7 +106,6 @@ where
         let request = match self.map_request_unary(req).await {
             Ok(r) => r,
             Err(status) => {
-
                 return self.map_response::<S::ResponseStream>(Err(status), compression);
             }
         };

--- a/tonic/src/server/grpc.rs
+++ b/tonic/src/server/grpc.rs
@@ -216,7 +216,7 @@ where
                     http::header::CONTENT_TYPE,
                     http::header::HeaderValue::from_static("application/grpc"),
                 );
-                compression.set_headers(&mut parts.headers);
+                compression.set_headers(&mut parts.headers, false);
 
                 let body = encode_server(self.codec.encoder(), body.into_stream(), compression);
 

--- a/tonic/src/server/grpc.rs
+++ b/tonic/src/server/grpc.rs
@@ -216,6 +216,7 @@ where
                     http::header::CONTENT_TYPE,
                     http::header::HeaderValue::from_static("application/grpc"),
                 );
+                compression.set_headers(&mut parts.headers);
 
                 let body = encode_server(self.codec.encoder(), body.into_stream(), compression);
 

--- a/tonic/src/server/grpc.rs
+++ b/tonic/src/server/grpc.rs
@@ -104,7 +104,8 @@ where
         let request = match self.map_request_unary(req).await {
             Ok(r) => r,
             Err(status) => {
-                return self.map_response::<S::ResponseStream>(Err(status), Compression::disabled());
+                return self
+                    .map_response::<S::ResponseStream>(Err(status), Compression::disabled());
             }
         };
 

--- a/tonic/src/server/grpc.rs
+++ b/tonic/src/server/grpc.rs
@@ -67,14 +67,13 @@ where
         B: Body + Send + Sync + 'static,
         B::Error: Into<crate::Error> + Send,
     {
-        let compression = Compression::response_from_headers(req.headers());
         let request = match self.map_request_unary(req).await {
             Ok(r) => r,
             Err(status) => {
                 return self
                     .map_response::<stream::Once<future::Ready<Result<T::Encode, Status>>>>(
                         Err(status),
-                        compression,
+                        Compression::disabled(),
                     );
             }
         };
@@ -102,11 +101,10 @@ where
         B: Body + Send + Sync + 'static,
         B::Error: Into<crate::Error> + Send,
     {
-        let compression = Compression::response_from_headers(req.headers());
         let request = match self.map_request_unary(req).await {
             Ok(r) => r,
             Err(status) => {
-                return self.map_response::<S::ResponseStream>(Err(status), compression);
+                return self.map_response::<S::ResponseStream>(Err(status), Compression::disabled());
             }
         };
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/hyperium/tonic/blob/master/CONTRIBUTING.md
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? If a new feature is being added, describe the intended
use case that feature fulfills.
-->

When a tonic server we deployed receive grpc messages that are compressed (as gzip by a Go client) it currently fail as decompression isn't currently supported (#282)

I wanted to support this limited case as simply as possible.

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

I took the solution of only implementing this very specific case because:
* gzip is the most common compression for grpc and the one that is available by default in the go and c++ implementations
* It's an hard-failure, if a tonic server client doesn't send compressed requests the other party will understand it. But when a compressed message is received the only way to handle it is to reject it if compression isn't implemented.
* It doesn't require any additional API surface as a single hardcoded compressor is supported and only enabled via feature flags.

On the code decisions:
* `Compressor` contains compression and decompression method and aims to be/become the equivalent of https://godoc.org/google.golang.org/grpc/encoding#Compressor it could be the trait that users could implement to provide additional compression methods.
* `Decompression` hosts the decompression information provided to 'decode' (A single http header for now)
* `Compression` is the same on the other direction but is only used for responses in cases where the request was compressed in all other cases no compression take place. *It also avoid a problem currently existing in envoy grpc-web support and mimics what grpc-go does*
* I looked at enabling some of the interop tests on compression but go-grpc doesn't implement them. I'm not sure of how this can easily be integration-tested before compression is there and it can be tested via roundtrip. The C++ tests support compression but they seem to test advanced aspects too that aren't implemented yet in tonic with this PR.

Tests done:
* Added benches with gzip
* Greeter and routeguide were tested both way against go, enabling gzip from the go side clients
* Deploying an internal project using tonic and accessing it with Go requiring compression and via grpc-web translated by envoy

---

Fixes https://github.com/hyperium/tonic/issues/282