### PR TITLE
Use fully qualified path for futures_core::Stream in codegen

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ members = [
     "tests/extern_path/uuid",
     "tests/ambiguous_methods",
     "tests/extern_path/my_application",
-    "tests/integration_tests"
+    "tests/integration_tests",
+    "tests/stream_conflict",
 ]
 

--- a/tests/stream_conflict/Cargo.toml
+++ b/tests/stream_conflict/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "stream_conflict"
+version = "0.1.0"
+authors = ["Ben Sully <ben@bsull.io>"]
+publish = false
+edition = "2018"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+tonic = { path = "../../tonic" }
+prost = "0.7"
+
+[build-dependencies]
+tonic-build = { path = "../../tonic-build" }

--- a/tests/stream_conflict/build.rs
+++ b/tests/stream_conflict/build.rs
@@ -1,0 +1,3 @@
+fn main() {
+    tonic_build::compile_protos("proto/stream_conflict.proto").unwrap();
+}

--- a/tests/stream_conflict/proto/stream_conflict.proto
+++ b/tests/stream_conflict/proto/stream_conflict.proto
@@ -1,0 +1,10 @@
+syntax = "proto3";
+package StreamConflict;
+
+message Message {
+  bool ok = 1;
+}
+
+service Stream {
+  rpc RunStream(Message) returns (stream Message);
+}

--- a/tests/stream_conflict/src/main.rs
+++ b/tests/stream_conflict/src/main.rs
@@ -1,0 +1,7 @@
+mod stream_conflict {
+    tonic::include_proto!("stream_conflict");
+}
+
+fn main() {
+    println!("Hello, world!");
+}

--- a/tonic-build/src/server.rs
+++ b/tonic-build/src/server.rs
@@ -182,7 +182,7 @@ fn generate_trait_methods<T: Service>(
 
                 quote! {
                     #stream_doc
-                    type #stream: Stream<Item = Result<#res_message, tonic::Status>> + Send + Sync + 'static;
+                    type #stream: futures_core::Stream<Item = Result<#res_message, tonic::Status>> + Send + Sync + 'static;
 
                     #method_doc
                     async fn #name(&self, request: tonic::Request<#req_message>)
@@ -198,7 +198,7 @@ fn generate_trait_methods<T: Service>(
 
                 quote! {
                     #stream_doc
-                    type #stream: Stream<Item = Result<#res_message, tonic::Status>> + Send + Sync + 'static;
+                    type #stream: futures_core::Stream<Item = Result<#res_message, tonic::Status>> + Send + Sync + 'static;
 
                     #method_doc
                     async fn #name(&self, request: tonic::Request<tonic::Streaming<#req_message>>)

--- a/tonic/src/codegen.rs
+++ b/tonic/src/codegen.rs
@@ -1,7 +1,7 @@
 //! Codegen exports used by `tonic-build`.
 
 pub use async_trait::async_trait;
-pub use futures_core::Stream;
+pub use futures_core;
 pub use futures_util::future::{ok, poll_fn, Ready};
 
 pub use http_body::Body as HttpBody;


### PR DESCRIPTION
I've encountered some proto files for upstream services which have a Service named 'Stream'. The generated trait for the service then conflicts with the futures_core trait.

This PR fixes this by not exporting `Stream` in tonic/codegen.rs, and instead refer to the trait using `futures_core::Stream` when generating code. There's a new test named 'stream_conflict' added to catch regressions.

Closes #588.