### PR TITLE
feat(transport): support customizing `Channel`'s async executor

### DIFF
--- a/tonic/src/transport/channel/endpoint.rs
+++ b/tonic/src/transport/channel/endpoint.rs
@@ -4,10 +4,9 @@ use super::Channel;
 use super::ClientTlsConfig;
 #[cfg(feature = "tls")]
 use crate::transport::service::TlsConnector;
-use crate::transport::{service::SharedExec, Error};
+use crate::transport::{service::SharedExec, Error, Executor};
 use bytes::Bytes;
 use http::{uri::Uri, HeaderValue};
-use service::Executor;
 use std::{
     convert::{TryFrom, TryInto},
     fmt,

--- a/tonic/src/transport/channel/endpoint.rs
+++ b/tonic/src/transport/channel/endpoint.rs
@@ -4,16 +4,20 @@ use super::Channel;
 use super::ClientTlsConfig;
 #[cfg(feature = "tls")]
 use crate::transport::service::TlsConnector;
-use crate::transport::Error;
+use crate::transport::{service::SharedExec, Error};
 use bytes::Bytes;
 use http::{uri::Uri, HeaderValue};
+use service::Executor;
 use std::{
     convert::{TryFrom, TryInto},
     fmt,
+    future::Future,
+    pin::Pin,
     str::FromStr,
     time::Duration,
 };
 use tower::make::MakeConnection;
+// use crate::transport::E
 
 /// Channel builder.
 ///
@@ -37,6 +41,7 @@ pub struct Endpoint {
     pub(crate) http2_keep_alive_while_idle: Option<bool>,
     pub(crate) connect_timeout: Option<Duration>,
     pub(crate) http2_adaptive_window: Option<bool>,
+    pub(crate) executor: SharedExec,
 }
 
 impl Endpoint {
@@ -263,6 +268,17 @@ impl Endpoint {
         }
     }
 
+    /// Sets the executor used to spawn async tasks.
+    ///
+    /// Uses `tokio::spawn` by default.
+    pub fn executor<E>(mut self, executor: E) -> Self
+    where
+        E: Executor<Pin<Box<dyn Future<Output = ()> + Send>>> + Send + Sync + 'static,
+    {
+        self.executor = SharedExec::new(executor);
+        self
+    }
+
     /// Create a channel from this config.
     pub async fn connect(&self) -> Result<Channel, Error> {
         let mut http = hyper::client::connect::HttpConnector::new();
@@ -396,6 +412,7 @@ impl From<Uri> for Endpoint {
             http2_keep_alive_while_idle: None,
             connect_timeout: None,
             http2_adaptive_window: None,
+            executor: SharedExec::tokio(),
         }
     }
 }

--- a/tonic/src/transport/mod.rs
+++ b/tonic/src/transport/mod.rs
@@ -99,9 +99,11 @@ pub use self::error::Error;
 #[doc(inline)]
 pub use self::server::{NamedService, Server};
 #[doc(inline)]
-pub use self::service::{executor::Executor, grpc_timeout::TimeoutExpired};
+pub use self::service::grpc_timeout::TimeoutExpired;
 pub use self::tls::Certificate;
 pub use hyper::{Body, Uri};
+
+pub(crate) use self::service::executor::Executor;
 
 #[cfg(feature = "tls")]
 #[cfg_attr(docsrs, doc(cfg(feature = "tls")))]

--- a/tonic/src/transport/mod.rs
+++ b/tonic/src/transport/mod.rs
@@ -99,7 +99,7 @@ pub use self::error::Error;
 #[doc(inline)]
 pub use self::server::{NamedService, Server};
 #[doc(inline)]
-pub use self::service::{Executor, TimeoutExpired};
+pub use self::service::{executor::Executor, grpc_timeout::TimeoutExpired};
 pub use self::tls::Certificate;
 pub use hyper::{Body, Uri};
 

--- a/tonic/src/transport/mod.rs
+++ b/tonic/src/transport/mod.rs
@@ -99,7 +99,7 @@ pub use self::error::Error;
 #[doc(inline)]
 pub use self::server::{NamedService, Server};
 #[doc(inline)]
-pub use self::service::TimeoutExpired;
+pub use self::service::{Executor, TimeoutExpired};
 pub use self::tls::Certificate;
 pub use hyper::{Body, Uri};
 

--- a/tonic/src/transport/service/connection.rs
+++ b/tonic/src/transport/service/connection.rs
@@ -39,6 +39,7 @@ impl Connection {
             .http2_initial_connection_window_size(endpoint.init_connection_window_size)
             .http2_only(true)
             .http2_keep_alive_interval(endpoint.http2_keep_alive_interval)
+            .executor(endpoint.executor.clone())
             .clone();
 
         if let Some(val) = endpoint.http2_keep_alive_timeout {

--- a/tonic/src/transport/service/executor.rs
+++ b/tonic/src/transport/service/executor.rs
@@ -1,11 +1,7 @@
 use futures_core::future::BoxFuture;
 use std::{future::Future, sync::Arc};
 
-/// An executor of futures.
-pub trait Executor<Fut> {
-    /// Place the future into the executor to be run.
-    fn execute(&self, fut: Fut);
-}
+pub(crate) use hyper::rt::Executor;
 
 #[derive(Copy, Clone)]
 struct TokioExec;
@@ -43,11 +39,5 @@ impl SharedExec {
 impl Executor<BoxFuture<'static, ()>> for SharedExec {
     fn execute(&self, fut: BoxFuture<'static, ()>) {
         self.inner.execute(fut)
-    }
-}
-
-impl hyper::rt::Executor<BoxFuture<'static, ()>> for SharedExec {
-    fn execute(&self, fut: BoxFuture<'static, ()>) {
-        Executor::execute(self, fut);
     }
 }

--- a/tonic/src/transport/service/executor.rs
+++ b/tonic/src/transport/service/executor.rs
@@ -1,0 +1,53 @@
+use futures_core::future::BoxFuture;
+use std::{future::Future, sync::Arc};
+
+/// An executor of futures.
+pub trait Executor<Fut> {
+    /// Place the future into the executor to be run.
+    fn execute(&self, fut: Fut);
+}
+
+#[derive(Copy, Clone)]
+struct TokioExec;
+
+impl<F> Executor<F> for TokioExec
+where
+    F: Future + Send + 'static,
+    F::Output: Send + 'static,
+{
+    fn execute(&self, fut: F) {
+        tokio::spawn(fut);
+    }
+}
+
+#[derive(Clone)]
+pub(crate) struct SharedExec {
+    inner: Arc<dyn Executor<BoxFuture<'static, ()>> + Send + Sync + 'static>,
+}
+
+impl SharedExec {
+    pub(crate) fn new<E>(exec: E) -> Self
+    where
+        E: Executor<BoxFuture<'static, ()>> + Send + Sync + 'static,
+    {
+        Self {
+            inner: Arc::new(exec),
+        }
+    }
+
+    pub(crate) fn tokio() -> Self {
+        Self::new(TokioExec)
+    }
+}
+
+impl Executor<BoxFuture<'static, ()>> for SharedExec {
+    fn execute(&self, fut: BoxFuture<'static, ()>) {
+        self.inner.execute(fut)
+    }
+}
+
+impl hyper::rt::Executor<BoxFuture<'static, ()>> for SharedExec {
+    fn execute(&self, fut: BoxFuture<'static, ()>) {
+        Executor::execute(self, fut);
+    }
+}

--- a/tonic/src/transport/service/mod.rs
+++ b/tonic/src/transport/service/mod.rs
@@ -2,8 +2,8 @@ mod add_origin;
 mod connection;
 mod connector;
 mod discover;
-mod executor;
-mod grpc_timeout;
+pub(crate) mod executor;
+pub(crate) mod grpc_timeout;
 mod io;
 mod reconnect;
 mod router;
@@ -22,6 +22,4 @@ pub(crate) use self::io::ServerIo;
 pub(crate) use self::tls::{TlsAcceptor, TlsConnector};
 pub(crate) use self::user_agent::UserAgent;
 
-pub use self::executor::Executor;
-pub use self::grpc_timeout::TimeoutExpired;
 pub use self::router::Routes;

--- a/tonic/src/transport/service/mod.rs
+++ b/tonic/src/transport/service/mod.rs
@@ -2,6 +2,7 @@ mod add_origin;
 mod connection;
 mod connector;
 mod discover;
+mod executor;
 mod grpc_timeout;
 mod io;
 mod reconnect;
@@ -14,11 +15,13 @@ pub(crate) use self::add_origin::AddOrigin;
 pub(crate) use self::connection::Connection;
 pub(crate) use self::connector::connector;
 pub(crate) use self::discover::DynamicServiceStream;
+pub(crate) use self::executor::SharedExec;
 pub(crate) use self::grpc_timeout::GrpcTimeout;
 pub(crate) use self::io::ServerIo;
 #[cfg(feature = "tls")]
 pub(crate) use self::tls::{TlsAcceptor, TlsConnector};
 pub(crate) use self::user_agent::UserAgent;
 
+pub use self::executor::Executor;
 pub use self::grpc_timeout::TimeoutExpired;
 pub use self::router::Routes;


### PR DESCRIPTION
## Motivation

At Embark we've been working on integrating tokio-console into our project and have used `hyper::client::Builder::executor` to pass our own executor that spawns named tasks. However its not possible to do that tonic, so tasks spawned by tonic are left unnamed.

## Solution

- Add tonic's own `Executor` trait. Its identical to hyper's but added here not to have a public dependency on hyper.
- Added `Endpoint::executor` builder method to support setting another executor.
- Spawn `tower::buffer::Buffer` tasks on the given executor.
- Still uses `tokio::spawn` by default.

I intentionally didn't touch the server side because we don't need that at Embark but could do that if we think its relevant.