### PR TITLE
Fix inner balance channel

### DIFF
--- a/examples/src/load_balance/client.rs
+++ b/examples/src/load_balance/client.rs
@@ -11,7 +11,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .iter()
         .map(|a| Channel::from_static(a));
 
-    let channel = Channel::balance_list(endpoints);
+    let (channel, _) = Channel::balance_list(endpoints).await;
 
     let mut client = EchoClient::new(channel);
 


### PR DESCRIPTION

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/hyperium/tonic/blob/master/CONTRIBUTING.md
-->

## Motivation

There are a few issues with the `Channel::balance_list` API.

First, the inner mpsc capacity was hardcoded to `1024` which is not necessary, I think. For a gRPC service cluster, the endpoints of it won't be changed so frequently to consume a 1024 length channel. Or maybe it would, it will be back pressured via the Future. Maybe 1024 is wasteful. Here I use `8` as default.

On the other hand, the original `Channel::balance_list` API only returns the created channel with the sender dropped. That means users can't change the service endpoints after the initialization. And also the inner mpsc channel will never get `Change`s.

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? If a new feature is being added, describe the intended
use case that feature fulfills.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->


- Reduce the inner mpsc channel capacity
- Use async `send` function and awaiting instead of `try_send` in case of the shrunk inner channel capacity has been reached (breaking)
- Return the inner sender for later updates (breaking)