### PR TITLE
Improve comment on Channel::builder()

### DIFF
--- a/tonic/src/transport/channel/mod.rs
+++ b/tonic/src/transport/channel/mod.rs
@@ -77,7 +77,7 @@ pub struct ResponseFuture {
 }
 
 impl Channel {
-    /// Create a [`Endpoint`] builder that can create [`Channel`]s.
+    /// Create an [`Endpoint`] builder that can create [`Channel`]s.
     pub fn builder(uri: Uri) -> Endpoint {
         Endpoint::from(uri)
     }

--- a/tonic/src/transport/channel/mod.rs
+++ b/tonic/src/transport/channel/mod.rs
@@ -77,7 +77,7 @@ pub struct ResponseFuture {
 }
 
 impl Channel {
-    /// Create a [`Endpoint`] builder that can create a [`Channel`]'s.
+    /// Create a [`Endpoint`] builder that can create [`Channel`]s.
     pub fn builder(uri: Uri) -> Endpoint {
         Endpoint::from(uri)
     }


### PR DESCRIPTION
This seems to be confused about plural vs singular (and gets the plural form wrong). I think plural is more appropriate since `Endpoint::connect()` and `Endpoint::connect_lazy()` only take a `&self`.