### PR TITLE
fix: remove patch caused cargo error

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,3 @@ members = [
   "tests/compression",
   "tonic-web/tests/integration",
 ]
-
-[patch.crates-io]
-prost-build = { git = "https://github.com/tokio-rs/prost/", branch = "lucio/format" }
-

--- a/tonic-build/Cargo.toml
+++ b/tonic-build/Cargo.toml
@@ -17,7 +17,7 @@ version = "0.8.2"
 [dependencies]
 prettyplease = { version = "0.1" }
 proc-macro2 = "1.0"
-prost-build = { version = "0.11.1", optional = true }
+prost-build = { version = "0.11.2", optional = true }
 quote = "1.0"
 syn = "1.0"
 


### PR DESCRIPTION
## Motivation
```text
error: failed to load source for dependency `prost-build`

Caused by:
  Unable to update https://github.com/tokio-rs/prost/?branch=lucio/format

Caused by:
  failed to fetch into: /Users/roger/.cargo/git/db/prost-93ab2781ba9c857f

Caused by:
  process didn't exit successfully: `git fetch --force --update-head-ok 'https://github.com/tokio-rs/prost/' '+refs/heads/lucio/format:refs/remotes/origin/lucio/format'` (exit status: 128)
  --- stderr
  fatal: Unable to find remote reference refs/heads/lucio/format
```