### PR TITLE
chore: Add `deny(broken_intra_doc_links)` to all crates

### DIFF
--- a/tonic-build/src/lib.rs
+++ b/tonic-build/src/lib.rs
@@ -67,6 +67,7 @@
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/tokio-rs/website/master/public/img/icons/tonic.svg"
 )]
+#![deny(broken_intra_doc_links)]
 #![doc(html_root_url = "https://docs.rs/tonic-build/0.4.2")]
 #![doc(issue_tracker_base_url = "https://github.com/hyperium/tonic/issues/")]
 #![doc(test(no_crate_inject, attr(deny(rust_2018_idioms))))]

--- a/tonic-health/src/lib.rs
+++ b/tonic-health/src/lib.rs
@@ -15,6 +15,7 @@
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/tokio-rs/website/master/public/img/icons/tonic.svg"
 )]
+#![deny(broken_intra_doc_links)]
 #![doc(html_root_url = "https://docs.rs/tonic-health/0.3.1")]
 #![doc(issue_tracker_base_url = "https://github.com/hyperium/tonic/issues/")]
 #![doc(test(no_crate_inject, attr(deny(rust_2018_idioms))))]

--- a/tonic-reflection/src/lib.rs
+++ b/tonic-reflection/src/lib.rs
@@ -9,6 +9,7 @@
 #![doc(
     html_logo_url = "https://github.com/hyperium/tonic/raw/master/.github/assets/tonic-docs.png"
 )]
+#![deny(broken_intra_doc_links)]
 #![doc(html_root_url = "https://docs.rs/tonic-reflection/0.1.0")]
 #![doc(issue_tracker_base_url = "https://github.com/hyperium/tonic/issues/")]
 #![doc(test(no_crate_inject, attr(deny(rust_2018_idioms))))]

--- a/tonic-types/src/lib.rs
+++ b/tonic-types/src/lib.rs
@@ -9,6 +9,7 @@
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/tokio-rs/website/master/public/img/icons/tonic.svg"
 )]
+#![deny(broken_intra_doc_links)]
 #![doc(html_root_url = "https://docs.rs/tonic-types/0.2.0")]
 #![doc(issue_tracker_base_url = "https://github.com/hyperium/tonic/issues/")]
 

--- a/tonic/src/lib.rs
+++ b/tonic/src/lib.rs
@@ -68,6 +68,7 @@
     rust_2018_idioms,
     unreachable_pub
 )]
+#![deny(broken_intra_doc_links)]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/tokio-rs/website/master/public/img/icons/tonic.svg"
 )]

--- a/tonic/src/macros.rs
+++ b/tonic/src/macros.rs
@@ -67,6 +67,8 @@ macro_rules! include_proto {
 ///     pub(crate) const FILE_DESCRIPTOR_SET: &[u8] = include_bytes!("/relative/protobuf/directory/descriptor_name.bin");
 /// }
 /// ```
+///
+/// [`OUT_DIR`]: https://doc.rust-lang.org/cargo/reference/environment-variables.html#environment-variables-cargo-sets-for-build-scripts
 #[macro_export]
 macro_rules! include_file_descriptor_set {
     ($package: tt) => {


### PR DESCRIPTION
I noticed this was missing while working on something else.