### PR TITLE
feat(build): Expose Prost generation plugin

### DIFF
--- a/tonic-build/src/lib.rs
+++ b/tonic-build/src/lib.rs
@@ -77,7 +77,7 @@ mod prost;
 
 #[cfg(feature = "prost")]
 #[cfg_attr(docsrs, doc(cfg(feature = "prost")))]
-pub use prost::{compile_protos, configure, Builder};
+pub use prost::{compile_protos, configure, Builder, ServiceGenerator};
 
 /// Service code generation for client
 pub mod client;

--- a/tonic-build/src/lib.rs
+++ b/tonic-build/src/lib.rs
@@ -77,7 +77,7 @@ mod prost;
 
 #[cfg(feature = "prost")]
 #[cfg_attr(docsrs, doc(cfg(feature = "prost")))]
-pub use prost::{compile_protos, configure, Builder, ServiceGenerator};
+pub use prost::{compile_protos, configure, Builder};
 
 /// Service code generation for client
 pub mod client;

--- a/tonic-build/src/prost.rs
+++ b/tonic-build/src/prost.rs
@@ -133,14 +133,22 @@ fn is_google_type(ty: &str) -> bool {
     ty.starts_with(".google.protobuf")
 }
 
-struct ServiceGenerator {
+/// A service generator compatible with `prost_build`'s one, to extend its code generator.
+///
+/// This is used internally by Tonic build, but also when the codegen output is not to be handled
+/// by prost or tonic; e.g. such as in a flow for a `protoc` code generation plugin. When compiling
+/// as part of a `build.rs` file, instead use [`compile_protos()`].
+#[derive(Debug)]
+pub struct ServiceGenerator {
     builder: Builder,
     clients: TokenStream,
     servers: TokenStream,
 }
 
 impl ServiceGenerator {
-    fn new(builder: Builder) -> Self {
+    /// Create a new service generator from a configured builder, ready to be passed to
+    /// `prost_build`'s `Config::service_generator`.
+    pub fn new(builder: Builder) -> Self {
         ServiceGenerator {
             builder,
             clients: TokenStream::default(),


### PR DESCRIPTION
Exposing such plugin allows independent code generators (outside of the vanilla `build.rs` workflow) to use tonic-build to get gRPC code generation. This paves the way for a `protoc-gen-tonic` plugin, opening integration in e.g. buf.

And indeed, you can find the plugin over here: https://github.com/Tuetuopay/protoc-gen-tonic

This builds on my work on [`protoc-gen-prost`](https://github.com/Tuetuopay/protoc-gen-prost), and allows integration in the wider protoc/buf/... ecosystem. You can read more on the motivation for such a change over on https://github.com/tokio-rs/prost/pull/492, and more about the features in the prost plugin repository. The tonic plugin inherits from all nice features (like crate gen) from the prost plugin.