### PR TITLE
Expose Extensions::into_http and Status::from_error

### DIFF
--- a/tonic/src/extensions.rs
+++ b/tonic/src/extensions.rs
@@ -7,6 +7,7 @@ use std::fmt;
 ///
 /// [`Interceptor`]: crate::service::Interceptor
 /// [`Request`]: crate::Request
+#[derive(Default)]
 pub struct Extensions {
     inner: http::Extensions,
 }
@@ -58,8 +59,9 @@ impl Extensions {
         Self { inner: http }
     }
 
+    /// Convert to `http::Extensions` and consume self.
     #[inline]
-    pub(crate) fn into_http(self) -> http::Extensions {
+    pub fn into_http(self) -> http::Extensions {
         self.inner
     }
 }

--- a/tonic/src/status.rs
+++ b/tonic/src/status.rs
@@ -310,8 +310,12 @@ impl Status {
         Self::from_error(err.into())
     }
 
+    /// Create a `Status` from various types of `Error`.
+    ///
+    /// Inspects the error source chain for recognizable errors, including statuses, HTTP2, and
+    /// hyper, and attempts to maps them to a `Status`, or else returns an Unknown `Status`.
     #[cfg_attr(not(feature = "transport"), allow(dead_code))]
-    pub(crate) fn from_error(err: Box<dyn Error + Send + Sync + 'static>) -> Status {
+    pub fn from_error(err: Box<dyn Error + Send + Sync + 'static>) -> Status {
         Status::try_from_error(err).unwrap_or_else(|err| {
             let mut status = Status::new(Code::Unknown, err.to_string());
             status.source = Some(err);


### PR DESCRIPTION
Expose Extensions::into_http and Status::from_error as public.

## Motivation

See #910. These functions must be public in order to implement async_interceptor in its own external crate.