### PR TITLE
chore: Update tracing-subscriber to 0.3

### DIFF
--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -194,7 +194,7 @@ serde_json = "1.0"
 tracing = "0.1.16"
 tracing-attributes = "0.1"
 tracing-futures = "0.2"
-tracing-subscriber = {version = "0.2", features = ["tracing-log"]}
+tracing-subscriber = {version = "0.3", features = ["tracing-log"]}
 # Required for wellknown types
 prost-types = "0.9"
 # Hyper example

--- a/interop/Cargo.toml
+++ b/interop/Cargo.toml
@@ -32,7 +32,7 @@ tonic = {path = "../tonic", features = ["tls"]}
 tower = {version = "0.4"}
 tracing = "0.1"
 tracing-log = "0.1"
-tracing-subscriber = "0.2"
+tracing-subscriber = {version = "0.3", features = ["env-filter"]}
 
 [build-dependencies]
 tonic-build = {path = "../tonic-build", features = ["prost"]}

--- a/tests/integration_tests/Cargo.toml
+++ b/tests/integration_tests/Cargo.toml
@@ -24,7 +24,7 @@ hyper = "0.14"
 tokio-stream = {version = "0.1.5", features = ["net"]}
 tower = {version = "0.4", features = []}
 tower-service = "0.3"
-tracing-subscriber = "0.2"
+tracing-subscriber = {version = "0.3", features = ["env-filter"]}
 
 [build-dependencies]
 tonic-build = {path = "../../tonic-build"}


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/hyperium/tonic/blob/master/CONTRIBUTING.md
-->

## Motivation

Update tracing-subscriber to version 0.3.

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? If a new feature is being added, describe the intended
use case that feature fulfills.
-->

## Solution

Update tracing-subscriber version to 0.3 and add `env-filter` that is removed from default features in this version. `interop` and `tests/integration_tests` use [`tracing_subscriber::fmt::SubscriberBuilder::with_env_filter`](https://docs.rs/tracing-subscriber/0.3.4/tracing_subscriber/fmt/struct.SubscriberBuilder.html#method.with_env_filter) and [`tracing_subscriber::EnvFilter`](https://docs.rs/tracing-subscriber/0.3.4/tracing_subscriber/struct.EnvFilter.html), but `examples` does not use `env-filter` feature because `tracing_subscriber::fmt()` returns `tracing_subscriber::fmt::SubscriberBuilder` and its `init` method does not use `env-filter` functionality.

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
