### PR TITLE
fix(transport): Bump axum for CVE-2022-3212

### DIFF
--- a/tonic/Cargo.toml
+++ b/tonic/Cargo.toml
@@ -81,7 +81,7 @@ tokio = {version = "1.0.1", features = ["net"], optional = true}
 tokio-stream = "0.1"
 tower = {version = "0.4.7", default-features = false, features = ["balance", "buffer", "discover", "limit", "load", "make", "timeout", "util"], optional = true}
 tracing-futures = {version = "0.2", optional = true}
-axum = {version = "0.5", default_features = false, optional = true}
+axum = {version = "0.5.15", default_features = false, optional = true}
 
 # rustls
 rustls-pemfile = { version = "1.0", optional = true }


### PR DESCRIPTION
Closes #1087
