### PR TITLE
fix: cargo-web compilation

### DIFF
--- a/tonic-web/tonic-web/src/service.rs
+++ b/tonic-web/tonic-web/src/service.rs
@@ -2,7 +2,7 @@ use std::task::{Context, Poll};
 
 use http::{header, HeaderMap, HeaderValue, Method, Request, Response, StatusCode, Version};
 use hyper::Body;
-use tonic::body::BoxBody;
+use tonic::body::{BoxBody, empty_body};
 use tonic::transport::NamedService;
 use tower_service::Service;
 use tracing::{debug, trace};
@@ -65,7 +65,7 @@ where
     fn no_content(&self, headers: HeaderMap) -> BoxFuture<S::Response, S::Error> {
         let mut res = Response::builder()
             .status(StatusCode::NO_CONTENT)
-            .body(BoxBody::empty())
+            .body(empty_body())
             .unwrap();
 
         res.headers_mut().extend(headers);
@@ -77,7 +77,7 @@ where
         Box::pin(async move {
             Ok(Response::builder()
                 .status(status)
-                .body(BoxBody::empty())
+                .body(empty_body())
                 .unwrap())
         })
     }

--- a/tonic/src/body.rs
+++ b/tonic/src/body.rs
@@ -7,6 +7,7 @@ pub type BoxBody = http_body::combinators::BoxBody<bytes::Bytes, crate::Status>;
 
 // this also exists in `crate::codegen` but we need it here since `codegen` has
 // `#[cfg(feature = "codegen")]`.
-pub(crate) fn empty_body() -> BoxBody {
+/// Create an empty `BoxBody`
+pub fn empty_body() -> BoxBody {
     http_body::Empty::new().map_err(|err| match err {}).boxed()
 }


### PR DESCRIPTION
## Motivation

Since the changement with the BoxBody #622 tonic-web wasn't compiling, the CI didn't detect it (this will be fixed with #648).

## Solution

Make `tonic::body::empty_body` public and use it instead of the old and non existant anymore `BoxBody::empty()`