### PR TITLE
Use dark mode for docs logo

### DIFF
--- a/.github/assets/tonic-banner.svg
+++ b/.github/assets/tonic-banner.svg
@@ -4,6 +4,7 @@
 	 viewBox="0 0 1500 350" style="enable-background:new 0 0 1500 350;" xml:space="preserve">
 <style type="text/css">
 	.st0{fill:#231F20;}
+	@media(prefers-color-scheme:dark){.st0{fill:#F0F6FC;}}
 </style>
 <g>
 	<g>


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/hyperium/tonic/blob/master/CONTRIBUTING.md
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? If a new feature is being added, describe the intended
use case that feature fulfills.
-->

The logo is very hard to see on Github's dark mode :(

![image](https://user-images.githubusercontent.com/174864/116420979-11fc1200-a804-11eb-8699-0b493b024854.png)

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

Use the same color that Github uses for icons / links in dark mode :)

![image](https://user-images.githubusercontent.com/174864/116421087-27713c00-a804-11eb-9acd-0644d1a446fb.png)

Note that this is imperfect, since users can override dark mode on github, but I think that case is less common than someone who uses dark mode and keeps Github in dark mode (I don't have data to back this up, it just makes sense to me).