### PR TITLE
feat(tls): add an option for optional TLS client authentication

### DIFF
--- a/tonic/src/transport/server/tls.rs
+++ b/tonic/src/transport/server/tls.rs
@@ -51,6 +51,9 @@ impl ServerTlsConfig {
     /// Sets whether client certificate verification is optional.
     ///
     /// This option has effect only if CA certificate is set.
+    ///
+    /// # Default
+    /// By default, this option is set to `false`.
     pub fn client_auth_optional(self, optional: bool) -> Self {
         ServerTlsConfig {
             client_auth_optional: optional,

--- a/tonic/src/transport/server/tls.rs
+++ b/tonic/src/transport/server/tls.rs
@@ -11,6 +11,7 @@ use std::fmt;
 pub struct ServerTlsConfig {
     identity: Option<Identity>,
     client_ca_root: Option<Certificate>,
+    client_auth_optional: bool,
 }
 
 #[cfg(feature = "tls")]
@@ -27,6 +28,7 @@ impl ServerTlsConfig {
         ServerTlsConfig {
             identity: None,
             client_ca_root: None,
+            client_auth_optional: false,
         }
     }
 
@@ -46,7 +48,21 @@ impl ServerTlsConfig {
         }
     }
 
+    /// Sets whether client certificate verification is optional.
+    ///
+    /// This option has effect only if CA certificate is set.
+    pub fn client_auth_optional(self, optional: bool) -> Self {
+        ServerTlsConfig {
+            client_auth_optional: optional,
+            ..self
+        }
+    }
+
     pub(crate) fn tls_acceptor(&self) -> Result<TlsAcceptor, crate::Error> {
-        TlsAcceptor::new(self.identity.clone().unwrap(), self.client_ca_root.clone())
+        TlsAcceptor::new(
+            self.identity.clone().unwrap(),
+            self.client_ca_root.clone(),
+            self.client_auth_optional,
+        )
     }
 }


### PR DESCRIPTION
Previously there were only two options for client authentication – either no authentication or mandatory authentication. With this change, a server can allow for optional authentication with a given root CA certificate and enforce client authentication on a per-request basis.

Refs: #687

## Motivation

Currently, there is no easy way of performing client authentication on a per-request basis with the API provided by `ServerTlsConfig`. This behavior is useful in scenarios like the one described in #687, i.e., when some endpoints should be publicly accessible while others not.

## Solution

Since `rustls` provides `ClientCertVerifier` with the desired behavior, it only needs to be made accessible from `ServerTlsConfig`. Currently, when the method `client_ca_cert` is called on a `ServerTlsConfig`, it forces mandatory client authentication with a given root CA certificate.

I propose to rename this method and change its input to a three-valued enum – no authentication (default), optional authentication with a provided root CA certificate, and mandatory authentication with a provided root CA certificate. I understand this is a breaking change, but it seems like a much cleaner solution than introducing a new method along `client_ca_certificate` that would set some `optional` flag in `ServerTlsConfig`, since the flag would have no meaning if the `client_ca_certificate` was not used.
