### PR TITLE
fix(build): Reduce `Default` bound requirement

### DIFF
--- a/tests/integration_tests/Cargo.toml
+++ b/tests/integration_tests/Cargo.toml
@@ -23,6 +23,7 @@ http-body = "0.4"
 hyper = "0.14"
 tokio-stream = {version = "0.1.5", features = ["net"]}
 tower = {version = "0.4", features = []}
+tower-http = { version = "0.2", features = ["full"] }
 tower-service = "0.3"
 tracing-subscriber = {version = "0.3", features = ["env-filter"]}
 

--- a/tests/integration_tests/Cargo.toml
+++ b/tests/integration_tests/Cargo.toml
@@ -23,7 +23,7 @@ http-body = "0.4"
 hyper = "0.14"
 tokio-stream = {version = "0.1.5", features = ["net"]}
 tower = {version = "0.4", features = []}
-tower-http = { version = "0.2", features = ["full"] }
+tower-http = { version = "0.2", features = ["set-header", "trace"] }
 tower-service = "0.3"
 tracing-subscriber = {version = "0.3", features = ["env-filter"]}
 

--- a/tests/integration_tests/tests/client_layer.rs
+++ b/tests/integration_tests/tests/client_layer.rs
@@ -8,10 +8,7 @@ use tonic::{
     Request, Response, Status,
 };
 use tower::ServiceBuilder;
-use tower_http::{
-    set_header::SetRequestHeaderLayer,
-    trace::TraceLayer,
-};
+use tower_http::{set_header::SetRequestHeaderLayer, trace::TraceLayer};
 
 #[tokio::test]
 async fn connect_supports_standard_tower_layers() {

--- a/tests/integration_tests/tests/client_layer.rs
+++ b/tests/integration_tests/tests/client_layer.rs
@@ -1,0 +1,61 @@
+use std::time::Duration;
+
+use futures::{channel::oneshot, FutureExt};
+use http::{header::HeaderName, HeaderValue};
+use integration_tests::pb::{test_client::TestClient, test_server, Input, Output};
+use tonic::{
+    transport::{Endpoint, Server},
+    Request, Response, Status,
+};
+use tower::ServiceBuilder;
+use tower_http::{
+    set_header::SetRequestHeaderLayer,
+    trace::TraceLayer,
+};
+
+#[tokio::test]
+async fn connect_supports_standard_tower_layers() {
+    struct Svc;
+
+    #[tonic::async_trait]
+    impl test_server::Test for Svc {
+        async fn unary_call(&self, req: Request<Input>) -> Result<Response<Output>, Status> {
+            match req.metadata().get("x-test") {
+                Some(_) => Ok(Response::new(Output {})),
+                None => Err(Status::internal("user-agent header is missing")),
+            }
+        }
+    }
+
+    let (tx, rx) = oneshot::channel();
+    let svc = test_server::TestServer::new(Svc);
+
+    // Start the server now, second call should succeed
+    let jh = tokio::spawn(async move {
+        Server::builder()
+            .add_service(svc)
+            .serve_with_shutdown("127.0.0.1:1340".parse().unwrap(), rx.map(drop))
+            .await
+            .unwrap();
+    });
+
+    let channel = Endpoint::from_static("http://127.0.0.1:1340").connect_lazy();
+
+    // prior to https://github.com/hyperium/tonic/pull/974
+    // this would not compile. (specifically the `TraceLayer`)
+    let mut client = TestClient::new(
+        ServiceBuilder::new()
+            .layer(SetRequestHeaderLayer::overriding(
+                HeaderName::from_static("x-test"),
+                HeaderValue::from_static("test-header"),
+            ))
+            .layer(TraceLayer::new_for_grpc())
+            .service(channel),
+    );
+
+    tokio::time::sleep(Duration::from_millis(100)).await;
+    client.unary_call(Request::new(Input {})).await.unwrap();
+
+    tx.send(()).unwrap();
+    jh.await.unwrap();
+}

--- a/tonic-build/src/client.rs
+++ b/tonic-build/src/client.rs
@@ -58,7 +58,7 @@ pub fn generate<T: Service>(
             where
                 T: tonic::client::GrpcService<tonic::body::BoxBody>,
                 T::Error: Into<StdError>,
-                T::ResponseBody: Default + Body<Data = Bytes> + Send  + 'static,
+                T::ResponseBody: Body<Data = Bytes> + Send  + 'static,
                 <T::ResponseBody as Body>::Error: Into<StdError> + Send,
             {
                 pub fn new(inner: T) -> Self {
@@ -69,6 +69,7 @@ pub fn generate<T: Service>(
                 pub fn with_interceptor<F>(inner: T, interceptor: F) -> #service_ident<InterceptedService<T, F>>
                 where
                     F: tonic::service::Interceptor,
+                    T::ResponseBody: Default,
                     T: tonic::codegen::Service<
                         http::Request<tonic::body::BoxBody>,
                         Response = http::Response<<T as tonic::client::GrpcService<tonic::body::BoxBody>>::ResponseBody>


### PR DESCRIPTION
## Motivation

https://github.com/hyperium/tonic/issues/973

It seems the `Default` bound was overly restrictive

## Solution

Move the `Default` bound to the `with_interceptor` function instead of the whole impl
