### PR TITLE
Expose `Request#into_parts` and `Request#from_parts`

### DIFF
--- a/tonic/src/request.rs
+++ b/tonic/src/request.rs
@@ -145,7 +145,8 @@ impl<T> Request<T> {
         (self.metadata, self.extensions, self.message)
     }
 
-    pub(crate) fn from_parts(metadata: MetadataMap, extensions: Extensions, message: T) -> Self {
+    /// Create a new gRPC request from metadata, extensions and message.
+    pub fn from_parts(metadata: MetadataMap, extensions: Extensions, message: T) -> Self {
         Self {
             metadata,
             extensions,

--- a/tonic/src/request.rs
+++ b/tonic/src/request.rs
@@ -140,7 +140,8 @@ impl<T> Request<T> {
         self.message
     }
 
-    pub(crate) fn into_parts(self) -> (MetadataMap, Extensions, T) {
+    /// Consumes `self` returning the parts of the request.
+    pub fn into_parts(self) -> (MetadataMap, Extensions, T) {
         (self.metadata, self.extensions, self.message)
     }
 


### PR DESCRIPTION
Fix #1116

## Motivation

See #1116

## Solution

This PR contains two changes:

* One as described in #1116 to expose `Request#into_parts`
* Another one is to expose `from_parts`, in order to have a symmetric api, consistent with `http::Request` as well (see https://docs.rs/http/0.2.8/http/request/struct.Request.html#method.into_parts and https://docs.rs/http/0.2.8/http/request/struct.Request.html#method.from_parts)