### PR TITLE
Fix ListFeaturesStream return type on RouteGuide Tutorial

### DIFF
--- a/examples/routeguide-tutorial.md
+++ b/examples/routeguide-tutorial.md
@@ -185,6 +185,7 @@ prost = "0.7"
 futures-core = "0.3"
 futures-util = "0.3"
 tokio = { version = "1.0", features = ["rt-multi-thread", "macros", "sync", "time"] }
+tokio-stream = "0.1"
 
 async-stream = "0.2"
 serde = { version = "1.0", features = ["derive"] }

--- a/examples/routeguide-tutorial.md
+++ b/examples/routeguide-tutorial.md
@@ -273,6 +273,7 @@ use std::pin::Pin;
 use std::sync::Arc;
 use tokio::sync::mpsc;
 use tonic::{Request, Response, Status};
+use tokio_stream::wrappers::ReceiverStream;
 ```
 
 ```rust
@@ -282,7 +283,7 @@ impl RouteGuide for RouteGuideService {
         unimplemented!()
     }
 
-    type ListFeaturesStream = mpsc::Receiver<Result<Feature, Status>>;
+    type ListFeaturesStream = ReceiverStream<Result<Feature, Status>>;
 
     async fn list_features(
         &self,
@@ -402,7 +403,7 @@ Now let's look at one of our streaming RPCs. `list_features` is a server-side st
 need to send back multiple `Feature`s to our client.
 
 ```rust
-type ListFeaturesStream = mpsc::Receiver<Result<Feature, Status>>;
+type ListFeaturesStream = ReceiverStream<Result<Feature, Status>>;
 
 async fn list_features(
     &self,

--- a/examples/routeguide-tutorial.md
+++ b/examples/routeguide-tutorial.md
@@ -420,7 +420,7 @@ async fn list_features(
         }
     });
 
-    Ok(Response::new(rx))
+    Ok(Response::new(ReceiverStream::new(rx)))
 }
 ```
 

--- a/examples/src/routeguide/server.rs
+++ b/examples/src/routeguide/server.rs
@@ -7,6 +7,7 @@ use futures::{Stream, StreamExt};
 use tokio::sync::mpsc;
 use tonic::transport::Server;
 use tonic::{Request, Response, Status};
+use tokio_stream::wrappers::ReceiverStream;
 
 use routeguide::route_guide_server::{RouteGuide, RouteGuideServer};
 use routeguide::{Feature, Point, Rectangle, RouteNote, RouteSummary};
@@ -36,8 +37,7 @@ impl RouteGuide for RouteGuideService {
         Ok(Response::new(Feature::default()))
     }
 
-    type ListFeaturesStream =
-        Pin<Box<dyn Stream<Item = Result<Feature, Status>> + Send + Sync + 'static>>;
+    type ListFeaturesStream = ReceiverStream<Result<Feature, Status>>;
 
     async fn list_features(
         &self,
@@ -59,9 +59,9 @@ impl RouteGuide for RouteGuideService {
             println!(" /// done sending");
         });
 
-        Ok(Response::new(Box::pin(
-            tokio_stream::wrappers::ReceiverStream::new(rx),
-        )))
+        Ok(Response::new(
+            ReceiverStream::new(rx),
+        ))
     }
 
     async fn record_route(

--- a/examples/src/routeguide/server.rs
+++ b/examples/src/routeguide/server.rs
@@ -5,9 +5,9 @@ use std::time::Instant;
 
 use futures::{Stream, StreamExt};
 use tokio::sync::mpsc;
+use tokio_stream::wrappers::ReceiverStream;
 use tonic::transport::Server;
 use tonic::{Request, Response, Status};
-use tokio_stream::wrappers::ReceiverStream;
 
 use routeguide::route_guide_server::{RouteGuide, RouteGuideServer};
 use routeguide::{Feature, Point, Rectangle, RouteNote, RouteSummary};
@@ -59,9 +59,7 @@ impl RouteGuide for RouteGuideService {
             println!(" /// done sending");
         });
 
-        Ok(Response::new(
-            ReceiverStream::new(rx),
-        ))
+        Ok(Response::new(ReceiverStream::new(rx)))
     }
 
     async fn record_route(


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/hyperium/tonic/blob/master/CONTRIBUTING.md
-->

## Motivation
I followed [routeguide-tutorial.md](https://github.com/hyperium/tonic/blob/master/examples/routeguide-tutorial.md) but there's a problem with ListFeaturesStream at compile time.
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? If a new feature is being added, describe the intended
use case that feature fulfills.
-->

## Solution
Luckily I found a [solution](https://github.com/hyperium/tonic/issues/540#issuecomment-771739578) in one of the issues.
This PR is to adopt what is suggested in the comment above both in `routeguide-tutorial.md` and `server.rs`.

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
