### PR TITLE
feat(tonic): derive Clone for RouterService

### DIFF
--- a/tonic/src/transport/server/mod.rs
+++ b/tonic/src/transport/server/mod.rs
@@ -99,7 +99,7 @@ pub struct Router<A, B, L = Identity> {
 /// This service implementation will route between multiple Tonic
 /// gRPC endpoints and can be consumed with the rest of the `tower`
 /// ecosystem.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct RouterService<S> {
     inner: S,
 }


### PR DESCRIPTION
## Motivation

Implementing `Clone` for `RouterService` makes it easier to use with `hyper::service::make_service_fn` and `tower::service_fn`. (For example, when using the pattern in [this example](https://github.com/hyperium/tonic/blob/master/examples/src/hyper_warp/server.rs#L54)).

## Solution

Derive `Clone` for `RouterService`.