### PR TITLE
chore: Prepare 0.6.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+# [0.6.2](https://github.com/hyperium/tonic/compare/v0.6.1...v0.6.2) (2021-12-07)
+
+
+### Bug Fixes
+
+* **tonic:** revert to 2018 edition ([#843](https://github.com/hyperium/tonic/issues/843)) ([101f2f7](https://github.com/hyperium/tonic/commit/101f2f76d4a62757cac8ca209b1eb6b57094d524))
+
+
 # [0.6.1](https://github.com/hyperium/tonic/compare/v0.6.0...v0.6.1) (2021-10-27)
 
 

--- a/tonic-build/Cargo.toml
+++ b/tonic-build/Cargo.toml
@@ -4,7 +4,7 @@ categories = ["network-programming", "asynchronous"]
 description = """
 Codegen module of `tonic` gRPC implementation.
 """
-documentation = "https://docs.rs/tonic-build/0.6.0/tonic_build/"
+documentation = "https://docs.rs/tonic-build/0.6.2/tonic_build/"
 edition = "2018"
 homepage = "https://github.com/hyperium/tonic"
 keywords = ["rpc", "grpc", "async", "codegen", "protobuf"]
@@ -12,7 +12,7 @@ license = "MIT"
 name = "tonic-build"
 readme = "README.md"
 repository = "https://github.com/hyperium/tonic"
-version = "0.6.0"
+version = "0.6.2"
 
 [dependencies]
 proc-macro2 = "1.0"

--- a/tonic-build/src/lib.rs
+++ b/tonic-build/src/lib.rs
@@ -68,7 +68,7 @@
     html_logo_url = "https://raw.githubusercontent.com/tokio-rs/website/master/public/img/icons/tonic.svg"
 )]
 #![deny(rustdoc::broken_intra_doc_links)]
-#![doc(html_root_url = "https://docs.rs/tonic-build/0.6.0")]
+#![doc(html_root_url = "https://docs.rs/tonic-build/0.6.2")]
 #![doc(issue_tracker_base_url = "https://github.com/hyperium/tonic/issues/")]
 #![doc(test(no_crate_inject, attr(deny(rust_2018_idioms))))]
 #![cfg_attr(docsrs, feature(doc_cfg))]

--- a/tonic/Cargo.toml
+++ b/tonic/Cargo.toml
@@ -13,14 +13,14 @@ categories = ["web-programming", "network-programming", "asynchronous"]
 description = """
 A gRPC over HTTP/2 implementation focused on high performance, interoperability, and flexibility.
 """
-documentation = "https://docs.rs/tonic/0.6.1/tonic/"
+documentation = "https://docs.rs/tonic/0.6.2/tonic/"
 edition = "2018"
 homepage = "https://github.com/hyperium/tonic"
 keywords = ["rpc", "grpc", "async", "futures", "protobuf"]
 license = "MIT"
 readme = "../README.md"
 repository = "https://github.com/hyperium/tonic"
-version = "0.6.1"
+version = "0.6.2"
 
 [features]
 codegen = ["async-trait"]

--- a/tonic/src/lib.rs
+++ b/tonic/src/lib.rs
@@ -79,7 +79,7 @@
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/tokio-rs/website/master/public/img/icons/tonic.svg"
 )]
-#![doc(html_root_url = "https://docs.rs/tonic/0.6.1")]
+#![doc(html_root_url = "https://docs.rs/tonic/0.6.2")]
 #![doc(issue_tracker_base_url = "https://github.com/hyperium/tonic/issues/")]
 #![doc(test(no_crate_inject, attr(deny(rust_2018_idioms))))]
 #![cfg_attr(docsrs, feature(doc_cfg))]


### PR DESCRIPTION
- Contains the revert to [rust 2018](https://github.com/hyperium/tonic/pull/847).
- Bumps both tonic and tonic-build.
- tonic-build goes from 0.6.0 to 0.6.2 since there was no 0.6.1. I
  believe we want tonic and tonic-build versions to follow each other.