### PR TITLE
Add client feature flag to support wasm32 targets.

### DIFF
--- a/tonic/Cargo.toml
+++ b/tonic/Cargo.toml
@@ -27,9 +27,11 @@ default = ["transport", "codegen", "prost"]
 codegen = ["async-trait"]
 transport = [
     "h2",
-    "hyper",
+    "hyper/full",
     "tokio",
+    "tokio/net",
     "tower",
+    "tower/balance",
     "tracing-futures",
     "tokio/macros",
     "tokio/time",
@@ -39,6 +41,13 @@ tls-roots-common = ["tls"]
 tls-roots = ["tls-roots-common", "rustls-native-certs"]
 tls-webpki-roots = ["tls-roots-common", "webpki-roots"]
 prost = ["prost1", "prost-derive"]
+client = [
+    "h2",
+    "hyper/client",
+    "hyper/http2",
+    "tokio",
+    "tower",
+]
 
 # [[bench]]
 # name = "bench_main"
@@ -69,8 +78,8 @@ async-trait = { version = "0.1.13", optional = true }
 
 # transport
 h2    = { version = "0.3", optional = true }
-hyper = { version = "0.14.2", features = ["full"], optional = true }
-tokio = { version = "1.0.1", features = ["net"], optional = true }
+hyper = { version = "0.14.2", default-features = false, optional = true }
+tokio = { version = "1.0.1", default-features = false, optional = true }
 tokio-stream = "0.1"
 tower = { version = "0.4.7", features = ["balance", "buffer", "discover", "limit", "load", "make", "timeout", "util"], optional = true }
 tracing-futures = { version = "0.2", optional = true }
@@ -79,6 +88,9 @@ tracing-futures = { version = "0.2", optional = true }
 tokio-rustls = { version = "0.22", optional = true }
 rustls-native-certs = { version = "0.5", optional = true }
 webpki-roots = { version = "0.21.1", optional = true }
+
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+wasm-bindgen-futures = "0.4.18"
 
 [dev-dependencies]
 tokio = { version = "1.0", features = ["rt", "macros"] }

--- a/tonic/src/lib.rs
+++ b/tonic/src/lib.rs
@@ -87,7 +87,7 @@ pub mod metadata;
 pub mod server;
 pub mod service;
 
-#[cfg(feature = "transport")]
+#[cfg(any(feature = "transport", feature = "client"))]
 #[cfg_attr(docsrs, doc(cfg(feature = "transport")))]
 pub mod transport;
 
@@ -111,6 +111,15 @@ pub use response::Response;
 pub use status::{Code, Status};
 
 pub(crate) type Error = Box<dyn std::error::Error + Send + Sync>;
+
+#[cfg(all(
+    any(feature = "transport", feature = "client"),
+    not(target_arch = "wasm32")
+))]
+pub(crate) use tokio::spawn;
+#[cfg(all(any(feature = "transport", feature = "client"), target_arch = "wasm32"))]
+#[cfg(target_arch = "wasm32")]
+pub(crate) use wasm_bindgen_futures::spawn_local as spawn;
 
 #[doc(hidden)]
 #[cfg(feature = "codegen")]

--- a/tonic/src/transport/channel/endpoint.rs
+++ b/tonic/src/transport/channel/endpoint.rs
@@ -241,6 +241,7 @@ impl Endpoint {
     }
 
     /// Create a channel from this config.
+    #[cfg(feature = "transport")]
     pub async fn connect(&self) -> Result<Channel, Error> {
         let mut http = hyper::client::connect::HttpConnector::new();
         http.enforce_http(false);
@@ -260,6 +261,7 @@ impl Endpoint {
     ///
     /// The channel returned by this method does not attempt to connect to the endpoint until first
     /// use.
+    #[cfg(feature = "transport")]
     pub fn connect_lazy(&self) -> Result<Channel, Error> {
         let mut http = hyper::client::connect::HttpConnector::new();
         http.enforce_http(false);

--- a/tonic/src/transport/mod.rs
+++ b/tonic/src/transport/mod.rs
@@ -87,6 +87,7 @@
 //! [rustls]: https://docs.rs/rustls/0.16.0/rustls/
 
 pub mod channel;
+#[cfg(feature = "transport")]
 pub mod server;
 
 mod error;
@@ -96,6 +97,7 @@ mod tls;
 #[doc(inline)]
 pub use self::channel::{Channel, Endpoint};
 pub use self::error::Error;
+#[cfg(feature = "transport")]
 #[doc(inline)]
 pub use self::server::{NamedService, Server};
 #[doc(inline)]

--- a/tonic/src/transport/service/io.rs
+++ b/tonic/src/transport/service/io.rs
@@ -1,3 +1,4 @@
+#[cfg(feature = "transport")]
 use crate::transport::server::Connected;
 use hyper::client::connect::{Connected as HyperConnected, Connection};
 use std::io;
@@ -28,6 +29,7 @@ impl Connection for BoxedIo {
     }
 }
 
+#[cfg(feature = "transport")]
 impl Connected for BoxedIo {
     type ConnectInfo = NoneConnectInfo;
 
@@ -67,21 +69,24 @@ impl AsyncWrite for BoxedIo {
     }
 }
 
+#[cfg(feature = "transport")]
 pub(crate) enum ServerIo<IO> {
     Io(IO),
     #[cfg(feature = "tls")]
     TlsIo(TlsStream<IO>),
 }
 
+#[cfg(feature = "transport")]
 use tower::util::Either;
 
-#[cfg(feature = "tls")]
+#[cfg(all(feature = "transport", feature = "tls"))]
 type ServerIoConnectInfo<IO> =
     Either<<IO as Connected>::ConnectInfo, <TlsStream<IO> as Connected>::ConnectInfo>;
 
-#[cfg(not(feature = "tls"))]
+#[cfg(all(feature = "transport", not(feature = "tls")))]
 type ServerIoConnectInfo<IO> = Either<<IO as Connected>::ConnectInfo, ()>;
 
+#[cfg(feature = "transport")]
 impl<IO> ServerIo<IO> {
     pub(in crate::transport) fn new_io(io: IO) -> Self {
         Self::Io(io)
@@ -92,7 +97,7 @@ impl<IO> ServerIo<IO> {
         Self::TlsIo(io)
     }
 
-    #[cfg(feature = "tls")]
+    #[cfg(all(feature = "transport", feature = "tls"))]
     pub(in crate::transport) fn connect_info(&self) -> ServerIoConnectInfo<IO>
     where
         IO: Connected,
@@ -104,7 +109,7 @@ impl<IO> ServerIo<IO> {
         }
     }
 
-    #[cfg(not(feature = "tls"))]
+    #[cfg(all(feature = "transport", not(feature = "tls")))]
     pub(in crate::transport) fn connect_info(&self) -> ServerIoConnectInfo<IO>
     where
         IO: Connected,
@@ -115,6 +120,7 @@ impl<IO> ServerIo<IO> {
     }
 }
 
+#[cfg(feature = "transport")]
 impl<IO> AsyncRead for ServerIo<IO>
 where
     IO: AsyncWrite + AsyncRead + Unpin,
@@ -132,6 +138,7 @@ where
     }
 }
 
+#[cfg(feature = "transport")]
 impl<IO> AsyncWrite for ServerIo<IO>
 where
     IO: AsyncWrite + AsyncRead + Unpin,

--- a/tonic/src/transport/service/mod.rs
+++ b/tonic/src/transport/service/mod.rs
@@ -1,10 +1,12 @@
 mod add_origin;
 mod connection;
 mod connector;
+#[cfg(feature = "transport")]
 mod discover;
 mod grpc_timeout;
 mod io;
 mod reconnect;
+#[cfg(feature = "transport")]
 mod router;
 #[cfg(feature = "tls")]
 mod tls;
@@ -13,9 +15,13 @@ mod user_agent;
 pub(crate) use self::add_origin::AddOrigin;
 pub(crate) use self::connection::Connection;
 pub(crate) use self::connector::connector;
+#[cfg(feature = "transport")]
 pub(crate) use self::discover::DynamicServiceStream;
+#[cfg(feature = "transport")]
 pub(crate) use self::grpc_timeout::GrpcTimeout;
+#[cfg(feature = "transport")]
 pub(crate) use self::io::ServerIo;
+#[cfg(feature = "transport")]
 pub(crate) use self::router::{Or, Routes};
 #[cfg(feature = "tls")]
 pub(crate) use self::tls::{TlsAcceptor, TlsConnector};


### PR DESCRIPTION
When protobuf is generated without the transport feature, the generated client can be compiled to wasm32 targets and used in browser environment.

To be able to run the client in browser, a `h2` version including the commit 5c72713 has to be used.

## Motivation

This enables tonic clients to compile to `wasm32-unknown-unknown` target and run in a Browser environment. For more information, please see #491.

## Solution

For this to work, we 

1. introduced a new feature flag, which only enables system independent parts of tonic transport,
2. added `spawn` function which either uses `tokio::spawn` or `wasm_bindgen_futures::spawn_local` dependening on the compilation target,
3. set `http2_max_concurrent_reset_streams` to 0 for wasm, to disable the `Instant::now` usage in h2 which is not available in Browser.