### PR TITLE
chore: Prepare tonic+tonic-build v0.5.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,12 @@
+# [0.5.2](https://github.com/hyperium/tonic/compare/v0.5.1...v0.5.2) (2021-08-10)
+
+* **tonic:** add `Interceptor` trait (#713) ([#713](https://github.com/hyperium/tonic/issues/713)) ([8c8f4d1](https://github.com/hyperium/tonic/commit/8c8f4d1))
+
 # [0.5.1](https://github.com/hyperium/tonic/compare/v0.5.0...v0.5.1) (2021-08-09)
 
 ### Features
 
 * **health:** Expose grpc_health_v1 file descriptor set ([#620](https://github.com/hyperium/tonic/issues/620)) ([167e8cb](https://github.com/hyperium/tonic/commit/167e8cb)), closes [#619](https://github.com/hyperium/tonic/issues/619)
-* **tonic:** add `Interceptor` trait (#713) ([#713](https://github.com/hyperium/tonic/issues/713)) ([8c8f4d1](https://github.com/hyperium/tonic/commit/8c8f4d1))
 * **tonic:** derive `Clone` for `RouterService` (#714) ([#714](https://github.com/hyperium/tonic/issues/714)) ([0a06603](https://github.com/hyperium/tonic/commit/0a06603))
 * **transport:** Add `Connected` impl for `DuplexStream` (#722) ([#722](https://github.com/hyperium/tonic/issues/722)) ([0e33a02](https://github.com/hyperium/tonic/commit/0e33a02))
 

--- a/tonic-build/Cargo.toml
+++ b/tonic-build/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "tonic-build"
-version = "0.5.1"
+version = "0.5.2"
 authors = ["Lucio Franco <luciofranco14@gmail.com>"]
 edition = "2018"
 license = "MIT"
-documentation = "https://docs.rs/tonic-build/0.5.1/tonic_build/"
+documentation = "https://docs.rs/tonic-build/0.5.2/tonic_build/"
 repository = "https://github.com/hyperium/tonic"
 homepage = "https://github.com/hyperium/tonic"
 description = """

--- a/tonic-build/src/lib.rs
+++ b/tonic-build/src/lib.rs
@@ -68,7 +68,7 @@
     html_logo_url = "https://raw.githubusercontent.com/tokio-rs/website/master/public/img/icons/tonic.svg"
 )]
 #![deny(broken_intra_doc_links)]
-#![doc(html_root_url = "https://docs.rs/tonic-build/0.5.1")]
+#![doc(html_root_url = "https://docs.rs/tonic-build/0.5.2")]
 #![doc(issue_tracker_base_url = "https://github.com/hyperium/tonic/issues/")]
 #![doc(test(no_crate_inject, attr(deny(rust_2018_idioms))))]
 #![cfg_attr(docsrs, feature(doc_cfg))]

--- a/tonic/Cargo.toml
+++ b/tonic/Cargo.toml
@@ -8,11 +8,11 @@ name = "tonic"
 #   - README.md
 # - Update CHANGELOG.md.
 # - Create "v0.5.x" git tag.
-version = "0.5.1"
+version = "0.5.2"
 authors = ["Lucio Franco <luciofranco14@gmail.com>"]
 edition = "2018"
 license = "MIT"
-documentation = "https://docs.rs/tonic/0.5.1/tonic/"
+documentation = "https://docs.rs/tonic/0.5.2/tonic/"
 repository = "https://github.com/hyperium/tonic"
 homepage = "https://github.com/hyperium/tonic"
 description = """

--- a/tonic/src/lib.rs
+++ b/tonic/src/lib.rs
@@ -79,7 +79,7 @@
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/tokio-rs/website/master/public/img/icons/tonic.svg"
 )]
-#![doc(html_root_url = "https://docs.rs/tonic/0.5.1")]
+#![doc(html_root_url = "https://docs.rs/tonic/0.5.2")]
 #![doc(issue_tracker_base_url = "https://github.com/hyperium/tonic/issues/")]
 #![doc(test(no_crate_inject, attr(deny(rust_2018_idioms))))]
 #![cfg_attr(docsrs, feature(doc_cfg))]


### PR DESCRIPTION
So as highlighted by https://github.com/hyperium/tonic/issues/730#issuecomment-895635088 it
turns out the new `Interceptor` trait required changes to tonic-build as
well, which I forgot to publish yesterday. Didn't see it because it wasn't
clear from the commit message.

So this bumps tonic _and_ tonic-build to 0.5.2 so we can release both.
There are no code changes.