### PR TITLE
fix: Return error on non https uri instead of panic

### DIFF
--- a/tonic/src/transport/service/connector.rs
+++ b/tonic/src/transport/service/connector.rs
@@ -5,6 +5,7 @@ use super::tls::TlsConnector;
 use http::Uri;
 #[cfg(feature = "tls-roots-common")]
 use std::convert::TryInto;
+use std::fmt;
 use std::task::{Context, Poll};
 use tower::make::MakeConnection;
 use tower_service::Service;
@@ -78,9 +79,17 @@ where
         #[cfg(feature = "tls-roots-common")]
         let tls = self.tls_or_default(uri.scheme_str(), uri.host());
 
+        let is_https = uri.scheme_str() == Some("https");
         let connect = self.inner.make_connection(uri);
 
         Box::pin(async move {
+            #[cfg(not(feature = "tls"))]
+            {
+                if is_https {
+                    return Err(HttpsUriWithoutTlsSupport(()).into());
+                }
+            }
+
             let io = connect.await?;
 
             #[cfg(feature = "tls")]
@@ -88,6 +97,8 @@ where
                 if let Some(tls) = tls {
                     let conn = tls.connect(io).await?;
                     return Ok(BoxedIo::new(conn));
+                } else if is_https {
+                    return Err(HttpsUriWithoutTlsSupport(()).into());
                 }
             }
 
@@ -95,3 +106,16 @@ where
         })
     }
 }
+
+/// Error returned when trying to connect to an HTTPS endpoint without TLS enabled.
+#[derive(Debug)]
+pub(crate) struct HttpsUriWithoutTlsSupport(());
+
+impl fmt::Display for HttpsUriWithoutTlsSupport {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "Connecting to HTTPS without TLS enabled")
+    }
+}
+
+// std::error::Error only requires a type to impl Debug and Display
+impl std::error::Error for HttpsUriWithoutTlsSupport {}


### PR DESCRIPTION
## Motivation

In getting started with tonic, I ran into an issue where issuing a first request with the default features and no explicit TLS configuration set would just result in a H2 `GoAway` frame without further context. Given that I was providing a `https` URL to the `Endpoint`, it seems reasonable that tonic should be able to give me a more meaningful error in this case.

## Solution

If the URI scheme is `https` and the `tls` feature is disabled, return an error from the connector. If the feature is enabled but there is no TLS config present, also return an error.