### PR TITLE
fix(codec): Allocate inbound buffer once

### DIFF
--- a/tonic/src/codec/decode.rs
+++ b/tonic/src/codec/decode.rs
@@ -180,6 +180,7 @@ impl<T> Streaming<T> {
                 }
             };
             let len = self.buf.get_u32() as usize;
+            self.buf.reserve(len);
 
             self.state = State::ReadBody {
                 compression: is_compressed,
@@ -235,16 +236,6 @@ impl<T> Stream for Streaming<T> {
             };
 
             if let Some(data) = chunk {
-                if data.remaining() > self.buf.remaining_mut() {
-                    let amt = if data.remaining() > BUFFER_SIZE {
-                        data.remaining()
-                    } else {
-                        BUFFER_SIZE
-                    };
-
-                    self.buf.reserve(amt);
-                }
-
                 self.buf.put(data);
             } else {
                 // FIXME: improve buf usage.


### PR DESCRIPTION
During profiling for bottlenecks in my tonic powered message queue, I noticed that a large amount of compute was spent in reallocating and `memmov`ing over read buffers. 

This PR gets rid of the reallocs entirely by pre-allocating the buffer for the entire message body directly after the message size is known instead of only reserving space for the next chunk when they come in.

In my testing with 8MiB messages, this improved throughput from 370MiB/s to 560MiB/s, which is roughly a 50% improvement. I originally mistyped the numbers, thus the "30-40%" in the commit message -- didn't want to force-push just for that. 
