### PR TITLE
Add example of detecting client drops in bidirectional streams on server side

### DIFF
--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -180,37 +180,46 @@ path = "src/streaming/server.rs"
 
 [dependencies]
 async-stream = "0.3"
-futures = {version = "0.3", default-features = false, features = ["alloc"]}
+futures = { version = "0.3", default-features = false, features = ["alloc"] }
 prost = "0.9"
-tokio = {version = "1.0", features = ["rt-multi-thread", "time", "fs", "macros", "net"]}
-tokio-stream = {version = "0.1", features = ["net"]}
-tonic = {path = "../tonic", features = ["tls", "compression"]}
-tower = {version = "0.4"}
+tokio = { version = "1.0", features = [
+  "rt-multi-thread",
+  "time",
+  "fs",
+  "macros",
+  "net",
+] }
+tokio-stream = { version = "0.1", features = ["net"] }
+tonic = { path = "../tonic", features = ["tls", "compression"] }
+tower = { version = "0.4" }
 # Required for routeguide
 rand = "0.8"
-serde = {version = "1.0", features = ["derive"]}
+serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 # Tracing
 tracing = "0.1.16"
 tracing-attributes = "0.1"
 tracing-futures = "0.2"
-tracing-subscriber = {version = "0.3", features = ["tracing-log"]}
+tracing-subscriber = { version = "0.3", features = ["tracing-log"] }
 # Required for wellknown types
 prost-types = "0.9"
 # Hyper example
 http = "0.2"
 http-body = "0.4.2"
-hyper = {version = "0.14", features = ["full"]}
+hyper = { version = "0.14", features = ["full"] }
 pin-project = "1.0"
 warp = "0.3"
 # Health example
-tonic-health = {path = "../tonic-health"}
+tonic-health = { path = "../tonic-health" }
 # Reflection example
 listenfd = "0.3"
-tonic-reflection = {path = "../tonic-reflection"}
+tonic-reflection = { path = "../tonic-reflection" }
 # grpc-web example
 bytes = "1"
-tonic-web = {path = "../tonic-web"}
+tonic-web = { path = "../tonic-web" }
+# streaming example
+h2 = "0.3"
+
 
 [build-dependencies]
-tonic-build = {path = "../tonic-build", features = ["prost", "compression"]}
+tonic-build = { path = "../tonic-build", features = ["prost", "compression"] }

--- a/examples/src/streaming/client.rs
+++ b/examples/src/streaming/client.rs
@@ -2,28 +2,84 @@ pub mod pb {
     tonic::include_proto!("grpc.examples.echo");
 }
 
+use futures::stream::Stream;
 use pb::{echo_client::EchoClient, EchoRequest};
+use std::time::Duration;
+use tokio_stream::StreamExt;
+use tonic::transport::Channel;
 
-#[tokio::main]
-async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let mut client = EchoClient::connect("http://[::1]:50051").await.unwrap();
+fn echo_requests_iter() -> impl Stream<Item = EchoRequest> {
+    tokio_stream::iter(1..usize::MAX).map(|i| EchoRequest {
+        message: format!("msg {:02}", i),
+    })
+}
 
+async fn streaming_echo(client: &mut EchoClient<Channel>, num: usize) {
     let stream = client
         .server_streaming_echo(EchoRequest {
             message: "foo".into(),
         })
         .await
+        .unwrap()
+        .into_inner();
+
+    let rev_task = tokio::spawn(async move {
+        // stream is infinite - take just 5 elements and then disconnect
+        let mut stream = stream.take(num);
+        while let Some(item) = stream.next().await {
+            println!("\trecived: {}", item.unwrap().message);
+        }
+        // stream is droped here and the disconnect info is send to server
+    });
+
+    rev_task.await.unwrap();
+}
+
+async fn bidirectional_streaming_echo(client: &mut EchoClient<Channel>, num: usize) {
+    let in_stream = echo_requests_iter().take(num);
+
+    let response = client
+        .bidirectional_streaming_echo(in_stream)
+        .await
         .unwrap();
 
-    println!("Connected...now sleeping for 2 seconds...");
+    let mut resp_stream = response.into_inner();
 
-    tokio::time::sleep(std::time::Duration::from_secs(2)).await;
+    while let Some(recived) = resp_stream.next().await {
+        let recived = recived.unwrap();
+        println!("\trecived message: `{}`", recived.message);
+    }
+}
 
-    // Disconnect
-    drop(stream);
-    drop(client);
+async fn bidirectional_streaming_echo_throttle(client: &mut EchoClient<Channel>, dur: Duration) {
+    let in_stream = echo_requests_iter().throttle(dur);
 
-    println!("Disconnected...");
+    let response = client
+        .bidirectional_streaming_echo(in_stream)
+        .await
+        .unwrap();
+
+    let mut resp_stream = response.into_inner();
+
+    while let Some(recived) = resp_stream.next().await {
+        let recived = recived.unwrap();
+        println!("\trecived message: `{}`", recived.message);
+    }
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let mut client = EchoClient::connect("http://[::1]:50051").await.unwrap();
+
+    println!("Streaming echo:");
+    streaming_echo(&mut client, 5).await;
+    tokio::time::sleep(Duration::from_secs(1)).await; //do not mess server println functions
+
+    println!("\r\nBidirectional stream echo:");
+    bidirectional_streaming_echo(&mut client, 17).await;
+
+    println!("\r\nBidirectional stream echo (kill client with CTLR+C):");
+    bidirectional_streaming_echo_throttle(&mut client, Duration::from_secs(2)).await;
 
     Ok(())
 }


### PR DESCRIPTION
closes #781 

I think that this example shows also a weakness of tonic. For example in `async fn server_streaming_echo()` function is impossible (or I do not know how) to get reason why `output_stream` wasn't able to send message to client. 

## Motivation

Provide example how to detect client disconnection on server side

## Solution

Use `tokio::spawn` to separate await on input stream from output stream.
