### PR TITLE
feat(build): use prettyplease to format output (#890)

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,6 @@ the generated code.
 
 ```bash
 $ rustup update
-$ rustup component add rustfmt
 $ cargo build
 ```
 

--- a/examples/helloworld-tutorial.md
+++ b/examples/helloworld-tutorial.md
@@ -26,7 +26,6 @@ feature.
 
 ```bash
 $ rustup update
-$ rustup component add rustfmt
 ```
 
 ## Defining the HelloWorld service

--- a/examples/routeguide-tutorial.md
+++ b/examples/routeguide-tutorial.md
@@ -47,12 +47,6 @@ Change your current directory to Tonic's repository root:
 $ cd tonic
 ```
 
-Tonic uses `rustfmt` to tidy up the code it generates, so we'll make sure it's installed.
-
-```shell
-$ rustup component add rustfmt
-```
-
 Run the server
 ```shell
 $ cargo run --bin routeguide-server

--- a/tonic-build/Cargo.toml
+++ b/tonic-build/Cargo.toml
@@ -15,6 +15,7 @@ repository = "https://github.com/hyperium/tonic"
 version = "0.6.2"
 
 [dependencies]
+prettyplease = {version = "0.1"}
 proc-macro2 = "1.0"
 prost-build = {version = "0.9", optional = true}
 quote = "1.0"
@@ -22,9 +23,8 @@ syn = "1.0"
 
 [features]
 compression = []
-default = ["transport", "rustfmt", "prost"]
+default = ["transport", "prost"]
 prost = ["prost-build"]
-rustfmt = []
 transport = []
 
 [package.metadata.docs.rs]

--- a/tonic-build/README.md
+++ b/tonic-build/README.md
@@ -4,8 +4,6 @@ Compiles proto files via prost and generates service stubs and proto definitione
 
 ## Features
 
-- rustfmt: This feature enables the use of rustfmt to format the output code this makes the code readable and the error messages nice. This requires that rustfmt is installed. This is enabled by default.
-
 Required dependencies
 
 ```toml

--- a/tonic-build/src/lib.rs
+++ b/tonic-build/src/lib.rs
@@ -1,12 +1,6 @@
 //! `tonic-build` compiles `proto` files via `prost` and generates service stubs
 //! and proto definitiones for use with `tonic`.
 //!
-//! # Features
-//!
-//! - `rustfmt`: This feature enables the use of `rustfmt` to format the output code
-//! this makes the code readable and the error messages nice. This requires that `rustfmt`
-//! is installed. This is enabled by default.
-//!
 //! # Required dependencies
 //!
 //! ```toml
@@ -84,13 +78,6 @@ mod prost;
 #[cfg(feature = "prost")]
 #[cfg_attr(docsrs, doc(cfg(feature = "prost")))]
 pub use prost::{compile_protos, configure, Builder};
-
-#[cfg(feature = "rustfmt")]
-#[cfg_attr(docsrs, doc(cfg(feature = "rustfmt")))]
-use std::io::{self, Write};
-#[cfg(feature = "rustfmt")]
-#[cfg_attr(docsrs, doc(cfg(feature = "rustfmt")))]
-use std::process::{exit, Command};
 
 /// Service code generation for client
 pub mod client;
@@ -215,42 +202,6 @@ fn generate_attributes<'a>(
                 .attrs
         })
         .collect::<Vec<_>>()
-}
-
-/// Format files under the out_dir with rustfmt
-#[cfg(feature = "rustfmt")]
-#[cfg_attr(docsrs, doc(cfg(feature = "rustfmt")))]
-pub fn fmt(out_dir: &str) {
-    let dir = std::fs::read_dir(out_dir).unwrap();
-
-    for entry in dir {
-        let file = entry.unwrap().file_name().into_string().unwrap();
-        if !file.ends_with(".rs") {
-            continue;
-        }
-        let result =
-            Command::new(std::env::var("RUSTFMT").unwrap_or_else(|_| "rustfmt".to_owned()))
-                .arg("--emit")
-                .arg("files")
-                .arg("--edition")
-                .arg("2018")
-                .arg(format!("{}/{}", out_dir, file))
-                .output();
-
-        match result {
-            Err(e) => {
-                eprintln!("error running rustfmt: {:?}", e);
-                exit(1)
-            }
-            Ok(output) => {
-                if !output.status.success() {
-                    io::stdout().write_all(&output.stdout).unwrap();
-                    io::stderr().write_all(&output.stderr).unwrap();
-                    exit(output.status.code().unwrap_or(1))
-                }
-            }
-        }
-    }
 }
 
 // Generate a singular line of a doc comment

--- a/tonic-build/src/prost.rs
+++ b/tonic-build/src/prost.rs
@@ -22,8 +22,6 @@ pub fn configure() -> Builder {
         client_attributes: Attributes::default(),
         proto_path: "super".to_string(),
         compile_well_known_types: false,
-        #[cfg(feature = "rustfmt")]
-        format: true,
         emit_package: true,
         protoc_args: Vec::new(),
         include_file: None,
@@ -184,7 +182,8 @@ impl prost_build::ServiceGenerator for ServiceGenerator {
                 #clients
             };
 
-            let code = format!("{}", client_service);
+            let ast: syn::File = syn::parse2(client_service).expect("not a valid tokenstream");
+            let code = prettyplease::unparse(&ast);
             buf.push_str(&code);
 
             self.clients = TokenStream::default();
@@ -197,7 +196,8 @@ impl prost_build::ServiceGenerator for ServiceGenerator {
                 #servers
             };
 
-            let code = format!("{}", server_service);
+            let ast: syn::File = syn::parse2(server_service).expect("not a valid tokenstream");
+            let code = prettyplease::unparse(&ast);
             buf.push_str(&code);
 
             self.servers = TokenStream::default();
@@ -223,8 +223,6 @@ pub struct Builder {
     pub(crate) include_file: Option<PathBuf>,
 
     out_dir: Option<PathBuf>,
-    #[cfg(feature = "rustfmt")]
-    format: bool,
 }
 
 impl Builder {
@@ -244,13 +242,6 @@ impl Builder {
     /// modules. This is required for implementing gRPC Server Reflection.
     pub fn file_descriptor_set_path(mut self, path: impl AsRef<Path>) -> Self {
         self.file_descriptor_set_path = Some(path.as_ref().to_path_buf());
-        self
-    }
-
-    /// Enable the output to be formated by rustfmt.
-    #[cfg(feature = "rustfmt")]
-    pub fn format(mut self, run: bool) -> Self {
-        self.format = run;
         self
     }
 
@@ -397,9 +388,6 @@ impl Builder {
             PathBuf::from(std::env::var("OUT_DIR").unwrap())
         };
 
-        #[cfg(feature = "rustfmt")]
-        let format = self.format;
-
         config.out_dir(out_dir.clone());
         if let Some(path) = self.file_descriptor_set_path.as_ref() {
             config.file_descriptor_set_path(path);
@@ -427,13 +415,6 @@ impl Builder {
         config.service_generator(Box::new(ServiceGenerator::new(self)));
 
         config.compile_protos(protos, includes)?;
-
-        #[cfg(feature = "rustfmt")]
-        {
-            if format {
-                super::fmt(out_dir.to_str().expect("Expected utf8 out_dir"));
-            }
-        }
 
         Ok(())
     }

--- a/tonic-health/Cargo.toml
+++ b/tonic-health/Cargo.toml
@@ -15,8 +15,7 @@ repository = "https://github.com/hyperium/tonic"
 version = "0.5.0"
 
 [features]
-default = ["transport", "rustfmt"]
-rustfmt = ["tonic-build/rustfmt"]
+default = ["transport"]
 transport = ["tonic/transport", "tonic-build/transport"]
 
 [dependencies]

--- a/tonic-health/build.rs
+++ b/tonic-health/build.rs
@@ -8,7 +8,6 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         .file_descriptor_set_path(grpc_health_v1_descriptor_set_path)
         .build_server(true)
         .build_client(true)
-        .format(false)
         .compile(&["proto/health.proto"], &["proto/"])?;
 
     Ok(())

--- a/tonic-reflection/Cargo.toml
+++ b/tonic-reflection/Cargo.toml
@@ -16,10 +16,6 @@ readme = "README.md"
 repository = "https://github.com/hyperium/tonic"
 version = "0.3.0"
 
-[features]
-default = ["rustfmt"]
-rustfmt = ["tonic-build/rustfmt"]
-
 [dependencies]
 bytes = "1.0"
 prost = "0.9"

--- a/tonic-reflection/build.rs
+++ b/tonic-reflection/build.rs
@@ -13,7 +13,6 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         )
         .build_server(true)
         .build_client(true) // Client is only used for tests
-        .format(true)
         .compile(&["proto/reflection.proto"], &["proto/"])?;
 
     Ok(())


### PR DESCRIPTION
Use prettyplease to format the output unconditionally and drop the optional rustfmt feature.

## Motivation

Having to ask people to install `rustfmt` to avoid spurious build errors was annoying. prettyplease can be installed as a regular dependency and format the code without having to shell out. Moreover this feature was asked for in #890.

## Solution

Add prettyplease 0.1.x and use it to format the token stream unconditionally. The few protos I tested were indistinguishable from having them formatted with rustfmt.