### PR TITLE
fix compile error when tower not updated

### DIFF
--- a/tonic/Cargo.toml
+++ b/tonic/Cargo.toml
@@ -68,7 +68,7 @@ h2    = { version = "0.3", optional = true }
 hyper = { version = "0.14.2", features = ["full"], optional = true }
 tokio = { version = "1.0.1", features = ["net"], optional = true }
 tokio-stream = "0.1"
-tower = { version = "0.4.4", features = ["balance", "buffer", "discover", "limit", "load", "make", "timeout", "util"], optional = true }
+tower = { version = "0.4.6", features = ["balance", "buffer", "discover", "limit", "load", "make", "timeout", "util"], optional = true }
 tracing-futures = { version = "0.2", optional = true }
 
 # rustls


### PR DESCRIPTION
## Motivation

Fix the following compile error caused by the version of `tower` in `Cargo.lock` not being at least v0.4.6:

```
error[E0599]: no method named `layer_fn` found for struct `ServiceBuilder<tower::layer::util::Identity>` in the current scope
  --> tonic/src/transport/service/connection.rs:54:14
   |
54 |             .layer_fn(|s| AddOrigin::new(s, endpoint.uri.clone()))
   |              ^^^^^^^^ method not found in `ServiceBuilder<tower::layer::util::Identity>`
```

Since the existing version in tonic's `Cargo.toml` is v0.4.4, cargo did not know to update that dependency automatically.

## Solution

Specify v0.4.6 for `tower` to esure `layer_fn` is available.