### PR TITLE
Export GrpcWeb

### DIFF
--- a/tonic-web/src/lib.rs
+++ b/tonic-web/src/lib.rs
@@ -88,13 +88,13 @@
 #![doc(issue_tracker_base_url = "https://github.com/hyperium/tonic/issues/")]
 
 pub use config::Config;
+pub use service::GrpcWeb;
 
 mod call;
 mod config;
 mod cors;
 mod service;
 
-use crate::service::GrpcWeb;
 use std::future::Future;
 use std::pin::Pin;
 use tonic::body::BoxBody;

--- a/tonic-web/src/service.rs
+++ b/tonic-web/src/service.rs
@@ -15,6 +15,7 @@ use crate::{BoxError, BoxFuture, Config};
 
 const GRPC: &str = "application/grpc";
 
+/// A wrapper around tonic services enabling them to handle grpc-web requests
 #[derive(Debug, Clone)]
 pub struct GrpcWeb<S> {
     inner: S,


### PR DESCRIPTION
## Motivation

I was trying to write a subroutine like the following:

```
pub fn grpc_web_enable<S>(service: S) -> GrpcWeb<S>
where
    S: Service<http::Request<hyper::Body>, Response = http::Response<BoxBody>>,
    S: NamedService + Clone + Send + 'static,
    S::Future: Send + 'static,
    S::Error: Into<Box<dyn std::error::Error + Send + Sync>> + Send,
{
    let web_config =
        tonic_web::Config::default().expose_headers(["grpc-status-details-bin"].into_iter());
    web_config.enable(service)
}
```

But because `GrpcWeb` isn't exported, this is impossible. It's also not good enough to return an `impl Trait` Object, because, when you try to call `add_service` on the output, you will run into https://github.com/rust-lang/rust/issues/52662 (there is a required trait bound on the associated Future of the `Service` which cannot be set)

## Solution

GrpcWeb is already a pub struct, it was just part of a hidden mod. 

The `Config::enable` function is a pub function which returns a private struct. I generally think any struct returned by a pub function should be a pub struct - even if all of its fields and methods are private.