### PR TITLE
Add `identity` to `from_encoding_header`

### DIFF
--- a/tonic/src/codec/compression.rs
+++ b/tonic/src/codec/compression.rs
@@ -80,6 +80,7 @@ impl CompressionEncoding {
 
         match header_value_str {
             "gzip" if gzip => Ok(Some(CompressionEncoding::Gzip)),
+            "identity" => Ok(None),
             other => {
                 let mut status = Status::unimplemented(format!(
                     "Content is compressed with `{}` which isn't supported",


### PR DESCRIPTION
This change is for #879 . It allows for `identity` to be sent back as a `grpc-encoding` header as it requires no decompression

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/hyperium/tonic/blob/master/CONTRIBUTING.md
-->

## Motivation
Some servers return `identity` as a `grpc-encoding` header
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? If a new feature is being added, describe the intended
use case that feature fulfills.
-->

## Solution
Allow the `identity` value of `grpc-encoding` to fall back to no compression
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
