### PR TITLE
chore: Prepare tonic v0.5.1 and tonic-health 0.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,11 @@
-# [0.5.1](https://github.com/hyperium/tonic/compare/v0.4.3...v0.5.0) (2021-07-12)
+# [0.5.1](https://github.com/hyperium/tonic/compare/v0.5.0...v0.5.1) (2021-08-09)
+
+### Features
+
+* **health:** Expose grpc_health_v1 file descriptor set ([#620](https://github.com/hyperium/tonic/issues/620)) ([167e8cb](https://github.com/hyperium/tonic/commit/167e8cb)), closes [#619](https://github.com/hyperium/tonic/issues/619)
+* **tonic:** add `Interceptor` trait (#713) ([#713](https://github.com/hyperium/tonic/issues/713)) ([8c8f4d1](https://github.com/hyperium/tonic/commit/8c8f4d1))
+* **tonic:** derive `Clone` for `RouterService` (#714) ([#714](https://github.com/hyperium/tonic/issues/714)) ([0a06603](https://github.com/hyperium/tonic/commit/0a06603))
+* **transport:** Add `Connected` impl for `DuplexStream` (#722) ([#722](https://github.com/hyperium/tonic/issues/722)) ([0e33a02](https://github.com/hyperium/tonic/commit/0e33a02))
 
 ### Bug Fixes
 

--- a/tonic-health/Cargo.toml
+++ b/tonic-health/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tonic-health"
-version = "0.4.0"
+version = "0.4.1"
 authors = ["James Nugent <james@jen20.com>"]
 edition = "2018"
 license = "MIT"

--- a/tonic-health/src/lib.rs
+++ b/tonic-health/src/lib.rs
@@ -16,7 +16,7 @@
     html_logo_url = "https://raw.githubusercontent.com/tokio-rs/website/master/public/img/icons/tonic.svg"
 )]
 #![deny(broken_intra_doc_links)]
-#![doc(html_root_url = "https://docs.rs/tonic-health/0.4.0")]
+#![doc(html_root_url = "https://docs.rs/tonic-health/0.4.1")]
 #![doc(issue_tracker_base_url = "https://github.com/hyperium/tonic/issues/")]
 #![doc(test(no_crate_inject, attr(deny(rust_2018_idioms))))]
 #![cfg_attr(docsrs, feature(doc_cfg))]

--- a/tonic/Cargo.toml
+++ b/tonic/Cargo.toml
@@ -8,11 +8,11 @@ name = "tonic"
 #   - README.md
 # - Update CHANGELOG.md.
 # - Create "v0.5.x" git tag.
-version = "0.5.0"
+version = "0.5.1"
 authors = ["Lucio Franco <luciofranco14@gmail.com>"]
 edition = "2018"
 license = "MIT"
-documentation = "https://docs.rs/tonic/0.5.0/tonic/"
+documentation = "https://docs.rs/tonic/0.5.1/tonic/"
 repository = "https://github.com/hyperium/tonic"
 homepage = "https://github.com/hyperium/tonic"
 description = """

--- a/tonic/src/lib.rs
+++ b/tonic/src/lib.rs
@@ -79,7 +79,7 @@
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/tokio-rs/website/master/public/img/icons/tonic.svg"
 )]
-#![doc(html_root_url = "https://docs.rs/tonic/0.5.0")]
+#![doc(html_root_url = "https://docs.rs/tonic/0.5.1")]
 #![doc(issue_tracker_base_url = "https://github.com/hyperium/tonic/issues/")]
 #![doc(test(no_crate_inject, attr(deny(rust_2018_idioms))))]
 #![cfg_attr(docsrs, feature(doc_cfg))]


### PR DESCRIPTION
# [0.5.1](https://github.com/hyperium/tonic/compare/v0.5.0...v0.5.1) (2021-08-09)

### Features

* **health:** Expose grpc_health_v1 file descriptor set ([#620](https://github.com/hyperium/tonic/issues/620)) ([167e8cb](https://github.com/hyperium/tonic/commit/167e8cb)), closes [#619](https://github.com/hyperium/tonic/issues/619)
* **tonic:** add `Interceptor` trait (#713) ([#713](https://github.com/hyperium/tonic/issues/713)) ([8c8f4d1](https://github.com/hyperium/tonic/commit/8c8f4d1))
* **tonic:** derive `Clone` for `RouterService` (#714) ([#714](https://github.com/hyperium/tonic/issues/714)) ([0a06603](https://github.com/hyperium/tonic/commit/0a06603))
* **transport:** Add `Connected` impl for `DuplexStream` (#722) ([#722](https://github.com/hyperium/tonic/issues/722)) ([0e33a02](https://github.com/hyperium/tonic/commit/0e33a02))

### Bug Fixes

* **build:** remove unnecessary `Debug` constraint for client streams ([#719](https://github.com/hyperium/tonic/issues/719)) ([167e8cb](https://github.com/hyperium/tonic/commit/167e8cb)), closes [#718](https://github.com/hyperium/tonic/issues/718)
* **build:** allow services to be named `Service` ([#709](https://github.com/hyperium/tonic/issues/709)) ([380d81d](https://github.com/hyperium/tonic/commit/380d81d)), closes [#676](https://github.com/hyperium/tonic/issues/676)

---

The two bug fixes of tonic-build are already released in tonic-build 0.5.1.