### PR TITLE
feat: Expose status constructors

### DIFF
--- a/tonic/src/status.rs
+++ b/tonic/src/status.rs
@@ -380,7 +380,8 @@ impl Status {
         Status::from_error(&*err.into())
     }
 
-    pub(crate) fn from_header_map(header_map: &HeaderMap) -> Option<Status> {
+    /// Extract a `Status` from a hyper `HeaderMap`.
+    pub fn from_header_map(header_map: &HeaderMap) -> Option<Status> {
         header_map.get(GRPC_STATUS_HEADER_CODE).map(|code| {
             let code = Code::from_bytes(code.as_ref());
             let error_message = header_map
@@ -661,7 +662,10 @@ impl Code {
         Code::from(i)
     }
 
-    pub(crate) fn from_bytes(bytes: &[u8]) -> Code {
+    /// Convert the string representation of a `Code` (as stored, for example, in the `grpc-status`
+    /// header in a response) into a `Code`. Returns `Code::Unknown` if the code string is not a
+    /// valid gRPC status code.
+    pub fn from_bytes(bytes: &[u8]) -> Code {
         match bytes.len() {
             1 => match bytes[0] {
                 b'0' => Code::Ok,


### PR DESCRIPTION
## Motivation

I have a `tower::Service` that generates time-series metrics for gRPC RPCs. That code currently has reimplementations of `Status::from_header_map` and `Code::from_bytes` to extract the gRPC status from a `hyper::http::Response`. I would rather not reimplement those functions.

## Solution

Export `Status::from_header_map` and `Code::from_bytes` from the crate.

