### PR TITLE
feat(build): support adding attributes to clients and servers

### DIFF
--- a/examples/build.rs
+++ b/examples/build.rs
@@ -16,6 +16,14 @@ fn main() {
     tonic_build::compile_protos("proto/echo/echo.proto").unwrap();
 
     tonic_build::configure()
+        .server_mod_attribute("attrs", "#[cfg(feature = \"server\")]")
+        .server_attribute("Echo", "#[derive(PartialEq)]")
+        .client_mod_attribute("attrs", "#[cfg(feature = \"client\")]")
+        .client_attribute("Echo", "#[derive(PartialEq)]")
+        .compile(&["proto/attrs/attrs.proto"], &["proto"])
+        .unwrap();
+
+    tonic_build::configure()
         .build_server(false)
         .compile(
             &["proto/googleapis/google/pubsub/v1/pubsub.proto"],

--- a/examples/proto/attrs/attrs.proto
+++ b/examples/proto/attrs/attrs.proto
@@ -1,0 +1,19 @@
+syntax = "proto3";
+
+package attrs;
+
+// EchoRequest is the request for echo.
+message EchoRequest {
+  string message = 1;
+}
+
+// EchoResponse is the response for echo.
+message EchoResponse {
+  string message = 1;
+}
+
+// Echo is the echo service.
+service Echo {
+  // UnaryEcho is unary echo.
+  rpc UnaryEcho(EchoRequest) returns (EchoResponse) {}
+}

--- a/tonic-build/src/server.rs
+++ b/tonic-build/src/server.rs
@@ -1,4 +1,4 @@
-use super::{Method, Service};
+use super::{Attributes, Method, Service};
 use crate::{generate_doc_comment, generate_doc_comments, naive_snake_case};
 use proc_macro2::{Span, TokenStream};
 use quote::quote;
@@ -13,6 +13,7 @@ pub fn generate<T: Service>(
     emit_package: bool,
     proto_path: &str,
     compile_well_known_types: bool,
+    attributes: &Attributes,
 ) -> TokenStream {
     let methods = generate_methods(service, proto_path, compile_well_known_types);
 
@@ -35,6 +36,8 @@ pub fn generate<T: Service>(
         service.identifier()
     );
     let transport = generate_transport(&server_service, &server_trait, &path);
+    let mod_attributes = attributes.for_mod(package);
+    let struct_attributes = attributes.for_struct(&path);
 
     let compression_enabled = cfg!(feature = "compression");
 
@@ -64,6 +67,7 @@ pub fn generate<T: Service>(
 
     quote! {
         /// Generated server implementations.
+        #(#mod_attributes)*
         pub mod #server_mod {
             #![allow(unused_variables, dead_code, missing_docs)]
             use tonic::codegen::*;
@@ -71,6 +75,7 @@ pub fn generate<T: Service>(
             #generated_trait
 
             #service_doc
+            #(#struct_attributes)*
             #[derive(Debug)]
             pub struct #server_service<T: #server_trait> {
                 inner: _Inner<T>,


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/hyperium/tonic/blob/master/CONTRIBUTING.md
-->

## Motivation

Implements #504.

Having the ability to add attributes to generated servers and clients allows things like feature gating or deriving additional service functionality without the need for a fork.

## Solution

This PR only changes `tonic-build`. Four new methods are added to `Builder`:

| method | description |
| -------- | ----------- |
| `server_mod_attribute` | Adds a new attribute to the `mod` wrapping the server implementation. |
| `server_attribute` | Adds a new attribute to the service server `struct`. |
| `client_mod_attribute` | Adds a new attribute to the `mod` wrapping the client implementation. |
| `client_attribute` | Adds a new attribute to the service client `struct`. |

These are all optional values. Calling them more than once is additive. 

Each method accepts a `pattern` and an `attribute`. `pattern` follows similar rules as `tonic`'s attribute matching rules.

If `pattern` matches for a given service, the respective `attribute` values are parsed as `syn::Attribute`s and added to the generated code in `server::generate` and `client::generate`.