### PR TITLE
Allow new Endpoint from String like types

### DIFF
--- a/tonic/src/transport/channel/mod.rs
+++ b/tonic/src/transport/channel/mod.rs
@@ -18,6 +18,7 @@ use http::{
 };
 use hyper::client::connect::Connection as HyperConnection;
 use std::{
+    convert::AsRef,
     fmt,
     future::Future,
     hash::Hash,
@@ -80,6 +81,25 @@ impl Channel {
     /// Create an [`Endpoint`] builder that can create [`Channel`]s.
     pub fn builder(uri: Uri) -> Endpoint {
         Endpoint::from(uri)
+    }
+
+
+    /// Create an `Endpoint` from String like types.
+    ///
+    /// ```
+    /// # use tonic::transport::Channel;
+    /// let url = "https://example.com";
+    /// Channel::from_static(url);
+    ///
+    /// let string_url =  "https://example.com".to_owned();
+    /// Channel::from_static(string_url);
+    ///
+    /// let string_url =  "https://example.com".to_owned();
+    /// Channel::from_static(&String_url);
+    /// ```
+    pub fn from_string<StringLike: AsRef<str>>(s: StringLike) -> Endpoint {
+        let uri = s.as_ref().to_string().parse::<Uri>().unwrap();
+        Self::builder(uri)
     }
 
     /// Create an `Endpoint` from a static string.


### PR DESCRIPTION

Adds a `from` style method to `tonic::transport::channel::Channel` that takes string like variables and returns an `Endpoint`.

## Motivation

When I was trying to create an endpoint I genuinely struggled to create one with a uri stored in a variable or a String returned from a function without having to specifically include the external crate 'http' and then using the `builder()` function.

I admit it might not be the most efficient way to do it though, got a better way or idea then I'm all ears.

## Solution

I added a function that can take `&str`, `String`, `&String` and return an endpoint just like `from_static`.