### PR TITLE
chore: update clap dependency, fix deprecations

### DIFF
--- a/interop/Cargo.toml
+++ b/interop/Cargo.toml
@@ -17,7 +17,7 @@ path = "src/bin/server.rs"
 [dependencies]
 async-stream = "0.3"
 bytes = "1.0"
-clap = {version = "3", features = ["derive"]}
+clap = {version = "3.2.1", features = ["derive"]}
 console = "0.14"
 futures-core = "0.3"
 futures-util = "0.3"

--- a/interop/src/bin/client.rs
+++ b/interop/src/bin/client.rs
@@ -1,4 +1,4 @@
-use clap::Parser;
+use clap::{ArgAction, Parser};
 use interop::client;
 use std::time::Duration;
 use tonic::transport::Endpoint;
@@ -6,14 +6,15 @@ use tonic::transport::{Certificate, ClientTlsConfig};
 
 #[derive(Parser)]
 struct Opts {
-    #[clap(name = "use_tls", long)]
+    #[clap(name = "use_tls", long, action = ArgAction::SetTrue)]
     use_tls: bool,
 
     #[clap(
         long = "test_case",
         use_value_delimiter = true,
         min_values = 1,
-        arg_enum
+        arg_enum,
+        action = ArgAction::Append
     )]
     test_case: Vec<Testcase>,
 }

--- a/interop/src/bin/server.rs
+++ b/interop/src/bin/server.rs
@@ -1,11 +1,11 @@
-use clap::Parser;
+use clap::{ArgAction, Parser};
 use interop::server;
 use tonic::transport::Server;
 use tonic::transport::{Identity, ServerTlsConfig};
 
 #[derive(Parser)]
 struct Opts {
-    #[clap(name = "use_tls", long)]
+    #[clap(name = "use_tls", long, action = ArgAction::SetTrue)]
     use_tls: bool,
 }
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/hyperium/tonic/blob/master/CONTRIBUTING.md
-->

## Motivation

Clap recently added new deprecations in 3.2. Because we deny warnings, these deprecation warnings end up as build failures. 

## Solution

This resolves those deprecations by updating to the usage to match the new API.
