### PR TITLE
feat: Add From<crate::Error> for Error

### DIFF
--- a/tonic/src/transport/error.rs
+++ b/tonic/src/transport/error.rs
@@ -85,3 +85,9 @@ impl StdError for Error {
             .map(|source| &**source as &(dyn StdError + 'static))
     }
 }
+
+impl From<crate::Error> for Error {
+    fn from(e: crate::Error) -> Error {
+        Error::from_source(e)
+    }
+}


### PR DESCRIPTION
## Motivation
The `From<tonic::Error>` was not exposed to public before. In deed, there was a `from_source()` method on `tonic::transport::Error` as 

https://github.com/hyperium/tonic/blob/33e22bbc5ef1b74de82394c3ebfea27382419620/tonic/src/transport/error.rs#L39

When implement `tower::Service`, we may want to return an error from the service, which needs transform it into the `tonic::transport::Error`. See 

https://github.com/sentinel-group/sentinel-rust/blob/c3ff9a574fe472c44c7f8ce1f7bb921ced96575e/middleware/tower/src/lib.rs#L126

## Solution

Just expose the `From<crate::Error>` for `tonic::transport::Error` as a bridge.