### PR TITLE
Enable `h2` errors

### DIFF
--- a/tonic/Cargo.toml
+++ b/tonic/Cargo.toml
@@ -26,6 +26,7 @@ keywords = ["rpc", "grpc", "async", "futures", "protobuf"]
 default = ["transport", "codegen", "prost"]
 codegen = ["async-trait"]
 transport = [
+    "h2",
     "hyper",
     "tokio",
     "tower",
@@ -64,6 +65,7 @@ prost-derive = { version = "0.6", optional = true }
 async-trait = { version = "0.1.13", optional = true }
 
 # transport
+h2    = { version = "0.2.2", optional = true }
 hyper = { version = "0.13.4", features = ["stream"], optional = true }
 tokio = { version = "0.2.13", features = ["tcp"], optional = true }
 tower = { version = "0.3", optional = true}

--- a/tonic/src/status.rs
+++ b/tonic/src/status.rs
@@ -114,7 +114,7 @@ impl Code {
     /// Get description of this `Code`.
     /// ```
     /// fn make_grpc_request() -> tonic::Code {
-    ///     // ...   
+    ///     // ...
     ///     tonic::Code::Ok
     /// }
     /// let code = make_grpc_request();
@@ -308,7 +308,7 @@ impl Status {
         Status::new(Code::Unauthenticated, message)
     }
 
-    #[cfg_attr(not(feature = "h2"), allow(dead_code))]
+    #[cfg_attr(not(feature = "transport"), allow(dead_code))]
     pub(crate) fn from_error(err: &(dyn Error + 'static)) -> Status {
         Status::try_from_error(err).unwrap_or_else(|| Status::new(Code::Unknown, err.to_string()))
     }
@@ -326,7 +326,7 @@ impl Status {
                 });
             }
 
-            #[cfg(feature = "h2")]
+            #[cfg(feature = "transport")]
             {
                 if let Some(h2) = err.downcast_ref::<h2::Error>() {
                     return Some(Status::from_h2_error(h2));
@@ -340,7 +340,7 @@ impl Status {
     }
 
     // FIXME: bubble this into `transport` and expose generic http2 reasons.
-    #[cfg(feature = "h2")]
+    #[cfg(feature = "transport")]
     fn from_h2_error(err: &h2::Error) -> Status {
         // See https://github.com/grpc/grpc/blob/3977c30/doc/PROTOCOL-HTTP2.md#errors
         let code = match err.reason() {
@@ -362,7 +362,7 @@ impl Status {
         Status::new(code, format!("h2 protocol error: {}", err))
     }
 
-    #[cfg(feature = "h2")]
+    #[cfg(feature = "transport")]
     fn to_h2_error(&self) -> h2::Error {
         // conservatively transform to h2 error codes...
         let reason = match self.code {
@@ -557,14 +557,14 @@ fn invalid_header_value_byte<Error: fmt::Display>(err: Error) -> Status {
     )
 }
 
-#[cfg(feature = "h2")]
+#[cfg(feature = "transport")]
 impl From<h2::Error> for Status {
     fn from(err: h2::Error) -> Self {
         Status::from_h2_error(&err)
     }
 }
 
-#[cfg(feature = "h2")]
+#[cfg(feature = "transport")]
 impl From<Status> for h2::Error {
     fn from(status: Status) -> Self {
         status.to_h2_error()
@@ -773,7 +773,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(feature = "h2")]
+    #[cfg(feature = "transport")]
     fn from_error_h2() {
         let orig = h2::Error::from(h2::Reason::CANCEL);
         let found = Status::from_error(&orig);
@@ -782,7 +782,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(feature = "h2")]
+    #[cfg(feature = "transport")]
     fn to_h2_error() {
         let orig = Status::new(Code::Cancelled, "stop eet!");
         let err = orig.to_h2_error();


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/hyperium/tonic/blob/master/CONTRIBUTING.md
-->

## Motivation
Solves #394 

## Solution
Adds `h2` as a dependency and feature gate under `transport`