### PR TITLE
feat(tonic): Add `Request::set_timeout`

### DIFF
--- a/tonic/src/metadata/map.rs
+++ b/tonic/src/metadata/map.rs
@@ -194,7 +194,6 @@ pub struct OccupiedEntry<'a, VE: ValueEncoding> {
     phantom: PhantomData<VE>,
 }
 
-#[cfg(feature = "transport")]
 pub(crate) const GRPC_TIMEOUT_HEADER: &str = "grpc-timeout";
 
 // ===== impl MetadataMap =====

--- a/tonic/src/metadata/mod.rs
+++ b/tonic/src/metadata/mod.rs
@@ -29,7 +29,6 @@ pub use self::value::AsciiMetadataValue;
 pub use self::value::BinaryMetadataValue;
 pub use self::value::MetadataValue;
 
-#[cfg(feature = "transport")]
 pub(crate) use self::map::GRPC_TIMEOUT_HEADER;
 
 /// The metadata::errors module contains types for errors that can occur

--- a/tonic/src/request.rs
+++ b/tonic/src/request.rs
@@ -225,6 +225,30 @@ impl<T> Request<T> {
     /// Set the max duration the request is allowed to take.
     ///
     /// Requires the server to support the `grpc-timeout` metadata, which Tonic does.
+    ///
+    /// The duration will be formatted according to [the spec] and use the most precise unit
+    /// possible.
+    ///
+    /// Example:
+    ///
+    /// ```rust
+    /// use std::time::Duration;
+    /// use tonic::Request;
+    ///
+    /// let mut request = Request::new(());
+    ///
+    /// request.set_timeout(Duration::from_secs(30));
+    ///
+    /// let value = request.metadata().get("grpc-timeout").unwrap();
+    ///
+    /// assert_eq!(
+    ///     value,
+    ///     // equivalent to 30 seconds
+    ///     "30000000u"
+    /// );
+    /// ```
+    ///
+    /// [the spec]: https://github.com/grpc/grpc/blob/master/doc/PROTOCOL-HTTP2.md
     pub fn set_timeout(&mut self, deadline: Duration) {
         let value = MetadataValue::from_str(&duration_to_grpc_timeout(deadline)).unwrap();
         self.metadata_mut()
@@ -325,14 +349,6 @@ mod tests {
 
         let http_request = r.into_http(Uri::default());
         assert!(http_request.headers().is_empty());
-    }
-
-    #[test]
-    fn setting_request_timeout() {
-        let mut req = Request::new(());
-        req.set_timeout(Duration::from_secs(30));
-
-        assert!(req.metadata().contains_key("grpc-timeout"));
     }
 
     #[test]


### PR DESCRIPTION
This will set the `grpc-timeout` to a value formatted according to [the spec](https://github.com/grpc/grpc/blob/master/doc/PROTOCOL-HTTP2.md).