### PR TITLE
tonic: Unhide docs for Ascii and Binary

### DIFF
--- a/tonic/src/metadata/encoding.rs
+++ b/tonic/src/metadata/encoding.rs
@@ -51,11 +51,27 @@ pub trait ValueEncoding: Clone + Eq + PartialEq + Hash + self::value_encoding::S
     fn is_valid_key(key: &str) -> bool;
 }
 
+/// gRPC metadata values can be either ASCII strings or binary. Note that only
+/// visible ASCII characters (32-127) are permitted.
+/// This type should never be instantiated -- in fact, it's impossible
+/// to, because there's no variants to instantiate. Instead, it's just used as
+/// a type parameter for [`MetadataKey`] and [`MetadataValue`].
+///
+/// [`MetadataKey`]: struct.MetadataKey.html
+/// [`MetadataValue`]: struct.MetadataValue.html
 #[derive(Clone, Debug, Eq, PartialEq, Hash)]
-#[doc(hidden)]
+#[non_exhaustive]
 pub enum Ascii {}
+
+/// gRPC metadata values can be either ASCII strings or binary.
+/// This type should never be instantiated -- in fact, it's impossible
+/// to, because there's no variants to instantiate. Instead, it's just used as
+/// a type parameter for [`MetadataKey`] and [`MetadataValue`].
+///
+/// [`MetadataKey`]: struct.MetadataKey.html
+/// [`MetadataValue`]: struct.MetadataValue.html
 #[derive(Clone, Debug, Eq, PartialEq, Hash)]
-#[doc(hidden)]
+#[non_exhaustive]
 pub enum Binary {}
 
 // ===== impl ValueEncoding =====


### PR DESCRIPTION
`MetadataValue::from<i16>` and other numeric types aren't shown in Rustdoc, because they're implemented for `Metadata<Ascii>`, and Ascii is hidden.

## Motivation

The [docs for MetadataValue](https://docs.rs/tonic/0.7.1/tonic/metadata/struct.MetadataValue.html) don't show any of its `From<>` impls for numerics like i16/i32/usize/etc. 

## Solution

Unhide the docs. I understand this makes the docs a bit noisier, so if there's a better solution I'd be open to that instead.
