### PR TITLE
feat(transport): port router to axum

### DIFF
--- a/tonic-build/src/client.rs
+++ b/tonic-build/src/client.rs
@@ -57,7 +57,8 @@ pub fn generate<T: Service>(
             impl<T> #service_ident<T>
             where
                 T: tonic::client::GrpcService<tonic::body::BoxBody>,
-                T::ResponseBody: Body + Send  + 'static,
+                T::ResponseBody: Body<Data = Bytes> + Send  + 'static,
+                <T::ResponseBody as Body>::Error: Into<StdError> + Send + 'static,
                 T::Error: Into<StdError>,
                 <T::ResponseBody as Body>::Error: Into<StdError> + Send,
             {

--- a/tonic-build/src/server.rs
+++ b/tonic-build/src/server.rs
@@ -119,7 +119,7 @@ pub fn generate<T: Service>(
                     B::Error: Into<StdError> + Send + 'static,
             {
                 type Response = http::Response<tonic::body::BoxBody>;
-                type Error = Never;
+                type Error = std::convert::Infallible;
                 type Future = BoxFuture<Self::Response, Self::Error>;
 
                 fn poll_ready(&mut self, _cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {

--- a/tonic/Cargo.toml
+++ b/tonic/Cargo.toml
@@ -32,6 +32,7 @@ tls-roots = ["tls-roots-common", "rustls-native-certs"]
 tls-roots-common = ["tls"]
 tls-webpki-roots = ["tls-roots-common", "webpki-roots"]
 transport = [
+  "axum",
   "h2",
   "hyper",
   "tokio",
@@ -77,6 +78,7 @@ tokio = {version = "1.0.1", features = ["net"], optional = true}
 tokio-stream = "0.1"
 tower = {version = "0.4.7", features = ["balance", "buffer", "discover", "limit", "load", "make", "timeout", "util"], optional = true}
 tracing-futures = {version = "0.2", optional = true}
+axum = {version = "0.3", default_features = false, optional = true}
 
 # rustls
 rustls-native-certs = {version = "0.5", optional = true}

--- a/tonic/Cargo.toml
+++ b/tonic/Cargo.toml
@@ -78,7 +78,7 @@ tokio = {version = "1.0.1", features = ["net"], optional = true}
 tokio-stream = "0.1"
 tower = {version = "0.4.7", features = ["balance", "buffer", "discover", "limit", "load", "make", "timeout", "util"], optional = true}
 tracing-futures = {version = "0.2", optional = true}
-axum = {version = "0.3", default_features = false, optional = true}
+axum = {version = "0.4", default_features = false, optional = true}
 
 # rustls
 rustls-native-certs = {version = "0.5", optional = true}

--- a/tonic/src/body.rs
+++ b/tonic/src/body.rs
@@ -6,7 +6,7 @@ use http_body::Body;
 pub type BoxBody = http_body::combinators::UnsyncBoxBody<bytes::Bytes, crate::Status>;
 
 /// Convert a [`http_body::Body`] into a [`BoxBody`].
-pub(crate) fn box_body<B>(body: B) -> BoxBody
+pub(crate) fn boxed<B>(body: B) -> BoxBody
 where
     B: http_body::Body<Data = bytes::Bytes> + Send + 'static,
     B::Error: Into<crate::Error>,

--- a/tonic/src/body.rs
+++ b/tonic/src/body.rs
@@ -5,6 +5,15 @@ use http_body::Body;
 /// A type erased HTTP body used for tonic services.
 pub type BoxBody = http_body::combinators::UnsyncBoxBody<bytes::Bytes, crate::Status>;
 
+/// Convert a [`http_body::Body`] into a [`BoxBody`].
+pub(crate) fn box_body<B>(body: B) -> BoxBody
+where
+    B: http_body::Body<Data = bytes::Bytes> + Send + 'static,
+    B::Error: Into<crate::Error>,
+{
+    body.map_err(crate::Status::map_error).boxed_unsync()
+}
+
 // this also exists in `crate::codegen` but we need it here since `codegen` has
 // `#[cfg(feature = "codegen")]`.
 /// Create an empty `BoxBody`

--- a/tonic/src/codegen.rs
+++ b/tonic/src/codegen.rs
@@ -13,6 +13,7 @@ pub type StdError = Box<dyn std::error::Error + Send + Sync + 'static>;
 #[cfg(feature = "compression")]
 pub use crate::codec::{CompressionEncoding, EnabledCompressionEncodings};
 pub use crate::service::interceptor::InterceptedService;
+pub use bytes::Bytes;
 pub use http_body::Body;
 
 pub type BoxFuture<T, E> = self::Pin<Box<dyn self::Future<Output = Result<T, E>> + Send + 'static>>;
@@ -22,17 +23,6 @@ pub type BoxStream<T> =
 pub mod http {
     pub use http::*;
 }
-
-#[derive(Debug)]
-pub enum Never {}
-
-impl std::fmt::Display for Never {
-    fn fmt(&self, _: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match *self {}
-    }
-}
-
-impl std::error::Error for Never {}
 
 pub fn empty_body() -> crate::body::BoxBody {
     http_body::Empty::new()

--- a/tonic/src/service/interceptor.rs
+++ b/tonic/src/service/interceptor.rs
@@ -234,7 +234,12 @@ where
                 .poll(cx)
                 .map(|result| result.map(|res| res.map(boxed))),
             KindProj::Status(status) => {
-                let response = status.take().unwrap().to_http().map(|_| B::default()).map(boxed);
+                let response = status
+                    .take()
+                    .unwrap()
+                    .to_http()
+                    .map(|_| B::default())
+                    .map(boxed);
                 Poll::Ready(Ok(response))
             }
         }

--- a/tonic/src/service/interceptor.rs
+++ b/tonic/src/service/interceptor.rs
@@ -3,7 +3,7 @@
 //! See [`Interceptor`] for more details.
 
 use crate::{
-    body::{box_body, BoxBody},
+    body::{boxed, BoxBody},
     request::SanitizeHeaders,
     Status,
 };
@@ -229,10 +229,10 @@ where
         match self.project().kind.project() {
             KindProj::Future(future) => future
                 .poll(cx)
-                .map(|result| result.map(|res| res.map(box_body)))
+                .map(|result| result.map(|res| res.map(boxed)))
                 .map_err(Into::into),
             KindProj::Status(status) => {
-                let res = status.take().unwrap().to_http().map(box_body);
+                let res = status.take().unwrap().to_http().map(boxed);
                 Poll::Ready(Ok(res))
             }
         }

--- a/tonic/src/transport/service/mod.rs
+++ b/tonic/src/transport/service/mod.rs
@@ -16,9 +16,9 @@ pub(crate) use self::connector::connector;
 pub(crate) use self::discover::DynamicServiceStream;
 pub(crate) use self::grpc_timeout::GrpcTimeout;
 pub(crate) use self::io::ServerIo;
-pub(crate) use self::router::{Or, Routes};
 #[cfg(feature = "tls")]
 pub(crate) use self::tls::{TlsAcceptor, TlsConnector};
 pub(crate) use self::user_agent::UserAgent;
 
 pub use self::grpc_timeout::TimeoutExpired;
+pub use self::router::Routes;

--- a/tonic/src/transport/service/router.rs
+++ b/tonic/src/transport/service/router.rs
@@ -1,5 +1,5 @@
 use crate::{
-    body::{box_body, BoxBody},
+    body::{boxed, BoxBody},
     transport::NamedService,
 };
 use axum::handler::Handler;
@@ -83,7 +83,7 @@ impl Future for RoutesFuture {
 
     fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         match futures_util::ready!(self.project().0.poll(cx)) {
-            Ok(res) => Ok(res.map(box_body)).into(),
+            Ok(res) => Ok(res.map(boxed)).into(),
             Err(err) => match err {},
         }
     }

--- a/tonic/src/transport/service/router.rs
+++ b/tonic/src/transport/service/router.rs
@@ -46,7 +46,7 @@ impl Routes {
         S::Future: Send + 'static,
         S::Error: Into<crate::Error> + Send,
     {
-        let svc = svc.map_response(|res| res.map(axum::body::box_body));
+        let svc = svc.map_response(|res| res.map(axum::body::boxed));
         self.router = self.router.route(&format!("/{}/*rest", S::NAME), svc);
         self
     }


### PR DESCRIPTION
This ports tonic's [previous routing setup](https://docs.rs/tonic/0.6.1/tonic/transport/server/struct.Router.html) to axum. This is mostly just a proposal. I think it lead to some decent wins but might not make that much difference in practice. Its a breaking change so we have to wait until 0.7 if we decide to go this way.

- The router type is no longer generic and conceptually simpler.
- Should resolve any compile time issues people might be having due to regression in Rust 1.56.
- Performance might be slightly better if users are routing between a lot of services. This is due to axum's router using [matchit](https://crates.io/crates/matchit) rather than the nested services.
- I also removed `Never` since axum requires services to use `Infallible`. Can easily convert between them but if we're making breaking changes we might as well remove `Never`.
- `add_service` now requires service's to be infallible. This shouldn't cause any breakage since generated services were already infallible, the trait bounds just didn't require it.