### PR TITLE
fix(codec): Fix streaming reponses w/ many status

### DIFF
--- a/tests/integration_tests/Cargo.toml
+++ b/tests/integration_tests/Cargo.toml
@@ -23,6 +23,7 @@ futures = "0.3"
 tower = { version = "0.4", features = [] }
 http-body = "0.4"
 http = "0.2"
+tracing-subscriber = "0.2"
 
 [build-dependencies]
 tonic-build = { path = "../../tonic-build" }

--- a/tests/integration_tests/build.rs
+++ b/tests/integration_tests/build.rs
@@ -1,3 +1,4 @@
 fn main() {
     tonic_build::compile_protos("proto/test.proto").unwrap();
+    tonic_build::compile_protos("proto/stream.proto").unwrap();
 }

--- a/tests/integration_tests/proto/stream.proto
+++ b/tests/integration_tests/proto/stream.proto
@@ -1,0 +1,10 @@
+syntax = "proto3";
+
+package stream;
+
+service TestStream {
+  rpc StreamCall(InputStream) returns (stream OutputStream);
+}
+
+message InputStream {}
+message OutputStream {}

--- a/tests/integration_tests/src/lib.rs
+++ b/tests/integration_tests/src/lib.rs
@@ -1,3 +1,4 @@
 pub mod pb {
     tonic::include_proto!("test");
+    tonic::include_proto!("stream");
 }

--- a/tonic/src/codec/decode.rs
+++ b/tonic/src/codec/decode.rs
@@ -258,7 +258,11 @@ impl<T> Stream for Streaming<T> {
             match ready!(Pin::new(&mut self.body).poll_trailers(cx)) {
                 Ok(trailer) => {
                     if let Err(e) = crate::status::infer_grpc_status(trailer.as_ref(), status) {
-                        return Some(Err(e)).into();
+                        if let Some(e) = e {
+                            return Some(Err(e)).into();
+                        } else {
+                            return Poll::Ready(None);
+                        }
                     } else {
                         self.trailers = trailer.map(MetadataMap::from_headers);
                     }


### PR DESCRIPTION
This fixes a bug found in #681 where sending a second status code in a stream would return an `Unknown` status code w/ the message that there was no `grpc-header`. From the grpc-h2 spec after the first status code returned in a streaming response we must end the stream. This change introduces the behavior with `infer_grpc_status` from trailers to map a `http::StatusCode::OK` to a empty/ended trailer stream. 

Closes #681