### PR TITLE
fix(transport): Emit `HttpsUriWithoutTlsSupport` only w/ tls feat

### DIFF
--- a/tonic/src/transport/service/connector.rs
+++ b/tonic/src/transport/service/connector.rs
@@ -79,17 +79,11 @@ where
         #[cfg(feature = "tls-roots-common")]
         let tls = self.tls_or_default(uri.scheme_str(), uri.host());
 
+        #[cfg(feature = "tls")]
         let is_https = uri.scheme_str() == Some("https");
         let connect = self.inner.make_connection(uri);
 
         Box::pin(async move {
-            #[cfg(not(feature = "tls"))]
-            {
-                if is_https {
-                    return Err(HttpsUriWithoutTlsSupport(()).into());
-                }
-            }
-
             let io = connect.await?;
 
             #[cfg(feature = "tls")]


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/hyperium/tonic/blob/master/CONTRIBUTING.md
-->

## Motivation

https://github.com/hyperium/tonic/pull/838 breaks custom connectors that do tls in some other way (in my case, `tokio-native-tls`

## Solution

Remove the error that was added in the other pr, if `tls` is not enabled
