### PR TITLE
add h2::Error as a `source` for tonic::Status when converting from h2::Error

### DIFF
--- a/tonic/src/client/grpc.rs
+++ b/tonic/src/client/grpc.rs
@@ -160,7 +160,11 @@ impl<T> Grpc<T> {
             .headers_mut()
             .insert(CONTENT_TYPE, HeaderValue::from_static("application/grpc"));
 
-        let response = self.inner.call(request).await.map_err(|err| err.into())?;
+        let response = self
+            .inner
+            .call(request)
+            .await
+            .map_err(|err| Status::from_error(err.into()))?;
 
         let status_code = response.status();
         let trailers_only_status = Status::from_header_map(response.headers());

--- a/tonic/src/client/grpc.rs
+++ b/tonic/src/client/grpc.rs
@@ -160,11 +160,7 @@ impl<T> Grpc<T> {
             .headers_mut()
             .insert(CONTENT_TYPE, HeaderValue::from_static("application/grpc"));
 
-        let response = self
-            .inner
-            .call(request)
-            .await
-            .map_err(|err| Status::from_error(&*(err.into())))?;
+        let response = self.inner.call(request).await.map_err(|err| err.into())?;
 
         let status_code = response.status();
         let trailers_only_status = Status::from_header_map(response.headers());

--- a/tonic/src/codec/prost.rs
+++ b/tonic/src/codec/prost.rs
@@ -116,7 +116,7 @@ mod tests {
 
         let msg = Vec::from(&[0u8; 1024][..]);
 
-        let messages = std::iter::repeat(Ok::<_, Status>(msg)).take(10000);
+        let messages = std::iter::repeat_with(move || Ok::<_, Status>(msg.clone())).take(10000);
         let source = futures_util::stream::iter(messages);
 
         let body = encode_server(encoder, source);

--- a/tonic/src/status.rs
+++ b/tonic/src/status.rs
@@ -592,14 +592,6 @@ fn invalid_header_value_byte<Error: fmt::Display>(err: Error) -> Status {
     )
 }
 
-impl TryFrom<Box<dyn Error + Send + Sync + 'static>> for Status {
-    type Error = Box<dyn Error + Send + Sync + 'static>;
-
-    fn try_from(err: Box<dyn Error + Send + Sync + 'static>) -> Result<Self, Self::Error> {
-        Status::try_from_error(err)
-    }
-}
-
 #[cfg(feature = "transport")]
 impl From<h2::Error> for Status {
     fn from(err: h2::Error) -> Self {

--- a/tonic/src/status.rs
+++ b/tonic/src/status.rs
@@ -355,7 +355,7 @@ impl Status {
         };
 
         let mut status = Self::new(code, format!("h2 protocol error: {}", err));
-        let error: Option<Box<dyn Error + Send + Sync + 'static>> = err
+        let error = err
             .reason()
             .map(h2::Error::from)
             .map(|err| Box::new(err) as Box<dyn Error + Send + Sync + 'static>);

--- a/tonic/src/status.rs
+++ b/tonic/src/status.rs
@@ -3,7 +3,6 @@ use crate::metadata::MetadataMap;
 use bytes::Bytes;
 use http::header::{HeaderMap, HeaderValue};
 use percent_encoding::{percent_decode, percent_encode, AsciiSet, CONTROLS};
-use std::convert::TryFrom;
 use std::{borrow::Cow, error::Error, fmt};
 use tracing::{debug, trace, warn};
 

--- a/tonic/src/status.rs
+++ b/tonic/src/status.rs
@@ -3,7 +3,7 @@ use crate::metadata::MetadataMap;
 use bytes::Bytes;
 use http::header::{HeaderMap, HeaderValue};
 use percent_encoding::{percent_decode, percent_encode, AsciiSet, CONTROLS};
-use std::{borrow::Borrow, borrow::Cow, error::Error, fmt};
+use std::{borrow::Cow, error::Error, fmt};
 use tracing::{debug, trace, warn};
 
 const ENCODING_SET: &AsciiSet = &CONTROLS
@@ -627,7 +627,7 @@ impl fmt::Display for Status {
 
 impl Error for Status {
     fn source(&self) -> Option<&(dyn Error + 'static)> {
-        self.source.map(|err| err.borrow())
+        self.source.as_ref().map(|err| (&**err) as _)
     }
 }
 

--- a/tonic/src/status.rs
+++ b/tonic/src/status.rs
@@ -326,7 +326,7 @@ impl Status {
             Err(err) => err,
         };
 
-        if let Some(status) = find_status_in_cause_chain(&*err) {
+        if let Some(status) = find_status_in_source_chain(&*err) {
             return Ok(status);
         }
 
@@ -531,10 +531,10 @@ impl Status {
     }
 }
 
-pub(crate) fn find_status_in_cause_chain(err: &(dyn Error + 'static)) -> Option<Status> {
-    let mut cause = Some(err);
+fn find_status_in_source_chain(err: &(dyn Error + 'static)) -> Option<Status> {
+    let mut source = Some(err);
 
-    while let Some(err) = cause {
+    while let Some(err) = source {
         if let Some(status) = err.downcast_ref::<Status>() {
             return Some(Status {
                 code: status.code,
@@ -547,7 +547,7 @@ pub(crate) fn find_status_in_cause_chain(err: &(dyn Error + 'static)) -> Option<
             });
         }
 
-        cause = err.source();
+        source = err.source();
     }
 
     None

--- a/tonic/src/status.rs
+++ b/tonic/src/status.rs
@@ -57,10 +57,11 @@ impl Clone for Status {
             details: self.details.clone(),
             metadata: self.metadata.clone(),
             // The following contortion to clone `h2_error` is required because `h2::Error`
-            // cannot implement `Clone` because one of the `Kind` variants  stores a
-            // `std::io::Error` (which does not implement `Clone`). Since we know that
-            // `h2_error` will always have a reason, just extract the reason and create a new
-            // `h2::Error` from it.
+            // cannot implement `Clone` because one of the `Kind` variants stores a
+            // `std::io::Error` (which does not implement `Clone`).
+            //
+            // We know that, if `h2_error` is a `Some`, then it will have a `reason` since it was
+            // created from that `reason`. If it is a `None`, this clone will not change anything.
             #[cfg(feature = "transport")]
             h2_error: self
                 .h2_error
@@ -581,9 +582,7 @@ impl fmt::Debug for Status {
 
         #[cfg(feature = "transport")]
         {
-            if self.h2_error.is_some() {
-                builder.field("h2_error", &self.h2_error);
-            }
+            builder.field("h2_error", &self.h2_error);
         }
 
         builder.finish()

--- a/tonic/src/transport/server/recover_error.rs
+++ b/tonic/src/transport/server/recover_error.rs
@@ -67,15 +67,14 @@ where
                 let response = response.map(MaybeEmptyBody::full);
                 Poll::Ready(Ok(response))
             }
-            Err(err) => {
-                if let Some(status) = Status::try_from_error(&*err) {
+            Err(err) => match Status::try_from_error(err) {
+                Ok(status) => {
                     let mut res = Response::new(MaybeEmptyBody::empty());
                     status.add_header(res.headers_mut()).unwrap();
                     Poll::Ready(Ok(res))
-                } else {
-                    Poll::Ready(Err(err))
                 }
-            }
+                Err(err) => Poll::Ready(Err(err)),
+            },
         }
     }
 }


### PR DESCRIPTION
## Motivation

A gRPC server may send a HTTP/2 GOAWAY frame with NO_ERROR status to gracefully shutdown a connection. This appears to Tonic users as a `tonic::Status` with `Code::Internal` and the message set to `h2 protocol error: protocol error: not a result of an error`.

The only way to currently detect this case and differentiate it from other internal errors (e.g., an application-level internal error) is to match on the message. A client may want to differentiate these cases because it may only want to alert on the application-level internal error and not on the transient transport-level issue. (Indeed, this is the use case for which I'm envisioning using this change.)

Matching on a message is not as robust, however, as matching on an `h2::Error` and its reason code. (The message could change for example if a future version of Tonic decided to vary the message. This would break any users that matched on the previous version of the message.)

## Solution

Store the `h2::Error` used when creating a `tonic::Status` from a `h2::Error` and provide it as the `source` for purposes of `std::error::Error`. This will allow users to downcast it and match on the original `h2::Reason`.

Note: `tonic::Status` must now manually implement `Clone` because`h2::Error` cannot implement `Clone` since one of the `Kind` variants stores a `std::io::Error` (which does not implement `Clone`). Since we know that `h2_error` will always have a reason since we only store it in that case, this manual implementation of `Clone` just extracts the reason and creates a new `h2::Error` from it to "clone" it.