### PR TITLE
Decouple `NamedService` from the `transport` feature

### DIFF
--- a/tonic-build/src/server.rs
+++ b/tonic-build/src/server.rs
@@ -35,7 +35,7 @@ pub fn generate<T: Service>(
         if package.is_empty() { "" } else { "." },
         service.identifier()
     );
-    let transport = generate_transport(&server_service, &server_trait, &path);
+    let named = generate_named(&server_service, &server_trait, &path);
     let mod_attributes = attributes.for_mod(package);
     let struct_attributes = attributes.for_struct(&path);
 
@@ -172,7 +172,7 @@ pub fn generate<T: Service>(
                 }
             }
 
-            #transport
+            #named
         }
     }
 }
@@ -268,8 +268,7 @@ fn generate_trait_methods<T: Service>(
     stream
 }
 
-#[cfg(feature = "transport")]
-fn generate_transport(
+fn generate_named(
     server_service: &syn::Ident,
     server_trait: &syn::Ident,
     service_name: &str,
@@ -277,19 +276,10 @@ fn generate_transport(
     let service_name = syn::LitStr::new(service_name, proc_macro2::Span::call_site());
 
     quote! {
-        impl<T: #server_trait> tonic::transport::NamedService for #server_service<T> {
+        impl<T: #server_trait> tonic::NamedService for #server_service<T> {
             const NAME: &'static str = #service_name;
         }
     }
-}
-
-#[cfg(not(feature = "transport"))]
-fn generate_transport(
-    _server_service: &syn::Ident,
-    _server_trait: &syn::Ident,
-    _service_name: &str,
-) -> TokenStream {
-    TokenStream::new()
 }
 
 fn generate_methods<T: Service>(

--- a/tonic/src/server/mod.rs
+++ b/tonic/src/server/mod.rs
@@ -15,3 +15,12 @@ pub use self::grpc::Grpc;
 pub use self::service::{
     ClientStreamingService, ServerStreamingService, StreamingService, UnaryService,
 };
+
+/// A trait to provide a static reference to the service's
+/// name. This is used for routing service's within the router.
+pub trait NamedService {
+    /// The `Service-Name` as described [here].
+    ///
+    /// [here]: https://github.com/grpc/grpc/blob/master/doc/PROTOCOL-HTTP2.md#requests
+    const NAME: &'static str;
+}

--- a/tonic/src/transport/server/mod.rs
+++ b/tonic/src/transport/server/mod.rs
@@ -10,6 +10,7 @@ mod tls;
 mod unix;
 
 pub use super::service::Routes;
+pub use crate::server::NamedService;
 pub use conn::{Connected, TcpConnectInfo};
 #[cfg(feature = "tls")]
 pub use tls::ServerTlsConfig;
@@ -121,15 +122,6 @@ impl Default for Server<Identity> {
 pub struct Router<L = Identity> {
     server: Server<L>,
     routes: Routes,
-}
-
-/// A trait to provide a static reference to the service's
-/// name. This is used for routing service's within the router.
-pub trait NamedService {
-    /// The `Service-Name` as described [here].
-    ///
-    /// [here]: https://github.com/grpc/grpc/blob/master/doc/PROTOCOL-HTTP2.md#requests
-    const NAME: &'static str;
 }
 
 impl<S: NamedService, T> NamedService for Either<S, T> {


### PR DESCRIPTION
The `tonic::transport::NamedService` trait is gated by the `transport`
feature. This means that generated server implementations can only
include this implementation when the `transport` feature is enabled on
`tonic-build`; and if the `transport` feature is not used at
generation-time, then a server cannot be used with
`tonic::transport::Server` at runtime.

We would like to publish a crate including generated protobuf/gRPC
bindings that does not _require_ a dependency on the `transport` feature
(and its fairly heavyweight dependency tree). But it would be nice if
its servers could still be used by applications that want to use
`tonic::transport::Server`.

By decoupling the `NamedService` trait from the `transport` feature,
`tonic-build` can be changed to always provide an implementation for
this trait without requiring all of the `transport` dependencies. This
enables generated servers to be used with `tonic::transport::Server`.

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/hyperium/tonic/blob/master/CONTRIBUTING.md
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? If a new feature is being added, describe the intended
use case that feature fulfills.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
