### PR TITLE
fix(build): allow services to be named `Service`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ members = [
     # Tests
     "tests/included_service",
     "tests/same_name",
+    "tests/service_named_service",
     "tests/wellknown",
     "tests/wellknown-compiled",
     "tests/extern_path/uuid",

--- a/tests/service_named_service/Cargo.toml
+++ b/tests/service_named_service/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "service_named_service"
+version = "0.1.0"
+authors = ["Lucio Franco <luciofranco14@gmail.com>"]
+edition = "2018"
+publish = false
+license = "MIT"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+tonic = { path = "../../tonic" }
+prost = "0.8"
+
+[build-dependencies]
+tonic-build = { path = "../../tonic-build" }

--- a/tests/service_named_service/build.rs
+++ b/tests/service_named_service/build.rs
@@ -1,0 +1,3 @@
+fn main() {
+    tonic_build::compile_protos("proto/foo.proto").unwrap();
+}

--- a/tests/service_named_service/proto/foo.proto
+++ b/tests/service_named_service/proto/foo.proto
@@ -1,0 +1,11 @@
+syntax = "proto3";
+
+package foo;
+
+service Service {
+  rpc Foo(stream FooRequest) returns (stream FooResponse) {}
+}
+
+message FooRequest {}
+
+message FooResponse {}

--- a/tests/service_named_service/src/lib.rs
+++ b/tests/service_named_service/src/lib.rs
@@ -1,0 +1,3 @@
+pub mod pb {
+    tonic::include_proto!("foo");
+}

--- a/tonic-build/src/client.rs
+++ b/tonic-build/src/client.rs
@@ -63,11 +63,11 @@ pub fn generate<T: Service>(
                 pub fn with_interceptor<F>(inner: T, interceptor: F) -> #service_ident<InterceptedService<T, F>>
                 where
                     F: FnMut(tonic::Request<()>) -> Result<tonic::Request<()>, tonic::Status>,
-                    T: Service<
+                    T: tonic::codegen::Service<
                         http::Request<tonic::body::BoxBody>,
                         Response = http::Response<<T as tonic::client::GrpcService<tonic::body::BoxBody>>::ResponseBody>
                     >,
-                    <T as Service<http::Request<tonic::body::BoxBody>>>::Error: Into<StdError> + Send + Sync,
+                    <T as tonic::codegen::Service<http::Request<tonic::body::BoxBody>>>::Error: Into<StdError> + Send + Sync,
                 {
                     #service_ident::new(InterceptedService::new(inner, interceptor))
                 }

--- a/tonic-build/src/server.rs
+++ b/tonic-build/src/server.rs
@@ -106,7 +106,7 @@ pub fn generate<T: Service>(
                 #configure_compression_methods
             }
 
-            impl<T, B> Service<http::Request<B>> for #server_service<T>
+            impl<T, B> tonic::codegen::Service<http::Request<B>> for #server_service<T>
                 where
                     T: #server_trait,
                     B: Body + Send + Sync + 'static,


### PR DESCRIPTION
Fixes https://github.com/hyperium/tonic/issues/676