### PR TITLE
fix: Handle interceptor errors as responses (#840)

### DIFF
--- a/tonic-build/src/client.rs
+++ b/tonic-build/src/client.rs
@@ -15,7 +15,7 @@ pub fn generate<T: Service>(
     attributes: &Attributes,
 ) -> TokenStream {
     let service_ident = quote::format_ident!("{}Client", service.name());
-    let client_mod = quote::format_ident!("{}_client", naive_snake_case(&service.name()));
+    let client_mod = quote::format_ident!("{}_client", naive_snake_case(service.name()));
     let methods = generate_methods(service, emit_package, proto_path, compile_well_known_types);
 
     let connect = generate_connect(&service_ident);
@@ -57,8 +57,8 @@ pub fn generate<T: Service>(
             impl<T> #service_ident<T>
             where
                 T: tonic::client::GrpcService<tonic::body::BoxBody>,
-                T::ResponseBody: Body + Send  + 'static,
                 T::Error: Into<StdError>,
+                T::ResponseBody: Default + Body<Data = Bytes> + Send  + 'static,
                 <T::ResponseBody as Body>::Error: Into<StdError> + Send,
             {
                 pub fn new(inner: T) -> Self {

--- a/tonic/src/codegen.rs
+++ b/tonic/src/codegen.rs
@@ -13,6 +13,7 @@ pub type StdError = Box<dyn std::error::Error + Send + Sync + 'static>;
 #[cfg(feature = "compression")]
 pub use crate::codec::{CompressionEncoding, EnabledCompressionEncodings};
 pub use crate::service::interceptor::InterceptedService;
+pub use bytes::Bytes;
 pub use http_body::Body;
 
 pub type BoxFuture<T, E> = self::Pin<Box<dyn self::Future<Output = Result<T, E>> + Send + 'static>>;


### PR DESCRIPTION
## Summary

This PR forwards `Interceptor` errors/`Status`es as valid HTTP responses, just like any other gRPC service generated by `tonic`.

## Motivation

In the very specific case of missing Content-Type headers when requests are intercepted, this PR fixes the bugs reported in #840 and #759.

In the more general case, this class of bug arose because interceptors and their statuses are treated differently from the rest of the gRPC service stack: their errors/`Status` are bubbled up as errors to be handled at the tower service layer, but not as a gRPC response. That means that a basic HTTP response is returned, sans trailers or headers of any kind (including the missing `Content-Type` header). [See this repository](https://github.com/NAlexPear/tonic-interceptor-response-repro) and [this comment](https://github.com/hyperium/tonic/issues/840#issue-1057846258) to compare the responses generated by returning a `Status` from a method versus an interceptor.

This behavior means that clients like `grpcurl` that encounter the responses from interceptors don't know how to handle them, and it's likely that this affects any consumer that depends on the `Content-Type` header (among others).

## Solution

The solution in this PR is to handle `Status` errors the same way in both interceptors and regular ol' gRPC services: by converting those statuses to valid responses in the Interceptor service itself, matching the behavior in the existing `grpc` module. 

The downside to this approach is [a few additional constraints on the response body type](https://github.com/NAlexPear/tonic/blob/b8ae4daf23770ea829e4b861060a92ee3486f7a1/tonic/src/service/interceptor.rs#L220). These constraints seem reasonable given that they match up with the current uses of interceptors in `tonic`, but they do make wrapping non-`tonic` services trickier.

## Next Steps

EDIT: looks like those constraints are too restrictive for `tonic-health` :facepalm:. I'll take a look at either relaxing those constraints or updating `tonic-health` accordingly.

EDIT 2: I've both relaxed the constraints _and_ added a bit of restriction to clients in `tonic-build`. I'm not sure what the right mix between the two should be for a final implementation, but this does solve the issue for my use-case.