### PR TITLE
feat(tonic): make it easier to add tower middleware to servers

### DIFF
--- a/tonic/src/transport/mod.rs
+++ b/tonic/src/transport/mod.rs
@@ -97,7 +97,7 @@ mod tls;
 pub use self::channel::{Channel, Endpoint};
 pub use self::error::Error;
 #[doc(inline)]
-pub use self::server::{NamedService, Server};
+pub use self::server::{Named, NamedService, Server};
 #[doc(inline)]
 pub use self::service::TimeoutExpired;
 pub use self::tls::{Certificate, Identity};

--- a/tonic/src/transport/server/incoming.rs
+++ b/tonic/src/transport/server/incoming.rs
@@ -17,7 +17,7 @@ use tokio::io::{AsyncRead, AsyncWrite};
 #[cfg(not(feature = "tls"))]
 pub(crate) fn tcp_incoming<IO, IE>(
     incoming: impl Stream<Item = Result<IO, IE>>,
-    _server: Server,
+    _server: Server<()>,
 ) -> impl Stream<Item = Result<ServerIo, crate::Error>>
 where
     IO: AsyncRead + AsyncWrite + Connected + Unpin + Send + 'static,
@@ -37,7 +37,7 @@ where
 #[cfg(feature = "tls")]
 pub(crate) fn tcp_incoming<IO, IE>(
     incoming: impl Stream<Item = Result<IO, IE>>,
-    server: Server,
+    server: Server<()>,
 ) -> impl Stream<Item = Result<ServerIo, crate::Error>>
 where
     IO: AsyncRead + AsyncWrite + Connected + Unpin + Send + 'static,

--- a/tonic/src/transport/server/mod.rs
+++ b/tonic/src/transport/server/mod.rs
@@ -357,7 +357,7 @@ impl<L> Server<L> {
         <<L as Layer<S>>::Service as Service<Request<Body>>>::Error: Into<crate::Error> + Send,
     {
         let (server, layer) = self.clone().into_parts();
-        let svc = NamedLayer::new(&layer).layer(svc);
+        let svc = Named::new(layer.layer(svc));
         Router::new(server, layer, svc)
     }
 
@@ -388,7 +388,7 @@ impl<L> Server<L> {
         };
 
         let (server, layer) = self.clone().into_parts();
-        let svc = NamedLayer::new(&layer).layer(svc);
+        let svc = Named::new(layer.layer(svc));
         Router::new(server, layer, svc)
     }
 
@@ -539,7 +539,7 @@ where
 
             path.starts_with(&svc_route)
         };
-        let svc = NamedLayer::new(&layer).layer(svc);
+        let svc = Named::new(layer.layer(svc));
         let routes = routes.push(pred, svc);
 
         Router {
@@ -585,7 +585,7 @@ where
             Some(some) => Either::A(some),
             None => Either::B(Unimplemented::default()),
         };
-        let svc = NamedLayer::new(&layer).layer(svc);
+        let svc = Named::new(layer.layer(svc));
         let routes = routes.push(pred, svc);
 
         Router {
@@ -798,28 +798,6 @@ impl Service<Request<Body>> for Unimplemented {
                 .body(BoxBody::empty())
                 .unwrap(),
         )
-    }
-}
-
-struct NamedLayer<'a, L> {
-    layer: &'a L,
-}
-
-impl<'a, L> NamedLayer<'a, L> {
-    fn new(layer: &'a L) -> Self {
-        Self { layer }
-    }
-}
-
-impl<'a, S, L> Layer<S> for NamedLayer<'a, L>
-where
-    L: Layer<S>,
-    S: NamedService,
-{
-    type Service = Named<S, L::Service>;
-
-    fn layer(&self, inner: S) -> Self::Service {
-        Named::new(self.layer.layer(inner))
     }
 }
 

--- a/tonic/src/transport/server/mod.rs
+++ b/tonic/src/transport/server/mod.rs
@@ -323,6 +323,7 @@ impl<L> Server<L> {
         }
     }
 
+    /// TODO(david): docs
     pub fn layer<NewLayer>(self, new_layer: NewLayer) -> Server<NewLayer> {
         Server {
             layer: new_layer,
@@ -822,6 +823,7 @@ where
     }
 }
 
+/// TODO(david): docs
 pub struct Named<A, B> {
     inner: B,
     _name: PhantomData<fn() -> A>,


### PR DESCRIPTION
This is an attempt at making tower easier to use with tonic. It only touches the server parts because I think [adding tower middleware to a client is already easy](https://github.com/hyperium/tonic/blob/master/examples/src/tower/client.rs#L13-L16).

The main limitations of the current setup I think are:

1. Tonic's router requires that all services implement `NamedService`. This is big downside because it means middleware defined in tower cannot be used since tower doesn't know anything about tonic.
2. Users who want to do middleware kind of things, that interceptors don't support, have to know that tower exists and works with tonic.
3. Tower middleware must use `http::Request` and `http::Response` to work with tonic. Thats quite surprising since tonic already has its own request and response types.

What I have so far solves 1 and 2. I'm not quite sure 3 has a good solution but might be possible to write a middleware that converts things back and forth behind the scenes.

## Using tower now

With this patch adding tower middleware to a tonic server looks like:

```rust
let greeter = MyGreeter::default();
let svc = GreeterServer::new(greeter);

// some large layer who's output service _doesn't_
// implement `NamedService`
let layer = tower::ServiceBuilder::new()
    // good old tower middlewares
    .timeout(Duration::from_secs(30))
    .concurrency_limit(42)
    // some custom middleware we wrote
    .layer(MyMiddlewareLayer::default())
    .into_inner();

Server::builder()
    // wrap all services in the layer
    .layer(layer)
    .add_service(svc.clone())
    // also supports optional services
    .add_optional_service(Some(svc))
    .serve(addr)
    .await?;
```

So `Server` becomes generic over a tower layer. The layer starts out as `Identity` but can be changed with the `Server::layer` method. All added services will be wrapped in that layer's service.

The way I get around the `NamedService` limitation is with a new middleware called `Named` (please bikeshed the name). `Named` has two generic type parameters:

- One from the original service before it had our layer applied. This service will implement `NamedService` and is used when implementing `NamedService for Named`.
- The second type is the wrapped service itself. This wont implement `NamedService` but thats fine since we get that name from the first type.

So a full type for `Named` would be something like `Named<GreeterServer<MyGreeter>, Timeout<GreeterServer<MyGreeter>>>`. Where the name comes from `GreeterServer<MyGreeter>` but the actual service used to handle requests is `Timeout<GreeterServer<MyGreeter>>`.

This is also nice because `Server::layer` will show up in the docs and gives us a place to mention and demo using tower to add middleware. That should hopefully increase awareness a bit.

The downside to this approach is that it complicates the types quite a bit and the type errors you get when things don't align are pretty bad. But thats hard to avoid when doing anything non trivial with tower anyway 🤷