### PR TITLE
chore: update tower-http

### DIFF
--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -225,7 +225,7 @@ h2 = "0.3"
 tokio-rustls = "*"
 hyper-rustls = { version = "0.23", features = ["http2"] }
 rustls-pemfile = "*"
-tower-http = { version = "0.2", features = ["add-extension"] }
+tower-http = { version = "0.3", features = ["add-extension"] }
 
 
 [build-dependencies]

--- a/tests/compression/Cargo.toml
+++ b/tests/compression/Cargo.toml
@@ -18,7 +18,7 @@ tokio = {version = "1.0", features = ["macros", "rt-multi-thread", "net"]}
 tokio-stream = {version = "0.1.5", features = ["net"]}
 tonic = {path = "../../tonic", features = ["compression"]}
 tower = {version = "0.4", features = []}
-tower-http = {version = "0.2", features = ["map-response-body", "map-request-body"]}
+tower-http = {version = "0.3", features = ["map-response-body", "map-request-body"]}
 
 [build-dependencies]
 tonic-build = {path = "../../tonic-build", features = ["compression"]}

--- a/tests/integration_tests/Cargo.toml
+++ b/tests/integration_tests/Cargo.toml
@@ -23,7 +23,7 @@ http-body = "0.4"
 hyper = "0.14"
 tokio-stream = {version = "0.1.5", features = ["net"]}
 tower = {version = "0.4", features = []}
-tower-http = { version = "0.2", features = ["set-header", "trace"] }
+tower-http = { version = "0.3", features = ["set-header", "trace"] }
 tower-service = "0.3"
 tracing-subscriber = {version = "0.3", features = ["env-filter"]}
 


### PR DESCRIPTION
I noticed [CI was failing](https://github.com/hyperium/tonic/runs/6192574486?check_suite_focus=true) probably because of an update to tower-http. This'll fix that.