### PR TITLE
[WIP] update to Tokio 0.3, latest Hyper

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,3 +18,6 @@ members = [
     "tests/extern_path/my_application",
     "tests/integration_tests"
 ]
+
+[patch.crates-io]
+hyper = { git = "https://github.com/hawkw/hyper", branch = "eliza/bump-tokio" }

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -157,7 +157,7 @@ tracing-futures = "0.2"
 # Required for wellknown types
 prost-types = "0.6"
 # Hyper example
-hyper = "0.13"
+hyper = { git = "https://github.com/hawkw/hyper", branch = "eliza/bump-tokio" }
 warp = { version = "0.2", default-features = false }
 http = "0.2"
 http-body = "0.3"
@@ -168,3 +168,6 @@ listenfd = "0.3"
 
 [build-dependencies]
 tonic-build = { path = "../tonic-build", features = ["prost"] }
+
+[patch.crates-io]
+hyper = { git = "https://github.com/hawkw/hyper", branch = "eliza/bump-tokio" }

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -157,10 +157,10 @@ tracing-futures = "0.2"
 # Required for wellknown types
 prost-types = "0.6"
 # Hyper example
-hyper = { git = "https://github.com/hawkw/hyper", branch = "eliza/bump-tokio" }
+hyper = { git = "https://github.com/hyperium/hyper", branch = "master" }
 warp = { version = "0.2", default-features = false }
 http = "0.2"
-http-body = "0.3"
+http-body  = { git = "https://github.com/hyperium/http-body", branch = "master" }
 pin-project = "0.4.17"
 # Health example
 tonic-health = { path = "../tonic-health" }

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -141,10 +141,10 @@ path = "src/hyper_warp_multiplex/server.rs"
 [dependencies]
 tonic = { path = "../tonic", features = ["tls"] }
 prost = "0.6"
-tokio = { version = "0.2", features = ["rt-threaded", "time", "stream", "fs", "macros", "uds"] }
+tokio = { version = "0.3", features = ["rt-multi-thread", "time", "stream", "fs", "macros", "net"] }
 futures = { version = "0.3", default-features = false, features = ["alloc"] }
 async-stream = "0.2"
-tower = "0.3"
+tower = { git = "https://github.com/tower-rs/tower", version = "0.4" }
 # Required for routeguide
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -140,7 +140,7 @@ path = "src/hyper_warp_multiplex/server.rs"
 
 [dependencies]
 tonic = { path = "../tonic", features = ["tls"] }
-prost = "0.6"
+prost = { git = "https://github.com/danburkert/prost" }
 tokio = { version = "0.3", features = ["rt-multi-thread", "time", "stream", "fs", "macros", "net"] }
 futures = { version = "0.3", default-features = false, features = ["alloc"] }
 async-stream = "0.2"
@@ -155,7 +155,7 @@ tracing-subscriber = { version = "0.2", features = ["tracing-log"] }
 tracing-attributes = "0.1"
 tracing-futures = "0.2"
 # Required for wellknown types
-prost-types = "0.6"
+prost-types = { git = "https://github.com/danburkert/prost" }
 # Hyper example
 hyper = { git = "https://github.com/hyperium/hyper", branch = "master" }
 warp = { version = "0.2", default-features = false }

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -168,6 +168,3 @@ listenfd = "0.3"
 
 [build-dependencies]
 tonic-build = { path = "../tonic-build", features = ["prost"] }
-
-[patch.crates-io]
-hyper = { git = "https://github.com/hawkw/hyper", branch = "eliza/bump-tokio" }

--- a/examples/src/autoreload/server.rs
+++ b/examples/src/autoreload/server.rs
@@ -36,9 +36,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     match listenfd::ListenFd::from_env().take_tcp_listener(0)? {
         Some(listener) => {
-            let mut listener = tokio::net::TcpListener::from_std(listener)?;
+            let listener = tokio::net::TcpListener::from_std(listener)?;
 
-            server.serve_with_incoming(listener.incoming()).await?;
+            server.serve_with_incoming(listener).await?;
         }
         None => {
             server.serve(addr).await?;

--- a/examples/src/blocking/client.rs
+++ b/examples/src/blocking/client.rs
@@ -24,11 +24,7 @@ impl BlockingClient {
         D: std::convert::TryInto<tonic::transport::Endpoint>,
         D::Error: Into<StdError>,
     {
-        let mut rt = Builder::new()
-            .basic_scheduler()
-            .enable_all()
-            .build()
-            .unwrap();
+        let rt = Builder::new_current_thread().enable_all().build().unwrap();
         let client = rt.block_on(GreeterClient::connect(dst))?;
 
         Ok(Self { rt, client })

--- a/examples/src/dynamic_load_balance/client.rs
+++ b/examples/src/dynamic_load_balance/client.rs
@@ -18,42 +18,42 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let e1 = Endpoint::from_static("http://[::1]:50051");
     let e2 = Endpoint::from_static("http://[::1]:50052");
 
-    let (channel, mut rx) = Channel::balance_channel(10);
+    let (channel, rx) = Channel::balance_channel(10);
     let mut client = EchoClient::new(channel);
 
     let done = Arc::new(AtomicBool::new(false));
     let demo_done = done.clone();
     tokio::spawn(async move {
-        tokio::time::delay_for(tokio::time::Duration::from_secs(5)).await;
+        tokio::time::sleep(tokio::time::Duration::from_secs(5)).await;
         println!("Added first endpoint");
         let change = Change::Insert("1", e1);
         let res = rx.send(change).await;
         println!("{:?}", res);
-        tokio::time::delay_for(tokio::time::Duration::from_secs(5)).await;
+        tokio::time::sleep(tokio::time::Duration::from_secs(5)).await;
         println!("Added second endpoint");
         let change = Change::Insert("2", e2);
         let res = rx.send(change).await;
         println!("{:?}", res);
-        tokio::time::delay_for(tokio::time::Duration::from_secs(5)).await;
+        tokio::time::sleep(tokio::time::Duration::from_secs(5)).await;
         println!("Removed first endpoint");
         let change = Change::Remove("1");
         let res = rx.send(change).await;
         println!("{:?}", res);
 
-        tokio::time::delay_for(tokio::time::Duration::from_secs(5)).await;
+        tokio::time::sleep(tokio::time::Duration::from_secs(5)).await;
         println!("Removed second endpoint");
         let change = Change::Remove("2");
         let res = rx.send(change).await;
         println!("{:?}", res);
 
-        tokio::time::delay_for(tokio::time::Duration::from_secs(5)).await;
+        tokio::time::sleep(tokio::time::Duration::from_secs(5)).await;
         println!("Added third endpoint");
         let e3 = Endpoint::from_static("http://[::1]:50051");
         let change = Change::Insert("3", e3);
         let res = rx.send(change).await;
         println!("{:?}", res);
 
-        tokio::time::delay_for(tokio::time::Duration::from_secs(5)).await;
+        tokio::time::sleep(tokio::time::Duration::from_secs(5)).await;
         println!("Removed third endpoint");
         let change = Change::Remove("3");
         let res = rx.send(change).await;
@@ -62,7 +62,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     });
 
     while !done.load(SeqCst) {
-        tokio::time::delay_for(tokio::time::Duration::from_millis(500)).await;
+        tokio::time::sleep(tokio::time::Duration::from_millis(500)).await;
         let request = tonic::Request::new(EchoRequest {
             message: "hello".into(),
         });

--- a/examples/src/health/server.rs
+++ b/examples/src/health/server.rs
@@ -3,7 +3,7 @@ use tonic::{transport::Server, Request, Response, Status};
 use hello_world::greeter_server::{Greeter, GreeterServer};
 use hello_world::{HelloReply, HelloRequest};
 use std::time::Duration;
-use tokio::time::delay_for;
+use tokio::time::sleep;
 use tonic_health::server::HealthReporter;
 
 pub mod hello_world {
@@ -34,7 +34,7 @@ async fn twiddle_service_status(mut reporter: HealthReporter) {
     let mut iter = 0u64;
     loop {
         iter += 1;
-        delay_for(Duration::from_secs(1)).await;
+        sleep(Duration::from_secs(1)).await;
 
         if iter % 2 == 0 {
             reporter.set_serving::<GreeterServer<MyGreeter>>().await;

--- a/examples/src/hyper_warp/server.rs
+++ b/examples/src/hyper_warp/server.rs
@@ -3,6 +3,9 @@
 //! To hit the warp server you can run this command:
 //! `curl localhost:50051/hello`
 
+// TODO(eliza): remove when this works again
+#![allow(unused_imports, dead_code)]
+
 use futures::future::{self, Either, TryFutureExt};
 use http::version::Version;
 use hyper::{service::make_service_fn, Server};
@@ -42,37 +45,38 @@ impl Greeter for MyGreeter {
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let addr = "[::1]:50051".parse().unwrap();
-    let greeter = MyGreeter::default();
+    todo!("bring back this example when Warp has been updated to use the latest Hyper");
+    // let addr = "[::1]:50051".parse().unwrap();
+    // let greeter = MyGreeter::default();
 
-    println!("GreeterServer listening on {}", addr);
+    // println!("GreeterServer listening on {}", addr);
 
-    let tonic = GreeterServer::new(greeter);
-    let mut warp = warp::service(warp::path("hello").map(|| "hello, world!"));
+    // let tonic = GreeterServer::new(greeter);
+    // let mut warp = warp::service(warp::path("hello").map(|| "hello, world!"));
 
-    Server::bind(&addr)
-        .serve(make_service_fn(move |_| {
-            let mut tonic = tonic.clone();
-            future::ok::<_, Infallible>(tower::service_fn(
-                move |req: hyper::Request<hyper::Body>| match req.version() {
-                    Version::HTTP_11 | Version::HTTP_10 => Either::Left(
-                        warp.call(req)
-                            .map_ok(|res| res.map(EitherBody::Left))
-                            .map_err(Error::from),
-                    ),
-                    Version::HTTP_2 => Either::Right(
-                        tonic
-                            .call(req)
-                            .map_ok(|res| res.map(EitherBody::Right))
-                            .map_err(Error::from),
-                    ),
-                    _ => unimplemented!(),
-                },
-            ))
-        }))
-        .await?;
+    // Server::bind(&addr)
+    //     .serve(make_service_fn(move |_| {
+    //         let mut tonic = tonic.clone();
+    //         future::ok::<_, Infallible>(tower::service_fn(
+    //             move |req: hyper::Request<hyper::Body>| match req.version() {
+    //                 Version::HTTP_11 | Version::HTTP_10 => Either::Left(
+    //                     warp.call(req)
+    //                         .map_ok(|res| res.map(EitherBody::Left))
+    //                         .map_err(Error::from),
+    //                 ),
+    //                 Version::HTTP_2 => Either::Right(
+    //                     tonic
+    //                         .call(req)
+    //                         .map_ok(|res| res.map(EitherBody::Right))
+    //                         .map_err(Error::from),
+    //                 ),
+    //                 _ => unimplemented!(),
+    //             },
+    //         ))
+    //     }))
+    //     .await?;
 
-    Ok(())
+    // Ok(())`
 }
 
 enum EitherBody<A, B> {

--- a/examples/src/hyper_warp_multiplex/server.rs
+++ b/examples/src/hyper_warp_multiplex/server.rs
@@ -3,6 +3,9 @@
 //! To hit the warp server you can run this command:
 //! `curl localhost:50051/hello`
 
+// TODO(eliza): remove when this works again
+#![allow(unused_imports, dead_code)]
+
 use futures::future::{self, Either, TryFutureExt};
 use futures::Stream;
 use http::version::Version;
@@ -94,40 +97,41 @@ impl Echo for MyEcho {
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let addr = "[::1]:50051".parse().unwrap();
+    todo!("bring this example back when Warp has been updated to the latest Hyper");
+    // let addr = "[::1]:50051".parse().unwrap();
 
-    let mut warp = warp::service(warp::path("hello").map(|| "hello, world!"));
+    // let mut warp = warp::service(warp::path("hello").map(|| "hello, world!"));
 
-    Server::bind(&addr)
-        .serve(make_service_fn(move |_| {
-            let greeter = GreeterServer::new(MyGreeter::default());
-            let echo = EchoServer::new(MyEcho::default());
+    // Server::bind(&addr)
+    //     .serve(make_service_fn(move |_| {
+    //         let greeter = GreeterServer::new(MyGreeter::default());
+    //         let echo = EchoServer::new(MyEcho::default());
 
-            let mut tonic = TonicServer::builder()
-                .add_service(greeter)
-                .add_service(echo)
-                .into_service();
+    //         let mut tonic = TonicServer::builder()
+    //             .add_service(greeter)
+    //             .add_service(echo)
+    //             .into_service();
 
-            future::ok::<_, Infallible>(tower::service_fn(
-                move |req: hyper::Request<hyper::Body>| match req.version() {
-                    Version::HTTP_11 | Version::HTTP_10 => Either::Left(
-                        warp.call(req)
-                            .map_ok(|res| res.map(EitherBody::Left))
-                            .map_err(Error::from),
-                    ),
-                    Version::HTTP_2 => Either::Right(
-                        tonic
-                            .call(req)
-                            .map_ok(|res| res.map(EitherBody::Right))
-                            .map_err(Error::from),
-                    ),
-                    _ => unimplemented!(),
-                },
-            ))
-        }))
-        .await?;
+    //         future::ok::<_, Infallible>(tower::service_fn(
+    //             move |req: hyper::Request<hyper::Body>| match req.version() {
+    //                 Version::HTTP_11 | Version::HTTP_10 => Either::Left(
+    //                     warp.call(req)
+    //                         .map_ok(|res| res.map(EitherBody::Left))
+    //                         .map_err(Error::from),
+    //                 ),
+    //                 Version::HTTP_2 => Either::Right(
+    //                     tonic
+    //                         .call(req)
+    //                         .map_ok(|res| res.map(EitherBody::Right))
+    //                         .map_err(Error::from),
+    //                 ),
+    //                 _ => unimplemented!(),
+    //             },
+    //         ))
+    //     }))
+    //     .await?;
 
-    Ok(())
+    // Ok(())
 }
 
 enum EitherBody<A, B> {

--- a/examples/src/routeguide/server.rs
+++ b/examples/src/routeguide/server.rs
@@ -44,7 +44,7 @@ impl RouteGuide for RouteGuideService {
     ) -> Result<Response<Self::ListFeaturesStream>, Status> {
         println!("ListFeatures = {:?}", request);
 
-        let (mut tx, rx) = mpsc::channel(4);
+        let (tx, rx) = mpsc::channel(4);
         let features = self.features.clone();
 
         tokio::spawn(async move {

--- a/examples/src/uds/server.rs
+++ b/examples/src/uds/server.rs
@@ -40,13 +40,13 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     tokio::fs::create_dir_all(Path::new(path).parent().unwrap()).await?;
 
-    let mut uds = UnixListener::bind(path)?;
+    let uds = UnixListener::bind(path)?;
 
     let greeter = MyGreeter::default();
 
     Server::builder()
         .add_service(GreeterServer::new(greeter))
-        .serve_with_incoming(uds.incoming().map_ok(unix::UnixStream))
+        .serve_with_incoming(uds.map_ok(unix::UnixStream))
         .await?;
 
     Ok(())
@@ -59,7 +59,7 @@ mod unix {
         task::{Context, Poll},
     };
 
-    use tokio::io::{AsyncRead, AsyncWrite};
+    use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
     use tonic::transport::server::Connected;
 
     #[derive(Debug)]
@@ -71,8 +71,8 @@ mod unix {
         fn poll_read(
             mut self: Pin<&mut Self>,
             cx: &mut Context<'_>,
-            buf: &mut [u8],
-        ) -> Poll<std::io::Result<usize>> {
+            buf: &mut ReadBuf<'_>,
+        ) -> Poll<std::io::Result<()>> {
             Pin::new(&mut self.0).poll_read(cx, buf)
         }
     }

--- a/interop/Cargo.toml
+++ b/interop/Cargo.toml
@@ -17,16 +17,16 @@ path = "src/bin/server.rs"
 [dependencies]
 tokio = { version = "0.3", features = ["rt-multi-thread", "time", "macros", "stream", "fs"] }
 tonic = { path = "../tonic", features = ["tls"] }
-prost = "0.6"
-prost-derive = "0.6"
-bytes = "0.5"
+prost = { git = "https://github.com/danburkert/prost" }
+prost-derive  = { git = "https://github.com/danburkert/prost" }
+bytes = "0.6"
 http = "0.2"
 futures-core = "0.3"
 futures-util = "0.3"
 async-stream = "0.2"
 tower = { git = "https://github.com/tower-rs/tower", version = "0.4" }
-http-body = "0.3"
-hyper = { git = "https://github.com/hawkw/hyper", branch = "eliza/bump-tokio", features = ["stream"] }
+http-body  = { git = "https://github.com/hyperium/http-body", branch = "master" }
+hyper = { git = "https://github.com/hyperium/hyper", branch = "master", features = ["stream"] }
 console = "0.9"
 structopt = "0.3"
 tracing = "0.1"

--- a/interop/Cargo.toml
+++ b/interop/Cargo.toml
@@ -15,7 +15,7 @@ name = "server"
 path = "src/bin/server.rs"
 
 [dependencies]
-tokio = { version = "0.2", features = ["rt-threaded", "time", "macros", "stream", "fs"] }
+tokio = { version = "0.3", features = ["rt-multi-thread", "time", "macros", "stream", "fs"] }
 tonic = { path = "../tonic", features = ["tls"] }
 prost = "0.6"
 prost-derive = "0.6"
@@ -24,9 +24,9 @@ http = "0.2"
 futures-core = "0.3"
 futures-util = "0.3"
 async-stream = "0.2"
-tower = "0.3"
+tower = { git = "https://github.com/tower-rs/tower", version = "0.4" }
 http-body = "0.3"
-hyper = "0.13"
+hyper = { git = "https://github.com/hawkw/hyper", branch = "eliza/bump-tokio", features = ["stream"] }
 console = "0.9"
 structopt = "0.3"
 tracing = "0.1"

--- a/interop/src/server.rs
+++ b/interop/src/server.rs
@@ -2,7 +2,7 @@ use crate::pb::{self, *};
 use async_stream::try_stream;
 use futures_util::{stream, StreamExt, TryStreamExt};
 use http::header::{HeaderMap, HeaderName, HeaderValue};
-use http_body::Body;
+use hyper::body::HttpBody;
 use std::future::Future;
 use std::pin::Pin;
 use std::task::{Context, Poll};
@@ -72,7 +72,7 @@ impl pb::test_service_server::TestService for TestService {
 
         let stream = try_stream! {
             for param in response_parameters {
-                tokio::time::delay_for(Duration::from_micros(param.interval_us as u64)).await;
+                tokio::time::sleep(Duration::from_micros(param.interval_us as u64)).await;
 
                 let payload = crate::server_payload(param.size as usize);
                 yield StreamingOutputCallResponse { payload: Some(payload) };
@@ -127,7 +127,7 @@ impl pb::test_service_server::TestService for TestService {
                     }
 
                     for param in msg.response_parameters {
-                        tokio::time::delay_for(Duration::from_micros(param.interval_us as u64)).await;
+                        tokio::time::sleep(Duration::from_micros(param.interval_us as u64)).await;
 
                         let payload = crate::server_payload(param.size as usize);
                         yield StreamingOutputCallResponse { payload: Some(payload) };
@@ -235,7 +235,7 @@ impl<B> MergeTrailers<B> {
     }
 }
 
-impl<B: Body + Unpin> Body for MergeTrailers<B> {
+impl<B: HttpBody + Unpin> HttpBody for MergeTrailers<B> {
     type Data = B::Data;
     type Error = B::Error;
 

--- a/tests/ambiguous_methods/Cargo.toml
+++ b/tests/ambiguous_methods/Cargo.toml
@@ -10,7 +10,7 @@ license = "MIT"
 
 [dependencies]
 tonic = { path= "../../tonic" }
-prost = "0.6"
+prost = { git = "https://github.com/danburkert/prost" }
 
 [build-dependencies]
 tonic-build = { path= "../../tonic-build" }

--- a/tests/extern_path/my_application/Cargo.toml
+++ b/tests/extern_path/my_application/Cargo.toml
@@ -10,8 +10,8 @@ license = "MIT"
 
 [dependencies]
 tonic = { path= "../../../tonic" }
-prost = "0.6"
-prost-types = "0.6"
+prost = { git = "https://github.com/danburkert/prost" }
+prost-types = { git = "https://github.com/danburkert/prost" }
 uuid = { package = "uuid1", path= "../uuid" }
 
 [build-dependencies]

--- a/tests/extern_path/uuid/Cargo.toml
+++ b/tests/extern_path/uuid/Cargo.toml
@@ -9,7 +9,7 @@ license = "MIT"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-prost = "0.6"
-bytes = "0.5"
+prost = { git = "https://github.com/danburkert/prost" }
+bytes = "0.6"
 [build-dependencies]
-prost-build = "0.6"
+prost-build = { git = "https://github.com/danburkert/prost" }

--- a/tests/included_service/Cargo.toml
+++ b/tests/included_service/Cargo.toml
@@ -10,7 +10,7 @@ license = "MIT"
 
 [dependencies]
 tonic = { path = "../../tonic" }
-prost = "0.6"
+prost = { git = "https://github.com/danburkert/prost" }
 
 [build-dependencies]
 tonic-build = { path = "../../tonic-build" }

--- a/tests/integration_tests/Cargo.toml
+++ b/tests/integration_tests/Cargo.toml
@@ -15,7 +15,7 @@ futures-util = "0.3"
 bytes = "0.5"
 
 [dev-dependencies]
-tokio = { version = "0.2", features = ["macros", "rt-core", "tcp"] }
+tokio = { version = "0.3", features = ["macros", "rt", "net"] }
 
 [build-dependencies]
 tonic-build = { path = "../../tonic-build" }

--- a/tests/integration_tests/Cargo.toml
+++ b/tests/integration_tests/Cargo.toml
@@ -10,9 +10,9 @@ license = "MIT"
 
 [dependencies]
 tonic = { path = "../../tonic" }
-prost = "0.6"
+prost = { git = "https://github.com/danburkert/prost" }
 futures-util = "0.3"
-bytes = "0.5"
+bytes = "0.6"
 
 [dev-dependencies]
 tokio = { version = "0.3", features = ["macros", "rt", "net"] }

--- a/tests/integration_tests/tests/connection.rs
+++ b/tests/integration_tests/tests/connection.rs
@@ -41,14 +41,14 @@ async fn connect_returns_err_via_call_after_connected() {
             .unwrap();
     });
 
-    tokio::time::delay_for(Duration::from_millis(100)).await;
+    tokio::time::sleep(Duration::from_millis(100)).await;
 
     let mut client = TestClient::connect("http://127.0.0.1:1338").await.unwrap();
 
     // First call should pass, then shutdown the server
     client.unary_call(Request::new(Input {})).await.unwrap();
 
-    tokio::time::delay_for(Duration::from_millis(100)).await;
+    tokio::time::sleep(Duration::from_millis(100)).await;
 
     let res = client.unary_call(Request::new(Input {})).await;
 
@@ -81,11 +81,11 @@ async fn connect_lazy_reconnects_after_first_failure() {
             .unwrap();
     });
 
-    tokio::time::delay_for(Duration::from_millis(100)).await;
+    tokio::time::sleep(Duration::from_millis(100)).await;
     client.unary_call(Request::new(Input {})).await.unwrap();
 
     // The server shut down, third call should fail
-    tokio::time::delay_for(Duration::from_millis(100)).await;
+    tokio::time::sleep(Duration::from_millis(100)).await;
     client.unary_call(Request::new(Input {})).await.unwrap_err();
 
     jh.await.unwrap();

--- a/tests/integration_tests/tests/status.rs
+++ b/tests/integration_tests/tests/status.rs
@@ -33,7 +33,7 @@ async fn status_with_details() {
             .unwrap();
     });
 
-    tokio::time::delay_for(Duration::from_millis(100)).await;
+    tokio::time::sleep(Duration::from_millis(100)).await;
 
     let mut channel = test_client::TestClient::connect("http://127.0.0.1:1337")
         .await
@@ -87,7 +87,7 @@ async fn status_with_metadata() {
             .unwrap();
     });
 
-    tokio::time::delay_for(Duration::from_millis(100)).await;
+    tokio::time::sleep(Duration::from_millis(100)).await;
 
     let mut channel = test_client::TestClient::connect("http://127.0.0.1:1338")
         .await

--- a/tests/integration_tests/tests/user_agent.rs
+++ b/tests/integration_tests/tests/user_agent.rs
@@ -33,7 +33,7 @@ async fn writes_user_agent_header() {
             .unwrap();
     });
 
-    tokio::time::delay_for(Duration::from_millis(100)).await;
+    tokio::time::sleep(Duration::from_millis(100)).await;
 
     let channel = Endpoint::from_static("http://127.0.0.1:1322")
         .user_agent("my-client")

--- a/tests/same_name/Cargo.toml
+++ b/tests/same_name/Cargo.toml
@@ -10,7 +10,7 @@ license = "MIT"
 
 [dependencies]
 tonic = { path = "../../tonic" }
-prost = "0.6"
+prost = { git = "https://github.com/danburkert/prost" }
 
 [build-dependencies]
 tonic-build = { path = "../../tonic-build" }

--- a/tests/wellknown/Cargo.toml
+++ b/tests/wellknown/Cargo.toml
@@ -10,8 +10,8 @@ license = "MIT"
 
 [dependencies]
 tonic = { path = "../../tonic" }
-prost = "0.6"
-prost-types = "0.6"
+prost = { git = "https://github.com/danburkert/prost" }
+prost-types = { git = "https://github.com/danburkert/prost" }
 
 [build-dependencies]
 tonic-build = { path = "../../tonic-build" }

--- a/tonic-build/Cargo.toml
+++ b/tonic-build/Cargo.toml
@@ -16,7 +16,7 @@ keywords = ["rpc", "grpc", "async", "codegen", "protobuf"]
 
 
 [dependencies]
-prost-build = { version = "0.6", optional = true }
+prost-build = { git = "https://github.com/danburkert/prost", optional = true }
 syn = "1.0"
 quote = "1.0"
 proc-macro2 = "1.0"

--- a/tonic-health/Cargo.toml
+++ b/tonic-health/Cargo.toml
@@ -19,13 +19,13 @@ transport = ["tonic/transport"]
 
 [dependencies]
 async-stream = "0.2"
-tokio = { version = "0.2", features = ["sync", "stream"] }
+tokio = { version = "0.3", features = ["sync", "stream"] }
 tonic = { version = "0.3", path = "../tonic", features = ["codegen", "prost"] }
-bytes = "0.5"
-prost = "0.6"
+bytes = "0.6"
+prost = { git = "https://github.com/danburkert/prost" }
 
 [dev-dependencies]
-tokio = { version = "0.2", features = ["rt-core", "macros"]}
+tokio = { version = "0.3", features = ["rt", "macros"]}
 
 [build-dependencies]
 tonic-build = { version = "0.3", path = "../tonic-build" }

--- a/tonic-types/Cargo.toml
+++ b/tonic-types/Cargo.toml
@@ -15,8 +15,8 @@ categories = ["web-programming", "network-programming", "asynchronous"]
 keywords = ["rpc", "grpc", "protobuf"]
 
 [dependencies]
-prost = "0.6"
-prost-types = "0.6"
+prost = { git = "https://github.com/danburkert/prost" }
+prost-types = { git = "https://github.com/danburkert/prost" }
 
 [build-dependencies]
-prost-build = "0.6"
+prost-build = { git = "https://github.com/danburkert/prost" }

--- a/tonic/Cargo.toml
+++ b/tonic/Cargo.toml
@@ -40,7 +40,7 @@ prost = ["prost1", "prost-derive"]
 # harness = false
 
 [dependencies]
-bytes = "0.5"
+bytes = "0.6"
 futures-core = { version = "0.3", default-features = false }
 futures-util = { version = "0.3", default-features = false }
 tracing = "0.1"
@@ -51,18 +51,18 @@ percent-encoding = "2.0"
 tower-service = "0.3"
 tokio-util = { version = "0.5", features = ["codec"] }
 async-stream = "0.2"
-http-body = "0.3"
+http-body = { git = "https://github.com/hyperium/http-body", branch = "master" }
 pin-project = "0.4.17"
 
 # prost
-prost1 = { package = "prost", version = "0.6", optional = true }
-prost-derive = { version = "0.6", optional = true }
+prost1 = { package = "prost", git = "https://github.com/danburkert/prost", optional = true }
+prost-derive = { git = "https://github.com/danburkert/prost", optional = true }
 
 # codegen
 async-trait = { version = "0.1.13", optional = true }
 
 # transport
-hyper = { git = "https://github.com/hawkw/hyper", branch = "eliza/bump-tokio", features = ["stream"], optional = true }
+hyper = { git = "https://github.com/hyperium/hyper", branch = "master", features = ["client", "http2", "server", "stream", "runtime"], optional = true }
 tokio = { version = "0.3.2", features = ["net", "sync"], optional = true }
 tracing-futures = { version = "0.2", optional = true }
 

--- a/tonic/Cargo.toml
+++ b/tonic/Cargo.toml
@@ -29,8 +29,6 @@ transport = [
     "hyper",
     "tokio",
     "tower",
-    "tower-balance",
-    "tower-load",
     "tracing-futures",
 ]
 tls = ["transport", "tokio-rustls"]
@@ -51,7 +49,7 @@ base64 = "0.12"
 
 percent-encoding = "2.0"
 tower-service = "0.3"
-tokio-util = { version = "0.3", features = ["codec"] }
+tokio-util = { version = "0.5", features = ["codec"] }
 async-stream = "0.2"
 http-body = "0.3"
 pin-project = "0.4.17"
@@ -64,20 +62,22 @@ prost-derive = { version = "0.6", optional = true }
 async-trait = { version = "0.1.13", optional = true }
 
 # transport
-hyper = { version = "0.13.4", features = ["stream"], optional = true }
-tokio = { version = "0.2.13", features = ["tcp"], optional = true }
-tower = { version = "0.3", optional = true}
-tower-make = { version = "0.3", features = ["connect"] }
-tower-balance =  { version = "0.3", optional = true }
-tower-load = { version = "0.3", optional = true }
+hyper = { git = "https://github.com/hawkw/hyper", branch = "eliza/bump-tokio", features = ["stream"], optional = true }
+tokio = { version = "0.3.2", features = ["net", "sync"], optional = true }
 tracing-futures = { version = "0.2", optional = true }
 
 # rustls
-tokio-rustls = { version = "0.14", optional = true }
+tokio-rustls = { version = "0.20", optional = true }
 rustls-native-certs = { version = "0.4", optional = true }
 
+[dependencies.tower]
+git = "https://github.com/tower-rs/tower"
+version = "0.4"
+features = ["balance", "load", "make", "buffer", "limit", "util", "timeout"]
+optional = true
+
 [dev-dependencies]
-tokio = { version = "0.2", features = ["rt-core", "macros"] }
+tokio = { version = "0.3", features = ["rt", "macros"] }
 static_assertions = "1.0"
 rand = "0.7"
 bencher = "0.1.5"

--- a/tonic/benches/decode.rs
+++ b/tonic/benches/decode.rs
@@ -11,8 +11,7 @@ use tonic::{codec::DecodeBuf, codec::Decoder, Status, Streaming};
 macro_rules! bench {
     ($name:ident, $message_size:expr, $chunk_size:expr, $message_count:expr) => {
         fn $name(b: &mut Bencher) {
-            let mut rt = tokio::runtime::Builder::new()
-                .basic_scheduler()
+            let rt = tokio::runtime::Builder::new_current_thread()
                 .build()
                 .expect("runtime");
 

--- a/tonic/src/body.rs
+++ b/tonic/src/body.rs
@@ -160,7 +160,7 @@ where
             Pin::new_unchecked(&mut me.0).poll_data(cx)
         };
         match futures_util::ready!(v) {
-            Some(Ok(mut i)) => Poll::Ready(Some(Ok(i.to_bytes()))),
+            Some(Ok(mut i)) => Poll::Ready(Some(Ok(i.copy_to_bytes(i.bytes().len())))),
             Some(Err(e)) => {
                 let err = Status::map_error(e.into());
                 Poll::Ready(Some(Err(err)))

--- a/tonic/src/transport/channel/endpoint.rs
+++ b/tonic/src/transport/channel/endpoint.rs
@@ -15,7 +15,7 @@ use std::{
     fmt,
     time::Duration,
 };
-use tower_make::MakeConnection;
+use tower::make::MakeConnection;
 
 /// Channel builder.
 ///

--- a/tonic/src/transport/channel/mod.rs
+++ b/tonic/src/transport/channel/mod.rs
@@ -30,12 +30,12 @@ use tokio::{
 };
 
 use tower::{
+    balance::p2c::Balance,
     buffer::{self, Buffer},
     discover::{Change, Discover},
     util::{BoxService, Either},
     Service,
 };
-use tower_balance::p2c::Balance;
 
 type Svc = Either<Connection, BoxService<Request<BoxBody>, Response<hyper::Body>, crate::Error>>;
 
@@ -166,9 +166,9 @@ impl Channel {
     where
         D: Discover<Service = Connection> + Unpin + Send + 'static,
         D::Error: Into<crate::Error>,
-        D::Key: Send + Clone,
+        D::Key: Hash + Send + Clone,
     {
-        let svc = Balance::from_entropy(discover);
+        let svc = Balance::new(discover);
 
         let svc = BoxService::new(svc);
         let svc = Buffer::new(Either::B(svc), buffer_size);

--- a/tonic/src/transport/channel/mod.rs
+++ b/tonic/src/transport/channel/mod.rs
@@ -109,7 +109,7 @@ impl Channel {
     /// This creates a [`Channel`] that will load balance accross all the
     /// provided endpoints.
     pub fn balance_list(list: impl Iterator<Item = Endpoint>) -> Self {
-        let (channel, mut tx) = Self::balance_channel(DEFAULT_BUFFER_SIZE);
+        let (channel, tx) = Self::balance_channel(DEFAULT_BUFFER_SIZE);
         list.for_each(|endpoint| {
             tx.try_send(Change::Insert(endpoint.uri.clone(), endpoint))
                 .unwrap();

--- a/tonic/src/transport/server/incoming.rs
+++ b/tonic/src/transport/server/incoming.rs
@@ -12,7 +12,7 @@ use std::{
     task::{Context, Poll},
     time::Duration,
 };
-use tokio::io::{AsyncRead, AsyncWrite};
+use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
 
 #[cfg_attr(not(feature = "tls"), allow(unused_variables))]
 pub(crate) fn tcp_incoming<IO, IE>(
@@ -105,8 +105,8 @@ where
     fn poll_read(
         self: Pin<&mut Self>,
         cx: &mut Context<'_>,
-        buf: &mut [u8],
-    ) -> Poll<std::io::Result<usize>> {
+        buf: &mut ReadBuf<'_>,
+    ) -> Poll<std::io::Result<()>> {
         use std::future::Future;
 
         let pin = self.get_mut();

--- a/tonic/src/transport/service/connection.rs
+++ b/tonic/src/transport/service/connection.rs
@@ -13,11 +13,11 @@ use tokio::io::{AsyncRead, AsyncWrite};
 use tower::{
     layer::Layer,
     limit::{concurrency::ConcurrencyLimitLayer, rate::RateLimitLayer},
+    load::Load,
     timeout::TimeoutLayer,
     util::BoxService,
     ServiceBuilder, ServiceExt,
 };
-use tower_load::Load;
 use tower_service::Service;
 
 pub(crate) type Request = http::Request<BoxBody>;

--- a/tonic/src/transport/service/connector.rs
+++ b/tonic/src/transport/service/connector.rs
@@ -4,7 +4,7 @@ use super::io::BoxedIo;
 use super::tls::TlsConnector;
 use http::Uri;
 use std::task::{Context, Poll};
-use tower_make::MakeConnection;
+use tower::make::MakeConnection;
 use tower_service::Service;
 
 #[cfg(not(feature = "tls"))]

--- a/tonic/src/transport/service/io.rs
+++ b/tonic/src/transport/service/io.rs
@@ -4,7 +4,7 @@ use std::io;
 use std::net::SocketAddr;
 use std::pin::Pin;
 use std::task::{Context, Poll};
-use tokio::io::{AsyncRead, AsyncWrite};
+use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
 
 pub(in crate::transport) trait Io:
     AsyncRead + AsyncWrite + Send + 'static
@@ -33,8 +33,8 @@ impl AsyncRead for BoxedIo {
     fn poll_read(
         mut self: Pin<&mut Self>,
         cx: &mut Context<'_>,
-        buf: &mut [u8],
-    ) -> Poll<io::Result<usize>> {
+        buf: &mut ReadBuf<'_>,
+    ) -> Poll<io::Result<()>> {
         Pin::new(&mut self.0).poll_read(cx, buf)
     }
 }
@@ -83,8 +83,8 @@ impl AsyncRead for ServerIo {
     fn poll_read(
         mut self: Pin<&mut Self>,
         cx: &mut Context<'_>,
-        buf: &mut [u8],
-    ) -> Poll<io::Result<usize>> {
+        buf: &mut ReadBuf<'_>,
+    ) -> Poll<io::Result<()>> {
         Pin::new(&mut self.0).poll_read(cx, buf)
     }
 }

--- a/tonic/src/transport/service/layer.rs
+++ b/tonic/src/transport/service/layer.rs
@@ -1,5 +1,5 @@
 use tower::{
-    layer::{Layer, Stack},
+    layer::{util::Stack, Layer},
     util::Either,
     ServiceBuilder,
 };

--- a/tonic/src/transport/service/reconnect.rs
+++ b/tonic/src/transport/service/reconnect.rs
@@ -6,7 +6,7 @@ use std::{
     pin::Pin,
     task::{Context, Poll},
 };
-use tower_make::MakeService;
+use tower::make::MakeService;
 use tower_service::Service;
 use tracing::trace;
 
@@ -203,7 +203,7 @@ where
         match me.inner.project() {
             InnerProj::Future(fut) => fut.poll(cx).map_err(Into::into),
             InnerProj::Error(e) => {
-                let e = e.take().expect("Polled after ready.").into();
+                let e = Option::take(e).expect("Polled after ready.").into();
                 Poll::Ready(Err(e))
             }
         }


### PR DESCRIPTION
This branch updates `tonic` to use `tokio` 0.3, `tower` 0.4,
and `bytes` 0.6

This currently depends on unreleased upstream dependencies,
so it can't be published until those crates are published:

* [ ] `tower` 0.4 on `master`
* [ ] `hyper` 0.14 on `master`
* [ ] `prost`