### PR TITLE
refactor: Reduce how much code gets monomorphized

### DIFF
--- a/tonic/src/client/grpc.rs
+++ b/tonic/src/client/grpc.rs
@@ -233,7 +233,11 @@ impl<T> Grpc<T> {
 
         let request = self.config.prepare_request(request, path);
 
-        let response = self.inner.call(request).await.map_err(Status::from_error)?;
+        let response = self
+            .inner
+            .call(request)
+            .await
+            .map_err(Status::from_error_generic)?;
 
         let decoder = codec.decoder();
 

--- a/tonic/src/client/grpc.rs
+++ b/tonic/src/client/grpc.rs
@@ -44,14 +44,7 @@ struct GrpcConfig {
 impl<T> Grpc<T> {
     /// Creates a new gRPC client with the provided [`GrpcService`].
     pub fn new(inner: T) -> Self {
-        Self {
-            inner,
-            config: GrpcConfig {
-                origin: Uri::default(),
-                send_compression_encodings: None,
-                accept_compression_encodings: EnabledCompressionEncodings::default(),
-            },
-        }
+        Self::with_origin(inner, Uri::default())
     }
 
     /// Creates a new gRPC client with the provided [`GrpcService`] and `Uri`.

--- a/tonic/src/client/grpc.rs
+++ b/tonic/src/client/grpc.rs
@@ -242,14 +242,15 @@ impl<T> Grpc<T> {
 
     // Keeping this code in a separate function from Self::streaming lets functions that return the
     // same output share the generated binary code
-    fn create_response<M2, B>(
+    fn create_response<M2>(
         &self,
         decoder: impl Decoder<Item = M2, Error = Status> + Send + 'static,
-        response: http::Response<B>,
+        response: http::Response<T::ResponseBody>,
     ) -> Result<Response<Streaming<M2>>, Status>
     where
-        B: Body + Send + 'static,
-        <B as Body>::Error: Into<crate::Error>,
+        T: GrpcService<BoxBody>,
+        T::ResponseBody: Body + Send + 'static,
+        <T::ResponseBody as Body>::Error: Into<crate::Error>,
     {
         let encoding = CompressionEncoding::from_encoding_header(
             response.headers(),

--- a/tonic/src/client/grpc.rs
+++ b/tonic/src/client/grpc.rs
@@ -233,11 +233,7 @@ impl<T> Grpc<T> {
 
         let request = self.config.prepare_request(request, path);
 
-        let response = self
-            .inner
-            .call(request)
-            .await
-            .map_err(|err| Status::from_error(err.into()))?;
+        let response = self.inner.call(request).await.map_err(Status::from_error)?;
 
         let decoder = codec.decoder();
 

--- a/tonic/src/codec/decode.rs
+++ b/tonic/src/codec/decode.rs
@@ -21,6 +21,10 @@ const BUFFER_SIZE: usize = 8 * 1024;
 /// to fetch the message stream and trailing metadata
 pub struct Streaming<T> {
     decoder: Box<dyn Decoder<Item = T, Error = Status> + Send + 'static>,
+    inner: StreamingInner,
+}
+
+struct StreamingInner {
     body: BoxBody,
     state: State,
     direction: Direction,
@@ -96,16 +100,18 @@ impl<T> Streaming<T> {
     {
         Self {
             decoder: Box::new(decoder),
-            body: body
-                .map_data(|mut buf| buf.copy_to_bytes(buf.remaining()))
-                .map_err(|err| Status::map_error(err.into()))
-                .boxed_unsync(),
-            state: State::ReadHeader,
-            direction,
-            buf: BytesMut::with_capacity(BUFFER_SIZE),
-            trailers: None,
-            decompress_buf: BytesMut::new(),
-            encoding,
+            inner: StreamingInner {
+                body: body
+                    .map_data(|mut buf| buf.copy_to_bytes(buf.remaining()))
+                    .map_err(|err| Status::map_error(err.into()))
+                    .boxed_unsync(),
+                state: State::ReadHeader,
+                direction,
+                buf: BytesMut::with_capacity(BUFFER_SIZE),
+                trailers: None,
+                decompress_buf: BytesMut::new(),
+                encoding,
+            },
         }
     }
 }
@@ -165,7 +171,7 @@ impl<T> Streaming<T> {
     pub async fn trailers(&mut self) -> Result<Option<MetadataMap>, Status> {
         // Shortcut to see if we already pulled the trailers in the stream step
         // we need to do that so that the stream can error on trailing grpc-status
-        if let Some(trailers) = self.trailers.take() {
+        if let Some(trailers) = self.inner.trailers.take() {
             return Ok(Some(trailers));
         }
 
@@ -174,13 +180,13 @@ impl<T> Streaming<T> {
 
         // Since we call poll_trailers internally on poll_next we need to
         // check if it got cached again.
-        if let Some(trailers) = self.trailers.take() {
+        if let Some(trailers) = self.inner.trailers.take() {
             return Ok(Some(trailers));
         }
 
         // Trailers were not caught during poll_next and thus lets poll for
         // them manually.
-        let map = future::poll_fn(|cx| Pin::new(&mut self.body).poll_trailers(cx))
+        let map = future::poll_fn(|cx| Pin::new(&mut self.inner.body).poll_trailers(cx))
             .await
             .map_err(|e| Status::from_error(Box::new(e)));
 
@@ -188,17 +194,17 @@ impl<T> Streaming<T> {
     }
 
     fn decode_chunk(&mut self) -> Result<Option<T>, Status> {
-        if let State::ReadHeader = self.state {
-            if self.buf.remaining() < HEADER_SIZE {
+        if let State::ReadHeader = self.inner.state {
+            if self.inner.buf.remaining() < HEADER_SIZE {
                 return Ok(None);
             }
 
-            let compression_encoding = match self.buf.get_u8() {
+            let compression_encoding = match self.inner.buf.get_u8() {
                 0 => None,
                 1 => {
                     {
-                        if self.encoding.is_some() {
-                            self.encoding
+                        if self.inner.encoding.is_some() {
+                            self.inner.encoding
                         } else {
                             // https://grpc.github.io/grpc/core/md_doc_compression.html
                             // An ill-constructed message with its Compressed-Flag bit set but lacking a grpc-encoding
@@ -210,7 +216,7 @@ impl<T> Streaming<T> {
                 }
                 f => {
                     trace!("unexpected compression flag");
-                    let message = if let Direction::Response(status) = self.direction {
+                    let message = if let Direction::Response(status) = self.inner.direction {
                         format!(
                             "protocol error: received message with invalid compression flag: {} (valid flags are 0 and 1) while receiving response with status: {}",
                             f, status
@@ -221,28 +227,32 @@ impl<T> Streaming<T> {
                     return Err(Status::new(Code::Internal, message));
                 }
             };
-            let len = self.buf.get_u32() as usize;
-            self.buf.reserve(len);
+            let len = self.inner.buf.get_u32() as usize;
+            self.inner.buf.reserve(len);
 
-            self.state = State::ReadBody {
+            self.inner.state = State::ReadBody {
                 compression: compression_encoding,
                 len,
             }
         }
 
-        if let State::ReadBody { len, compression } = self.state {
+        if let State::ReadBody { len, compression } = self.inner.state {
             // if we haven't read enough of the message then return and keep
             // reading
-            if self.buf.remaining() < len || self.buf.len() < len {
+            if self.inner.buf.remaining() < len || self.inner.buf.len() < len {
                 return Ok(None);
             }
 
             let decoding_result = if let Some(encoding) = compression {
-                self.decompress_buf.clear();
+                self.inner.decompress_buf.clear();
 
-                if let Err(err) = decompress(encoding, &mut self.buf, &mut self.decompress_buf, len)
-                {
-                    let message = if let Direction::Response(status) = self.direction {
+                if let Err(err) = decompress(
+                    encoding,
+                    &mut self.inner.buf,
+                    &mut self.inner.decompress_buf,
+                    len,
+                ) {
+                    let message = if let Direction::Response(status) = self.inner.direction {
                         format!(
                             "Error decompressing: {}, while receiving response with status: {}",
                             err, status
@@ -252,18 +262,19 @@ impl<T> Streaming<T> {
                     };
                     return Err(Status::new(Code::Internal, message));
                 }
-                let decompressed_len = self.decompress_buf.len();
+                let decompressed_len = self.inner.decompress_buf.len();
                 self.decoder.decode(&mut DecodeBuf::new(
-                    &mut self.decompress_buf,
+                    &mut self.inner.decompress_buf,
                     decompressed_len,
                 ))
             } else {
-                self.decoder.decode(&mut DecodeBuf::new(&mut self.buf, len))
+                self.decoder
+                    .decode(&mut DecodeBuf::new(&mut self.inner.buf, len))
             };
 
             return match decoding_result {
                 Ok(Some(msg)) => {
-                    self.state = State::ReadHeader;
+                    self.inner.state = State::ReadHeader;
                     Ok(Some(msg))
                 }
                 Ok(None) => Ok(None),
@@ -280,7 +291,7 @@ impl<T> Stream for Streaming<T> {
 
     fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
         loop {
-            if let State::Error = &self.state {
+            if let State::Error = &self.inner.state {
                 return Poll::Ready(None);
             }
 
@@ -291,10 +302,10 @@ impl<T> Stream for Streaming<T> {
                 return Poll::Ready(Some(Ok(item)));
             }
 
-            let chunk = match ready!(Pin::new(&mut self.body).poll_data(cx)) {
+            let chunk = match ready!(Pin::new(&mut self.inner.body).poll_data(cx)) {
                 Some(Ok(d)) => Some(d),
                 Some(Err(e)) => {
-                    let _ = std::mem::replace(&mut self.state, State::Error);
+                    let _ = std::mem::replace(&mut self.inner.state, State::Error);
                     let err: crate::Error = e.into();
                     debug!("decoder inner stream error: {:?}", err);
                     let status = Status::from_error(err);
@@ -304,10 +315,10 @@ impl<T> Stream for Streaming<T> {
             };
 
             if let Some(data) = chunk {
-                self.buf.put(data);
+                self.inner.buf.put(data);
             } else {
                 // FIXME: improve buf usage.
-                if self.buf.has_remaining() {
+                if self.inner.buf.has_remaining() {
                     trace!("unexpected EOF decoding stream");
                     return Poll::Ready(Some(Err(Status::new(
                         Code::Internal,
@@ -319,8 +330,8 @@ impl<T> Stream for Streaming<T> {
             }
         }
 
-        if let Direction::Response(status) = self.direction {
-            match ready!(Pin::new(&mut self.body).poll_trailers(cx)) {
+        if let Direction::Response(status) = self.inner.direction {
+            match ready!(Pin::new(&mut self.inner.body).poll_trailers(cx)) {
                 Ok(trailer) => {
                     if let Err(e) = crate::status::infer_grpc_status(trailer.as_ref(), status) {
                         if let Some(e) = e {
@@ -329,7 +340,7 @@ impl<T> Stream for Streaming<T> {
                             return Poll::Ready(None);
                         }
                     } else {
-                        self.trailers = trailer.map(MetadataMap::from_headers);
+                        self.inner.trailers = trailer.map(MetadataMap::from_headers);
                     }
                 }
                 Err(e) => {

--- a/tonic/src/codec/encode.rs
+++ b/tonic/src/codec/encode.rs
@@ -98,18 +98,22 @@ where
             }
 
             // now that we know length, we can write the header
-            let len = buf.len() - HEADER_SIZE;
-            assert!(len <= std::u32::MAX as usize);
-            {
-                let mut buf = &mut buf[..HEADER_SIZE];
-                buf.put_u8(compression_encoding.is_some() as u8);
-                buf.put_u32(len as u32);
-            }
-
-            Ok(buf.split_to(len + HEADER_SIZE).freeze())
+            Ok(finish_encoding(compression_encoding, &mut buf))
         })();
         async { result }
     })
+}
+
+fn finish_encoding(compression_encoding: Option<CompressionEncoding>, buf: &mut BytesMut) -> Bytes {
+    let len = buf.len() - HEADER_SIZE;
+    assert!(len <= std::u32::MAX as usize);
+    {
+        let mut buf = &mut buf[..HEADER_SIZE];
+        buf.put_u8(compression_encoding.is_some() as u8);
+        buf.put_u32(len as u32);
+    }
+
+    buf.split_to(len + HEADER_SIZE).freeze()
 }
 
 #[derive(Debug)]

--- a/tonic/src/status.rs
+++ b/tonic/src/status.rs
@@ -304,7 +304,12 @@ impl Status {
     }
 
     #[cfg_attr(not(feature = "transport"), allow(dead_code))]
-    pub(crate) fn from_error(err: Box<dyn Error + Send + Sync + 'static>) -> Status {
+    pub(crate) fn from_error(err: impl Into<Box<dyn Error + Send + Sync + 'static>>) -> Status {
+        Self::from_error_impl(err.into())
+    }
+
+    #[cfg_attr(not(feature = "transport"), allow(dead_code))]
+    fn from_error_impl(err: Box<dyn Error + Send + Sync + 'static>) -> Status {
         Status::try_from_error(err).unwrap_or_else(|err| {
             let mut status = Status::new(Code::Unknown, err.to_string());
             status.source = Some(err);

--- a/tonic/src/status.rs
+++ b/tonic/src/status.rs
@@ -304,12 +304,14 @@ impl Status {
     }
 
     #[cfg_attr(not(feature = "transport"), allow(dead_code))]
-    pub(crate) fn from_error(err: impl Into<Box<dyn Error + Send + Sync + 'static>>) -> Status {
-        Self::from_error_impl(err.into())
+    pub(crate) fn from_error_generic(
+        err: impl Into<Box<dyn Error + Send + Sync + 'static>>,
+    ) -> Status {
+        Self::from_error(err.into())
     }
 
     #[cfg_attr(not(feature = "transport"), allow(dead_code))]
-    fn from_error_impl(err: Box<dyn Error + Send + Sync + 'static>) -> Status {
+    pub(crate) fn from_error(err: Box<dyn Error + Send + Sync + 'static>) -> Status {
         Status::try_from_error(err).unwrap_or_else(|err| {
             let mut status = Status::new(Code::Unknown, err.to_string());
             status.source = Some(err);

--- a/tonic/src/transport/server/incoming.rs
+++ b/tonic/src/transport/server/incoming.rs
@@ -23,13 +23,7 @@ where
     IO: AsyncRead + AsyncWrite + Connected + Unpin + Send + 'static,
     IE: Into<crate::Error>,
 {
-    async_stream::try_stream! {
-        futures_util::pin_mut!(incoming);
-
-        while let Some(stream) = incoming.try_next().await? {
-            yield ServerIo::new_io(stream);
-        }
-    }
+    incoming.err_into().map_ok(ServerIo::new_io)
 }
 
 #[cfg(feature = "tls")]


### PR DESCRIPTION
## Motivation

`tonic` has a lot of generic code which causes a lot of monormorphization and therefore bloated compile times and binaries. 

## Solution

By extracting code which does not need to be generic over a type parameter into non generic (or less generic functions) we can reduce how much code gets instantiated and passed to LLVM.

This gives a ~23% reduction in the output of LLVM IR (according to `cargo llvm-lines -p examples --bin streaming-client`) and reduces the compilation time of `cargo build --release --bin streaming-client` by ~1.5s (21s to 19.5s). (Measured by just switching branches between this one and master to force recompilations)

### Before
```
  Lines         Copies       Function name
  -----         ------       -------------
  Lines         Copies       Function name
  -----         ------       -------------
  45542 (100%)  1250 (100%)  (TOTAL)
   3588 (7.9%)     3 (0.2%)  tonic::client::grpc::Grpc<T>::streaming::{{closure}}
   3320 (7.3%)     3 (0.2%)  tonic::codec::encode::encode::{{closure}}
   1282 (2.8%)     1 (0.1%)  <tonic::codec::decode::Streaming<T> as futures_core::stream::Stream>::poll_next
   1035 (2.3%)    19 (1.5%)  core::result::Result<T,E>::map_err
    997 (2.2%)    21 (1.7%)  <core::future::from_generator::GenFuture<T> as core::future::future::Future>::poll
    924 (2.0%)    21 (1.7%)  core::pin::Pin<&mut T>::map_unchecked_mut
    872 (1.9%)     2 (0.2%)  tonic::transport::channel::Channel::connect::{{closure}}
    760 (1.7%)    95 (7.6%)  core::pin::Pin<P>::new_unchecked
    720 (1.6%)     2 (0.2%)  streaming_client::pb::echo_client::EchoClient<T>::bidirectional_streaming_echo::{{closure}}
    710 (1.6%)     1 (0.1%)  tonic::codec::decode::Streaming<T>::decode_chunk
    621 (1.4%)     8 (0.6%)  std::thread::local::LocalKey<T>::try_with
    618 (1.4%)     3 (0.2%)  <tonic::codec::encode::EncodeBody<S> as http_body::Body>::poll_trailers
    605 (1.3%)     1 (0.1%)  prost::encoding::decode_varint_slice
    566 (1.2%)    13 (1.0%)  <core::result::Result<T,E> as core::ops::try_trait::Try>::branch
    555 (1.2%)     3 (0.2%)  <tonic::codec::encode::EncodeBody<S> as http_body::Body>::poll_data
    455 (1.0%)     7 (0.6%)  tonic::request::Request<T>::map
    430 (0.9%)     1 (0.1%)  streaming_client::main::{{closure}}
    420 (0.9%)     9 (0.7%)  tonic::codec::encode::encode::{{closure}}::{{closure}}
    417 (0.9%)     1 (0.1%)  tonic::transport::channel::endpoint::Endpoint::connect::{{closure}}
    414 (0.9%)     9 (0.7%)  tonic::client::grpc::Grpc<T>::streaming::{{closure}}::{{closure}}
    373 (0.8%)     1 (0.1%)  core::ptr::drop_in_place<tonic::codec::encode::encode<tonic::codec::prost::ProstEncoder<streaming_client::pb::EchoRequest>,futures_util::stream::stream::map::Map<futures_util::stream::once::Once<futures_util::future::ready::Ready<streaming_client::pb::EchoRequest>>,core::result::Result<streaming_client::pb::EchoRequest,tonic::status::Status>::Ok>>::{{closure}}>
    373 (0.8%)     1 (0.1%)  core::ptr::drop_in_place<tonic::codec::encode::encode<tonic::codec::prost::ProstEncoder<streaming_client::pb::EchoRequest>,futures_util::stream::stream::map::Map<tokio_stream::stream_ext::throttle::Throttle<tokio_stream::stream_ext::map::Map<tokio_stream::iter::Iter<core::ops::range::Range<usize>>,streaming_client::echo_requests_iter::{{closure}}>>,core::result::Result<streaming_client::pb::EchoRequest,tonic::status::Status>::Ok>>::{{closure}}>
    367 (0.8%)     1 (0.1%)  streaming_client::pb::echo_client::EchoClient<T>::server_streaming_echo::{{closure}}

```
### After
```
 Lines         Copies       Function name
  -----         ------       -------------
  35425 (100%)  1074 (100%)  (TOTAL)
   1587 (4.5%)     3 (0.3%)  tonic::client::grpc::Grpc<T>::streaming::{{closure}}
   1035 (2.9%)    19 (1.8%)  core::result::Result<T,E>::map_err
   1024 (2.9%)    21 (2.0%)  <core::future::from_generator::GenFuture<T> as core::future::future::Future>::poll
    924 (2.6%)    21 (2.0%)  core::pin::Pin<&mut T>::map_unchecked_mut
    912 (2.6%)     6 (0.6%)  tonic::codec::encode::encode::{{closure}}::{{closure}}
    872 (2.5%)     2 (0.2%)  tonic::transport::channel::Channel::connect::{{closure}}
    720 (2.0%)     2 (0.2%)  streaming_client::pb::echo_client::EchoClient<T>::bidirectional_streaming_echo::{{closure}}
    688 (1.9%)    86 (8.0%)  core::pin::Pin<P>::new_unchecked
    605 (1.7%)     1 (0.1%)  prost::encoding::decode_varint_slice
    591 (1.7%)     3 (0.3%)  <futures_util::stream::try_stream::and_then::AndThen<St,Fut,F> as futures_core::stream::Stream>::poll_next
    586 (1.7%)    13 (1.2%)  <core::result::Result<T,E> as core::ops::try_trait::Try>::branch
    582 (1.6%)     3 (0.3%)  <tonic::codec::encode::EncodeBody<S> as http_body::Body>::poll_data
    455 (1.3%)     7 (0.7%)  tonic::request::Request<T>::map
    430 (1.2%)     1 (0.1%)  streaming_client::main::{{closure}}
    420 (1.2%)     9 (0.8%)  tonic::codec::encode::encode::{{closure}}::{{closure}}::{{closure}}
    417 (1.2%)     9 (0.8%)  tonic::client::grpc::Grpc<T>::streaming::{{closure}}::{{closure}}
    417 (1.2%)     1 (0.1%)  tonic::transport::channel::endpoint::Endpoint::connect::{{closure}}
    391 (1.1%)     5 (0.5%)  std::thread::local::LocalKey<T>::try_with
    367 (1.0%)     1 (0.1%)  streaming_client::pb::echo_client::EchoClient<T>::server_streaming_echo::{{closure}}
    347 (1.0%)     1 (0.1%)  tokio::runtime::basic_scheduler::CoreGuard::block_on::{{closure}}
    324 (0.9%)     2 (0.2%)  tonic::transport::service::connection::Connection::connect::{{closure}}
    320 (0.9%)     2 (0.2%)  tokio::park::thread::CachedParkThread::block_on
    314 (0.9%)     4 (0.4%)  tokio::coop::with_budget::{{closure}}
    312 (0.9%)     3 (0.3%)  tonic::codec::encode::encode
    310 (0.9%)     1 (0.1%)  streaming_client::streaming_echo::{{closure}}
    306 (0.9%)     1 (0.1%)  streaming_client::bidirectional_streaming_echo_throttle::{{closure}}
    306 (0.9%)     1 (0.1%)  streaming_client::pb::echo_client::EchoClient<tonic::transport::channel::Channel>::connect::{{closure}}

```

Closes #849 (supersedes it)