### PR TITLE
Fix Prost codec tests and cfg

### DIFF
--- a/tonic/src/codec/prost.rs
+++ b/tonic/src/codec/prost.rs
@@ -75,14 +75,15 @@ fn from_decode_error(error: prost1::DecodeError) -> crate::Status {
     Status::new(Code::Internal, error.to_string())
 }
 
-#[cfg(tests)]
+#[cfg(test)]
 mod tests {
-    use super::{encode_server, Decoder, Encoder, Streaming};
     use crate::codec::buffer::DecodeBuf;
     use crate::codec::EncodeBuf;
+    use crate::codec::{encode_server, Decoder, Encoder, Streaming};
     use crate::Status;
     use bytes::{Buf, BufMut, BytesMut};
     use http_body::Body;
+    use std::io::Read;
 
     const LEN: usize = 10000;
 
@@ -151,7 +152,7 @@ mod tests {
         type Error = Status;
 
         fn decode(&mut self, buf: &mut DecodeBuf<'_>) -> Result<Option<Self::Item>, Self::Error> {
-            let out = Vec::from(buf.bytes());
+            let out = Vec::from(buf.chunk());
             buf.advance(LEN);
             Ok(Some(out))
         }

--- a/tonic/src/codec/prost.rs
+++ b/tonic/src/codec/prost.rs
@@ -77,13 +77,10 @@ fn from_decode_error(error: prost1::DecodeError) -> crate::Status {
 
 #[cfg(test)]
 mod tests {
-    use crate::codec::buffer::DecodeBuf;
-    use crate::codec::EncodeBuf;
-    use crate::codec::{encode_server, Decoder, Encoder, Streaming};
+    use crate::codec::{encode_server, DecodeBuf, Decoder, EncodeBuf, Encoder, Streaming};
     use crate::Status;
     use bytes::{Buf, BufMut, BytesMut};
     use http_body::Body;
-    use std::io::Read;
 
     const LEN: usize = 10000;
 


### PR DESCRIPTION
## Motivation

I was curious how one would go about writing a custom Tonic Codec. While looking at the MockEncoder and MockDecoder I came across this issue: https://github.com/hyperium/tonic/issues/583

## Solution

The configures the Prost tests module, fixes the imports, and reading the decode buffer.