### PR TITLE
feat(transport): Connect lazily in the load balanced channel

### DIFF
--- a/tonic/src/transport/service/discover.rs
+++ b/tonic/src/transport/service/discover.rs
@@ -1,9 +1,8 @@
-use super::super::{service, BoxFuture};
+use super::super::{service};
 use super::connection::Connection;
 use crate::transport::Endpoint;
 
 use std::{
-    future::Future,
     hash::Hash,
     pin::Pin,
     task::{Context, Poll},
@@ -16,14 +15,12 @@ type DiscoverResult<K, S, E> = Result<Change<K, S>, E>;
 
 pub(crate) struct DynamicServiceStream<K: Hash + Eq + Clone> {
     changes: Receiver<Change<K, Endpoint>>,
-    connecting: Option<(K, BoxFuture<Connection, crate::Error>)>,
 }
 
 impl<K: Hash + Eq + Clone> DynamicServiceStream<K> {
     pub(crate) fn new(changes: Receiver<Change<K, Endpoint>>) -> Self {
         Self {
             changes,
-            connecting: None,
         }
     }
 }
@@ -38,20 +35,9 @@ impl<K: Hash + Eq + Clone> Discover for DynamicServiceStream<K> {
         cx: &mut Context<'_>,
     ) -> Poll<DiscoverResult<Self::Key, Self::Service, Self::Error>> {
         loop {
-            if let Some((key, connecting)) = &mut self.connecting {
-                let svc = futures_core::ready!(Pin::new(connecting).poll(cx))?;
-                let key = key.to_owned();
-                self.connecting = None;
-                let change = Ok(Change::Insert(key, svc));
-                return Poll::Ready(change);
-            };
-
             let c = &mut self.changes;
-            match Pin::new(&mut *c).poll_next(cx) {
-                Poll::Pending => return Poll::Pending,
-                Poll::Ready(None) => {
-                    return Poll::Pending;
-                }
+            return match Pin::new(&mut *c).poll_next(cx) {
+                Poll::Pending | Poll::Ready(None) => Poll::Pending,
                 Poll::Ready(Some(change)) => match change {
                     Change::Insert(k, endpoint) => {
                         let mut http = hyper::client::connect::HttpConnector::new();
@@ -59,15 +45,15 @@ impl<K: Hash + Eq + Clone> Discover for DynamicServiceStream<K> {
                         http.set_keepalive(endpoint.tcp_keepalive);
                         http.enforce_http(false);
                         #[cfg(feature = "tls")]
-                        let connector = service::connector(http, endpoint.tls.clone());
+                            let connector = service::connector(http, endpoint.tls.clone());
 
                         #[cfg(not(feature = "tls"))]
-                        let connector = service::connector(http);
-                        let fut = Connection::connect(connector, endpoint);
-                        self.connecting = Some((k, Box::pin(fut)));
-                        continue;
+                            let connector = service::connector(http);
+                        let connection = Connection::lazy(connector, endpoint);
+                        let change = Ok(Change::Insert(k, connection));
+                        Poll::Ready(change)
                     }
-                    Change::Remove(k) => return Poll::Ready(Ok(Change::Remove(k))),
+                    Change::Remove(k) => Poll::Ready(Ok(Change::Remove(k))),
                 },
             }
         }

--- a/tonic/src/transport/service/discover.rs
+++ b/tonic/src/transport/service/discover.rs
@@ -1,4 +1,4 @@
-use super::super::{service};
+use super::super::service;
 use super::connection::Connection;
 use crate::transport::Endpoint;
 
@@ -19,9 +19,7 @@ pub(crate) struct DynamicServiceStream<K: Hash + Eq + Clone> {
 
 impl<K: Hash + Eq + Clone> DynamicServiceStream<K> {
     pub(crate) fn new(changes: Receiver<Change<K, Endpoint>>) -> Self {
-        Self {
-            changes,
-        }
+        Self { changes }
     }
 }
 
@@ -45,17 +43,17 @@ impl<K: Hash + Eq + Clone> Discover for DynamicServiceStream<K> {
                         http.set_keepalive(endpoint.tcp_keepalive);
                         http.enforce_http(false);
                         #[cfg(feature = "tls")]
-                            let connector = service::connector(http, endpoint.tls.clone());
+                        let connector = service::connector(http, endpoint.tls.clone());
 
                         #[cfg(not(feature = "tls"))]
-                            let connector = service::connector(http);
+                        let connector = service::connector(http);
                         let connection = Connection::lazy(connector, endpoint);
                         let change = Ok(Change::Insert(k, connection));
                         Poll::Ready(change)
                     }
                     Change::Remove(k) => Poll::Ready(Ok(Change::Remove(k))),
                 },
-            }
+            };
         }
     }
 }


### PR DESCRIPTION
## Motivation

If the first connection to the endpoint in an `Insert` changeset fails, the service goes into a failed state and the channel is dropped:

```
[2020-11-17T19:49:49.555562881+00:00] DEBUG: test/19660 on luca-XPS-15-9570: connecting to 127.0.0.124:5000
[2020-11-17T19:49:49.555756890+00:00] DEBUG: test/19660 on luca-XPS-15-9570: updating from discover
[2020-11-17T19:49:49.555879512+00:00] DEBUG: test/19660 on luca-XPS-15-9570: service failed
    error: load balancer discovery error: error trying to connect: tcp connect error: Connection refused (os error 111)
```

This is not coherent with the behavior we observe if the connection is broken after having successfully connected at least once - the channel remains open and we try to reconnect without disrupting calls.

## Solution

The current PR makes the connection step lazy by default in the load balanced channel.
An alternative approach would be to allow the caller to choose if it should connect eagerly (and crash if the first connection fails) or be lazy - maybe as an additional parameter on `balance_channel`? Or a `balance_channel_lazy`? Or a `lazy` property on the `Endpoint`? 

## Why are we touching this?

We have been trying to build a client-side load balanced gRPC client on top of `tonic` load balanced channel using a background task probing the DNS on a schedule. We'd be happy to add it as an example to `tonic` itself (including the test that got us here :sweat_smile: )
