### PR TITLE
feat(tonic): implement `From<Code>` for `i32`

### DIFF
--- a/tonic/src/status.rs
+++ b/tonic/src/status.rs
@@ -746,6 +746,13 @@ impl From<i32> for Code {
     }
 }
 
+impl From<Code> for i32 {
+    #[inline]
+    fn from(code: Code) -> i32 {
+        code as i32
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;


### PR DESCRIPTION
`Code` is already trivial to convert into an `i32` however that isn't
immediately obvious by looking at the docs. This has tripped me up
before.

Implementing `From<Code>` for `i32` should hopefully make it a bit more
obvious.