### PR TITLE
Refactor connect_lazy to return Channel directly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ This release includes a new crate `tonic-web` which is versioned at `0.1` and su
 * **transport:** Add a tls-webpki-roots feature to add trust roots from webpki-roots ([#660](https://github.com/hyperium/tonic/issues/660)) ([32173dc](https://github.com/hyperium/tonic/commit/32173dc7f6521bad8f26b055b6a86d807348f151))
 * **transport:** add connect timeout to `Endpoint` ([#662](https://github.com/hyperium/tonic/issues/662)) ([2b60a00](https://github.com/hyperium/tonic/commit/2b60a00614c5c4260ce0acaaa599da89bebfd267))
 * **transport:** provide generic access to connect info ([#647](https://github.com/hyperium/tonic/issues/647)) ([e5e3118](https://github.com/hyperium/tonic/commit/e5e311853bff347355722bc829d40f54e8954aee))
+* **transport:** Refactor Endpoint::connect_lazy method to return Channel directly instead of Result ([#392](https://github.com/hyperium/tonic/issues/708)) ([3b45565](https://github.com/3b45565b178a7298622c6b35bc6705b309beb410
 
 
 

--- a/tests/integration_tests/tests/connection.rs
+++ b/tests/integration_tests/tests/connection.rs
@@ -63,9 +63,7 @@ async fn connect_lazy_reconnects_after_first_failure() {
     let sender = Arc::new(Mutex::new(Some(tx)));
     let svc = test_server::TestServer::new(Svc(sender));
 
-    let channel = Endpoint::from_static("http://127.0.0.1:1339")
-        .connect_lazy()
-        .unwrap();
+    let channel = Endpoint::from_static("http://127.0.0.1:1339").connect_lazy();
 
     let mut client = TestClient::new(channel);
 

--- a/tonic/src/transport/channel/endpoint.rs
+++ b/tonic/src/transport/channel/endpoint.rs
@@ -284,7 +284,7 @@ impl Endpoint {
     ///
     /// The channel returned by this method does not attempt to connect to the endpoint until first
     /// use.
-    pub fn connect_lazy(&self) -> Result<Channel, Error> {
+    pub fn connect_lazy(&self) -> Channel {
         let mut http = hyper::client::connect::HttpConnector::new();
         http.enforce_http(false);
         http.set_nodelay(self.tcp_nodelay);
@@ -299,9 +299,9 @@ impl Endpoint {
         if let Some(connect_timeout) = self.connect_timeout {
             let mut connector = hyper_timeout::TimeoutConnector::new(connector);
             connector.set_connect_timeout(Some(connect_timeout));
-            Ok(Channel::new(connector, self.clone()))
+            Channel::new(connector, self.clone())
         } else {
-            Ok(Channel::new(connector, self.clone()))
+            Channel::new(connector, self.clone())
         }
     }
 


### PR DESCRIPTION
Fixes #708 

## Motivation

Most of the object creation and error validation is already done in `Endpoint::new` and as such `Endpoint::connect_lazy` should not be returning any errors since the connection is evaluated on-demand and cannot fail when building a channel. Meanwhile the API gives the wrong impression that the call may fail (does it ping the service beforehand? who knows)

## Solution

Use `Channel` directly instead of wrapping it in `Ok(Channel)`
