### PR TITLE
fix(build): clippy warning for must_use

### DIFF
--- a/tonic-build/src/client.rs
+++ b/tonic-build/src/client.rs
@@ -82,12 +82,14 @@ pub fn generate<T: Service>(
                 ///
                 /// This requires the server to support it otherwise it might respond with an
                 /// error.
+                #[must_use]
                 pub fn send_gzip(mut self) -> Self {
                     self.inner = self.inner.send_gzip();
                     self
                 }
 
                 /// Enable decompressing responses with `gzip`.
+                #[must_use]
                 pub fn accept_gzip(mut self) -> Self {
                     self.inner = self.inner.accept_gzip();
                     self

--- a/tonic-build/src/server.rs
+++ b/tonic-build/src/server.rs
@@ -50,12 +50,14 @@ pub fn generate<T: Service>(
     let configure_compression_methods = if compression_enabled {
         quote! {
             /// Enable decompressing requests with `gzip`.
+            #[must_use]
             pub fn accept_gzip(mut self) -> Self {
                 self.accept_compression_encodings.enable_gzip();
                 self
             }
 
             /// Compress responses with `gzip`, if the client supports it.
+            #[must_use]
             pub fn send_gzip(mut self) -> Self {
                 self.send_compression_encodings.enable_gzip();
                 self


### PR DESCRIPTION
fix clippy warns: https://rust-lang.github.io/rust-clippy/master/#return_self_not_must_use 
