### PR TITLE
add reporting infrastructure on server RPCs + time-series metrics

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ members = [
     "tonic",
     "tonic-build",
     "tonic-health",
+    "tonic-metrics",
     "tonic-types",
     "tonic-reflection",
 

--- a/tests/integration_tests/Cargo.toml
+++ b/tests/integration_tests/Cargo.toml
@@ -10,12 +10,14 @@ license = "MIT"
 
 [dependencies]
 tonic = { path = "../../tonic" }
+tonic-metrics = { path = "../../tonic-metrics" }
 prost = "0.7"
 futures-util = "0.3"
 bytes = "1.0"
 
 [dev-dependencies]
 tokio = { version = "1.0", features = ["macros", "rt-multi-thread", "net"] }
+metrics = "0.14"
 
 [build-dependencies]
 tonic-build = { path = "../../tonic-build" }

--- a/tests/integration_tests/tests/reporter.rs
+++ b/tests/integration_tests/tests/reporter.rs
@@ -1,0 +1,176 @@
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use bytes::Bytes;
+use futures_util::FutureExt;
+use integration_tests::pb::{test_client, test_server, Input, Output};
+use metrics::{GaugeValue, Key, Recorder, Unit};
+use tokio::sync::oneshot;
+use tonic::{transport::Server, Code, Request, Response, Status};
+
+#[tokio::test]
+async fn generates_metrics() {
+    struct Svc;
+
+    #[tonic::async_trait]
+    impl test_server::Test for Svc {
+        async fn unary_call(&self, _: Request<Input>) -> Result<Response<Output>, Status> {
+            Err(Status::with_details(
+                Code::ResourceExhausted,
+                "Too many requests",
+                Bytes::from_static(&[1]),
+            ))
+        }
+    }
+
+    struct TestRecorderInner {
+        counters: Vec<(Key, u64)>,
+        histograms: Vec<(Key, f64)>,
+    }
+
+    struct TestRecorder {
+        inner: Arc<Mutex<TestRecorderInner>>,
+    }
+
+    impl Recorder for TestRecorder {
+        fn register_counter(
+            &self,
+            _key: Key,
+            _unit: Option<Unit>,
+            _description: Option<&'static str>,
+        ) {
+        }
+
+        fn register_gauge(
+            &self,
+            _key: Key,
+            _unit: Option<Unit>,
+            _description: Option<&'static str>,
+        ) {
+        }
+
+        fn register_histogram(
+            &self,
+            _key: Key,
+            _unit: Option<Unit>,
+            _description: Option<&'static str>,
+        ) {
+        }
+
+        fn increment_counter(&self, key: Key, value: u64) {
+            let mut inner = self.inner.lock().unwrap();
+            inner.counters.push((key, value));
+        }
+
+        fn update_gauge(&self, _key: Key, _value: GaugeValue) {}
+
+        fn record_histogram(&self, key: Key, value: f64) {
+            let mut inner = self.inner.lock().unwrap();
+            inner.histograms.push((key, value));
+        }
+    }
+
+    let recorder_inner = Arc::new(Mutex::new(TestRecorderInner {
+        counters: Vec::new(),
+        histograms: Vec::new(),
+    }));
+
+    let recorder = TestRecorder {
+        inner: recorder_inner.clone(),
+    };
+
+    metrics::set_boxed_recorder(Box::new(recorder)).unwrap();
+
+    let svc = test_server::TestServer::with_reporter(Svc, tonic_metrics::metrics_reporter_fn);
+
+    let (tx, rx) = oneshot::channel::<()>();
+
+    let jh = tokio::spawn(async move {
+        Server::builder()
+            .add_service(svc)
+            .serve_with_shutdown("127.0.0.1:1399".parse().unwrap(), rx.map(drop))
+            .await
+            .unwrap();
+    });
+
+    tokio::time::sleep(Duration::from_millis(100)).await;
+
+    let mut channel = test_client::TestClient::connect("http://127.0.0.1:1399")
+        .await
+        .unwrap();
+
+    let _ = channel
+        .unary_call(Request::new(Input {}))
+        .await
+        .unwrap_err();
+
+    tx.send(()).unwrap();
+
+    jh.await.unwrap();
+
+    let inner = recorder_inner.lock().unwrap();
+
+    assert_eq!(inner.counters.len(), 3);
+
+    let expected_labels = vec![
+        ("grpc_method", "unary_call"),
+        ("grpc_service", "test.Test"),
+        ("grpc_type", "unary"),
+    ];
+
+    let counter = &inner.counters[0];
+    assert_eq!(format!("{}", counter.0.name()), "grpc_server_started_total");
+    let mut labels = counter
+        .0
+        .labels()
+        .map(|l| (l.key(), l.value()))
+        .collect::<Vec<_>>();
+    labels.sort();
+    assert_eq!(labels, expected_labels);
+    assert_eq!(counter.1, 1);
+
+    let counter = &inner.counters[1];
+    assert_eq!(
+        format!("{}", counter.0.name()),
+        "grpc_server_msg_received_total"
+    );
+    let mut labels = counter
+        .0
+        .labels()
+        .map(|l| (l.key(), l.value()))
+        .collect::<Vec<_>>();
+    labels.sort();
+    assert_eq!(labels, expected_labels);
+    assert_eq!(counter.1, 1);
+
+    let counter = &inner.counters[2];
+    assert_eq!(format!("{}", counter.0.name()), "grpc_server_handled_total");
+    let mut labels = counter
+        .0
+        .labels()
+        .map(|l| (l.key(), l.value()))
+        .collect::<Vec<_>>();
+    labels.sort();
+    let expected_labels_with_code = {
+        let mut new_expected_labels = expected_labels.clone();
+        new_expected_labels.insert(0, ("grpc_code", "ResourceExhausted"));
+        new_expected_labels
+    };
+    assert_eq!(labels, expected_labels_with_code);
+    assert_eq!(counter.1, 1);
+
+    assert_eq!(inner.histograms.len(), 1);
+    let histogram = &inner.histograms[0];
+    assert_eq!(
+        format!("{}", histogram.0.name()),
+        "grpc_server_handling_seconds"
+    );
+    let mut labels = histogram
+        .0
+        .labels()
+        .map(|l| (l.key(), l.value()))
+        .collect::<Vec<_>>();
+    labels.sort();
+    assert_eq!(labels, expected_labels);
+    assert!(histogram.1 > 0.0);
+}

--- a/tonic-build/src/server.rs
+++ b/tonic-build/src/server.rs
@@ -338,11 +338,8 @@ fn generate_unary<T: Method>(
 
     let (request, response) = method.request_response_name(proto_path, compile_well_known_types);
 
-    #[cfg(feature = "transport")]
     let named_method_impl =
         generate_named_method_impl(&service_ident, &server_trait, service_path, method.name());
-    #[cfg(not(feature = "transport"))]
-    let named_method_impl = TokenStream::new();
 
     quote! {
         #[allow(non_camel_case_types)]
@@ -402,11 +399,8 @@ fn generate_server_streaming<T: Method>(
 
     let response_stream = quote::format_ident!("{}Stream", method.identifier());
 
-    #[cfg(feature = "transport")]
     let named_method_impl =
         generate_named_method_impl(&service_ident, &server_trait, service_path, method.name());
-    #[cfg(not(feature = "transport"))]
-    let named_method_impl = TokenStream::new();
 
     quote! {
         #[allow(non_camel_case_types)]
@@ -465,11 +459,8 @@ fn generate_client_streaming<T: Method>(
     let (request, response) = method.request_response_name(proto_path, compile_well_known_types);
     let codec_name = syn::parse_str::<syn::Path>(T::CODEC_PATH).unwrap();
 
-    #[cfg(feature = "transport")]
     let named_method_impl =
         generate_named_method_impl(&service_ident, &server_trait, service_path, method.name());
-    #[cfg(not(feature = "transport"))]
-    let named_method_impl = TokenStream::new();
 
     quote! {
         #[allow(non_camel_case_types)]
@@ -531,11 +522,8 @@ fn generate_streaming<T: Method>(
 
     let response_stream = quote::format_ident!("{}Stream", method.identifier());
 
-    #[cfg(feature = "transport")]
     let named_method_impl =
         generate_named_method_impl(&service_ident, &server_trait, service_path, method.name());
-    #[cfg(not(feature = "transport"))]
-    let named_method_impl = TokenStream::new();
 
     quote! {
         #[allow(non_camel_case_types)]
@@ -581,6 +569,7 @@ fn generate_streaming<T: Method>(
     }
 }
 
+#[cfg(feature = "transport")]
 fn generate_named_method_impl(
     server_service: &Ident,
     server_trait: &Ident,
@@ -593,4 +582,14 @@ fn generate_named_method_impl(
             const METHOD_NAME: &'static str = #method_name;
         }
     }
+}
+
+#[cfg(not(feature = "transport"))]
+fn generate_named_method_impl(
+    _server_service: &Ident,
+    _server_trait: &Ident,
+    _service_path: &str,
+    _method_name: &str,
+) -> TokenStream {
+    TokenStream::new()
 }

--- a/tonic-metrics/Cargo.toml
+++ b/tonic-metrics/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "tonic-metrics"
+version = "0.0.1"
+authors = [
+    "James Nugent <james@jen20.com>",
+    "Samani G. Gikandi <samani@gojulas.com>"
+]
+edition = "2018"
+license = "MIT"
+repository = "https://github.com/hyperium/tonic"
+homepage = "https://github.com/hyperium/tonic"
+description = """
+Metrics module of `tonic` gRPC implementation.
+"""
+readme = "README.md"
+categories = ["network-programming", "asynchronous"]
+keywords = ["rpc", "grpc", "async", "reflection"]
+
+[dependencies]
+metrics = "0.14"
+tonic = { version = "0.4", path = "../tonic" }

--- a/tonic-metrics/src/lib.rs
+++ b/tonic-metrics/src/lib.rs
@@ -1,0 +1,111 @@
+//! A `tonic` based gRPC Metrics implementation.
+
+use std::time::Instant;
+
+use tonic::reporter::{ReporterCallback, RpcType};
+use tonic::{Code, Status};
+
+#[derive(Clone)]
+struct MetricsReporterCallback {
+    service_name: &'static str,
+    method_name: &'static str,
+    rpc_type: &'static str,
+    start_time: Instant,
+}
+
+/// Returns a reporting callback that implement metrics compatible with
+/// https://github.com/grpc-ecosystem/go-grpc-prometheus.
+pub fn metrics_reporter_fn(
+    service_name: &'static str,
+    method_name: &'static str,
+    rpc_type: RpcType,
+) -> Box<dyn ReporterCallback + Send + Sync + 'static> {
+    metrics::increment_counter!(
+        "grpc_server_started_total",
+        "grpc_type" => convert_rpc_type(rpc_type),
+        "grpc_service" => service_name,
+        "grpc_method" => method_name,
+    );
+
+    let callback = MetricsReporterCallback {
+        service_name,
+        method_name,
+        rpc_type: convert_rpc_type(rpc_type),
+        start_time: Instant::now(),
+    };
+    Box::new(callback)
+}
+
+impl ReporterCallback for MetricsReporterCallback {
+    fn rpc_complete(&self, status: Status) {
+        let elapsed = self.start_time.elapsed();
+
+        metrics::increment_counter!(
+            "grpc_server_handled_total",
+            "grpc_type" => self.rpc_type,
+            "grpc_service" => self.service_name,
+            "grpc_method" => self.method_name,
+            "grpc_code" => convert_status_code(status.code()),
+        );
+
+        metrics::histogram!(
+            "grpc_server_handling_seconds",
+            elapsed,
+            "grpc_type" => self.rpc_type,
+            "grpc_service" => self.service_name,
+            "grpc_method" => self.method_name,
+        );
+    }
+
+    fn stream_message_received(&self) {
+        metrics::increment_counter!(
+            "grpc_server_msg_received_total",
+            "grpc_type" => self.rpc_type,
+            "grpc_service" => self.service_name,
+            "grpc_method" => self.method_name,
+        );
+    }
+
+    fn stream_message_sent(&self) {
+        metrics::increment_counter!(
+            "grpc_server_msg_sent_total",
+            "grpc_type" => self.rpc_type,
+            "grpc_service" => self.service_name,
+            "grpc_method" => self.method_name,
+        );
+    }
+}
+
+#[inline]
+fn convert_status_code(code: Code) -> &'static str {
+    match code {
+        Code::Ok => "OK",
+        Code::Cancelled => "Canceled",
+        Code::Unknown => "Unknown",
+        Code::InvalidArgument => "InvalidArgument",
+        Code::DeadlineExceeded => "DeadlineExceeded",
+        Code::NotFound => "NotFound",
+        Code::AlreadyExists => "AlreadyExists",
+        Code::PermissionDenied => "PermissionDenied",
+        Code::ResourceExhausted => "ResourceExhausted",
+        Code::FailedPrecondition => "FailedPrecondition",
+        Code::Aborted => "Aborted",
+        Code::OutOfRange => "OutOfRange",
+        Code::Unimplemented => "Unimplemented",
+        Code::Internal => "Internal",
+        Code::Unavailable => "Unavailable",
+        Code::DataLoss => "DataLoss",
+        Code::Unauthenticated => "Unauthenticated",
+        _ => "**INVALID**",
+    }
+}
+
+#[inline]
+fn convert_rpc_type(rpc_type: RpcType) -> &'static str {
+    match rpc_type {
+        RpcType::Unary => "unary",
+        RpcType::ClientStreaming => "client_stream",
+        RpcType::ServerStreaming => "server_stream",
+        RpcType::Streaming => "bidi_stream",
+    }
+}

--- a/tonic/benches/decode.rs
+++ b/tonic/benches/decode.rs
@@ -22,7 +22,7 @@ macro_rules! bench {
             b.iter(|| {
                 rt.block_on(async {
                     let decoder = MockDecoder::new($message_size);
-                    let mut stream = Streaming::new_request(decoder, body.clone());
+                    let mut stream = Streaming::new_request(decoder, body.clone(), None);
 
                     let mut count = 0;
                     while let Some(msg) = stream.message().await.unwrap() {

--- a/tonic/src/client/grpc.rs
+++ b/tonic/src/client/grpc.rs
@@ -202,9 +202,9 @@ impl<T> Grpc<T> {
 
         let response = response.map(|body| {
             if expect_additional_trailers {
-                Streaming::new_response(codec.decoder(), body, status_code)
+                Streaming::new_response(codec.decoder(), body, status_code, None)
             } else {
-                Streaming::new_empty(codec.decoder(), body)
+                Streaming::new_empty(codec.decoder(), body, None)
             }
         });
 

--- a/tonic/src/lib.rs
+++ b/tonic/src/lib.rs
@@ -80,6 +80,7 @@ pub mod body;
 pub mod client;
 pub mod codec;
 pub mod metadata;
+pub mod reporter;
 pub mod server;
 
 #[cfg(feature = "transport")]

--- a/tonic/src/reporter.rs
+++ b/tonic/src/reporter.rs
@@ -1,0 +1,137 @@
+//! Contains data structures and utilities for reporting of RPC life cycle events.
+
+use std::fmt;
+use std::sync::Arc;
+
+use crate::Status;
+
+/// The type of RPC call
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub enum RpcType {
+    /// Unary RPC call
+    Unary,
+
+    /// Client streaming RPC call
+    ClientStreaming,
+
+    /// Server streaming RPC call
+    ServerStreaming,
+
+    /// Bidirectional streaming RPC call
+    Streaming,
+}
+
+/// Type alias for functions used to receive the initial report callback.
+type ReporterFn = Arc<
+    dyn Fn(&'static str, &'static str, RpcType) -> Box<dyn ReporterCallback + Send + Sync + 'static>
+        + Send
+        + Sync
+        + 'static,
+>;
+
+/// Represents a gRPC reporter.
+///
+/// A gRPC reporter provides a way to receive notifications during the life cycle of RPC calls.
+/// The main intended use for `Reporter` is for generating time-series metrics (and possibily
+/// tracing spans related to RPC calls in the future).
+///
+/// See the `tonic-metrics` crate for an example of a reporting callback that generates
+/// time-series metrics similar to what the Go GRPC client has available in an add-on module.
+#[derive(Clone)]
+pub struct Reporter {
+    f: ReporterFn,
+}
+
+impl Reporter {
+    /// Create a new `Reporter` from the given callback closure.
+    ///
+    /// The callback function will receive the fully-qualified service name, method name, and
+    /// RPC type. It returns a boxed instance of ReporterCallback which receives future
+    /// reporting events relating to the same RPC.
+    pub fn new(
+        f: impl Fn(
+                &'static str,
+                &'static str,
+                RpcType,
+            ) -> Box<dyn ReporterCallback + Send + Sync + 'static>
+            + Send
+            + Sync
+            + 'static,
+    ) -> Self {
+        Reporter { f: Arc::new(f) }
+    }
+
+    /// Helper function for invoking the callback closure.
+    pub(crate) fn report_rpc_start(
+        &self,
+        service_path: &'static str,
+        method_name: &'static str,
+        rpc_type: RpcType,
+    ) -> Box<dyn ReporterCallback + Send + Sync + 'static> {
+        (self.f)(service_path, method_name, rpc_type)
+    }
+}
+
+impl<F> From<F> for Reporter
+where
+    F: Fn(&'static str, &'static str, RpcType) -> Box<dyn ReporterCallback + Send + Sync + 'static>
+        + Send
+        + Sync
+        + 'static,
+{
+    fn from(f: F) -> Self {
+        Reporter::new(f)
+    }
+}
+
+/// Reporting callbacks for a single RPC
+pub trait ReporterCallback {
+    /// Called when the RPC completes regardless of success or failure.
+    fn rpc_complete(&self, status: Status);
+
+    /// Called each time a stream message is received from the remote peer.
+    fn stream_message_received(&self);
+
+    /// Called each time a stream message is sent to the remote peer.
+    fn stream_message_sent(&self);
+}
+
+impl<R> ReporterCallback for Box<R>
+where
+    R: ReporterCallback + Send + Sync + 'static + ?Sized,
+{
+    fn rpc_complete(&self, status: Status) {
+        (**self).rpc_complete(status)
+    }
+
+    fn stream_message_received(&self) {
+        (**self).stream_message_received();
+    }
+
+    fn stream_message_sent(&self) {
+        (**self).stream_message_sent();
+    }
+}
+
+impl<R> ReporterCallback for Arc<R>
+where
+    R: ReporterCallback + Send + Sync + 'static + ?Sized,
+{
+    fn rpc_complete(&self, status: Status) {
+        (**self).rpc_complete(status)
+    }
+
+    fn stream_message_received(&self) {
+        (**self).stream_message_received();
+    }
+
+    fn stream_message_sent(&self) {
+        (**self).stream_message_sent();
+    }
+}
+
+impl fmt::Debug for Reporter {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Reporter").finish()
+    }
+}

--- a/tonic/src/server/mod.rs
+++ b/tonic/src/server/mod.rs
@@ -13,5 +13,5 @@ mod service;
 
 pub use self::grpc::Grpc;
 pub use self::service::{
-    ClientStreamingService, ServerStreamingService, StreamingService, UnaryService,
+    ClientStreamingService, NamedMethod, ServerStreamingService, StreamingService, UnaryService,
 };

--- a/tonic/src/server/service.rs
+++ b/tonic/src/server/service.rs
@@ -120,3 +120,18 @@ where
         Service::call(self, request)
     }
 }
+
+/// Provides a static reference to the name of a service and method. This is useful
+/// for gRPC handlers that need to know the name of a method as well as its service,
+/// e.g. to emit time-series metrics.
+pub trait NamedMethod {
+    /// The `Service-Name` as described [here].
+    ///
+    /// [here]: https://github.com/grpc/grpc/blob/master/doc/PROTOCOL-HTTP2.md#requests
+    const SERVICE_NAME: &'static str;
+
+    /// The method name as described [here].
+    ///
+    /// [here]: https://github.com/grpc/grpc/blob/master/doc/PROTOCOL-HTTP2.md#requests
+    const METHOD_NAME: &'static str;
+}


### PR DESCRIPTION
## Motivation

The goal of this PR is to allow applications to generate comprehensive time-series metrics for server-side RPCs. gRPC servers written in Go can already easily add such functionality through Go modules like [go-grpc-prometheus](https://github.com/grpc-ecosystem/go-grpc-prometheus). This PR provides a comparable solution for Tonic servers.

_Why is this PR necessary?_ The existing mechanisms for hooking into the request stack did not seem to support the time-series metrics use case well enough because:

1. Interceptors do receive the status code from calling the underlying service (nor any notification for that matter that an RPC had ended). Thus, an interceptor cannot be used to generate metrics relating to completion of RPCs.

2. The generated server stubs implement `Service<http::Request, Response = <http::Response>>`. Any "metrics service" wrapping those servers would have no access to some of the data it would need without additional hacky parsing. For example, the method name would need to be parsed again from the request path (while the service name could come from `NamedService`). And the status code would have to be parsed from the `grpc-status` header stored in the `http::Response`.  Both of those solutions seem very hacky.

## Solution

This PR defines a `tonic::reporter::Reporter` struct which wraps a function/closure that is called with the service name, method name, and the RPC type of each inbound RPC call. The function returns an instance of the `ReportingCallback` trait which receives all further events related to that specific RPC, specifically, stream message received, stream message sent, and RPC completion.

The generated server stubs gain support for:
- `with_reporter` and `with_interceptor_reporter` methods which add a reporter to a server.
- a `NamedMethod` trait impl to supply the parsed service name and method name to `tonic::server::Grpc` without any need for double parsing of the request path.

The new `tonic-metrics` crate contains a reporting callback that use the [`metrics` crate](https://crates.io/crates/metrics) to generate the following metrics:

- Counters:
  * `grpc_server_started_total` with labels `grpc_type`, `grpc_service`, and `grpc_method`
  * `grpc_server_handled_total` with labels `grpc_type`, `grpc_service`, `grpc_method`, and `grpc_code`
  * `grpc_server_msg_received_total` with labels `grpc_type`, `grpc_service`, and `grpc_method`
  * `grpc_server_msg_sent_total` with labels `grpc_type`, `grpc_service`, and `grpc_method`
- Histogram:
  * `grpc_server_handling_seconds` with labels `grpc_type`, `grpc_service`, and `grpc_method`

Open Questions:

- This change is somewhat behind the `transport` feature. Maybe it should be behind a separate `reporting` feature instead? And probably needs me to recheck it is all behind the `transport` feature.

## Future

- _Client Support_: The changes made to `tonic::server::Grpc` could also be made in a similar manner to `tonic::client::Grpc`. This would serve the same purpose of generating time-series metrics and tracing spans.

## Alternatives

- This use case could also probably be solved by reorganizing Tonic and generated stubs to better support middleware that want to use Tonic types in their signature like `tonic:Status` for errors instead of `http::Response`. That sort of solution seemed more complicated to me though than providing the reporter abstraction in this PR. Moreover, such a reorganization  would probably require a significant amount of design work by someone more familiar with Tonic than me.