### PR TITLE
feat(build): Use `RUSTFMT` to find `rustfmt` binary

### DIFF
--- a/tonic-build/src/lib.rs
+++ b/tonic-build/src/lib.rs
@@ -161,13 +161,14 @@ pub fn fmt(out_dir: &str) {
         if !file.ends_with(".rs") {
             continue;
         }
-        let result = Command::new("rustfmt")
-            .arg("--emit")
-            .arg("files")
-            .arg("--edition")
-            .arg("2018")
-            .arg(format!("{}/{}", out_dir, file))
-            .output();
+        let result =
+            Command::new(std::env::var("RUSTFMT").unwrap_or_else(|_| "rustfmt".to_owned()))
+                .arg("--emit")
+                .arg("files")
+                .arg("--edition")
+                .arg("2018")
+                .arg(format!("{}/{}", out_dir, file))
+                .output();
 
         match result {
             Err(e) => {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/hyperium/tonic/blob/master/CONTRIBUTING.md
-->

## Motivation

The Rust Bazel rules ([rules_rust](https://github.com/bazelbuild/rules_rust)) is looking to add some tools for building targets with Tonic. In development of https://github.com/bazelbuild/rules_rust/pull/479 it was found that `tonic-build` calls `rustfmt` and expects this to be in the user's PATH. This is generally not going to be the case when Building in Bazel. We're looking for a way to specify this binary without needing to rely on or modify PATH.
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? If a new feature is being added, describe the intended
use case that feature fulfills.
-->

## Solution
Cargo already has a [pattern for specifying environment variables](https://doc.rust-lang.org/cargo/reference/environment-variables.html#environment-variables-cargo-reads) to control what binaries are used during builds. The change here adopts the same functionality as Cargo and allows for an environment variable (`RUSTFMT`) to optionally specify the location of the `rustfmt` binary.
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
