### PR TITLE
tonic: Introduce a new method on Endpoint to override the origin

### DIFF
--- a/tests/integration_tests/tests/origin.rs
+++ b/tests/integration_tests/tests/origin.rs
@@ -1,0 +1,100 @@
+use futures::future::BoxFuture;
+use futures_util::FutureExt;
+use integration_tests::pb::test_client;
+use integration_tests::pb::{test_server, Input, Output};
+use std::task::Context;
+use std::task::Poll;
+use std::time::Duration;
+use tokio::sync::oneshot;
+use tonic::codegen::http::Request;
+use tonic::{
+    transport::{Endpoint, Server},
+    Response, Status,
+};
+use tower::Layer;
+use tower::Service;
+
+#[tokio::test]
+async fn writes_origin_header() {
+    struct Svc;
+
+    #[tonic::async_trait]
+    impl test_server::Test for Svc {
+        async fn unary_call(
+            &self,
+            _req: tonic::Request<Input>,
+        ) -> Result<Response<Output>, Status> {
+            Ok(Response::new(Output {}))
+        }
+    }
+
+    let svc = test_server::TestServer::new(Svc);
+
+    let (tx, rx) = oneshot::channel::<()>();
+
+    let jh = tokio::spawn(async move {
+        Server::builder()
+            .layer(OriginLayer {})
+            .add_service(svc)
+            .serve_with_shutdown("127.0.0.1:1442".parse().unwrap(), rx.map(drop))
+            .await
+            .unwrap();
+    });
+
+    tokio::time::sleep(Duration::from_millis(100)).await;
+
+    let channel = Endpoint::from_static("http://127.0.0.1:1442")
+        .origin("https://docs.rs".parse().expect("valid uri"))
+        .connect()
+        .await
+        .unwrap();
+
+    let mut client = test_client::TestClient::new(channel);
+
+    match client.unary_call(Input {}).await {
+        Ok(_) => {}
+        Err(status) => panic!("{}", status.message()),
+    }
+
+    tx.send(()).unwrap();
+
+    jh.await.unwrap();
+}
+
+#[derive(Clone)]
+struct OriginLayer {}
+
+impl<S> Layer<S> for OriginLayer {
+    type Service = OriginService<S>;
+
+    fn layer(&self, inner: S) -> Self::Service {
+        OriginService { inner }
+    }
+}
+
+#[derive(Clone)]
+struct OriginService<S> {
+    inner: S,
+}
+
+impl<T> Service<Request<tonic::transport::Body>> for OriginService<T>
+where
+    T: Service<Request<tonic::transport::Body>>,
+    T::Future: Send + 'static,
+    T::Error: Into<Box<dyn std::error::Error + Send + Sync>>,
+{
+    type Response = T::Response;
+    type Error = Box<dyn std::error::Error + Send + Sync>;
+    type Future = BoxFuture<'static, Result<Self::Response, Self::Error>>;
+
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.inner.poll_ready(cx).map_err(Into::into)
+    }
+
+    fn call(&mut self, req: Request<tonic::transport::Body>) -> Self::Future {
+        assert_eq!(req.uri().host(), Some("docs.rs"));
+        let fut = self.inner.call(req);
+
+        Box::pin(async move { fut.await.map_err(Into::into) })
+    }
+}

--- a/tonic/src/transport/channel/endpoint.rs
+++ b/tonic/src/transport/channel/endpoint.rs
@@ -117,6 +117,7 @@ impl Endpoint {
     /// # use tonic::transport::Endpoint;
     /// # let mut builder = Endpoint::from_static("https://proxy.com");
     /// builder.origin("https://example.com".parse().expect("http://example.com must be a valid URI"));
+    /// // origin: "https://example.com"
     /// ```
     pub fn origin(self, origin: Uri) -> Self {
         Endpoint {

--- a/tonic/src/transport/service/connection.rs
+++ b/tonic/src/transport/service/connection.rs
@@ -55,7 +55,15 @@ impl Connection {
         }
 
         let stack = ServiceBuilder::new()
-            .layer_fn(|s| AddOrigin::new(s, endpoint.uri.clone()))
+            .layer_fn(|s| {
+                let origin = endpoint
+                    .origin
+                    .as_ref()
+                    .unwrap_or_else(|| &endpoint.uri)
+                    .clone();
+
+                AddOrigin::new(s, origin)
+            })
             .layer_fn(|s| UserAgent::new(s, endpoint.user_agent.clone()))
             .layer_fn(|s| GrpcTimeout::new(s, endpoint.timeout))
             .option_layer(endpoint.concurrency_limit.map(ConcurrencyLimitLayer::new))

--- a/tonic/src/transport/service/connection.rs
+++ b/tonic/src/transport/service/connection.rs
@@ -56,11 +56,7 @@ impl Connection {
 
         let stack = ServiceBuilder::new()
             .layer_fn(|s| {
-                let origin = endpoint
-                    .origin
-                    .as_ref()
-                    .unwrap_or_else(|| &endpoint.uri)
-                    .clone();
+                let origin = endpoint.origin.as_ref().unwrap_or(&endpoint.uri).clone();
 
                 AddOrigin::new(s, origin)
             })


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/hyperium/tonic/blob/master/CONTRIBUTING.md
-->

## Motivation

At @znly, we use Envoy as a service mesh to distribute the traffic across the services.
Meaning that:
- we have an auto-scaled farm of Envoy which proxy the entire traffic.
- we have to refresh the IPs periodically (due to auto-scaling).
- we have to talk to the IPs directly.

That said, the requests end with an unavailable error, why? because Envoy is called with the URI (the IP in our case) and can't determine which service we are trying to reach.

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? If a new feature is being added, describe the intended
use case that feature fulfills.
-->

## Solution

A new method named `origin` has been added to override the origin sent.
We tried it in production and it's working fine.
Let me know if you have a better solution.
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
