### PR TITLE
chore: fix warnings around unused TLS code

### DIFF
--- a/tonic/src/transport/mod.rs
+++ b/tonic/src/transport/mod.rs
@@ -100,7 +100,7 @@ pub use self::error::Error;
 pub use self::server::{NamedService, Server};
 #[doc(inline)]
 pub use self::service::TimeoutExpired;
-pub use self::tls::{Certificate, Identity};
+pub use self::tls::Certificate;
 pub use hyper::{Body, Uri};
 
 #[cfg(feature = "tls")]
@@ -109,6 +109,9 @@ pub use self::channel::ClientTlsConfig;
 #[cfg(feature = "tls")]
 #[cfg_attr(docsrs, doc(cfg(feature = "tls")))]
 pub use self::server::ServerTlsConfig;
+#[cfg(feature = "tls")]
+#[cfg_attr(docsrs, doc(cfg(feature = "tls")))]
+pub use self::tls::Identity;
 
 type BoxFuture<T, E> =
     std::pin::Pin<Box<dyn std::future::Future<Output = Result<T, E>> + Send + 'static>>;

--- a/tonic/src/transport/service/tls.rs
+++ b/tonic/src/transport/service/tls.rs
@@ -18,13 +18,6 @@ use tokio_rustls::{
 #[cfg(feature = "tls")]
 const ALPN_H2: &str = "h2";
 
-#[derive(Debug, Clone)]
-pub(crate) struct Cert {
-    pub(crate) ca: Vec<u8>,
-    pub(crate) key: Option<Vec<u8>>,
-    pub(crate) domain: String,
-}
-
 #[derive(Debug)]
 enum TlsError {
     #[allow(dead_code)]

--- a/tonic/src/transport/tls.rs
+++ b/tonic/src/transport/tls.rs
@@ -5,6 +5,8 @@ pub struct Certificate {
 }
 
 /// Represents a private key and X509 certificate.
+#[cfg(feature = "tls")]
+#[cfg_attr(docsrs, doc(cfg(feature = "tls")))]
 #[derive(Debug, Clone)]
 pub struct Identity {
     pub(crate) cert: Certificate,
@@ -42,6 +44,7 @@ impl AsRef<[u8]> for Certificate {
     }
 }
 
+#[cfg(feature = "tls")]
 impl Identity {
     /// Parse a PEM encoded certificate and private key.
     ///


### PR DESCRIPTION
## Motivation

Fix warnings about unused fields.

## Solution

Remove a type that seems to be unused.