### PR TITLE
docs: document Streaming::message() return values

### DIFF
--- a/tonic/src/codec/decode.rs
+++ b/tonic/src/codec/decode.rs
@@ -136,6 +136,20 @@ impl<T> Streaming<T> {
 
 impl<T> Streaming<T> {
     /// Fetch the next message from this stream.
+    ///
+    /// # Return value
+    ///
+    /// - `Result::Err(val)` means a gRPC error was sent by the sender instead
+    /// of a valid response message. Refer to [`Status::code`] and
+    /// [`Status::message`] to examine possible error causes.
+    ///
+    /// - `Result::Ok(None)` means the stream was closed by the sender and no
+    /// more messages will be delivered. Further attempts to call
+    /// [`Streaming::message`] will result in the same return value.
+    ///
+    /// - `Result::Ok(Some(val))` means the sender streamed a valid response
+    /// message `val`.
+    ///
     /// ```rust
     /// # use tonic::{Streaming, Status, codec::Decoder};
     /// # use std::fmt::Debug;


### PR DESCRIPTION
## Motivation

I was not clear what the difference between `Err(_)` and `Ok(None)` was and asked on the discord channel. @davidpdrsn gave a compelling answer which makes sense to put in the docs.

## Solution

Document the return values of `Streaming::message()`.