### PR TITLE
Make TcpIncoming public

### DIFF
--- a/tonic/src/transport/server/incoming.rs
+++ b/tonic/src/transport/server/incoming.rs
@@ -140,6 +140,27 @@ impl TcpIncoming {
     /// Creates an instance by binding (opening) the specified socket address
     /// to which the specified TCP 'nodelay' and 'keepalive' parameters are applied.
     /// Returns a TcpIncoming if the socket address was successfully bound.
+    ///
+    /// # Examples
+    /// ```no_run
+    /// # use tower_service::Service;
+    /// # use http::{request::Request, response::Response};
+    /// # use tonic::{body::BoxBody, transport::{Body, NamedService, Server, server::TcpIncoming}};
+    /// # use core::convert::Infallible;
+    /// # use std::error::Error;
+    /// # fn main() { }  // Cannot have type parameters, hence instead define:
+    /// # fn run<S>(some_service: S) -> Result<(), Box<dyn Error + Send + Sync>>
+    /// # where
+    /// #   S: Service<Request<Body>, Response = Response<BoxBody>, Error = Infallible> + NamedService + Clone + Send + 'static,
+    /// #   S::Future: Send + 'static,
+    /// # {
+    /// let addr = "127.0.0.1:8123".parse().unwrap();
+    /// let tinc = TcpIncoming::new(addr, true, None)?;
+    /// Server::builder()
+    ///    .add_service(some_service)
+    ///    .serve_with_incoming(tinc);
+    /// # Ok(())
+    /// # }
     pub fn new(
         addr: SocketAddr,
         nodelay: bool,

--- a/tonic/src/transport/server/incoming.rs
+++ b/tonic/src/transport/server/incoming.rs
@@ -180,3 +180,17 @@ impl Stream for TcpIncoming {
         Pin::new(&mut self.inner).poll_accept(cx)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::transport::server::TcpIncoming;
+    #[tokio::test]
+    async fn one_tcpincoming_at_a_time() {
+        let addr = "127.0.0.1:1322".parse().unwrap();
+        {
+            let _t1 = TcpIncoming::new(addr, true, None).unwrap();
+            let _t2 = TcpIncoming::new(addr, true, None).unwrap_err();
+        }
+        let _t3 = TcpIncoming::new(addr, true, None).unwrap();
+    }
+}

--- a/tonic/src/transport/server/incoming.rs
+++ b/tonic/src/transport/server/incoming.rs
@@ -154,8 +154,15 @@ impl TcpIncoming {
     /// #   S: Service<Request<Body>, Response = Response<BoxBody>, Error = Infallible> + NamedService + Clone + Send + 'static,
     /// #   S::Future: Send + 'static,
     /// # {
-    /// let addr = "127.0.0.1:8123".parse().unwrap();
-    /// let tinc = TcpIncoming::new(addr, true, None)?;
+    /// // Find a free port
+    /// let mut port = 1322;
+    /// let tinc = loop {
+    ///    let addr = format!("127.0.0.1:{}", port).parse().unwrap();
+    ///    match TcpIncoming::new(addr, true, None) {
+    ///       Ok(t) => break t,
+    ///       Err(_) => port += 1
+    ///    }
+    /// };
     /// Server::builder()
     ///    .add_service(some_service)
     ///    .serve_with_incoming(tinc);

--- a/tonic/src/transport/server/incoming.rs
+++ b/tonic/src/transport/server/incoming.rs
@@ -127,11 +127,19 @@ enum SelectOutput<A> {
     Done,
 }
 
+/// Binds a socket address for a [Router](super::Router)
+///
+/// An incoming stream, usable with [Router::serve_with_incoming](super::Router::serve_with_incoming),
+/// of `AsyncRead + AsyncWrite` that communicate with clients that connect to a socket address.
+#[derive(Debug)]
 pub struct TcpIncoming {
     inner: AddrIncoming,
 }
 
 impl TcpIncoming {
+    /// Creates an instance by binding (opening) the specified socket address
+    /// to which the specified TCP 'nodelay' and 'keepalive' parameters are applied.
+    /// Returns a TcpIncoming if the socket address was successfully bound.
     pub fn new(
         addr: SocketAddr,
         nodelay: bool,

--- a/tonic/src/transport/server/incoming.rs
+++ b/tonic/src/transport/server/incoming.rs
@@ -127,12 +127,12 @@ enum SelectOutput<A> {
     Done,
 }
 
-pub(crate) struct TcpIncoming {
+pub struct TcpIncoming {
     inner: AddrIncoming,
 }
 
 impl TcpIncoming {
-    pub(crate) fn new(
+    pub fn new(
         addr: SocketAddr,
         nodelay: bool,
         keepalive: Option<Duration>,

--- a/tonic/src/transport/server/mod.rs
+++ b/tonic/src/transport/server/mod.rs
@@ -24,7 +24,7 @@ use super::service::TlsAcceptor;
 #[cfg(unix)]
 pub use unix::UdsConnectInfo;
 
-use incoming::TcpIncoming;
+pub use incoming::TcpIncoming;
 
 #[cfg(feature = "tls")]
 pub(crate) use tokio_rustls::server::TlsStream;


### PR DESCRIPTION
## Motivation

We call the `serve_with_shutdown` method of tonic::transport::server::Router passing a local socket address. If the server is unable to bind the address, that returns an Err (quite quickly). If it *is* able to bind the address, it returns Ok only much later, when serving is complete.

We'd like to know when(/whether) the server has successfully bound the address, i.e. as soon as we know that bind isn't going to fail, and when a client can begin connecting to it (avoiding any race condition).

## Solution

The above can be done using the `serve_with_incoming_shutdown` method instead, passing a `TcpIncoming` struct - exactly as `serve_with_shutdown` does (it first builds the TcpIncoming, which binds the socket and may fail; and then passes that to the serve_with_incoming... method). By performing these two steps itself, the client can detect success/failure of constructing the TcpIncoming before calling the long-running serve... method.

Hence, the "solution" is merely to make the TcpIncoming struct public - it is currently `pub(crate)` within tonic::transport::server::incoming - and to `pub use` rather than `use` it from tonic::transport::server.

## Tests

I note the contribution guidelines state "Bug fixes and new features should include tests. I'm not clear whether this constitutes a bug fix or a new feature. Whilst I can imagine a test that started a server and then tried to create a second TcpIncoming on the same socket-address (looking for a failure), that test sounds like a much larger change than the rest of the PR. So, guidance as to what tests might be appropriate would be appreciated :-), thank you!