### PR TITLE
feat: Implement hash for `Code`

### DIFF
--- a/tonic/src/status.rs
+++ b/tonic/src/status.rs
@@ -53,7 +53,7 @@ pub struct Status {
 /// These variants match the [gRPC status codes].
 ///
 /// [gRPC status codes]: https://github.com/grpc/grpc/blob/master/doc/statuscodes.md#status-codes-and-their-use-in-grpc
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 pub enum Code {
     /// The operation completed successfully.
     Ok = 0,


### PR DESCRIPTION
## Motivation

I want to have a `HashMap<Code, u64>` to keep some statistics on various codes servers return. But `Code` is not `Hash`. I don't see any reason why it would not be. It's just a simple enum.

I can of course keep a `HashMap<u32, u64>` and upon insertion cast the enum to an integer. But I don't know the width of the integer as it's not part of the public API. And it also does not allow me to get the nice string description of the code out of the hashmap keys later.

## Solution

Implement `Hash` for `Code`.
