### PR TITLE
feat(build): add constructor `from_arc` for gRPC servers

### DIFF
--- a/tonic-build/src/server.rs
+++ b/tonic-build/src/server.rs
@@ -93,7 +93,10 @@ pub fn generate<T: Service>(
 
             impl<T: #server_trait> #server_service<T> {
                 pub fn new(inner: T) -> Self {
-                    let inner = Arc::new(inner);
+                    Self::from_arc(Arc::new(inner))
+                }
+
+                pub fn from_arc(inner: Arc<T>) -> Self {
                     let inner = _Inner(inner);
                     Self {
                         inner,


### PR DESCRIPTION
## Motivation

I found myself in a situation where I wanted to spawn a task on a timer in the background that interacts with the data in a gRPC service that I spawned. With the current code that is generated for servers, in order to do that, I'd have to add a second and unnecessary layer of `Arc<Inner>` to be able to access my data from both the spawned task and the gRPC service.

## Solution

This PR adds a second constructor `from_arc` to the generated server, allowing the user to pass in their own `Arc<Service>`, making the second layer of `Arc<T>` unnecessary.

## Possible drawbacks

The solution exposes the implementation detail of `Arc` being used internally to the user, making it harder to move away from using `Arc` if that should ever be desired.