### PR TITLE
chore: Prepare tonic `0.4.3`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+# [0.4.3](https://github.com/hyperium/tonic/compare/v0.4.2...v0.4.3) (2021-04-29)
+
+### Features
+
+* **client:** Add `Request::set_timeout` ([#615](https://github.com/hyperium/tonic/issues/615)) ([dae31d0](https://github.com/hyperium/tonic/commit/dae31d0))
+* **transport:** Configure TLS automatically when possible ([#445](https://github.com/hyperium/tonic/issues/445)) ([b04c1c6](https://github.com/hyperium/tonic/commit/b04c1c6))
+* **transport:** Support timeouts with `grpc-timeout` header ([#606](https://github.com/hyperium/tonic/issues/606)) ([9ff4f7b](https://github.com/hyperium/tonic/commit/9ff4f7b))
+
 # [0.4.2](https://github.com/hyperium/tonic/compare/v0.4.1...v0.4.2) (2021-04-13)
 
 ### Bug Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 * **client:** Add `Request::set_timeout` ([#615](https://github.com/hyperium/tonic/issues/615)) ([dae31d0](https://github.com/hyperium/tonic/commit/dae31d0))
 * **transport:** Configure TLS automatically when possible ([#445](https://github.com/hyperium/tonic/issues/445)) ([b04c1c6](https://github.com/hyperium/tonic/commit/b04c1c6))
-* **transport:** Support timeouts with `grpc-timeout` header ([#606](https://github.com/hyperium/tonic/issues/606)) ([9ff4f7b](https://github.com/hyperium/tonic/commit/9ff4f7b))
+* **transport:** Support timeouts with the `grpc-timeout` header ([#606](https://github.com/hyperium/tonic/issues/606)) ([9ff4f7b](https://github.com/hyperium/tonic/commit/9ff4f7b))
 
 # [0.4.2](https://github.com/hyperium/tonic/compare/v0.4.1...v0.4.2) (2021-04-13)
 

--- a/tonic/Cargo.toml
+++ b/tonic/Cargo.toml
@@ -8,11 +8,11 @@ name = "tonic"
 #   - README.md
 # - Update CHANGELOG.md.
 # - Create "v0.4.x" git tag.
-version = "0.4.2"
+version = "0.4.3"
 authors = ["Lucio Franco <luciofranco14@gmail.com>"]
 edition = "2018"
 license = "MIT"
-documentation = "https://docs.rs/tonic/0.4.2/tonic/"
+documentation = "https://docs.rs/tonic/0.4.3/tonic/"
 repository = "https://github.com/hyperium/tonic"
 homepage = "https://github.com/hyperium/tonic"
 description = """

--- a/tonic/src/lib.rs
+++ b/tonic/src/lib.rs
@@ -72,7 +72,7 @@
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/tokio-rs/website/master/public/img/icons/tonic.svg"
 )]
-#![doc(html_root_url = "https://docs.rs/tonic/0.4.2")]
+#![doc(html_root_url = "https://docs.rs/tonic/0.4.3")]
 #![doc(issue_tracker_base_url = "https://github.com/hyperium/tonic/issues/")]
 #![doc(test(no_crate_inject, attr(deny(rust_2018_idioms))))]
 #![cfg_attr(docsrs, feature(doc_cfg))]


### PR DESCRIPTION
# [0.4.3](https://github.com/hyperium/tonic/compare/v0.4.2...v0.4.3) (2021-04-29)

### Features

* **client:** Add `Request::set_timeout` ([#615](https://github.com/hyperium/tonic/issues/615)) ([dae31d0](https://github.com/hyperium/tonic/commit/dae31d0))
* **transport:** Configure TLS automatically when possible ([#445](https://github.com/hyperium/tonic/issues/445)) ([b04c1c6](https://github.com/hyperium/tonic/commit/b04c1c6))
* **transport:** Support timeouts with the `grpc-timeout` header ([#606](https://github.com/hyperium/tonic/issues/606)) ([9ff4f7b](https://github.com/hyperium/tonic/commit/9ff4f7b))
