### PR TITLE
Upgrade to Tokio 1.0.0 ecosystem

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,20 +1,20 @@
 [workspace]
 members = [
     "tonic",
-    "tonic-build",
-    "tonic-health",
-    "tonic-types",
-
-    # Non-published crates
-    "examples",
-    "interop",
-
-    # Tests
-    "tests/included_service",
-    "tests/same_name",
-    "tests/wellknown",
-    "tests/extern_path/uuid",
-    "tests/ambiguous_methods",
-    "tests/extern_path/my_application",
-    "tests/integration_tests"
+#    "tonic-build",
+#    "tonic-health",
+#    "tonic-types",
+#
+#    # Non-published crates
+#    "examples",
+#    "interop",
+#
+#    # Tests
+#    "tests/included_service",
+#    "tests/same_name",
+#    "tests/wellknown",
+#    "tests/extern_path/uuid",
+#    "tests/ambiguous_methods",
+#    "tests/extern_path/my_application",
+#    "tests/integration_tests"
 ]

--- a/tonic/Cargo.toml
+++ b/tonic/Cargo.toml
@@ -28,9 +28,9 @@ codegen = ["async-trait"]
 transport = [
     "hyper",
     "tokio",
+    "tokio-stream",
     "tower",
-    "tower-balance",
-    "tower-load",
+    "tower-layer",
     "tracing-futures",
 ]
 tls = ["transport", "tokio-rustls"]
@@ -42,44 +42,43 @@ prost = ["prost1", "prost-derive"]
 # harness = false
 
 [dependencies]
-bytes = "0.5"
+bytes = "1"
 futures-core = { version = "0.3", default-features = false }
 futures-util = { version = "0.3", default-features = false }
 tracing = "0.1"
 http = "0.2"
-base64 = "0.12"
+base64 = "0.13"
 
 percent-encoding = "2.0"
 tower-service = "0.3"
-tokio-util = { version = "0.3", features = ["codec"] }
-async-stream = "0.2"
-http-body = "0.3"
-pin-project = "0.4.17"
+tokio-util = { version = "0.6", features = ["codec", "io"] }
+async-stream = "0.3"
+http-body = "0.4"
+pin-project = "1"
 
 # prost
-prost1 = { package = "prost", version = "0.6", optional = true }
-prost-derive = { version = "0.6", optional = true }
+prost1 = { package = "prost", version = "0.7", optional = true }
+prost-derive = { version = "0.7", optional = true }
 
 # codegen
-async-trait = { version = "0.1.13", optional = true }
+async-trait = { version = "0.1.42", optional = true }
 
 # transport
-hyper = { version = "0.13.4", features = ["stream"], optional = true }
-tokio = { version = "0.2.13", features = ["tcp"], optional = true }
-tower = { version = "0.3", optional = true}
-tower-make = { version = "0.3", features = ["connect"] }
-tower-balance =  { version = "0.3", optional = true }
-tower-load = { version = "0.3", optional = true }
-tracing-futures = { version = "0.2", optional = true }
+hyper = { version = "0.14.1", features = ["full"], optional = true }
+tokio = { version = "1.0.1", features = ["net"], optional = true }
+tokio-stream = { version = "0.1", optional = true }
+tower = { git = "https://github.com/tower-rs/tower", features = ["balance", "buffer", "discover", "limit", "load", "make", "timeout", "util"], optional = true }
+tower-layer = { git = "https://github.com/tower-rs/tower", optional = true }
+tracing-futures = { version = "0.2.4", optional = true }
 
 # rustls
-tokio-rustls = { version = "0.14", optional = true }
-rustls-native-certs = { version = "0.4", optional = true }
+tokio-rustls = { version = "0.22", optional = true }
+rustls-native-certs = { version = "0.5", optional = true }
 
 [dev-dependencies]
-tokio = { version = "0.2", features = ["rt-core", "macros"] }
-static_assertions = "1.0"
-rand = "0.7"
+tokio = { version = "1", features = ["rt", "macros"] }
+static_assertions = "1.1"
+rand = "0.8"
 bencher = "0.1.5"
 
 [package.metadata.docs.rs]
@@ -89,4 +88,3 @@ rustdoc-args = ["--cfg", "docsrs"]
 [[bench]]
 name = "decode"
 harness = false
-

--- a/tonic/src/body.rs
+++ b/tonic/src/body.rs
@@ -160,7 +160,7 @@ where
             Pin::new_unchecked(&mut me.0).poll_data(cx)
         };
         match futures_util::ready!(v) {
-            Some(Ok(mut i)) => Poll::Ready(Some(Ok(i.to_bytes()))),
+            Some(Ok(mut i)) => Poll::Ready(Some(Ok(i.copy_to_bytes(i.remaining())))),
             Some(Err(e)) => {
                 let err = Status::map_error(e.into());
                 Poll::Ready(Some(Err(err)))

--- a/tonic/src/transport/channel/endpoint.rs
+++ b/tonic/src/transport/channel/endpoint.rs
@@ -15,7 +15,7 @@ use std::{
     fmt,
     time::Duration,
 };
-use tower_make::MakeConnection;
+use tower::make::MakeConnection;
 
 /// Channel builder.
 ///

--- a/tonic/src/transport/channel/mod.rs
+++ b/tonic/src/transport/channel/mod.rs
@@ -29,13 +29,13 @@ use tokio::{
     sync::mpsc::{channel, Sender},
 };
 
+use tower::balance::p2c::Balance;
 use tower::{
     buffer::{self, Buffer},
     discover::{Change, Discover},
     util::{BoxService, Either},
     Service,
 };
-use tower_balance::p2c::Balance;
 
 type Svc = Either<Connection, BoxService<Request<BoxBody>, Response<hyper::Body>, crate::Error>>;
 
@@ -109,7 +109,7 @@ impl Channel {
     /// This creates a [`Channel`] that will load balance accross all the
     /// provided endpoints.
     pub fn balance_list(list: impl Iterator<Item = Endpoint>) -> Self {
-        let (channel, mut tx) = Self::balance_channel(DEFAULT_BUFFER_SIZE);
+        let (channel, tx) = Self::balance_channel(DEFAULT_BUFFER_SIZE);
         list.for_each(|endpoint| {
             tx.try_send(Change::Insert(endpoint.uri.clone(), endpoint))
                 .unwrap();
@@ -166,9 +166,9 @@ impl Channel {
     where
         D: Discover<Service = Connection> + Unpin + Send + 'static,
         D::Error: Into<crate::Error>,
-        D::Key: Send + Clone,
+        D::Key: Send + Clone + Hash,
     {
-        let svc = Balance::from_entropy(discover);
+        let svc = Balance::new(discover);
 
         let svc = BoxService::new(svc);
         let svc = Buffer::new(Either::B(svc), buffer_size);

--- a/tonic/src/transport/service/connection.rs
+++ b/tonic/src/transport/service/connection.rs
@@ -10,6 +10,7 @@ use std::{
     task::{Context, Poll},
 };
 use tokio::io::{AsyncRead, AsyncWrite};
+use tower::load::Load;
 use tower::{
     layer::Layer,
     limit::{concurrency::ConcurrencyLimitLayer, rate::RateLimitLayer},
@@ -17,7 +18,6 @@ use tower::{
     util::BoxService,
     ServiceBuilder, ServiceExt,
 };
-use tower_load::Load;
 use tower_service::Service;
 
 pub(crate) type Request = http::Request<BoxBody>;

--- a/tonic/src/transport/service/connector.rs
+++ b/tonic/src/transport/service/connector.rs
@@ -4,7 +4,7 @@ use super::io::BoxedIo;
 use super::tls::TlsConnector;
 use http::Uri;
 use std::task::{Context, Poll};
-use tower_make::MakeConnection;
+use tower::make::MakeConnection;
 use tower_service::Service;
 
 #[cfg(not(feature = "tls"))]

--- a/tonic/src/transport/service/discover.rs
+++ b/tonic/src/transport/service/discover.rs
@@ -7,9 +7,10 @@ use std::{
     pin::Pin,
     task::{Context, Poll},
 };
-use tokio::{stream::Stream, sync::mpsc::Receiver};
+use tokio::sync::mpsc::Receiver;
 
-use tower::discover::{Change, Discover};
+use tokio_stream::Stream;
+use tower::discover::Change;
 
 type DiscoverResult<K, S, E> = Result<Change<K, S>, E>;
 
@@ -23,17 +24,12 @@ impl<K: Hash + Eq + Clone> DynamicServiceStream<K> {
     }
 }
 
-impl<K: Hash + Eq + Clone> Discover for DynamicServiceStream<K> {
-    type Key = K;
-    type Service = Connection;
-    type Error = crate::Error;
+impl<K: Hash + Eq + Clone> Stream for DynamicServiceStream<K> {
+    type Item = DiscoverResult<K, Connection, crate::Error>;
 
-    fn poll_discover(
-        mut self: Pin<&mut Self>,
-        cx: &mut Context<'_>,
-    ) -> Poll<DiscoverResult<Self::Key, Self::Service, Self::Error>> {
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
         let c = &mut self.changes;
-        match Pin::new(&mut *c).poll_next(cx) {
+        match Pin::new(&mut *c).poll_recv(cx) {
             Poll::Pending | Poll::Ready(None) => Poll::Pending,
             Poll::Ready(Some(change)) => match change {
                 Change::Insert(k, endpoint) => {
@@ -48,9 +44,9 @@ impl<K: Hash + Eq + Clone> Discover for DynamicServiceStream<K> {
                     let connector = service::connector(http);
                     let connection = Connection::lazy(connector, endpoint);
                     let change = Ok(Change::Insert(k, connection));
-                    Poll::Ready(change)
+                    Poll::Ready(Some(change))
                 }
-                Change::Remove(k) => Poll::Ready(Ok(Change::Remove(k))),
+                Change::Remove(k) => Poll::Ready(Some(Ok(Change::Remove(k)))),
             },
         }
     }

--- a/tonic/src/transport/service/io.rs
+++ b/tonic/src/transport/service/io.rs
@@ -4,7 +4,7 @@ use std::io;
 use std::net::SocketAddr;
 use std::pin::Pin;
 use std::task::{Context, Poll};
-use tokio::io::{AsyncRead, AsyncWrite};
+use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
 
 pub(in crate::transport) trait Io:
     AsyncRead + AsyncWrite + Send + 'static
@@ -33,8 +33,8 @@ impl AsyncRead for BoxedIo {
     fn poll_read(
         mut self: Pin<&mut Self>,
         cx: &mut Context<'_>,
-        buf: &mut [u8],
-    ) -> Poll<io::Result<usize>> {
+        buf: &mut ReadBuf<'_>,
+    ) -> Poll<io::Result<()>> {
         Pin::new(&mut self.0).poll_read(cx, buf)
     }
 }
@@ -83,8 +83,8 @@ impl AsyncRead for ServerIo {
     fn poll_read(
         mut self: Pin<&mut Self>,
         cx: &mut Context<'_>,
-        buf: &mut [u8],
-    ) -> Poll<io::Result<usize>> {
+        buf: &mut ReadBuf<'_>,
+    ) -> Poll<io::Result<()>> {
         Pin::new(&mut self.0).poll_read(cx, buf)
     }
 }

--- a/tonic/src/transport/service/layer.rs
+++ b/tonic/src/transport/service/layer.rs
@@ -1,8 +1,5 @@
-use tower::{
-    layer::{Layer, Stack},
-    util::Either,
-    ServiceBuilder,
-};
+use tower::{layer::Layer, util::Either, ServiceBuilder};
+use tower_layer::Stack;
 
 pub(crate) trait ServiceBuilderExt<L> {
     fn layer_fn<F: Fn(S) -> Out, S, Out>(self, f: F) -> ServiceBuilder<Stack<LayerFn<F>, L>>;

--- a/tonic/src/transport/service/reconnect.rs
+++ b/tonic/src/transport/service/reconnect.rs
@@ -6,7 +6,7 @@ use std::{
     pin::Pin,
     task::{Context, Poll},
 };
-use tower_make::MakeService;
+use tower::make::MakeService;
 use tower_service::Service;
 use tracing::trace;
 


### PR DESCRIPTION
This is work in progress, but perhaps enough progress has been made to open a pull request here. Currently the only crate upgraded is `tonic`, and the others have been commented out of the workspace for now - the next step is to upgrade each in turn.

Tests are passing in `tonic` except for two of the doc tests which complain about missing TLS types, which needs investigating.

Since an upgraded version of `tower` has not been released to crates.io, a git dependency is taken for now.

(Edit: Sorry I meant to open this as a draft pull request but can't find a way to convert it to one).