### PR TITLE
chore: Update tokio-util to 0.7

### DIFF
--- a/tonic/Cargo.toml
+++ b/tonic/Cargo.toml
@@ -59,7 +59,7 @@ async-stream = "0.3"
 http-body = "0.4.4"
 percent-encoding = "2.1"
 pin-project = "1.0"
-tokio-util = {version = "0.6", features = ["codec"]}
+tokio-util = {version = "0.7", features = ["codec"]}
 tower-layer = "0.3"
 tower-service = "0.3"
 


### PR DESCRIPTION
## Motivation

The tokio ecosystem has been moving to tokio-util 0.7 -- e.g. h2 has just upgraded to it. In my project, tonic is the only holdout still on 0.6, so if we upgrade, my project will have fewer crates to compile.

## Solution

Bump tokio-util from 0.6 to 0.7
