### PR TITLE
fix(tonic): Preserve HTTP method in interceptor

### DIFF
--- a/tonic/src/client/grpc.rs
+++ b/tonic/src/client/grpc.rs
@@ -248,7 +248,12 @@ impl<T> Grpc<T> {
             })
             .map(BoxBody::new);
 
-        let mut request = request.into_http(uri, SanitizeHeaders::Yes);
+        let mut request = request.into_http(
+            uri,
+            http::Method::POST,
+            http::Version::HTTP_2,
+            SanitizeHeaders::Yes,
+        );
 
         // Add the gRPC related HTTP headers
         request

--- a/tonic/src/request.rs
+++ b/tonic/src/request.rs
@@ -169,12 +169,14 @@ impl<T> Request<T> {
     pub(crate) fn into_http(
         self,
         uri: http::Uri,
+        method: http::Method,
+        version: http::Version,
         sanitize_headers: SanitizeHeaders,
     ) -> http::Request<T> {
         let mut request = http::Request::new(self.message);
 
-        *request.version_mut() = http::Version::HTTP_2;
-        *request.method_mut() = http::Method::POST;
+        *request.version_mut() = version;
+        *request.method_mut() = method;
         *request.uri_mut() = uri;
         *request.headers_mut() = match sanitize_headers {
             SanitizeHeaders::Yes => self.metadata.into_sanitized_headers(),
@@ -441,7 +443,12 @@ mod tests {
                 .insert(*header, MetadataValue::from_static("invalid"));
         }
 
-        let http_request = r.into_http(Uri::default(), SanitizeHeaders::Yes);
+        let http_request = r.into_http(
+            Uri::default(),
+            http::Method::POST,
+            http::Version::HTTP_2,
+            SanitizeHeaders::Yes,
+        );
         assert!(http_request.headers().is_empty());
     }
 

--- a/tonic/src/service/interceptor.rs
+++ b/tonic/src/service/interceptor.rs
@@ -330,6 +330,7 @@ mod tests {
         assert_eq!(expected.headers(), response.headers());
     }
 
+    #[tokio::test]
     async fn doesnt_change_http_method() {
         let svc = tower::service_fn(|request: http::Request<hyper::Body>| async move {
             assert_eq!(request.method(), http::Method::OPTIONS);

--- a/tonic/src/service/interceptor.rs
+++ b/tonic/src/service/interceptor.rs
@@ -169,7 +169,7 @@ where
         let (metadata, extensions, msg) = req.into_parts();
 
         match self
-            .fg
+            .f
             .call(crate::Request::from_parts(metadata, extensions, ()))
         {
             Ok(req) => {

--- a/tonic/src/service/interceptor.rs
+++ b/tonic/src/service/interceptor.rs
@@ -169,7 +169,7 @@ where
         let (metadata, extensions, msg) = req.into_parts();
 
         match self
-            .f
+            .fg
             .call(crate::Request::from_parts(metadata, extensions, ()))
         {
             Ok(req) => {


### PR DESCRIPTION
## Motivation

See Issue #911 

## Solution

The function for converting a Tonic request into an HTTP request, `Request::into_http`, is public only to the crate and only used in a few places. Currently, HTTP2 and POST are hardcoded for HTTP method and version. Thus, we can simply add `method` and `version` params and update the callers, and then fix the interceptor to preserve them.