### PR TITLE
fix(codec): Remove `Default` bound on `Codec`

### DIFF
--- a/tonic/src/codec/mod.rs
+++ b/tonic/src/codec/mod.rs
@@ -33,7 +33,7 @@ const HEADER_SIZE: usize =
     std::mem::size_of::<u32>();
 
 /// Trait that knows how to encode and decode gRPC messages.
-pub trait Codec: Default {
+pub trait Codec {
     /// The encodable message.
     type Encode: Send + 'static;
     /// The decodable message.


### PR DESCRIPTION
## Motivation

I implemented a custom codec to use with a dynamic method where the types are not known at compile time. However this bound is mildly annoying since there's no sensible way to implement default
https://github.com/andrewhickman/grpc-client/blob/487c5409e78afef200a064c81ae1ade1b37c3c28/src/grpc/codec.rs#L63

## Solution

The bound is never used so we can just remove it. I think this is technically a breaking change for consumers of the `Codec` trait, however anything using `ProstCodec`, like generated code, still works.
