### PR TITLE
Load balancing example and test

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,5 +16,6 @@ members = [
     "tests/extern_path/uuid",
     "tests/ambiguous_methods",
     "tests/extern_path/my_application",
-    "tests/integration_tests"
+    "tests/integration_tests",
+    "tests/load_balancing"
 ]

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -138,13 +138,25 @@ path = "src/hyper_warp_multiplex/client.rs"
 name = "hyper-warp-multiplex-server"
 path = "src/hyper_warp_multiplex/server.rs"
 
+[lib]
+name = "examples"
+path = "src/lib.rs"
+
+[[bin]]
+name = "load-balanced-channel"
+path = "src/load_balanced_channel/client.rs"
+
 [dependencies]
 tonic = { path = "../tonic", features = ["tls"] }
 prost = "0.6"
 tokio = { version = "0.2", features = ["rt-threaded", "time", "stream", "fs", "macros", "uds"] }
 futures = { version = "0.3", default-features = false, features = ["alloc"] }
 async-stream = "0.2"
+async-trait = "0.1"
+anyhow = "1"
+trust-dns-resolver = "0.19.6"
 tower = "0.3"
+tower-discover = "0.3"
 # Required for routeguide
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/examples/src/lib.rs
+++ b/examples/src/lib.rs
@@ -1,0 +1,1 @@
+pub mod load_balanced_channel;

--- a/examples/src/load_balanced_channel/client.rs
+++ b/examples/src/load_balanced_channel/client.rs
@@ -1,0 +1,36 @@
+use examples::load_balanced_channel::LoadBalancedChannelBuilder;
+use tonic::transport::Certificate;
+use tonic::transport::ClientTlsConfig;
+
+pub mod pb {
+    tonic::include_proto!("grpc.examples.echo");
+}
+
+use crate::pb::echo_client::EchoClient;
+use crate::pb::EchoRequest;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let pem = tokio::fs::read("examples/data/tls/ca.pem").await?;
+    let ca = Certificate::from_pem(pem);
+
+    let tls = ClientTlsConfig::new().ca_certificate(ca);
+
+    let channel = LoadBalancedChannelBuilder::new_with_service(("localhost", 5000 as u16))
+        .await?
+        .with_tls(tls)
+        .dns_probe_interval(std::time::Duration::from_secs(5))
+        .channel();
+
+    let mut client = EchoClient::new(channel);
+
+    let request = tonic::Request::new(EchoRequest {
+        message: "hello".into(),
+    });
+
+    let response = client.unary_echo(request).await?;
+
+    println!("RESPONSE={:?}", response);
+
+    Ok(())
+}

--- a/examples/src/load_balanced_channel/client_channel.rs
+++ b/examples/src/load_balanced_channel/client_channel.rs
@@ -15,20 +15,6 @@ use tonic::transport::channel::{Channel, ClientTlsConfig};
 static GRPC_REPORT_ENDPOINTS_CHANNEL_SIZE: usize = 1024;
 
 /// Implements tonic `GrpcService` for a client-side load balanced `Channel` (using `The Power of
-/// Two Choices`).
-/// ```rust
-/// #[tokio::main]
-/// async fn main() {
-///     use truelayer_tonic::client::{LoadBalancedChannelBuilder,LoadBalancedChannel};
-///     use truelayer_tonic::pb::tester_client::TesterClient;
-///
-///     let load_balanced_channel =
-///     LoadBalancedChannelBuilder::new_with_service(("my_hostname", 5000)).await
-///                                     .expect("failed to read system conf").channel();
-///     let client: TesterClient<LoadBalancedChannel> = TesterClient::new(load_balanced_channel);
-/// }
-/// ```
-///
 #[derive(Debug, Clone)]
 pub struct LoadBalancedChannel(Channel);
 

--- a/examples/src/load_balanced_channel/client_channel.rs
+++ b/examples/src/load_balanced_channel/client_channel.rs
@@ -1,0 +1,153 @@
+use crate::load_balanced_channel::{
+    DnsResolver, GrpcServiceProbe, GrpcServiceProbeConfig, LookupService, ServiceDefinition,
+};
+use http::Request;
+use std::task::{Context, Poll};
+use tokio::time::Duration;
+use tonic::body::BoxBody;
+use tonic::client::GrpcService;
+use tonic::transport::channel::{Channel, ClientTlsConfig};
+
+// Determines the channel size of the channel we use
+// to report endpoint changes to tonic.
+// This is effectively how many changes we can report in one go.
+// We set the number high to avoid any blocking on our side.
+static GRPC_REPORT_ENDPOINTS_CHANNEL_SIZE: usize = 1024;
+
+/// Implements tonic `GrpcService` for a client-side load balanced `Channel` (using `The Power of
+/// Two Choices`).
+/// ```rust
+/// #[tokio::main]
+/// async fn main() {
+///     use truelayer_tonic::client::{LoadBalancedChannelBuilder,LoadBalancedChannel};
+///     use truelayer_tonic::pb::tester_client::TesterClient;
+///
+///     let load_balanced_channel =
+///     LoadBalancedChannelBuilder::new_with_service(("my_hostname", 5000)).await
+///                                     .expect("failed to read system conf").channel();
+///     let client: TesterClient<LoadBalancedChannel> = TesterClient::new(load_balanced_channel);
+/// }
+/// ```
+///
+#[derive(Debug, Clone)]
+pub struct LoadBalancedChannel(Channel);
+
+impl Into<Channel> for LoadBalancedChannel {
+    fn into(self) -> Channel {
+        self.0
+    }
+}
+
+impl GrpcService<BoxBody> for LoadBalancedChannel {
+    type ResponseBody = <Channel as GrpcService<BoxBody>>::ResponseBody;
+    type Error = <Channel as GrpcService<BoxBody>>::Error;
+    type Future = <Channel as GrpcService<BoxBody>>::Future;
+
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.0.poll_ready(cx)
+    }
+
+    fn call(&mut self, request: Request<BoxBody>) -> Self::Future {
+        self.0.call(request)
+    }
+}
+
+/// Builder to configure a `LoadBalancedChannel`.
+pub struct LoadBalancedChannelBuilder<T> {
+    service_definition: ServiceDefinition,
+    probe_interval: Option<Duration>,
+    timeout: Option<Duration>,
+    tls_config: Option<ClientTlsConfig>,
+    lookup_host: T,
+}
+
+impl LoadBalancedChannelBuilder<DnsResolver> {
+    /// Set the `ServiceDefinition` of the gRPC server service
+    /// -  e.g. `google.com` and `5000`.
+    ///
+    /// All the service endpoints of a `ServiceDefinition` will be
+    /// constructed by resolving all ips from `ServiceDefinition::hostname`, and
+    /// using the portnumber `ServiceDefinition::port`.
+    pub async fn new_with_service<H: Into<ServiceDefinition>>(
+        service_definition: H,
+    ) -> Result<LoadBalancedChannelBuilder<DnsResolver>, anyhow::Error> {
+        Ok(Self {
+            service_definition: service_definition.into(),
+            probe_interval: None,
+            timeout: None,
+            tls_config: None,
+            lookup_host: DnsResolver::from_system_config().await?,
+        })
+    }
+
+    /// Configure the channel to use tls.
+    /// A `tls_config` MUST be specified to use the `HTTPS` scheme.
+    pub fn lookup_host<T: LookupService + Send + Sync + 'static>(
+        self,
+        lookup_host: T,
+    ) -> LoadBalancedChannelBuilder<T> {
+        LoadBalancedChannelBuilder {
+            lookup_host,
+            service_definition: self.service_definition,
+            probe_interval: self.probe_interval,
+            tls_config: self.tls_config,
+            timeout: self.timeout,
+        }
+    }
+}
+
+impl<T: LookupService + Send + Sync + 'static + Sized> LoadBalancedChannelBuilder<T> {
+    /// Set the how often, the client should probe for changes to  gRPC server endpoints.
+    /// Default interval in seconds is 10.
+    pub fn dns_probe_interval(self, interval: Duration) -> LoadBalancedChannelBuilder<T> {
+        Self {
+            probe_interval: Some(interval),
+            ..self
+        }
+    }
+
+    /// Set a timeout that will be applied to every new `Endpoint`.
+    pub fn timeout(self, timeout: Duration) -> LoadBalancedChannelBuilder<T> {
+        Self {
+            timeout: Some(timeout),
+            ..self
+        }
+    }
+
+    /// Configure the channel to use tls.
+    /// A `tls_config` MUST be specified to use the `HTTPS` scheme.
+    pub fn with_tls(self, mut tls_config: ClientTlsConfig) -> LoadBalancedChannelBuilder<T> {
+        // Since we resolve the hostname to an IP, which is not a valid DNS name,
+        // we have to set the hostname explicitly on the tls config,
+        // otherwise the IP will be set as the domain name and tls handshake will fail.
+        tls_config = tls_config.domain_name(self.service_definition.hostname.clone());
+
+        Self {
+            tls_config: Some(tls_config),
+            ..self
+        }
+    }
+
+    /// Construct a `LoadBalancedChannel` from the `LoadBalancedChannelBuilder` instance.
+    pub fn channel(self) -> LoadBalancedChannel {
+        let (channel, sender) = Channel::balance_channel(GRPC_REPORT_ENDPOINTS_CHANNEL_SIZE);
+
+        let config = GrpcServiceProbeConfig {
+            service_definition: self.service_definition,
+            dns_lookup: self.lookup_host,
+            endpoint_timeout: self.timeout,
+            probe_interval: self
+                .probe_interval
+                .unwrap_or_else(|| Duration::from_secs(10)),
+        };
+        let mut service_probe = GrpcServiceProbe::new_with_reporter(config, sender);
+
+        if let Some(tls_config) = self.tls_config {
+            service_probe = service_probe.with_tls(tls_config);
+        }
+
+        tokio::spawn(service_probe.probe());
+
+        LoadBalancedChannel(channel)
+    }
+}

--- a/examples/src/load_balanced_channel/mod.rs
+++ b/examples/src/load_balanced_channel/mod.rs
@@ -1,0 +1,9 @@
+pub mod client_channel;
+mod resolve;
+mod service;
+mod service_probe;
+
+pub use client_channel::*;
+pub use resolve::*;
+pub use service::*;
+pub use service_probe::*;

--- a/examples/src/load_balanced_channel/resolve.rs
+++ b/examples/src/load_balanced_channel/resolve.rs
@@ -1,0 +1,66 @@
+use crate::load_balanced_channel::ServiceDefinition;
+use anyhow::Context;
+use std::collections::HashSet;
+use std::net::SocketAddr;
+use trust_dns_resolver::{system_conf, AsyncResolver, TokioAsyncResolver};
+
+/// Interface that provides functionality to
+/// acquire a list of ips given a valid host name.
+#[async_trait::async_trait]
+pub trait LookupService {
+    /// Return a list of unique `SockAddr` associated with the provided
+    /// `ServiceDefinition` containing the `hostname` `port` of the service.
+    /// If no ip addresses were resolved, an empty `HashSet` is returned.
+    async fn resolve_service_endpoints(
+        &self,
+        definition: &ServiceDefinition,
+    ) -> Result<HashSet<SocketAddr>, anyhow::Error>;
+}
+
+/// Implements `LookupService` by resolving the `hostname`
+/// of the `ServiceDefinition` with a DNS lookup.
+pub struct DnsResolver {
+    /// The trust-dns resolver which contacts the dns service directly such
+    /// that we bypass os-specific dns caching.
+    dns: TokioAsyncResolver,
+}
+
+impl DnsResolver {
+    /// Construct a new `DnsResolver` from env and system configration, e.g `resolv.conf`.
+    pub async fn from_system_config() -> Result<Self, anyhow::Error> {
+        let (config, mut opts) = system_conf::read_system_conf()
+            .context("failed to read dns services from system configuration")?;
+
+        // We do not want any caching on out side.
+        opts.cache_size = 0;
+
+        let dns = AsyncResolver::tokio(config, opts)
+            .await
+            .expect("resolver must be valid");
+
+        Ok(Self { dns })
+    }
+}
+
+#[async_trait::async_trait]
+impl LookupService for DnsResolver {
+    #[tracing::instrument(level = "debug", skip(self))]
+    async fn resolve_service_endpoints(
+        &self,
+        definition: &ServiceDefinition,
+    ) -> Result<HashSet<SocketAddr>, anyhow::Error> {
+        match self.dns.lookup_ip(definition.hostname.as_ref()).await {
+            Ok(lookup) => {
+                tracing::debug!("dns query expires in: {:?}", lookup.valid_until());
+                Ok(lookup
+                    .iter()
+                    .map(|ip_addr| {
+                        tracing::debug!("result: ip {}", ip_addr);
+                        (ip_addr, definition.port).into()
+                    })
+                    .collect())
+            }
+            Err(err) => Err(err.into()),
+        }
+    }
+}

--- a/examples/src/load_balanced_channel/service.rs
+++ b/examples/src/load_balanced_channel/service.rs
@@ -1,0 +1,18 @@
+/// Defines a gRPC service with a `hostname` and a `port`.
+/// The hostname will be resolved to the concrete ips of the service servers.
+#[derive(Debug)]
+pub struct ServiceDefinition {
+    /// The hostname of the service.
+    pub hostname: String,
+    /// The service port.
+    pub port: u16,
+}
+
+impl Into<ServiceDefinition> for (&str, u16) {
+    fn into(self) -> ServiceDefinition {
+        ServiceDefinition {
+            hostname: self.0.to_string(),
+            port: self.1,
+        }
+    }
+}

--- a/examples/src/load_balanced_channel/service_probe.rs
+++ b/examples/src/load_balanced_channel/service_probe.rs
@@ -1,0 +1,203 @@
+use crate::load_balanced_channel::resolve::LookupService;
+use crate::load_balanced_channel::ServiceDefinition;
+use std::collections::HashSet;
+use std::net::SocketAddr;
+use tokio::sync::mpsc::Sender;
+use tonic::transport::channel::{ClientTlsConfig, Endpoint};
+use tower_discover::Change;
+
+/// `GrpcServiceProbe` looks up IP addresses associated with the configured `host_name` every `probe_interval`.
+///  If a new IP address is discovered or an old one disappears it notifies the `tonic` gRPC client.
+///
+/// The tonic load balancing side that is being notified work under the following assumptions:
+///     * Tonic will never remove an endpoint from its set of servers to contact
+///       unless we report a `Change::Remove` explicitly.
+///     * Tonic does not perform any retries, which means that a subsequent call
+///       after a failed one will succeed if there are enough servers, or if the
+///       client manages to reconnect.
+///     * Tonic will try reconnecting to a server if the connection to it breaks,
+///       and we have not instructed the removal of that server's address from the
+///       set of endpoints known to the tonic client.
+///
+pub struct GrpcServiceProbe<Lookup>
+where
+    Lookup: LookupService,
+{
+    service_definition: ServiceDefinition,
+    scheme: http::uri::Scheme,
+    dns_lookup: Lookup,
+    probe_interval: tokio::time::Duration,
+    endpoint_timeout: Option<tokio::time::Duration>,
+    /// The set of last reported endpoints by `dns_lookup`.
+    endpoints: HashSet<SocketAddr>,
+    endpoint_reporter: Sender<Change<SocketAddr, Endpoint>>,
+    tls_config: Option<ClientTlsConfig>,
+}
+
+/// Config parameters to customize the behavior of `GrpcServiceProbe`.
+pub struct GrpcServiceProbeConfig<Lookup>
+where
+    Lookup: LookupService,
+{
+    /// the host name to resolve dns for and the service port.
+    pub service_definition: ServiceDefinition,
+    /// The lookup resolver.
+    /// We are using a generic parameter and a trait constraint to allow mocking of DNS resolution in tests.
+    pub dns_lookup: Lookup,
+    /// How often the probe should update the ips.
+    pub probe_interval: tokio::time::Duration,
+    /// A timeout that will be applied to every endpoint.
+    pub endpoint_timeout: Option<tokio::time::Duration>,
+}
+
+impl<Lookup: LookupService> GrpcServiceProbe<Lookup> {
+    /// Construct `GrpcServiceProbe` with a `GrpcServiceProbeConfig` and
+    /// the channel `endpoint_reporter` that will send endpoint changes.
+    pub fn new_with_reporter(
+        config: GrpcServiceProbeConfig<Lookup>,
+        endpoint_reporter: Sender<Change<SocketAddr, Endpoint>>,
+    ) -> GrpcServiceProbe<Lookup> {
+        Self {
+            service_definition: config.service_definition,
+            dns_lookup: config.dns_lookup,
+            probe_interval: config.probe_interval,
+            endpoint_timeout: config.endpoint_timeout,
+            endpoints: HashSet::new(),
+            endpoint_reporter,
+            scheme: http::uri::Scheme::HTTP,
+            tls_config: None,
+        }
+    }
+
+    /// Enable tls for all endpoints.
+    pub fn with_tls(self, tls_config: ClientTlsConfig) -> GrpcServiceProbe<Lookup> {
+        Self {
+            tls_config: Some(tls_config),
+            scheme: http::uri::Scheme::HTTPS,
+            ..self
+        }
+    }
+
+    /// Start probing the provided `host_name` for IP address changes.
+    /// The function will error if the receiving end of the tonic balance channel
+    /// is closed, e.g, the client has been deconstructed.
+    /// Any other errors are seen as transient, and therefore retried after `self.probe_interval`.
+    pub async fn probe(mut self) -> Result<(), anyhow::Error> {
+        loop {
+            match self
+                .dns_lookup
+                .resolve_service_endpoints(&self.service_definition)
+                .await
+            {
+                Ok(endpoints) => {
+                    let changeset = self.create_changeset(&endpoints).await;
+
+                    // Report the changeset to `tonic` and commit the new endpoints
+                    // if we succeed to report the changeset.
+                    self.report_and_commit(changeset, endpoints).await?;
+                }
+                Err(err) => {
+                    // We received an unrecoverable error, we just log it and continue runnning.
+                    tracing::warn!("failed to resolve ips from host: {:?}", err);
+                }
+            }
+
+            tokio::time::delay_for(self.probe_interval).await;
+        }
+    }
+
+    /// Construct a changeset and report the endpoint changes to tonic.
+    async fn create_changeset(
+        &mut self,
+        endpoints: &HashSet<SocketAddr>,
+    ) -> Vec<Change<SocketAddr, Endpoint>> {
+        let mut changeset = Vec::new();
+
+        let remove_set: HashSet<SocketAddr> = self
+            .endpoints
+            .difference(&endpoints)
+            .cloned()
+            .into_iter()
+            .collect();
+
+        let add_set: HashSet<SocketAddr> = endpoints
+            .difference(&self.endpoints)
+            .cloned()
+            .into_iter()
+            .collect();
+
+        changeset.extend(
+            add_set
+                .into_iter()
+                .filter_map(|addr| self.build_endpoint(&addr).map(|endpoint| (addr, endpoint)))
+                .map(|(addr, endpoint)| Change::Insert(addr, endpoint)),
+        );
+
+        changeset.extend(remove_set.into_iter().map(Change::Remove));
+
+        changeset
+    }
+
+    /// Update the endpoint working set to be equal to the result of the last probe.
+    fn overwrite_endpoints(&mut self, current_ips: HashSet<SocketAddr>) {
+        self.endpoints = current_ips;
+    }
+
+    /// Report `changeset` to the gRPC client and commit the changes
+    /// by setting the new working set to the most recent list of endpoints.
+    ///
+    /// Function fails if the `Sender` is closed.
+    async fn report_and_commit(
+        &mut self,
+        changeset: Vec<Change<SocketAddr, Endpoint>>,
+        endpoints: HashSet<SocketAddr>,
+    ) -> Result<(), anyhow::Error> {
+        tracing::debug!("reporting changeset: {:?}", changeset);
+
+        for change in changeset {
+            if self.endpoint_reporter.send(change).await.is_err() {
+                return Err(anyhow::anyhow!("tried to report endpoint changes on a closed channel, this is probably due to the gRPC client being dropped."));
+            }
+        }
+
+        tracing::debug!("changeset reported");
+
+        // When we reach this point we have sent all the changes to the client
+        // and can overwrite the endpoints.
+        // If we failed earlier the client died so we're in the clear!
+        self.overwrite_endpoints(endpoints);
+
+        Ok(())
+    }
+
+    fn build_endpoint(&self, ip_address: &SocketAddr) -> Option<Endpoint> {
+        let uri = format!(
+            "{}://{}:{}",
+            self.scheme,
+            ip_address.ip().to_string(),
+            ip_address.port()
+        );
+
+        let mut endpoint = Endpoint::from_shared(uri)
+            .map_err(|err| {
+                tracing::warn!("endpoint creation error: {:?}", err);
+            })
+            .ok()?;
+
+        if let Some(ref tls_config) = self.tls_config {
+            endpoint = endpoint
+                .tls_config(tls_config.clone())
+                .map_err(|err| {
+                    tracing::warn!("tls error: {:?}", err);
+                    err
+                })
+                .ok()?;
+        }
+
+        if let Some(ref timeout) = self.endpoint_timeout {
+            endpoint = endpoint.timeout(*timeout);
+        }
+
+        Some(endpoint)
+    }
+}

--- a/tests/load_balancing/Cargo.toml
+++ b/tests/load_balancing/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "load-balancing"
+version = "0.1.0"
+authors = ["Helge Hoff <helge.hoff@truelayer.com>"]
+edition = "2018"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+tonic = { path = "../../tonic" }
+examples = { path = "../../examples" }
+async-trait = "0.1"
+tokio = { version = "0.2", features = ["full"] }
+prost = "0.6"
+http = "0.2"
+anyhow = "1"
+tracing = "0.1.16"
+tower-service = "0.3"
+hyper = "0.13.9"
+futures = "0.3.8"
+
+[build-dependencies]
+tonic-build = { path = "../../tonic-build" }

--- a/tests/load_balancing/build.rs
+++ b/tests/load_balancing/build.rs
@@ -1,0 +1,3 @@
+fn main() {
+    tonic_build::compile_protos("proto/test.proto").unwrap();
+}

--- a/tests/load_balancing/proto/test.proto
+++ b/tests/load_balancing/proto/test.proto
@@ -1,0 +1,18 @@
+syntax = "proto3";
+
+package test;
+
+message Ping {}
+
+message Pong {
+    oneof payload {
+        string raw = 1;
+    }
+}
+
+// The tester service definition.
+service Tester {
+  rpc Test (Ping) returns (Pong) {}
+}
+
+

--- a/tests/load_balancing/src/lib.rs
+++ b/tests/load_balancing/src/lib.rs
@@ -1,0 +1,8 @@
+pub mod lookup;
+pub mod test;
+
+pub mod pb {
+    tonic::include_proto!("test");
+}
+
+pub use test::*;

--- a/tests/load_balancing/src/lookup.rs
+++ b/tests/load_balancing/src/lookup.rs
@@ -1,0 +1,117 @@
+use crate::pb::pong::Payload;
+use crate::pb::tester_server::Tester;
+use crate::pb::tester_server::TesterServer;
+use crate::pb::{Ping, Pong};
+use crate::TestServer;
+use examples::load_balanced_channel::{LookupService, ServiceDefinition};
+use std::collections::{HashMap, HashSet};
+use std::net::SocketAddr;
+use std::sync::Arc;
+use tokio::sync::{Mutex, RwLock};
+use tonic::transport::ServerTlsConfig;
+use tonic::Status;
+
+#[derive(Clone)]
+pub struct TesterImpl {
+    pub sender: Arc<Mutex<tokio::sync::mpsc::Sender<String>>>,
+    pub name: String,
+}
+
+#[async_trait::async_trait]
+impl Tester for TesterImpl {
+    async fn test(&self, _req: tonic::Request<Ping>) -> Result<tonic::Response<Pong>, Status> {
+        {
+            self.sender
+                .lock()
+                .await
+                .send(self.name.clone())
+                .await
+                .unwrap();
+        }
+        Ok(tonic::Response::new(Pong {
+            payload: Some(Payload::Raw(String::from(self.name.clone()))),
+        }))
+    }
+}
+
+#[derive(Clone)]
+pub struct TestDnsResolver {
+    pub ips: Arc<RwLock<HashMap<String, String>>>,
+    pub servers: Arc<RwLock<HashMap<String, TestServer>>>,
+    pub tls_config: Option<ServerTlsConfig>,
+}
+
+impl TestDnsResolver {
+    pub fn new_with_tls(tls: ServerTlsConfig) -> Self {
+        Self {
+            ips: Arc::new(RwLock::new(HashMap::new())),
+            servers: Arc::new(RwLock::new(HashMap::new())),
+            tls_config: Some(tls),
+        }
+    }
+}
+
+impl Default for TestDnsResolver {
+    fn default() -> Self {
+        Self {
+            ips: Arc::new(RwLock::new(HashMap::new())),
+            servers: Arc::new(RwLock::new(HashMap::new())),
+            tls_config: None,
+        }
+    }
+}
+
+impl TestDnsResolver {
+    pub async fn remove_server(&mut self, server: String) {
+        let mut ips = self.ips.write().await;
+        ips.remove(&server).expect("server is not in the hashmap");
+        let mut servers = self.servers.write().await;
+        let server = servers
+            .remove(&server)
+            .expect("server is not in the hashmap");
+        server.shutdown_sync().await;
+    }
+
+    pub async fn add_server_with_provided_impl(&mut self, name: String, server: impl Tester) {
+        let mut ips = self.ips.write().await;
+        let mut servers = self.servers.write().await;
+        let test_server =
+            TestServer::start(TesterServer::new(server), None, self.tls_config.clone()).await;
+
+        tracing::debug!(
+            "Adding server with name {} and address {}",
+            name,
+            test_server.address()
+        );
+        (*ips).insert(name.to_string(), test_server.address().to_string());
+        (*servers).insert(name, test_server);
+    }
+
+    pub async fn add_ip_without_server(&mut self, name: String, ip: String) {
+        let mut ips = self.ips.write().await;
+        (*ips).insert(name.to_string(), ip);
+    }
+
+    pub async fn remove_ip_and_not_server(&mut self, name: String) {
+        let mut ips = self.ips.write().await;
+        ips.remove(&name)
+            .expect("No IP registered against that name.");
+    }
+}
+
+#[async_trait::async_trait]
+impl LookupService for TestDnsResolver {
+    async fn resolve_service_endpoints(
+        &self,
+        _definition: &ServiceDefinition,
+    ) -> Result<HashSet<SocketAddr>, anyhow::Error> {
+        let ips = self.ips.read().await;
+
+        Ok(ips
+            .values()
+            .cloned()
+            .into_iter()
+            .map(|address| address.parse().expect("not a valid ip address"))
+            .collect())
+    }
+}

--- a/tests/load_balancing/src/test.rs
+++ b/tests/load_balancing/src/test.rs
@@ -1,0 +1,100 @@
+use futures::future::FutureExt;
+use hyper::{Body, Request, Response};
+use tokio::net::TcpListener;
+use tonic::{
+    body::BoxBody,
+    transport::{server::Server, NamedService, ServerTlsConfig},
+};
+use tower_service::Service;
+
+/// Manages construction and destruction of a tonic gRPC server for testing.
+pub struct TestServer {
+    shutdown_handle: Option<tokio::sync::oneshot::Sender<()>>,
+    server_addr: String,
+    server_future:
+        Option<tokio::task::JoinHandle<std::result::Result<(), tonic::transport::Error>>>,
+}
+
+impl Drop for TestServer {
+    fn drop(&mut self) {
+        // Gracefully shutdown the gRPC Server.
+        if let Some(sender) = self.shutdown_handle.take() {
+            let _res = sender.send(());
+        }
+    }
+}
+
+impl TestServer {
+    /// Bootstrap a tonic `TestServer`, with the provided `Service`.
+    ///
+    /// This function will run the server asynchronously, and
+    /// tear it down when `Self` is dropped.
+    pub async fn start<S, T: Into<Option<String>>>(
+        service: S,
+        address: T,
+        tls: Option<ServerTlsConfig>,
+    ) -> Self
+    where
+        S: Service<Request<Body>, Response = Response<BoxBody>>
+            + NamedService
+            + Clone
+            + Send
+            + 'static,
+        S::Future: Send + 'static,
+        S::Error: Into<Box<dyn std::error::Error + Send + Sync>> + Send,
+    {
+        let (shutdown_handle, shutdown) = tokio::sync::oneshot::channel::<()>();
+
+        let listener =
+            TcpListener::bind(address.into().unwrap_or_else(|| "127.0.0.1:0".to_string()))
+                .await
+                .expect("failed to bind tcplistener");
+
+        let server_addr = format!(
+            "127.0.0.1:{}",
+            listener
+                .local_addr()
+                .expect("failed to retrieve sockeaddr from tokio listener")
+                .port()
+        );
+        tracing::info!("server address: {}", server_addr);
+
+        let mut server_builder = Server::builder();
+
+        if let Some(config) = tls {
+            server_builder = server_builder
+                .tls_config(config)
+                .expect("failed to set tls config");
+        }
+
+        let server = server_builder.add_service(service);
+        let server_future =
+            tokio::spawn(server.serve_with_incoming_shutdown(listener, shutdown.map(|_| ())));
+
+        TestServer {
+            shutdown_handle: Some(shutdown_handle),
+            server_addr,
+            server_future: Some(server_future),
+        }
+    }
+
+    /// Get the address `TestServer` is listening on.
+    pub fn address(&self) -> &str {
+        &self.server_addr
+    }
+
+    /// Shut the server down.
+    pub async fn shutdown_sync(mut self) {
+        // Gracefully shutdown the gRPC Server.
+        if let Some(sender) = self.shutdown_handle.take() {
+            let _res = sender.send(());
+        }
+
+        if let Some(server_future) = self.server_future.take() {
+            server_future
+                .await
+                .expect("server did not exit gracefully")
+                .expect("");
+        }
+    }
+}

--- a/tests/load_balancing/tests/service_probe.rs
+++ b/tests/load_balancing/tests/service_probe.rs
@@ -1,0 +1,325 @@
+use examples::load_balanced_channel::LoadBalancedChannelBuilder;
+use load_balancing::lookup::TestDnsResolver;
+use load_balancing::lookup::TesterImpl;
+use load_balancing::pb::pong::Payload;
+use load_balancing::pb::tester_client::TesterClient;
+use load_balancing::pb::Ping;
+use std::collections::HashSet;
+use std::sync::Arc;
+use tokio::sync::Mutex;
+use tonic::transport::{Certificate, ClientTlsConfig, ServerTlsConfig};
+
+fn get_payload_raw(payload: Payload) -> String {
+    match payload {
+        Payload::Raw(s) => s,
+    }
+}
+
+#[tokio::test]
+async fn load_balance_succeeds_with_churn() {
+    // Steps:
+    //  1. Create a server that is added to the list of endpoints.
+    //  2. Do a gRPC call.
+    //  3. Remove the server from the list of endpoints and shut it down.
+    //  4. Repeat 1-3.
+    // What we want to test:
+    //  Clients function normally when servers are removed and added.
+
+    // Arrange
+    let (sender, mut receiver) = tokio::sync::mpsc::channel(1);
+    let sender = Arc::new(Mutex::new(sender));
+    let mut resolver = TestDnsResolver::default();
+
+    let load_balanced_channel = LoadBalancedChannelBuilder::new_with_service(("test", 5000))
+        .await
+        .expect("failed to init")
+        .lookup_host(resolver.clone())
+        .dns_probe_interval(tokio::time::Duration::from_millis(1))
+        .channel();
+    let mut client = TesterClient::new(load_balanced_channel);
+
+    let servers: Vec<String> = (0..10).into_iter().map(|s| s.to_string()).collect();
+    let mut servers_called = Vec::new();
+
+    // Act
+    for server in &servers {
+        resolver
+            .add_server_with_provided_impl(
+                server.to_string(),
+                TesterImpl {
+                    sender: Arc::clone(&sender),
+                    name: server.to_string(),
+                },
+            )
+            .await;
+
+        let res = client
+            .test(tonic::Request::new(Ping {}))
+            .await
+            .expect("failed to call server");
+        let server = receiver.recv().await.expect("");
+        assert_eq!(
+            server,
+            get_payload_raw(res.into_inner().payload.expect("no payload"))
+        );
+        servers_called.push(server.clone());
+        resolver.remove_server(server).await;
+    }
+
+    // Assert
+    assert_eq!(servers, servers_called);
+}
+
+#[tokio::test]
+async fn load_balance_succeeds_with_churn_with_tls_enabled() {
+    // Arrange
+    let (sender, mut receiver) = tokio::sync::mpsc::channel(1);
+    let sender = Arc::new(Mutex::new(sender));
+
+    let server_root_ca_cert = tokio::fs::read("../../examples/data/tls/ca.pem")
+        .await
+        .expect("feaild to read ca");
+    let server_root_ca_cert = Certificate::from_pem(server_root_ca_cert);
+
+    let cert = tokio::fs::read("../../examples/data/tls/server.pem")
+        .await
+        .expect("failed to read server cert");
+    let key = tokio::fs::read("../../examples/data/tls/server.key")
+        .await
+        .expect("failed to read server pkey");
+
+    let identity = tonic::transport::Identity::from_pem(&cert, &key);
+
+    let server_config = ServerTlsConfig::new().identity(identity);
+
+    let mut resolver = TestDnsResolver::new_with_tls(server_config);
+
+    let config = ClientTlsConfig::new().ca_certificate(server_root_ca_cert);
+
+    let load_balanced_channel = LoadBalancedChannelBuilder::new_with_service(("example.com", 5000))
+        .await
+        .expect("failed to init")
+        .lookup_host(resolver.clone())
+        .with_tls(config)
+        .dns_probe_interval(tokio::time::Duration::from_millis(1))
+        .channel();
+    let mut client = TesterClient::new(load_balanced_channel);
+
+    let servers: Vec<String> = (0..10).into_iter().map(|s| s.to_string()).collect();
+    let mut servers_called = Vec::new();
+
+    // Act
+    for server in &servers {
+        resolver
+            .add_server_with_provided_impl(
+                server.to_string(),
+                TesterImpl {
+                    sender: Arc::clone(&sender),
+                    name: server.to_string(),
+                },
+            )
+            .await;
+
+        let res = client
+            .test(tonic::Request::new(Ping {}))
+            .await
+            .expect("failed to call server");
+        let server = receiver.recv().await.expect("");
+        assert_eq!(
+            server,
+            get_payload_raw(res.into_inner().payload.expect("no payload"))
+        );
+        servers_called.push(server.clone());
+        resolver.remove_server(server).await;
+    }
+
+    // Assert
+    assert_eq!(servers, servers_called);
+}
+
+#[tokio::test]
+async fn load_balance_invalid_tls_shall_fail_on_call() {
+    // Arrange
+    let (sender, _receiver) = tokio::sync::mpsc::channel(1);
+    let sender = Arc::new(Mutex::new(sender));
+
+    let server_root_ca_cert = tokio::fs::read("../../examples/data/tls/ca.pem")
+        .await
+        .expect("feaild to read ca");
+    let server_root_ca_cert = Certificate::from_pem(server_root_ca_cert);
+
+    let cert = tokio::fs::read("../../examples/data/tls/server.pem")
+        .await
+        .expect("failed to read server cert");
+    let key = tokio::fs::read("../../examples/data/tls/server.key")
+        .await
+        .expect("failed to read server pkey");
+
+    let identity = tonic::transport::Identity::from_pem(&cert, &key);
+
+    let server_config = ServerTlsConfig::new().identity(identity);
+
+    let mut resolver = TestDnsResolver::new_with_tls(server_config);
+
+    let config = ClientTlsConfig::new().ca_certificate(server_root_ca_cert);
+
+    // We just set an invalid host name, that makes the endpoint connection fail.
+    let load_balanced_channel =
+        LoadBalancedChannelBuilder::new_with_service(("123.123.123.123", 5000))
+            .await
+            .expect("failed to init")
+            .lookup_host(resolver.clone())
+            .with_tls(config)
+            .dns_probe_interval(tokio::time::Duration::from_millis(1))
+            .channel();
+    let mut client = TesterClient::new(load_balanced_channel);
+
+    resolver
+        .add_server_with_provided_impl(
+            "server_a".to_string(),
+            TesterImpl {
+                sender: Arc::clone(&sender),
+                name: "server_a".to_string(),
+            },
+        )
+        .await;
+
+    // Test that we actially consume the error
+    client
+        .test(tonic::Request::new(Ping {}))
+        .await
+        .expect_err("call should fail");
+}
+
+#[tokio::test]
+async fn load_balance_happy_path_scenario_calls_all_endpoints() {
+    // Steps:
+    //  1. Create 3 server that is added to the list of endpoints.
+    //  2. Do 20 gRPC calls.
+    //  3. Assert that all 3 servers have been called.
+    // What we want to test:
+    //  A common load balaning scenario in which you have more calls
+    //  than servers, and you want all servers to be called.
+
+    let num_calls = 20;
+    let (sender, mut receiver) = tokio::sync::mpsc::channel(num_calls);
+    let sender = Arc::new(Mutex::new(sender));
+    let mut resolver = TestDnsResolver::default();
+
+    let load_balanced_channel = LoadBalancedChannelBuilder::new_with_service(("test", 5000))
+        .await
+        .expect("failed to init")
+        .lookup_host(resolver.clone())
+        .dns_probe_interval(tokio::time::Duration::from_millis(3))
+        .channel();
+    let mut client = TesterClient::new(load_balanced_channel);
+
+    resolver
+        .add_server_with_provided_impl(
+            "server_a".to_string(),
+            TesterImpl {
+                sender: Arc::clone(&sender),
+                name: "server_a".to_string(),
+            },
+        )
+        .await;
+    resolver
+        .add_server_with_provided_impl(
+            "server_b".to_string(),
+            TesterImpl {
+                sender: Arc::clone(&sender),
+                name: "server_b".to_string(),
+            },
+        )
+        .await;
+    resolver
+        .add_server_with_provided_impl(
+            "server_c".to_string(),
+            TesterImpl {
+                sender: Arc::clone(&sender),
+                name: "server_c".to_string(),
+            },
+        )
+        .await;
+
+    let mut servers_called = HashSet::new();
+
+    for _ in 0..num_calls {
+        let res = client
+            .test(tonic::Request::new(Ping {}))
+            .await
+            .expect("failed to call server");
+
+        let server = receiver.recv().await.expect("");
+        assert_eq!(
+            server,
+            get_payload_raw(res.into_inner().payload.expect("no payload"))
+        );
+
+        servers_called.insert(server);
+    }
+
+    assert_eq!(3, servers_called.len());
+}
+
+#[tokio::test(threaded_scheduler)]
+async fn connection_timeout_is_not_fatal() {
+    // Scenario:
+    // The DNS probe returns an IP that we fail to connect to.
+    // We want to ensure that our client keeps working as expected
+    // as long as another good server comes up.
+    // Steps:
+    //   * Discover an IP without a backing server (`ghost_server`)
+    //   * See the client call fail
+    //   * Discover an IP with a backing server (`good_server`)
+    //   * Wait for discovery update to happen in the probe task
+    //   * See the client call succeed
+    let (sender, mut receiver) = tokio::sync::mpsc::channel(10);
+    let sender = Arc::new(Mutex::new(sender));
+    let mut resolver = TestDnsResolver::default();
+    let probe_interval = tokio::time::Duration::from_millis(3);
+
+    let load_balanced_channel = LoadBalancedChannelBuilder::new_with_service(("test", 5000))
+        .await
+        .expect("failed to init")
+        .lookup_host(resolver.clone())
+        .timeout(tokio::time::Duration::from_millis(500))
+        .dns_probe_interval(probe_interval)
+        .channel();
+    let mut client = TesterClient::new(load_balanced_channel);
+
+    resolver
+        .add_ip_without_server("ghost_server".into(), "127.0.0.124:5000".into())
+        .await;
+    client
+        .test(tonic::Request::new(Ping {}))
+        .await
+        .expect_err("The call without a backing server should fail");
+    resolver
+        .remove_ip_and_not_server("ghost_server".into())
+        .await;
+
+    resolver
+        .add_server_with_provided_impl(
+            "good_server".to_string(),
+            TesterImpl {
+                sender: Arc::clone(&sender),
+                name: "good_server".to_string(),
+            },
+        )
+        .await;
+
+    // Give time to the DNS probe to add the new good server
+    tokio::time::delay_for(probe_interval * 5).await;
+
+    let res = client
+        .test(tonic::Request::new(Ping {}))
+        .await
+        .expect("failed to call server");
+
+    let server = receiver.recv().await.expect("");
+    assert_eq!(
+        server,
+        get_payload_raw(res.into_inner().payload.expect("no payload"))
+    );
+}

--- a/tonic/Cargo.toml
+++ b/tonic/Cargo.toml
@@ -8,7 +8,7 @@ name = "tonic"
 #   - README.md
 # - Update CHANGELOG.md.
 # - Create "v0.1.x" git tag.
-version = "0.3.1"
+version = "0.3.3"
 authors = ["Lucio Franco <luciofranco14@gmail.com>"]
 edition = "2018"
 license = "MIT"

--- a/tonic/Cargo.toml
+++ b/tonic/Cargo.toml
@@ -8,7 +8,7 @@ name = "tonic"
 #   - README.md
 # - Update CHANGELOG.md.
 # - Create "v0.1.x" git tag.
-version = "0.3.3"
+version = "0.3.1"
 authors = ["Lucio Franco <luciofranco14@gmail.com>"]
 edition = "2018"
 license = "MIT"


### PR DESCRIPTION
This PR adds, as an example, the load balancing scenario that provoked bug [1](https://github.com/hyperium/tonic/pull/493), and [2](https://github.com/hyperium/tonic/pull/495), as well as tests that cover the those fixes.

The load balancing example tries to solve a client-side load balancing scenario in which the set of server ips
are not static, and the way of retrieving the current set of ips at any time is done through resolving a hostname that maps
all server ips.
In the example, a detached task tries to resolve a hostname at a fixed interval and if any changes to the set of server ips
is detected, it will be reflected on the gRPC client by notifying the discovery logic through the channel retrieved with `Channel::balance_channel`.
While developing this load balancing scheme, the two aforementioned bugs were found to which we added tests.

The tests are added as an integration test that leverages the code from our load balancing example.