### PR TITLE
tonic-health: Implement overall server health as described in protocol standard

### DIFF
--- a/tonic-health/src/server.rs
+++ b/tonic-health/src/server.rs
@@ -250,6 +250,21 @@ mod tests {
     async fn test_service_watch() {
         let (mut reporter, service) = make_test_service().await;
 
+        // Overall server health
+        let resp = service
+            .watch(Request::new(HealthCheckRequest {
+                service: "".to_string(),
+            }))
+            .await;
+        assert!(resp.is_ok());
+        let mut resp = resp.unwrap().into_inner();
+        let item = resp
+            .next()
+            .await
+            .expect("streamed response is Some")
+            .expect("response is ok");
+        assert_serving_status(item.status, ServingStatus::Serving);
+
         // Unregistered service
         let resp = service
             .watch(Request::new(HealthCheckRequest {

--- a/tonic-health/src/server.rs
+++ b/tonic-health/src/server.rs
@@ -40,7 +40,10 @@ pub struct HealthReporter {
 
 impl HealthReporter {
     fn new() -> Self {
-        let statuses = Arc::new(RwLock::new(HashMap::new()));
+        // According to the gRPC Health Check specification, the empty service "" corresponds to the overall server health
+        let server_status = ("".to_string(), watch::channel(ServingStatus::Serving));
+
+        let statuses = Arc::new(RwLock::new(HashMap::from([server_status])));
 
         HealthReporter { statuses }
     }
@@ -166,9 +169,7 @@ mod tests {
     use crate::proto::HealthCheckRequest;
     use crate::server::{HealthReporter, HealthService};
     use crate::ServingStatus;
-    use std::collections::HashMap;
-    use std::sync::Arc;
-    use tokio::sync::{watch, RwLock};
+    use tokio::sync::watch;
     use tokio_stream::StreamExt;
     use tonic::{Code, Request, Status};
 
@@ -183,22 +184,34 @@ mod tests {
     }
 
     async fn make_test_service() -> (HealthReporter, HealthService) {
-        let state = Arc::new(RwLock::new(HashMap::new()));
-        state.write().await.insert(
-            "TestService".to_string(),
-            watch::channel(ServingStatus::Unknown),
-        );
-        (
-            HealthReporter {
-                statuses: state.clone(),
-            },
-            HealthService::new(state.clone()),
-        )
+        let health_reporter = HealthReporter::new();
+
+        // insert test value
+        {
+            let mut statuses = health_reporter.statuses.write().await;
+            statuses.insert(
+                "TestService".to_string(),
+                watch::channel(ServingStatus::Unknown),
+            );
+        }
+
+        let health_service = HealthService::new(health_reporter.statuses.clone());
+        (health_reporter, health_service)
     }
 
     #[tokio::test]
     async fn test_service_check() {
         let (mut reporter, service) = make_test_service().await;
+
+        // Overall server health
+        let resp = service
+            .check(Request::new(HealthCheckRequest {
+                service: "".to_string(),
+            }))
+            .await;
+        assert!(resp.is_ok());
+        let resp = resp.unwrap().into_inner();
+        assert_serving_status(resp.status, ServingStatus::Serving);
 
         // Unregistered service
         let resp = service


### PR DESCRIPTION
This PR adds a service of empty name (`""`) to each Health Reporter, which will always return a `SERVING` status.

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/hyperium/tonic/blob/master/CONTRIBUTING.md
-->

## Motivation
The description of the GRPC Health Checking Protocol includes the following line:
> The server should use an empty string as the key for server's overall health status, so that a client not interested in a specific service can query the server's status with an empty request. 
(https://github.com/grpc/grpc/blob/master/doc/health-checking.md)

At the moment, this behavior is not implemented in the `tonic-health` crate. In particular, this can cause problems when running health checkers in their default settings.
For example, if you try to run Google's GRPC Health Probe script (https://github.com/grpc-ecosystem/grpc-health-probe) like described in the example, it will cause an unexpected error:
```
error: health rpc failed: rpc error: code = NotFound desc = service not registered
```
The expected behavior would be to return `status: SERVING`. 

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? If a new feature is being added, describe the intended
use case that feature fulfills.
-->

## Solution
My PR changes `HealthReporter::new` such that on creation, we register a service `""` and associate it with `ServingStatus::Serving`. Instead of `HashMap::new()`, a HashMap based on this service is used when the HealthReporter is initiated.
I also expanded the tests to check for this particular behavior.

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
