### PR TITLE
feat(tls): extends ServerTlsConfig for optional KeyLogFile

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -86,6 +86,12 @@ $ cargo run --bin tls-client
 $ cargo run --bin tls-server
 ```
 
+For [Wireshark TLS decryption](https://gitlab.com/wireshark/wireshark/-/wikis/TLS#using-the-pre-master-secret)
+
+```bash
+$ SSLKEYLOGFILE=./keylogfile.txt cargo run --bin tls-server
+```
+
 ## Health Checking
 
 ### Server

--- a/examples/src/tls/server.rs
+++ b/examples/src/tls/server.rs
@@ -73,7 +73,11 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let server = EchoServer::default();
 
     Server::builder()
-        .tls_config(ServerTlsConfig::new().identity(identity))?
+        .tls_config(
+            ServerTlsConfig::new()
+                .identity(identity)
+                .install_key_log_file(cfg!(debug_assertions)),
+        )?
         .add_service(pb::echo_server::EchoServer::new(server))
         .serve(addr)
         .await?;

--- a/tonic/src/transport/server/tls.rs
+++ b/tonic/src/transport/server/tls.rs
@@ -11,6 +11,7 @@ use std::fmt;
 pub struct ServerTlsConfig {
     identity: Option<Identity>,
     client_ca_root: Option<Certificate>,
+    install_key_log_file: bool,
 }
 
 #[cfg(feature = "tls")]
@@ -27,6 +28,7 @@ impl ServerTlsConfig {
         ServerTlsConfig {
             identity: None,
             client_ca_root: None,
+            install_key_log_file: false,
         }
     }
 
@@ -46,7 +48,19 @@ impl ServerTlsConfig {
         }
     }
 
+    /// Per session TLS secrets will be written to a file given by the SSLKEYLOGFILE environment variable.
+    pub fn install_key_log_file(self, install_key_log_file: bool) -> Self {
+        ServerTlsConfig {
+            install_key_log_file,
+            ..self
+        }
+    }
+
     pub(crate) fn tls_acceptor(&self) -> Result<TlsAcceptor, crate::Error> {
-        TlsAcceptor::new(self.identity.clone().unwrap(), self.client_ca_root.clone())
+        TlsAcceptor::new(
+            self.identity.clone().unwrap(),
+            self.client_ca_root.clone(),
+            self.install_key_log_file,
+        )
     }
 }

--- a/tonic/src/transport/service/tls.rs
+++ b/tonic/src/transport/service/tls.rs
@@ -127,7 +127,10 @@ impl TlsAcceptor {
     pub(crate) fn new(
         identity: Identity,
         client_ca_root: Option<Certificate>,
+        install_key_log_file: bool,
     ) -> Result<Self, crate::Error> {
+        use tokio_rustls::rustls::KeyLogFile;
+
         let builder = ServerConfig::builder().with_safe_defaults();
 
         let builder = match client_ca_root {
@@ -142,6 +145,10 @@ impl TlsAcceptor {
 
         let (cert, key) = rustls_keys::load_identity(identity)?;
         let mut config = builder.with_single_cert(cert, key)?;
+
+        if install_key_log_file {
+            config.key_log = Arc::new(KeyLogFile::new());
+        }
 
         config.alpn_protocols.push(ALPN_H2.as_bytes().to_vec());
         Ok(Self {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/hyperium/tonic/blob/master/CONTRIBUTING.md
-->

## Motivation

Tonic no longer allows setting Rustls config directly.

## Solution

This PR starts off down the road adding piecemeal configurability into the Tonic TLS config to aim for Rustls config parity from Tonic once more. In this instance a setting to install KeyLogFile, reinstating the possibility of Wireshark TLS decryption. 
