### PR TITLE
Merge trailer and inital headers into status on err

### DIFF
--- a/tonic/src/client/grpc.rs
+++ b/tonic/src/client/grpc.rs
@@ -103,7 +103,11 @@ impl<T> Grpc<T> {
 
         let message = body
             .try_next()
-            .await?
+            .await
+            .map_err(|mut status| {
+                status.metadata_mut().merge(parts.clone());
+                status
+            })?
             .ok_or_else(|| Status::new(Code::Internal, "Missing response message."))?;
 
         if let Some(trailers) = body.trailers().await? {


### PR DESCRIPTION
## Motivation

The C++ gRPC server sometimes returns both headers and trailers. An
excerpt from Wireshark:

```
Stream: HEADERS, Stream ID: 1, Length 136, 200 OK
    Header: :status: 200 OK
    Header: x-middleware: expected value
    Header: content-type: application/grpc
    Header: grpc-accept-encoding: identity,deflate,gzip
    Header: accept-encoding: identity,gzip

Stream: HEADERS, Stream ID: 1, Length 92
    Header: grpc-status: 2
    Header: grpc-message: Unknown
    Header: x-arrow-status: 9
    Header: x-arrow-status-message-bin: VW5rbm93bg
```

Before this commit, only the metadata from the trailer would be
available, missing the `x-middleware` header:

```
MetadataMap {
    headers: {
        "x-arrow-status-message-bin": "VW5rbm93bg",
        "x-arrow-status": "9",
    },
}
```

## Solution

Merge the metadata before returning the error