### PR TITLE
transport: impl Service for Channel instead of GrpcService

### DIFF
--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -75,6 +75,14 @@ name = "tower-client"
 path = "src/tower/client.rs"
 
 [[bin]]
+name = "timeout-server"
+path = "src/timeout/server.rs"
+
+[[bin]]
+name = "timeout-client"
+path = "src/timeout/client.rs"
+
+[[bin]]
 name = "multiplex-server"
 path = "src/multiplex/server.rs"
 

--- a/examples/src/timeout/client.rs
+++ b/examples/src/timeout/client.rs
@@ -1,0 +1,28 @@
+use hello_world::greeter_client::GreeterClient;
+use hello_world::HelloRequest;
+use std::time::Duration;
+use tower::timeout::Timeout;
+
+use tonic::transport::Channel;
+
+pub mod hello_world {
+    tonic::include_proto!("helloworld");
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let channel = Channel::from_static("http://[::1]:50051").connect().await?;
+    let timeout_channel = Timeout::new(channel, Duration::from_millis(1000));
+
+    let mut client = GreeterClient::new(timeout_channel);
+
+    let request = tonic::Request::new(HelloRequest {
+        name: "Tonic".into(),
+    });
+
+    let response = client.say_hello(request).await?;
+
+    println!("RESPONSE={:?}", response);
+
+    Ok(())
+}

--- a/examples/src/timeout/server.rs
+++ b/examples/src/timeout/server.rs
@@ -1,0 +1,45 @@
+use std::time::Duration;
+use tokio::time::delay_for;
+use tonic::{transport::Server, Request, Response, Status};
+
+use hello_world::greeter_server::{Greeter, GreeterServer};
+use hello_world::{HelloReply, HelloRequest};
+
+pub mod hello_world {
+    tonic::include_proto!("helloworld");
+}
+
+#[derive(Default)]
+pub struct MyGreeter {}
+
+#[tonic::async_trait]
+impl Greeter for MyGreeter {
+    async fn say_hello(
+        &self,
+        request: Request<HelloRequest>,
+    ) -> Result<Response<HelloReply>, Status> {
+        println!("Got a request from {:?}", request.remote_addr());
+
+        delay_for(Duration::from_millis(5000)).await;
+
+        let reply = hello_world::HelloReply {
+            message: format!("Hello {}!", request.into_inner().name),
+        };
+        Ok(Response::new(reply))
+    }
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let addr = "[::1]:50051".parse().unwrap();
+    let greeter = MyGreeter::default();
+
+    println!("GreeterServer listening on {}", addr);
+
+    Server::builder()
+        .add_service(GreeterServer::new(greeter))
+        .serve(addr)
+        .await?;
+
+    Ok(())
+}

--- a/examples/src/tower/client.rs
+++ b/examples/src/tower/client.rs
@@ -32,7 +32,6 @@ mod service {
     use std::pin::Pin;
     use std::task::{Context, Poll};
     use tonic::body::BoxBody;
-    use tonic::client::GrpcService;
     use tonic::transport::Body;
     use tonic::transport::Channel;
     use tower::Service;

--- a/tonic/src/transport/channel/mod.rs
+++ b/tonic/src/transport/channel/mod.rs
@@ -10,7 +10,7 @@ pub use endpoint::Endpoint;
 pub use tls::ClientTlsConfig;
 
 use super::service::{Connection, DynamicServiceStream};
-use crate::{body::BoxBody, client::GrpcService};
+use crate::body::BoxBody;
 use bytes::Bytes;
 use http::{
     uri::{InvalidUri, Uri},
@@ -177,17 +177,18 @@ impl Channel {
     }
 }
 
-impl GrpcService<BoxBody> for Channel {
-    type ResponseBody = hyper::Body;
+impl Service<http::Request<BoxBody>> for Channel {
+    type Response = http::Response<super::Body>;
     type Error = super::Error;
     type Future = ResponseFuture;
 
     fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
-        GrpcService::poll_ready(&mut self.svc, cx).map_err(super::Error::from_source)
+        Service::poll_ready(&mut self.svc, cx).map_err(super::Error::from_source)
     }
 
-    fn call(&mut self, request: Request<BoxBody>) -> Self::Future {
-        let inner = GrpcService::call(&mut self.svc, request);
+    fn call(&mut self, request: http::Request<BoxBody>) -> Self::Future {
+        let inner = Service::call(&mut self.svc, request);
+
         ResponseFuture { inner }
     }
 }


### PR DESCRIPTION
## Motivation

Fixes #481. Adds `Service` impl for `Channel`.

## Solution

This PR replaces `GrpcService` impl for `tonic::transport::Channel` with `Service` impl. The two trait implementations cannot co-exist due to name conflict, but the former impl will be still alive thanks to the [general trait implementation for `Service` implementors](https://github.com/hyperium/tonic/blob/90858926b6a788f78f9c7bbdd7dda127f7f41e2c/tonic/src/client/service.rs#L33-L51).

**Notes**:

After applying this change, _existing codes that both imports `GrpcService` and `Service` traits can be broken_ due to multiple method definitions. This can be easily fixed by removing an import whichever or calling the preferable method explicitly. In this crate, only `examples/src/tower/client.rs` will be affected, so I fixed that in the second commit.

Finally, I added `timeout` example, which makes use of the unlocked feature by this change: wraps a channel with `tower` service.