### PR TITLE
fixes routeguide tutorial URL to async book

### DIFF
--- a/examples/routeguide-tutorial.md
+++ b/examples/routeguide-tutorial.md
@@ -315,7 +315,7 @@ uses [async-trait] internally. You can learn more about `async fn` in traits in 
 
 [cargo book]: https://doc.rust-lang.org/cargo/reference/environment-variables.html#environment-variables-cargo-sets-for-build-scripts
 [async-trait]: https://github.com/dtolnay/async-trait
-[async book]: https://rust-lang.github.io/async-book/07_workarounds/06_async_in_traits.html
+[async book]: https://rust-lang.github.io/async-book/07_workarounds/05_async_in_traits.html
 
 ### Server state
 Our service needs access to an immutable list of features. When the server starts, we are going to


### PR DESCRIPTION
## Motivation

The URL to the Async Trait section of the Rust Async Book needed updating.

## Solution

Update the URL.