### PR TITLE
fix: don't enable default features in tower

### DIFF
--- a/tonic/Cargo.toml
+++ b/tonic/Cargo.toml
@@ -75,7 +75,7 @@ hyper = {version = "0.14.14", features = ["full"], optional = true}
 hyper-timeout = {version = "0.4", optional = true}
 tokio = {version = "1.0.1", features = ["net"], optional = true}
 tokio-stream = "0.1"
-tower = {version = "0.4.7", features = ["balance", "buffer", "discover", "limit", "load", "make", "timeout", "util"], optional = true}
+tower = {version = "0.4.7", default-features = false, features = ["balance", "buffer", "discover", "limit", "load", "make", "timeout", "util"], optional = true}
 tracing-futures = {version = "0.2", optional = true}
 
 # rustls


### PR DESCRIPTION
The default features in tower enable log support in tracing, which unfortunately makes a lot of user code non-send. In other words, this feature is not additive and thus tower should probably not be enabling it anyways, especially by default.