### PR TITLE
fix(build): remove unnecessary `Debug` constraint for client streams

### DIFF
--- a/tonic-build/src/client.rs
+++ b/tonic-build/src/client.rs
@@ -224,7 +224,7 @@ fn generate_client_streaming<T: Method>(
         pub async fn #ident(
             &mut self,
             request: impl tonic::IntoStreamingRequest<Message = #request>
-        ) -> Result<tonic::Response<#response>, tonic::Status> where T: std::fmt::Debug {
+        ) -> Result<tonic::Response<#response>, tonic::Status> {
             self.inner.ready().await.map_err(|e| {
                         tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
             })?;


### PR DESCRIPTION
This was accidentally committed as part of https://github.com/hyperium/tonic/pull/692.

Fixes https://github.com/hyperium/tonic/issues/718