### PR TITLE
Support timeouts with "grpc-timeout" header

### DIFF
--- a/tests/integration_tests/tests/timeout.rs
+++ b/tests/integration_tests/tests/timeout.rs
@@ -2,10 +2,7 @@ use futures_util::FutureExt;
 use integration_tests::pb::{test_client, test_server, Input, Output};
 use std::time::Duration;
 use tokio::sync::oneshot;
-use tonic::{
-    transport::Server,
-    Request, Response, Status,
-};
+use tonic::{transport::Server, Request, Response, Status};
 
 #[tokio::test]
 async fn cancelation_on_timeout() {
@@ -39,7 +36,8 @@ async fn cancelation_on_timeout() {
         .unwrap();
 
     let mut req = Request::new(Input {});
-    req.metadata_mut().insert("grpc-timeout", "500m".parse().unwrap());
+    req.metadata_mut()
+        .insert("grpc-timeout", "500m".parse().unwrap());
 
     let err = client.unary_call(req).await.unwrap_err();
     assert!(err.message().contains("Timeout expired"));

--- a/tests/integration_tests/tests/timeout.rs
+++ b/tests/integration_tests/tests/timeout.rs
@@ -1,0 +1,52 @@
+use futures_util::FutureExt;
+use integration_tests::pb::{test_client, test_server, Input, Output};
+use std::time::Duration;
+use tokio::sync::oneshot;
+use tonic::{
+    transport::Server,
+    Request, Response, Status,
+};
+
+#[tokio::test]
+async fn cancelation_on_timeout() {
+    struct Svc;
+
+    #[tonic::async_trait]
+    impl test_server::Test for Svc {
+        async fn unary_call(&self, _req: Request<Input>) -> Result<Response<Output>, Status> {
+            // Wait for a time longer than the timeout
+            tokio::time::delay_for(Duration::from_millis(1_000)).await;
+            Ok(Response::new(Output {}))
+        }
+    }
+
+    let svc = test_server::TestServer::new(Svc);
+
+    let (tx, rx) = oneshot::channel::<()>();
+
+    let jh = tokio::spawn(async move {
+        Server::builder()
+            .add_service(svc)
+            .serve_with_shutdown("127.0.0.1:1322".parse().unwrap(), rx.map(drop))
+            .await
+            .unwrap();
+    });
+
+    tokio::time::delay_for(Duration::from_millis(100)).await;
+
+    let mut client = test_client::TestClient::connect("http://127.0.0.1:1322")
+        .await
+        .unwrap();
+
+    let mut req = Request::new(Input {});
+    req.metadata_mut().insert("grpc-timeout", "500m".parse().unwrap());
+
+    let err = client.unary_call(req).await.unwrap_err();
+    assert!(err.message().contains("Timeout expired"));
+    // TODO: Need to return the correct type of code
+    // assert_eq!(err.code(), Code::Cancelled);
+
+    tx.send(()).unwrap();
+
+    jh.await.unwrap();
+}

--- a/tonic/Cargo.toml
+++ b/tonic/Cargo.toml
@@ -65,7 +65,7 @@ async-trait = { version = "0.1.13", optional = true }
 
 # transport
 hyper = { version = "0.13.4", features = ["stream"], optional = true }
-tokio = { version = "0.2.13", features = ["tcp"], optional = true }
+tokio = { version = "0.2.13", features = ["tcp", "time"], optional = true }
 tower = { version = "0.3", optional = true}
 tower-make = { version = "0.3", features = ["connect"] }
 tower-balance =  { version = "0.3", optional = true }

--- a/tonic/src/metadata/map.rs
+++ b/tonic/src/metadata/map.rs
@@ -198,11 +198,10 @@ pub struct OccupiedEntry<'a, VE: ValueEncoding> {
 
 impl MetadataMap {
     // Headers reserved by the gRPC protocol.
-    pub(crate) const GRPC_RESERVED_HEADERS: [&'static str; 8] = [
+    pub(crate) const GRPC_RESERVED_HEADERS: [&'static str; 7] = [
         "te",
         "user-agent",
         "content-type",
-        "grpc-timeout",
         "grpc-message",
         "grpc-encoding",
         "grpc-message-type",

--- a/tonic/src/transport/service/connection.rs
+++ b/tonic/src/transport/service/connection.rs
@@ -1,5 +1,5 @@
 use super::super::BoxFuture;
-use super::{layer::ServiceBuilderExt, reconnect::Reconnect, AddOrigin, UserAgent};
+use super::{layer::ServiceBuilderExt, reconnect::Reconnect, AddOrigin, Timeout, UserAgent};
 use crate::{body::BoxBody, transport::Endpoint};
 use http::Uri;
 use hyper::client::conn::Builder;
@@ -13,7 +13,6 @@ use tokio::io::{AsyncRead, AsyncWrite};
 use tower::{
     layer::Layer,
     limit::{concurrency::ConcurrencyLimitLayer, rate::RateLimitLayer},
-    timeout::TimeoutLayer,
     util::BoxService,
     ServiceBuilder, ServiceExt,
 };
@@ -53,7 +52,7 @@ impl Connection {
         let stack = ServiceBuilder::new()
             .layer_fn(|s| AddOrigin::new(s, endpoint.uri.clone()))
             .layer_fn(|s| UserAgent::new(s, endpoint.user_agent.clone()))
-            .optional_layer(endpoint.timeout.map(TimeoutLayer::new))
+            .layer_fn(|s| Timeout::new(s, endpoint.timeout))
             .optional_layer(endpoint.concurrency_limit.map(ConcurrencyLimitLayer::new))
             .optional_layer(endpoint.rate_limit.map(|(l, d)| RateLimitLayer::new(l, d)))
             .into_inner();

--- a/tonic/src/transport/service/mod.rs
+++ b/tonic/src/transport/service/mod.rs
@@ -6,6 +6,7 @@ mod io;
 mod layer;
 mod reconnect;
 mod router;
+mod timeout;
 #[cfg(feature = "tls")]
 mod tls;
 mod user_agent;
@@ -17,6 +18,7 @@ pub(crate) use self::discover::DynamicServiceStream;
 pub(crate) use self::io::ServerIo;
 pub(crate) use self::layer::ServiceBuilderExt;
 pub(crate) use self::router::{Or, Routes};
+pub(crate) use self::timeout::Timeout;
 #[cfg(feature = "tls")]
 pub(crate) use self::tls::{TlsAcceptor, TlsConnector};
 pub(crate) use self::user_agent::UserAgent;

--- a/tonic/src/transport/service/timeout.rs
+++ b/tonic/src/transport/service/timeout.rs
@@ -1,0 +1,216 @@
+use http::Request;
+use std::{
+    task::{Context, Poll},
+    time::Duration,
+};
+use tower_service::Service;
+use tracing::{debug, warn};
+
+pub(crate) struct Timeout<S> {
+    inner: S,
+    server_timeout: Option<Duration>,
+}
+
+impl<S> Timeout<S> {
+    pub(crate) fn new(inner: S, server_timeout: Option<Duration>) -> Self {
+        Self {
+            inner,
+            server_timeout,
+        }
+    }
+}
+
+impl<S, ReqBody> Service<Request<ReqBody>> for Timeout<S>
+where
+    S: Service<Request<ReqBody>>,
+    S::Error: Into<crate::Error>,
+{
+    type Response = S::Response;
+    type Error = crate::Error;
+    type Future = future::TimeoutFuture<S::Future>;
+
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.inner.poll_ready(cx).map_err(Into::into)
+    }
+
+    fn call(&mut self, req: Request<ReqBody>) -> Self::Future {
+        // Try to parse the `grpc-timeout` header, if it is present
+        let header_timeout = headers::try_parse_grpc_timeout(req.headers()).unwrap_or_else(|e| {
+            warn!("Error parsing grpc-timeout header {:?}", e);
+            None
+        });
+
+        // Use the shorter of the two durations, if either are set
+        let timeout_duration = match (header_timeout, self.server_timeout) {
+            (None, None) => None,
+            (Some(dur), None) => Some(dur),
+            (None, Some(dur)) => Some(dur),
+            (Some(header), Some(server)) => {
+                let shorter_duration = std::cmp::min(header, server);
+                debug!(
+                    "both grpc-timeout header present: {:?},\
+                     and server timeout set: {:?}.\
+                     Using server timeout of: {:?}",
+                    header, server, shorter_duration,
+                );
+                Some(shorter_duration)
+            }
+        };
+
+        let inner_future = self.inner.call(req);
+        future::TimeoutFuture::new(inner_future, timeout_duration)
+    }
+}
+
+/// Utility methods for parsing the gRPC headers
+mod headers {
+    use http::{HeaderMap, HeaderValue};
+    use std::time::Duration;
+
+    const GRPC_TIMEOUT_HEADER: &str = "grpc-timeout";
+
+    const SECONDS_IN_HOUR: u64 = 60 * 60;
+    const SECONDS_IN_MINUTE: u64 = 60;
+
+    /// Tries to parse the `grpc-timeout` header if it is present. If we fail to parse, returns
+    /// the value we attempted to parse.
+    ///
+    /// Follows the [gRPC over HTTP2 spec](https://github.com/grpc/grpc/blob/master/doc/PROTOCOL-HTTP2.md).
+    pub(crate) fn try_parse_grpc_timeout(
+        headers: &HeaderMap<HeaderValue>,
+    ) -> Result<Option<Duration>, &HeaderValue> {
+        match headers.get(GRPC_TIMEOUT_HEADER) {
+            Some(val) => {
+                let str_val = val.to_str().map_err(|_| val)?;
+                let (timeout_value, timeout_unit) = try_split_last(str_val).map_err(|_| val)?;
+                let timeout_value: u64 = timeout_value.parse().map_err(|_| val)?;
+
+                let duration = match timeout_unit {
+                    // Hours
+                    "H" => Duration::from_secs(timeout_value * SECONDS_IN_HOUR),
+                    // Minutes
+                    "M" => Duration::from_secs(timeout_value * SECONDS_IN_MINUTE),
+                    // Seconds
+                    "S" => Duration::from_secs(timeout_value),
+                    // Milliseconds
+                    "m" => Duration::from_millis(timeout_value),
+                    // Microseconds
+                    "u" => Duration::from_micros(timeout_value),
+                    // Nanoseconds
+                    "n" => Duration::from_nanos(timeout_value),
+                    _ => return Err(val),
+                };
+
+                Ok(Some(duration))
+            }
+            None => Ok(None),
+        }
+    }
+
+    /// Tries to split the last character of the string, from the rest of the string,
+    /// returning (rest_of_string, last_char), if successful.
+    ///
+    /// `str.split_at(...)` panics if we're not on a UTF-8 code point boundary. This
+    /// should never happen in practice because the `grpc-timeout` header should be only
+    /// ASCII characters.
+    fn try_split_last(val: &str) -> Result<(&str, &str), &str> {
+        std::panic::catch_unwind(|| val.split_at(val.len() - 1)).map_err(|_| val)
+    }
+}
+
+/// A custom error type that the Timeout Service returns.
+mod error {
+    use std::{fmt, time::Duration};
+
+    // Note: The wrapped Duration should only be used for logging purposes. It is **not** the
+    // actual duration that elapsed, resulting in a timeout, instead it is a close approximation
+    #[derive(Debug)]
+    pub(crate) struct TimeoutExpired(pub(crate) Duration);
+
+    impl fmt::Display for TimeoutExpired {
+        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+            write!(f, "Timeout expired after {:?}", self.0)
+        }
+    }
+
+    // std::error::Error only requires a type to impl Debug and Display
+    impl std::error::Error for TimeoutExpired {}
+}
+
+/// A Future that returns `T`, if it resolves before a provided `Duration`
+mod future {
+    use super::error::TimeoutExpired;
+    use pin_project::pin_project;
+    use std::{
+        future::Future,
+        pin::Pin,
+        task::{Context, Poll},
+        time::{Duration, Instant},
+    };
+    use tokio::time::{delay_for, Delay};
+
+    #[pin_project(project = TimeoutFutureProj)]
+    #[derive(Debug)]
+    pub(crate) enum TimeoutFuture<T> {
+        NoOp(#[pin] T),
+        Timeout {
+            #[pin]
+            inner: T,
+            #[pin]
+            timeout: Delay,
+            log_start: Instant,
+        },
+    }
+
+    impl<T> TimeoutFuture<T> {
+        pub(crate) fn new(inner: T, duration: Option<Duration>) -> Self {
+            match duration {
+                Some(dur) => {
+                    // Create a Future that resolves after duration
+                    let timeout = delay_for(dur);
+                    // Record the current instant as when the Future starts, used for logging
+                    let log_start = Instant::now();
+
+                    TimeoutFuture::Timeout {
+                        inner,
+                        timeout,
+                        log_start,
+                    }
+                }
+                None => TimeoutFuture::NoOp(inner),
+            }
+        }
+    }
+
+    impl<F, T, E> Future for TimeoutFuture<F>
+    where
+        F: Future<Output = Result<T, E>>,
+        E: Into<crate::Error>,
+    {
+        type Output = Result<T, crate::Error>;
+
+        fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+            match self.project() {
+                TimeoutFutureProj::NoOp(inner) => inner.poll(cx).map_err(Into::into),
+                TimeoutFutureProj::Timeout {
+                    inner,
+                    timeout,
+                    log_start,
+                } => {
+                    // Poll our inner future, returning the result if it's ready
+                    if let Poll::Ready(output) = inner.poll(cx) {
+                        return Poll::Ready(output.map_err(Into::into));
+                    };
+
+                    // Poll the timeout, returning an error if it's already resolved
+                    match timeout.poll(cx) {
+                        Poll::Pending => Poll::Pending,
+                        Poll::Ready(_) => {
+                            Poll::Ready(Err(Box::new(TimeoutExpired(log_start.elapsed()))))
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/tonic/src/transport/service/timeout.rs
+++ b/tonic/src/transport/service/timeout.rs
@@ -225,12 +225,9 @@ mod future {
 // Unit tests related to timeouts, mainly testing header parsing
 #[cfg(test)]
 mod tests {
-    use http::{
-        HeaderMap,
-        HeaderValue,
-    };
-    use std::time::Duration;
     use super::headers::try_parse_grpc_timeout;
+    use http::{HeaderMap, HeaderValue};
+    use std::time::Duration;
 
     const GRPC_TIMEOUT_HEADER: &str = "grpc-timeout";
 


### PR DESCRIPTION
## Motivation

This PR fixes issue #75, which is to implement support for the "grpc-timeout" header in tonic. Setting a timeout/deadline is an official part of the gRPC spec, and is a [recommended](https://grpc.io/blog/deadlines/) practice.

## Solution

### Server

This PR creates a new `Timeout` struct that implements `tower::Service` and is added as a `layer_fn(...)` in a `Connection`'s `tower::ServiceBuilder`. The `Timeout` service then parses the `grpc-timeout` header, and wraps an inner future in a timeout.

I'm relying on `tokio::time::Delay` for the actual timeout logic (`Delay` seems to be 1:1 with `Sleep` in tokio 1.0, which should make migration easy). I realize this prevents the `Timeout` service from being runtime agnostic, but since the service lives within the `transport` module, which already depends on tokio, I thought this was okay. If we don't want to rely on `tokio::time::Delay`, we can hand write our own Delay-like future, with a downside being, we won't be able to use mock timers for testing.

A `tonic::transport::Server` already supports a default timeout, I handle the presence of a server timeout, and a `grpc-timeout` header, by using which ever duration is the shortest, essentially the server timeout becomes a ceiling. The reasoning here is I didn't want a client to be able to override a server's settings, but if a client wants to timeout faster, the server shouldn't care about that.

### Client

This PR doesn't (yet) make any changes to gRPC clients. It could, similar to what the [gRPC docs](https://grpc.io/blog/deadlines/#c) have as examples for other libraries, but I thought the server/client impls would be a good separation for different PRs.

### Note

I had previously opened #362 a few months ago which tries to add the same feature, supporting timeouts with the "grpc-timeout" header. I'm opening a new PR now because I had deleted my previous fork of tonic that was used to open that previous PR. I hope this is okay 🙂
