### PR TITLE
chore: Prepare 0.8 release

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -26,6 +26,10 @@ jobs:
       run: rustup component add rustfmt
     - name: Install cargo-hack
       run: cargo install cargo-hack
+    - name: Install Protoc
+      uses: arduino/setup-protoc@v1
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }} 
     - uses: Swatinem/rust-cache@v1
     - name: Check fmt
       run: cargo fmt -- --check
@@ -59,6 +63,10 @@ jobs:
         rust-version: ${{ matrix.rust }}
     - name: Install rustfmt
       run: rustup component add rustfmt
+    - name: Install Protoc
+      uses: arduino/setup-protoc@v1
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }} 
     - uses: Swatinem/rust-cache@v1
     - uses: actions/checkout@master
     - name: Run tests
@@ -82,6 +90,10 @@ jobs:
     - name: Install rustfmt
       run: rustup component add rustfmt
     - uses: actions/checkout@master
+    - name: Install Protoc
+      uses: arduino/setup-protoc@v1
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }} 
     - uses: Swatinem/rust-cache@v1
     - name: Run interop tests
       run: ./interop/test.sh

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,20 @@
+# [v0.8.0](https://github.com/hyperium/tonic/compare/v0.7.2...v0.8.0) (2022-07-29)
+
+
+### Features
+
+* Add `Grpc::with_origin` for clients ([#1017](https://github.com/hyperium/tonic/issues/1017)) ([10f6d2f](https://github.com/hyperium/tonic/commit/10f6d2f1a9fa3969599ebd674f7be27f4f458754))
+* **build:** Add option to emit rerun-if-changed instructions ([#1021](https://github.com/hyperium/tonic/issues/1021)) ([1d2083a](https://github.com/hyperium/tonic/commit/1d2083a1a690edcb3f95343edfe229339c4257b7))
+* **build:** Better support for custom codecs ([#999](https://github.com/hyperium/tonic/issues/999)) ([de2e4ac](https://github.com/hyperium/tonic/commit/de2e4ac077c076736dc451f3415ea7da1a61a560))
+* Decouple `NamedService` from the `transport` feature ([#969](https://github.com/hyperium/tonic/issues/969)) ([feae96c](https://github.com/hyperium/tonic/commit/feae96c5be1247af368e6ce665c8df757d298e35))
+* reflection: Export server types.
+* reflection: Add `with_service_name`.
+
+### BREAKING CHANGES
+
+* **build:** `CODEC_PATH` moved from const to fn
+* **tonic** Remove codegen depedency on `compression` feature.
+
 # [v0.7.2](https://github.com/hyperium/tonic/compare/v0.7.1...v0.7.2) (2022-05-04)
 
 

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -197,7 +197,7 @@ path = "src/json-codec/server.rs"
 [dependencies]
 async-stream = "0.3"
 futures = { version = "0.3", default-features = false, features = ["alloc"] }
-prost = "0.10"
+prost = "0.11"
 tokio = { version = "1.0", features = [ "rt-multi-thread", "time", "fs", "macros", "net",] }
 tokio-stream = { version = "0.1", features = ["net"] }
 tonic = { path = "../tonic", features = ["tls", "gzip"] }

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -212,7 +212,7 @@ tracing-attributes = "0.1"
 tracing-futures = "0.2"
 tracing-subscriber = { version = "0.3", features = ["tracing-log"] }
 # Required for wellknown types
-prost-types = "0.10"
+prost-types = "0.11"
 # Hyper example
 http = "0.2"
 http-body = "0.4.2"

--- a/examples/helloworld-tutorial.md
+++ b/examples/helloworld-tutorial.md
@@ -112,12 +112,12 @@ name = "helloworld-client"
 path = "src/client.rs"
 
 [dependencies]
-tonic = "0.7"
-prost = "0.10"
+tonic = "0.8"
+prost = "0.11"
 tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
 
 [build-dependencies]
-tonic-build = "0.7"
+tonic-build = "0.8"
 ```
 
 We include `tonic-build` as a useful way to incorporate the generation of our client and server gRPC code into the build process of our application. We will setup this build process now:

--- a/examples/routeguide-tutorial.md
+++ b/examples/routeguide-tutorial.md
@@ -174,8 +174,8 @@ Edit `Cargo.toml` and add all the dependencies we'll need for this example:
 
 ```toml
 [dependencies]
-tonic = "0.7"
-prost = "0.10"
+tonic = "0.8"
+prost = "0.11"
 futures-core = "0.3"
 futures-util = "0.3"
 tokio = { version = "1.0", features = ["rt-multi-thread", "macros", "sync", "time"] }
@@ -187,7 +187,7 @@ serde_json = "1.0"
 rand = "0.7"
 
 [build-dependencies]
-tonic-build = "0.7"
+tonic-build = "0.8"
 ```
 
 Create a `build.rs` file at the root of your crate:

--- a/interop/Cargo.toml
+++ b/interop/Cargo.toml
@@ -24,7 +24,7 @@ futures-util = "0.3"
 http = "0.2"
 http-body = "0.4.2"
 hyper = "0.14"
-prost = "0.10"
+prost = "0.11"
 prost-derive = "0.10"
 tokio = {version = "1.0", features = ["rt-multi-thread", "time", "macros", "fs"]}
 tokio-stream = "0.1"

--- a/interop/Cargo.toml
+++ b/interop/Cargo.toml
@@ -25,7 +25,7 @@ http = "0.2"
 http-body = "0.4.2"
 hyper = "0.14"
 prost = "0.11"
-prost-derive = "0.10"
+prost-derive = "0.11"
 tokio = {version = "1.0", features = ["rt-multi-thread", "time", "macros", "fs"]}
 tokio-stream = "0.1"
 tonic = {path = "../tonic", features = ["tls"]}

--- a/tests/ambiguous_methods/Cargo.toml
+++ b/tests/ambiguous_methods/Cargo.toml
@@ -9,7 +9,7 @@ version = "0.1.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-prost = "0.10"
+prost = "0.11"
 tonic = {path = "../../tonic"}
 
 [build-dependencies]

--- a/tests/compression/Cargo.toml
+++ b/tests/compression/Cargo.toml
@@ -13,7 +13,7 @@ http = "0.2"
 http-body = "0.4"
 hyper = "0.14.3"
 pin-project = "1.0"
-prost = "0.10"
+prost = "0.11"
 tokio = {version = "1.0", features = ["macros", "rt-multi-thread", "net"]}
 tokio-stream = {version = "0.1.5", features = ["net"]}
 tonic = {path = "../../tonic", features = ["gzip"]}

--- a/tests/extern_path/my_application/Cargo.toml
+++ b/tests/extern_path/my_application/Cargo.toml
@@ -10,7 +10,7 @@ version = "0.1.0"
 
 [dependencies]
 prost = "0.11"
-prost-types = "0.10"
+prost-types = "0.11"
 tonic = {path = "../../../tonic"}
 uuid = {package = "uuid1", path = "../uuid"}
 

--- a/tests/extern_path/my_application/Cargo.toml
+++ b/tests/extern_path/my_application/Cargo.toml
@@ -9,7 +9,7 @@ version = "0.1.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-prost = "0.10"
+prost = "0.11"
 prost-types = "0.10"
 tonic = {path = "../../../tonic"}
 uuid = {package = "uuid1", path = "../uuid"}

--- a/tests/extern_path/uuid/Cargo.toml
+++ b/tests/extern_path/uuid/Cargo.toml
@@ -12,4 +12,4 @@ version = "0.1.0"
 bytes = "1.0"
 prost = "0.11"
 [build-dependencies]
-prost-build = "0.10"
+prost-build = "0.11"

--- a/tests/extern_path/uuid/Cargo.toml
+++ b/tests/extern_path/uuid/Cargo.toml
@@ -10,6 +10,6 @@ version = "0.1.0"
 
 [dependencies]
 bytes = "1.0"
-prost = "0.10"
+prost = "0.11"
 [build-dependencies]
 prost-build = "0.10"

--- a/tests/included_service/Cargo.toml
+++ b/tests/included_service/Cargo.toml
@@ -9,7 +9,7 @@ version = "0.1.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-prost = "0.10"
+prost = "0.11"
 tonic = {path = "../../tonic"}
 
 [build-dependencies]

--- a/tests/integration_tests/Cargo.toml
+++ b/tests/integration_tests/Cargo.toml
@@ -11,7 +11,7 @@ version = "0.1.0"
 [dependencies]
 bytes = "1.0"
 futures-util = "0.3"
-prost = "0.10"
+prost = "0.11"
 tokio = {version = "1.0", features = ["macros", "rt-multi-thread", "net"]}
 tonic = {path = "../../tonic"}
 

--- a/tests/root-crate-path/Cargo.toml
+++ b/tests/root-crate-path/Cargo.toml
@@ -7,7 +7,7 @@ publish = false
 version = "0.1.0"
 
 [dependencies]
-prost = "0.10"
+prost = "0.11"
 tonic = {path = "../../tonic"}
 
 [build_dependencies]

--- a/tests/same_name/Cargo.toml
+++ b/tests/same_name/Cargo.toml
@@ -9,7 +9,7 @@ version = "0.1.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-prost = "0.10"
+prost = "0.11"
 tonic = {path = "../../tonic"}
 
 [build-dependencies]

--- a/tests/service_named_service/Cargo.toml
+++ b/tests/service_named_service/Cargo.toml
@@ -9,7 +9,7 @@ version = "0.1.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-prost = "0.10"
+prost = "0.11"
 tonic = {path = "../../tonic"}
 
 [build-dependencies]

--- a/tests/stream_conflict/Cargo.toml
+++ b/tests/stream_conflict/Cargo.toml
@@ -9,7 +9,7 @@ license = "MIT"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-prost = "0.10"
+prost = "0.11"
 tonic = { path = "../../tonic" }
 
 [build-dependencies]

--- a/tests/wellknown-compiled/Cargo.toml
+++ b/tests/wellknown-compiled/Cargo.toml
@@ -12,7 +12,7 @@ version = "0.1.0"
 doctest = false
 
 [dependencies]
-prost = "0.10"
+prost = "0.11"
 tonic = {path = "../../tonic"}
 
 [build-dependencies]

--- a/tests/wellknown-compiled/Cargo.toml
+++ b/tests/wellknown-compiled/Cargo.toml
@@ -16,5 +16,5 @@ prost = "0.11"
 tonic = {path = "../../tonic"}
 
 [build-dependencies]
-prost-build = "0.10"
+prost-build = "0.11"
 tonic-build = {path = "../../tonic-build"}

--- a/tests/wellknown/Cargo.toml
+++ b/tests/wellknown/Cargo.toml
@@ -9,7 +9,7 @@ version = "0.1.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-prost = "0.10"
+prost = "0.11"
 prost-types = "0.10"
 tonic = {path = "../../tonic"}
 

--- a/tests/wellknown/Cargo.toml
+++ b/tests/wellknown/Cargo.toml
@@ -10,7 +10,7 @@ version = "0.1.0"
 
 [dependencies]
 prost = "0.11"
-prost-types = "0.10"
+prost-types = "0.11"
 tonic = {path = "../../tonic"}
 
 [build-dependencies]

--- a/tonic-build/Cargo.toml
+++ b/tonic-build/Cargo.toml
@@ -12,7 +12,7 @@ license = "MIT"
 name = "tonic-build"
 readme = "README.md"
 repository = "https://github.com/hyperium/tonic"
-version = "0.7.2"
+version = "0.8.0"
 
 [dependencies]
 prettyplease = {version = "0.1"}

--- a/tonic-build/Cargo.toml
+++ b/tonic-build/Cargo.toml
@@ -17,7 +17,7 @@ version = "0.8.0"
 [dependencies]
 prettyplease = {version = "0.1"}
 proc-macro2 = "1.0"
-prost-build = {version = "0.10", optional = true}
+prost-build = {version = "0.11", optional = true}
 quote = "1.0"
 syn = "1.0"
 

--- a/tonic-build/src/lib.rs
+++ b/tonic-build/src/lib.rs
@@ -62,7 +62,7 @@
     html_logo_url = "https://raw.githubusercontent.com/tokio-rs/website/master/public/img/icons/tonic.svg"
 )]
 #![deny(rustdoc::broken_intra_doc_links)]
-#![doc(html_root_url = "https://docs.rs/tonic-build/0.7.2")]
+#![doc(html_root_url = "https://docs.rs/tonic-build/0.8.0")]
 #![doc(issue_tracker_base_url = "https://github.com/hyperium/tonic/issues/")]
 #![doc(test(no_crate_inject, attr(deny(rust_2018_idioms))))]
 #![cfg_attr(docsrs, feature(doc_cfg))]

--- a/tonic-health/Cargo.toml
+++ b/tonic-health/Cargo.toml
@@ -4,7 +4,7 @@ categories = ["network-programming", "asynchronous"]
 description = """
 Health Checking module of `tonic` gRPC implementation.
 """
-documentation = "https://docs.rs/tonic-health/0.6.0/tonic-health/"
+documentation = "https://docs.rs/tonic-health/0.7.0/tonic-health/"
 edition = "2018"
 homepage = "https://github.com/hyperium/tonic"
 keywords = ["rpc", "grpc", "async", "healthcheck"]
@@ -12,7 +12,7 @@ license = "MIT"
 name = "tonic-health"
 readme = "README.md"
 repository = "https://github.com/hyperium/tonic"
-version = "0.6.0"
+version = "0.7.0"
 
 [features]
 default = ["transport"]
@@ -21,13 +21,13 @@ transport = ["tonic/transport", "tonic-build/transport"]
 [dependencies]
 async-stream = "0.3"
 bytes = "1.0"
-prost = "0.10"
+prost = "0.11"
 tokio = {version = "1.0", features = ["sync"]}
 tokio-stream = "0.1"
-tonic = {version = "0.7", path = "../tonic", features = ["codegen", "prost"]}
+tonic = {version = "0.8", path = "../tonic", features = ["codegen", "prost"]}
 
 [dev-dependencies]
 tokio = {version = "1.0", features = ["rt-multi-thread", "macros"]}
 
 [build-dependencies]
-tonic-build = {version = "0.7", path = "../tonic-build", features = ["prost"]}
+tonic-build = {version = "0.8", path = "../tonic-build", features = ["prost"]}

--- a/tonic-reflection/Cargo.toml
+++ b/tonic-reflection/Cargo.toml
@@ -20,7 +20,7 @@ version = "0.5.0"
 [dependencies]
 bytes = "1.0"
 prost = "0.11"
-prost-types = "0.10"
+prost-types = "0.11"
 tokio = {version = "1.0", features = ["sync"]}
 tokio-stream = {version = "0.1", features = ["net"]}
 tonic = {version = "0.8", path = "../tonic", features = ["codegen", "prost"]}

--- a/tonic-reflection/Cargo.toml
+++ b/tonic-reflection/Cargo.toml
@@ -9,24 +9,24 @@ Server Reflection module of `tonic` gRPC implementation.
 """
 edition = "2018"
 homepage = "https://github.com/hyperium/tonic"
-documentation = "https://docs.rs/tonic-reflection/0.4.0/tonic-reflection/"
+documentation = "https://docs.rs/tonic-reflection/0.5.0/tonic-reflection/"
 keywords = ["rpc", "grpc", "async", "reflection"]
 license = "MIT"
 name = "tonic-reflection"
 readme = "README.md"
 repository = "https://github.com/hyperium/tonic"
-version = "0.4.0"
+version = "0.5.0"
 
 [dependencies]
 bytes = "1.0"
-prost = "0.10"
+prost = "0.11"
 prost-types = "0.10"
 tokio = {version = "1.0", features = ["sync"]}
 tokio-stream = {version = "0.1", features = ["net"]}
-tonic = {version = "0.7", path = "../tonic", features = ["codegen", "prost"]}
+tonic = {version = "0.8", path = "../tonic", features = ["codegen", "prost"]}
 
 [build-dependencies]
-tonic-build = {version = "0.7", path = "../tonic-build", features = ["transport", "prost"]}
+tonic-build = {version = "0.8", path = "../tonic-build", features = ["transport", "prost"]}
 
 [dev-dependencies]
 futures = "0.3"

--- a/tonic-types/Cargo.toml
+++ b/tonic-types/Cargo.toml
@@ -12,10 +12,10 @@ license = "MIT"
 name = "tonic-types"
 readme = "../README.md"
 repository = "https://github.com/hyperium/tonic"
-version = "0.5.0"
+version = "0.6.0"
 
 [dependencies]
-prost = "0.10"
+prost = "0.11"
 prost-types = "0.10"
 
 [build-dependencies]

--- a/tonic-types/Cargo.toml
+++ b/tonic-types/Cargo.toml
@@ -16,7 +16,7 @@ version = "0.6.0"
 
 [dependencies]
 prost = "0.11"
-prost-types = "0.10"
+prost-types = "0.11"
 
 [build-dependencies]
-prost-build = "0.10"
+prost-build = "0.11"

--- a/tonic-types/src/lib.rs
+++ b/tonic-types/src/lib.rs
@@ -10,7 +10,7 @@
     html_logo_url = "https://raw.githubusercontent.com/tokio-rs/website/master/public/img/icons/tonic.svg"
 )]
 #![deny(rustdoc::broken_intra_doc_links)]
-#![doc(html_root_url = "https://docs.rs/tonic-types/0.5.0")]
+#![doc(html_root_url = "https://docs.rs/tonic-types/0.6.0")]
 #![doc(issue_tracker_base_url = "https://github.com/hyperium/tonic/issues/")]
 
 mod pb {

--- a/tonic-web/Cargo.toml
+++ b/tonic-web/Cargo.toml
@@ -22,7 +22,7 @@ http = "0.2"
 http-body = "0.4"
 hyper = "0.14"
 pin-project = "1"
-tonic = {version = "0.7", path = "../tonic", default-features = false, features = ["transport"]}
+tonic = {version = "0.8", path = "../tonic", default-features = false, features = ["transport"]}
 tower-service = "0.3"
 tracing = "0.1"
 

--- a/tonic-web/tests/integration/Cargo.toml
+++ b/tonic-web/tests/integration/Cargo.toml
@@ -10,7 +10,7 @@ license = "MIT"
 base64 = "0.13"
 bytes = "1.0"
 hyper = "0.14"
-prost = "0.10"
+prost = "0.11"
 tokio = { version = "1", features = ["macros", "rt", "net"] }
 tokio-stream = { version = "0.1", features = ["net"] }
 tonic = { path = "../../../tonic" }

--- a/tonic/Cargo.toml
+++ b/tonic/Cargo.toml
@@ -13,14 +13,14 @@ categories = ["web-programming", "network-programming", "asynchronous"]
 description = """
 A gRPC over HTTP/2 implementation focused on high performance, interoperability, and flexibility.
 """
-documentation = "https://docs.rs/tonic/0.7.2/tonic/"
+documentation = "https://docs.rs/tonic/0.8.0/tonic/"
 edition = "2018"
 homepage = "https://github.com/hyperium/tonic"
 keywords = ["rpc", "grpc", "async", "futures", "protobuf"]
 license = "MIT"
 readme = "../README.md"
 repository = "https://github.com/hyperium/tonic"
-version = "0.7.2"
+version = "0.8.0"
 
 [features]
 codegen = ["async-trait"]

--- a/tonic/Cargo.toml
+++ b/tonic/Cargo.toml
@@ -67,8 +67,8 @@ tower-layer = "0.3"
 tower-service = "0.3"
 
 # prost
-prost-derive = {version = "0.10", optional = true}
-prost1 = {package = "prost", version = "0.10", optional = true}
+prost-derive = {version = "0.11", optional = true}
+prost1 = {package = "prost", version = "0.11", optional = true}
 
 # codegen
 async-trait = {version = "0.1.13", optional = true}

--- a/tonic/src/lib.rs
+++ b/tonic/src/lib.rs
@@ -81,7 +81,7 @@
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/tokio-rs/website/master/public/img/icons/tonic.svg"
 )]
-#![doc(html_root_url = "https://docs.rs/tonic/0.7.2")]
+#![doc(html_root_url = "https://docs.rs/tonic/0.8.0")]
 #![doc(issue_tracker_base_url = "https://github.com/hyperium/tonic/issues/")]
 #![doc(test(no_crate_inject, attr(deny(rust_2018_idioms))))]
 #![cfg_attr(docsrs, feature(doc_cfg))]


### PR DESCRIPTION

# [v0.8.0](https://github.com/hyperium/tonic/compare/v0.7.2...v0.8.0) (2022-07-29)


### Features

* Add `Grpc::with_origin` for clients ([#1017](https://github.com/hyperium/tonic/issues/1017)) ([10f6d2f](https://github.com/hyperium/tonic/commit/10f6d2f1a9fa3969599ebd674f7be27f4f458754))
* **build:** Add option to emit rerun-if-changed instructions ([#1021](https://github.com/hyperium/tonic/issues/1021)) ([1d2083a](https://github.com/hyperium/tonic/commit/1d2083a1a690edcb3f95343edfe229339c4257b7))
* **build:** Better support for custom codecs ([#999](https://github.com/hyperium/tonic/issues/999)) ([de2e4ac](https://github.com/hyperium/tonic/commit/de2e4ac077c076736dc451f3415ea7da1a61a560))
* Decouple `NamedService` from the `transport` feature ([#969](https://github.com/hyperium/tonic/issues/969)) ([feae96c](https://github.com/hyperium/tonic/commit/feae96c5be1247af368e6ce665c8df757d298e35))
* reflection: Export server types.
* reflection: Add `with_service_name`.

### BREAKING CHANGES

* **build:** `CODEC_PATH` moved from const to fn
* **tonic** Remove codegen depedency on `compression` feature.