### PR TITLE
build: show all rustfmt output on errors

### DIFF
--- a/tonic-build/src/lib.rs
+++ b/tonic-build/src/lib.rs
@@ -182,6 +182,7 @@ pub fn fmt(out_dir: &str) {
             }
             Ok(output) => {
                 if !output.status.success() {
+                    io::stdout().write_all(&output.stdout).unwrap();
                     io::stderr().write_all(&output.stderr).unwrap();
                     exit(output.status.code().unwrap_or(1))
                 }


### PR DESCRIPTION
Sometimes error output from rustfmt might be printed to stdout instead
of stderr. So to help users debug rustfmt issues this makes stdout get
printed as well.

Fixes https://github.com/hyperium/tonic/issues/600