### PR TITLE
fix: Depend on at least tower 0.4.4

### DIFF
--- a/tonic/Cargo.toml
+++ b/tonic/Cargo.toml
@@ -68,7 +68,7 @@ h2    = { version = "0.3", optional = true }
 hyper = { version = "0.14.2", features = ["full"], optional = true }
 tokio = { version = "1.0.1", features = ["net"], optional = true }
 tokio-stream = "0.1"
-tower = { version = "0.4", features = ["balance", "buffer", "discover", "limit", "load", "make", "timeout", "util"], optional = true}
+tower = { version = "0.4.4", features = ["balance", "buffer", "discover", "limit", "load", "make", "timeout", "util"], optional = true }
 tracing-futures = { version = "0.2", optional = true }
 
 # rustls


### PR DESCRIPTION
In tower 0.4.0 we missed a couple of re-exports that tonic 0.4.0 depends
on. So tonic really depends on tower at least version 0.4.1. Since
specifying your tower depedency as 0.4 means you might get 0.4.0, you
might get build errors when updating tonic. Such as [#553] and [#552].

This fixes that by bumping tonic's dependency on tower to 0.4.4. That
means users will get at least tower version 0.4.4, but semver compatible
updates are still allowed.

Fixes https://github.com/hyperium/tonic/issues/553

[#553]: https://github.com/hyperium/tonic/issues/553
[#552]: https://github.com/hyperium/tonic/issues/552