### PR TITLE
test(tonic-web): fix grpc_web_content_types() test not covering all cases

### DIFF
--- a/tonic-web/src/service.rs
+++ b/tonic-web/src/service.rs
@@ -337,7 +337,7 @@ mod tests {
         async fn grpc_web_content_types() {
             let mut svc = crate::enable(Svc);
 
-            for ct in &[GRPC_WEB_TEXT, GRPC_WEB_PROTO, GRPC_WEB_PROTO, GRPC_WEB] {
+            for ct in &[GRPC_WEB_TEXT, GRPC_WEB_PROTO, GRPC_WEB_TEXT_PROTO, GRPC_WEB] {
                 let mut req = request();
                 req.headers_mut()
                     .insert(CONTENT_TYPE, HeaderValue::from_static(ct));


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/hyperium/tonic/blob/master/CONTRIBUTING.md
-->

## Motivation

The grpc_web_content_types() test function had a duplicate `GRPC_WEB_PROTO` in the array, where one of these should have been `GRPC_WEB_TEXT_PROTO`.

