### PR TITLE
chore: bumping dependency `axum` to version 0.5.16

### DIFF
--- a/tonic/Cargo.toml
+++ b/tonic/Cargo.toml
@@ -81,7 +81,7 @@ tokio = {version = "1.0.1", features = ["net"], optional = true}
 tokio-stream = "0.1"
 tower = {version = "0.4.7", default-features = false, features = ["balance", "buffer", "discover", "limit", "load", "make", "timeout", "util"], optional = true}
 tracing-futures = {version = "0.2", optional = true}
-axum = {version = "0.5.15", default_features = false, optional = true}
+axum = {version = "0.5.16", default_features = false, optional = true}
 
 # rustls
 rustls-pemfile = { version = "1.0", optional = true }


### PR DESCRIPTION
## Motivation
There is a security vulnerability in the `axum-core` crate ([RUSTSEC-2022-0055](https://rustsec.org/advisories/RUSTSEC-2022-0055)), which is used in `axum` and subsequently `tonic`.

I'm not sure if directly impacts `tonic` or not, but it may be related to https://github.com/hyperium/tonic/issues/1097.

## Solution
Proposing to upgrade the version of `axum` to 0.5.16, which contains the patched version of `axum-core`.