### PR TITLE
fix(build): generate root crate paths correctly

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,5 +20,6 @@ members = [
     "tests/extern_path/my_application",
     "tests/integration_tests",
     "tests/stream_conflict",
+    "tests/root-crate-path",
 ]
 

--- a/tests/root-crate-path/Cargo.toml
+++ b/tests/root-crate-path/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "root-crate-path"
+version = "0.1.0"
+authors = ["Lucio Franco <luciofranco14@gmail.com>"]
+edition = "2018"
+publish = false
+license = "MIT"
+
+[dependencies]
+tonic = { path = "../../tonic" }
+prost = "0.7"
+
+[build_dependencies]
+tonic-build = { path = "../../tonic-build" }

--- a/tests/root-crate-path/build.rs
+++ b/tests/root-crate-path/build.rs
@@ -1,0 +1,7 @@
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    tonic_build::configure()
+        .extern_path(".foo.bar.baz.Animal", "crate::Animal")
+        .compile(&["foo.proto"], &["."])?;
+
+    Ok(())
+}

--- a/tests/root-crate-path/foo.proto
+++ b/tests/root-crate-path/foo.proto
@@ -1,0 +1,10 @@
+syntax = "proto2";
+
+package foo.bar.baz;
+
+message Animal {
+  optional string name = 1;
+}
+service Zoo {
+  rpc process_animal(Animal) returns (Animal) {};
+}

--- a/tests/root-crate-path/src/main.rs
+++ b/tests/root-crate-path/src/main.rs
@@ -1,0 +1,19 @@
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct Animal {
+    #[prost(string, optional, tag = "1")]
+    pub name: ::core::option::Option<::prost::alloc::string::String>,
+}
+
+// pub mod foo;
+
+pub mod foo {
+    pub mod bar {
+        pub mod baz {
+            tonic::include_proto!("foo.bar.baz");
+        }
+    }
+}
+
+fn main() {
+    println!("Hello, world!");
+}


### PR DESCRIPTION
We shouldn't append `proto_path` (`super` by default) if the path starts
with `crate::`.

Fixes https://github.com/hyperium/tonic/issues/548
