### PR TITLE
chore: add FromStr for Endpoint

### DIFF
--- a/tonic/src/transport/channel/endpoint.rs
+++ b/tonic/src/transport/channel/endpoint.rs
@@ -13,6 +13,7 @@ use http::{
 use std::{
     convert::{TryFrom, TryInto},
     fmt,
+    str::FromStr,
     time::Duration,
 };
 use tower::make::MakeConnection;
@@ -349,5 +350,13 @@ impl TryFrom<&'static str> for Endpoint {
 impl fmt::Debug for Endpoint {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("Endpoint").finish()
+    }
+}
+
+impl FromStr for Endpoint {
+    type Err = InvalidUri;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Self::try_from(s.to_string())
     }
 }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/hyperium/tonic/blob/master/CONTRIBUTING.md
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? If a new feature is being added, describe the intended
use case that feature fulfills.
-->

This is particularly handy when combined with `clap::value_t`.

Here's demo of it working with Clap:

```bash
cargo +stable init --bin tonic-demo
cd tonic-demo
cat <<-EOF >> Cargo.toml
  clap = "*"
  tonic = { path = "../hyperium/tonic/tonic" }
EOF
cat <<-EOF > src/main.rs
    use clap::{value_t, App, Arg};
    use tonic::transport::Endpoint;
    fn main() {
        let matches = App::new("tonic-demo")
            .arg(Arg::with_name("host"))
            .get_matches();
        let x = value_t!(matches.value_of("host"), Endpoint);
        println!("{:?}", x);
    }
EOF
cargo +stable run -- https://127.0.0.1:443
```

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

Add a `impl FromStr for Endpoint`. It clones since the `s`'s lifetime is too short otherwise.
