### PR TITLE
add healthcheck example

### DIFF
--- a/examples/src/health/README.md
+++ b/examples/src/health/README.md
@@ -1,0 +1,16 @@
+# Health checks
+
+gRPC has a [health checking protocol](https://github.com/grpc/grpc/blob/master/doc/health-checking.md) that defines how health checks for services should be carried out. Tonic supports this protocol with the optional [tonic health crate](https://docs.rs/tonic-health).
+
+This example uses the crate to set up a HealthServer that will run alongside the application service. In order to test it, you may use community tools like [grpc_health_probe](https://github.com/grpc-ecosystem/grpc-health-probe).
+
+For example, running the following bash script:
+
+```bash
+while [ true ]; do
+./grpc_health_probe -addr=[::1]:50051 -service=helloworld.Greeter
+sleep 1
+done
+```
+
+will show the change in health status of the service over time.

--- a/tonic-health/README.md
+++ b/tonic-health/README.md
@@ -1,6 +1,8 @@
 # tonic-health
 
-A `tonic` based gRPC healthcheck implementation.
+A `tonic` based gRPC healthcheck implementation. It closely follows the official [health checking protocol](https://github.com/grpc/grpc/blob/master/doc/health-checking.md), although it may not implement all features described in the specs.
+
+Please follow the example in the [main repo](https://github.com/hyperium/tonic/tree/master/examples/src/health) to see how it works.
 
 ## Features
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/hyperium/tonic/blob/master/CONTRIBUTING.md
-->

## Motivation

I didn't know how to run health checks for a tonic server. As per https://github.com/hyperium/tonic/issues/471, the client for the health service is not exposed.

This example is an easy way I found to run the checks. Other users may benefit from it 

## Solution

See the script added
