### PR TITLE
tonic: add methods to retrieve the uri and the method from a Request

### DIFF
--- a/tonic/src/client/grpc.rs
+++ b/tonic/src/client/grpc.rs
@@ -248,8 +248,13 @@ impl<T> Grpc<T> {
             })
             .map(BoxBody::new);
 
+        let (headers, extensions, _, msg) = request.into_parts();
+
+        // inject uri into the request
+        let request =
+            Request::from_http_parts(headers.into_headers(), extensions.into_http(), uri, msg);
+
         let mut request = request.into_http(
-            uri,
             http::Method::POST,
             http::Version::HTTP_2,
             SanitizeHeaders::Yes,

--- a/tonic/src/request.rs
+++ b/tonic/src/request.rs
@@ -137,6 +137,16 @@ impl<T> Request<T> {
         &mut self.metadata
     }
 
+    /// Get a reference to the URI.
+    pub fn uri(&self) -> &http::Uri {
+        &self.uri
+    }
+
+    /// Get the name of the RPC called.
+    pub fn method(&self) -> Option<&str> {
+        self.uri.path().rsplit_once('/').map(|(_, method)| method)
+    }
+
     /// Consumes `self`, returning the message
     pub fn into_inner(self) -> T {
         self.message

--- a/tonic/src/server/grpc.rs
+++ b/tonic/src/server/grpc.rs
@@ -350,7 +350,7 @@ where
             .await?
             .ok_or_else(|| Status::new(Code::Internal, "Missing request message."))?;
 
-        let mut req = Request::from_http_parts(parts, message);
+        let mut req = Request::from_http_parts(parts.headers, parts.extensions, parts.uri, message);
 
         if let Some(trailers) = stream.trailers().await? {
             req.metadata_mut().merge(trailers);


### PR DESCRIPTION
## Motivation

Fixes https://github.com/hyperium/tonic/issues/772

## Solution

Two new methods have been added to `Request`:
 - `uri()` to get a `&Uri` which is now owned by `Request` 
 - `method()` to get the method name of the RPC

## Misc

I've also reduced the clones done by the interceptor service, let me if it's useful and if yes if you want a dedicated PR.