### PR TITLE
fix: do not panic while encoding oversized bodies

### DIFF
--- a/tonic/src/codec/prost.rs
+++ b/tonic/src/codec/prost.rs
@@ -136,6 +136,8 @@ mod tests {
         }
     }
 
+    // skip on windows because CI stumbles over our 4GB allocation
+    #[cfg(not(target_family = "windows"))]
     #[tokio::test]
     async fn encode_too_big() {
         let encoder = MockEncoder::default();


### PR DESCRIPTION
## Motivation
Fixes #1141.

## Solution
Replace assertion w/ an ordinary error path.
