### PR TITLE
feat(tonic): remove `Code::__NonExhaustive`

### DIFF
--- a/tonic/src/status.rs
+++ b/tonic/src/status.rs
@@ -104,10 +104,6 @@ pub enum Code {
 
     /// The request does not have valid authentication credentials
     Unauthenticated = 16,
-
-    // New Codes may be added in the future, so never exhaustively match!
-    #[doc(hidden)]
-    __NonExhaustive,
 }
 
 impl Code {
@@ -146,9 +142,6 @@ impl Code {
             Code::Unavailable => "The service is currently unavailable",
             Code::DataLoss => "Unrecoverable data loss or corruption",
             Code::Unauthenticated => "The request does not have valid authentication credentials",
-            Code::__NonExhaustive => {
-                unreachable!("__NonExhaustive variant must not be constructed")
-            }
         }
     }
 }
@@ -717,8 +710,6 @@ impl Code {
             Code::Unavailable => HeaderValue::from_static("14"),
             Code::DataLoss => HeaderValue::from_static("15"),
             Code::Unauthenticated => HeaderValue::from_static("16"),
-
-            Code::__NonExhaustive => unreachable!("Code::__NonExhaustive"),
         }
     }
 
@@ -823,7 +814,7 @@ mod tests {
     fn code_from_i32() {
         // This for loop should catch if we ever add a new variant and don't
         // update From<i32>.
-        for i in 0..(Code::__NonExhaustive as i32) {
+        for i in 0..(Code::Unauthenticated as i32) {
             let code = Code::from(i);
             assert_eq!(
                 i, code as i32,
@@ -833,7 +824,6 @@ mod tests {
         }
 
         assert_eq!(Code::from(-1), Code::Unknown);
-        assert_eq!(Code::from(Code::__NonExhaustive as i32), Code::Unknown);
     }
 
     #[test]


### PR DESCRIPTION
**Note:** This is a breaking change.

I agree with
https://github.com/hyperium/tonic/issues/384#issuecomment-652653446 its
probably fine to remove `Code::__NonExhaustive` and require users to do
an exhaustive match. Seems unlikely that new error codes will be added.

Fixes https://github.com/hyperium/tonic/issues/384