### PR TITLE
Update docs to reflect changes to compression feature

### DIFF
--- a/tonic/src/lib.rs
+++ b/tonic/src/lib.rs
@@ -32,6 +32,7 @@
 //! - `prost`: Enables the [`prost`] based gRPC [`Codec`] implementation.
 //! - `gzip`: Enables compressing requests, responses, and streams.
 //! Depends on [flate2]. Not enabled by default.
+//! Replaces the `compression` flag from earlier versions of `tonic`.
 //!
 //! # Structure
 //!

--- a/tonic/src/lib.rs
+++ b/tonic/src/lib.rs
@@ -30,9 +30,8 @@
 //! - `tls-webpki-roots`: Add the standard trust roots from the `webpki-roots` crate to
 //! `rustls`-based gRPC clients. Not enabled by default.
 //! - `prost`: Enables the [`prost`] based gRPC [`Codec`] implementation.
-//! - `compression`: Enables compressing requests, responses, and streams. Note
-//! that you must enable the `compression` feature on both `tonic` and
-//! `tonic-build` to use it. Depends on [flate2]. Not enabled by default.
+//! - `gzip`: Enables compressing requests, responses, and streams.
+//! Depends on [flate2]. Not enabled by default.
 //!
 //! # Structure
 //!

--- a/tonic/src/lib.rs
+++ b/tonic/src/lib.rs
@@ -32,7 +32,7 @@
 //! - `prost`: Enables the [`prost`] based gRPC [`Codec`] implementation.
 //! - `gzip`: Enables compressing requests, responses, and streams.
 //! Depends on [flate2]. Not enabled by default.
-//! Replaces the `compression` flag from earlier versions of `tonic`.
+//! Replaces the `compression` flag from earlier versions of `tonic` (<= 0.7).
 //!
 //! # Structure
 //!


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/hyperium/tonic/blob/master/CONTRIBUTING.md
-->
The [current docs](https://docs.rs/tonic/0.8.0/tonic/index.html#feature-flags) still reference the outdated feature flag `compression`, which has been superseded by `gzip` in `tonic` and removed from `tonic-build` entirely.

See #1004 (commit a585a72) for more information on the changes to the `compression` feature in `tonic` `0.8`.

## Motivation
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? If a new feature is being added, describe the intended
use case that feature fulfills.
-->

Have the docs reflect the current state of the crate(s).

## Solution
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

Fix the `tonic` docs to reference `gzip` and to no longer state that `tonic-build` also needs a flag to be specified.