### PR TITLE
fix(tonic): don't include error's cause in Display impl

### DIFF
--- a/tonic/src/transport/error.rs
+++ b/tonic/src/transport/error.rs
@@ -73,11 +73,7 @@ impl fmt::Debug for Error {
 
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        if let Some(source) = &self.inner.source {
-            write!(f, "{}: {}", self.description(), source)
-        } else {
-            f.write_str(self.description())
-        }
+        f.write_str(self.description())
     }
 }
 


### PR DESCRIPTION
At Embark we have a little helper function that converts a `&dyn
std::error::Error` into a `String` by walking the full chain of sources
(with `std::error::Error::source`) and joining them into a `String`.

We use that where we log errors to get as much information as possible
about whats causing an error. Works particularly well with anyhow's
`.context()` method.

However since `tonic::transport::Error` include its cause in their
`Display` impl we get the sources more than once.

As the cause can already be obtained through `std::error::Error::source`
no information should be lost by doing this.

Fixes https://github.com/hyperium/tonic/issues/632