### PR TITLE
feat(tonic): expose setting for `http2_adaptive_window`

### DIFF
--- a/tonic/src/transport/channel/endpoint.rs
+++ b/tonic/src/transport/channel/endpoint.rs
@@ -38,6 +38,7 @@ pub struct Endpoint {
     pub(crate) http2_keep_alive_interval: Option<Duration>,
     pub(crate) http2_keep_alive_timeout: Option<Duration>,
     pub(crate) http2_keep_alive_while_idle: Option<bool>,
+    pub(crate) http2_adaptive_window: Option<bool>,
 }
 
 impl Endpoint {
@@ -231,6 +232,14 @@ impl Endpoint {
         }
     }
 
+    /// Sets whether to use an adaptive flow control. Uses `hyper`'s default otherwise.
+    pub fn http2_adaptive_window(self, enabled: bool) -> Self {
+        Endpoint {
+            http2_adaptive_window: Some(enabled),
+            ..self
+        }
+    }
+
     /// Create a channel from this config.
     pub async fn connect(&self) -> Result<Channel, Error> {
         let mut http = hyper::client::connect::HttpConnector::new();
@@ -319,6 +328,7 @@ impl From<Uri> for Endpoint {
             http2_keep_alive_interval: None,
             http2_keep_alive_timeout: None,
             http2_keep_alive_while_idle: None,
+            http2_adaptive_window: None,
         }
     }
 }

--- a/tonic/src/transport/service/connection.rs
+++ b/tonic/src/transport/service/connection.rs
@@ -49,6 +49,10 @@ impl Connection {
             settings.http2_keep_alive_while_idle(val);
         }
 
+        if let Some(val) = endpoint.http2_adaptive_window {
+            settings.http2_adaptive_window(val);
+        }
+
         let stack = ServiceBuilder::new()
             .layer_fn(|s| AddOrigin::new(s, endpoint.uri.clone()))
             .layer_fn(|s| UserAgent::new(s, endpoint.user_agent.clone()))


### PR DESCRIPTION
Fixes https://github.com/hyperium/tonic/issues/358