### PR TITLE
fix(examples): Fix autoreload example (#798)

### DIFF
--- a/examples/src/autoreload/server.rs
+++ b/examples/src/autoreload/server.rs
@@ -36,6 +36,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     match listenfd::ListenFd::from_env().take_tcp_listener(0)? {
         Some(listener) => {
+            listener.set_nonblocking(true)?;
             let listener = tokio_stream::wrappers::TcpListenerStream::new(
                 tokio::net::TcpListener::from_std(listener)?,
             );


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/hyperium/tonic/blob/master/CONTRIBUTING.md
-->

## Motivation

Fix #798.

## Solution

Set the std TCP listener to nonblocking mode. Tokio makes no assumptions towards TCP listeners from std before converting them to `tokio::net::TcpListener`, so setting nonblocking mode on must be done manually.
