### PR TITLE
chore(reflection): Use write macro instead of write_fmt

### DIFF
--- a/tonic-reflection/src/server.rs
+++ b/tonic-reflection/src/server.rs
@@ -39,7 +39,7 @@ impl Display for Error {
         match self {
             Error::DecodeError(_) => f.write_str("error decoding FileDescriptorSet from buffer"),
             Error::InvalidFileDescriptorSet(s) => {
-                f.write_fmt(format_args!("invalid FileDescriptorSet - {}", s))
+                write!(f, "invalid FileDescriptorSet - {}", s)
             }
         }
     }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/hyperium/tonic/blob/master/CONTRIBUTING.md
-->

## Motivation

Refactoring.

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? If a new feature is being added, describe the intended
use case that feature fulfills.
-->

## Solution

Follows to the document of [`write_fmt`](https://doc.rust-lang.org/stable/std/fmt/trait.Write.html#method.write_fmt).

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
