### PR TITLE
Server signals ephemeral port when ready

### DIFF
--- a/tonic/src/transport/server/incoming.rs
+++ b/tonic/src/transport/server/incoming.rs
@@ -127,12 +127,15 @@ enum SelectOutput<A> {
     Done,
 }
 
-pub(crate) struct TcpIncoming {
+/// Wrapper around AddrIncoming for TCP
+#[derive(Debug)]
+pub struct TcpIncoming {
     inner: AddrIncoming,
 }
 
+
 impl TcpIncoming {
-    pub(crate) fn new(
+    pub fn new(
         addr: SocketAddr,
         nodelay: bool,
         keepalive: Option<Duration>,
@@ -141,6 +144,13 @@ impl TcpIncoming {
         inner.set_nodelay(nodelay);
         inner.set_keepalive(keepalive);
         Ok(TcpIncoming { inner })
+    }
+
+
+    /// Return the actually bound socket address
+    /// Useful for binding ephemeral server ports and testing
+    pub fn get_local_socket_addr(&self) -> SocketAddr {
+        self.inner.local_addr()
     }
 }
 


### PR DESCRIPTION
Creating client/server unit tests has two classical problems:

1) How do you find a port that's unused that the server can
    bind but also communicate it to the client.  Typically
    hard coding one in a test means the test will fail anytime
    that port is bound (1338 in current code)
2) How do you start the server and the client as fast as possible
    (think 100s of tests running) without using a sleep() which
    either is too small (causing race conditions) or too large
    (causing testing delays)

This patch proposes a way for the client to register a signal
and the server to send the ephemeral port back on that signal
when it's ready, solving both problems.

I created an example unit test to show how this could be used
but I can fix up the rest and add the right documentation if
folks agree with the general direction.

Feedback welcome.

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/hyperium/tonic/blob/master/CONTRIBUTING.md
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? If a new feature is being added, describe the intended
use case that feature fulfills.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
