### PR TITLE
fix(transport): Make `Server::layer()` support more than one layer

### DIFF
--- a/tonic/src/transport/server/mod.rs
+++ b/tonic/src/transport/server/mod.rs
@@ -75,7 +75,7 @@ const DEFAULT_HTTP2_KEEPALIVE_TIMEOUT_SECS: u64 = 20;
 /// a very good out of the box http2 server for use with tonic but is also a
 /// reference implementation that should be a good starting point for anyone
 /// wanting to create a more complex and/or specific implementation.
-#[derive(Default, Clone)]
+#[derive(Clone)]
 pub struct Server<L = Identity> {
     trace_interceptor: Option<TraceInterceptor>,
     concurrency_limit: Option<usize>,
@@ -91,7 +91,29 @@ pub struct Server<L = Identity> {
     http2_keepalive_timeout: Option<Duration>,
     max_frame_size: Option<u32>,
     accept_http1: bool,
-    layer: L,
+    service_builder: ServiceBuilder<L>,
+}
+
+impl Default for Server<Identity> {
+    fn default() -> Self {
+        Self {
+            trace_interceptor: None,
+            concurrency_limit: None,
+            timeout: None,
+            #[cfg(feature = "tls")]
+            tls: None,
+            init_stream_window_size: None,
+            init_connection_window_size: None,
+            max_concurrent_streams: None,
+            tcp_keepalive: None,
+            tcp_nodelay: false,
+            http2_keepalive_interval: None,
+            http2_keepalive_timeout: None,
+            max_frame_size: None,
+            accept_http1: false,
+            service_builder: Default::default(),
+        }
+    }
 }
 
 /// A stack based `Service` router.
@@ -411,9 +433,9 @@ impl<L> Server<L> {
     /// [eco]: https://github.com/tower-rs
     /// [`ServiceBuilder`]: tower::ServiceBuilder
     /// [interceptors]: crate::service::Interceptor
-    pub fn layer<NewLayer>(self, new_layer: NewLayer) -> Server<Stack<L, NewLayer>> {
+    pub fn layer<NewLayer>(self, new_layer: NewLayer) -> Server<Stack<NewLayer, L>> {
         Server {
-            layer: Stack::new(self.layer, new_layer),
+            service_builder: self.service_builder.layer(new_layer),
             trace_interceptor: self.trace_interceptor,
             concurrency_limit: self.concurrency_limit,
             timeout: self.timeout,
@@ -464,7 +486,7 @@ impl<L> Server<L> {
             .http2_keepalive_timeout
             .unwrap_or_else(|| Duration::new(DEFAULT_HTTP2_KEEPALIVE_TIMEOUT_SECS, 0));
 
-        let svc = self.layer.layer(svc);
+        let svc = self.service_builder.service(svc);
 
         let tcp = incoming::tcp_incoming(incoming, self);
         let incoming = accept::from_stream::<_, _, crate::Error>(tcp);
@@ -661,7 +683,7 @@ impl<L> Router<L> {
         ResBody: http_body::Body<Data = Bytes> + Send + 'static,
         ResBody::Error: Into<crate::Error>,
     {
-        self.server.layer.layer(self.routes)
+        self.server.service_builder.service(self.routes)
     }
 }
 

--- a/tonic/src/transport/server/mod.rs
+++ b/tonic/src/transport/server/mod.rs
@@ -54,7 +54,10 @@ use std::{
 };
 use tokio::io::{AsyncRead, AsyncWrite};
 use tower::{
-    layer::util::Identity, layer::Layer, limit::concurrency::ConcurrencyLimitLayer, util::Either,
+    layer::util::{Identity, Stack},
+    layer::Layer,
+    limit::concurrency::ConcurrencyLimitLayer,
+    util::Either,
     Service, ServiceBuilder,
 };
 
@@ -408,9 +411,9 @@ impl<L> Server<L> {
     /// [eco]: https://github.com/tower-rs
     /// [`ServiceBuilder`]: tower::ServiceBuilder
     /// [interceptors]: crate::service::Interceptor
-    pub fn layer<NewLayer>(self, new_layer: NewLayer) -> Server<NewLayer> {
+    pub fn layer<NewLayer>(self, new_layer: NewLayer) -> Server<Stack<L, NewLayer>> {
         Server {
-            layer: new_layer,
+            layer: Stack::new(self.layer, new_layer),
             trace_interceptor: self.trace_interceptor,
             concurrency_limit: self.concurrency_limit,
             timeout: self.timeout,


### PR DESCRIPTION
The current behavior is to replace the previous layer with the newly specified layer.  The new behavior is to chain the layers together.  The current behavior might actually be intentional, but IMO it's not very intuitive given how services are added by chaining method calls.

I can adjust the docs and/or tests as necessary, so let me know if you want me to do so.

## Motivation

We were using `Server::layer()` and assumed it supported more than one layer (without using `Stack` from `tower`) given the example in the docs (which has an interceptor for authentication that, with the current behavior, gets replaced with effectively an identity interceptor afaict).

## Solution

This change basically just uses `Stack` internally rather than requiring users to use it themselves manually.