### PR TITLE
Fix CodeGen8uilder typo

### DIFF
--- a/tonic-build/src/code_gen.rs
+++ b/tonic-build/src/code_gen.rs
@@ -6,7 +6,7 @@ use crate::{Attributes, Service};
 
 /// Builder for the generic code generation of server and clients.
 #[derive(Debug)]
-pub struct CodeGen8uilder {
+pub struct CodeGenBuilder {
     emit_package: bool,
     compile_well_known_types: bool,
     attributes: Attributes,
@@ -14,7 +14,7 @@ pub struct CodeGen8uilder {
     disable_comments: HashSet<String>,
 }
 
-impl CodeGen8uilder {
+impl CodeGenBuilder {
     /// Create a new code gen builder with default options.
     pub fn new() -> Self {
         Default::default()
@@ -89,7 +89,7 @@ impl CodeGen8uilder {
     }
 }
 
-impl Default for CodeGen8uilder {
+impl Default for CodeGenBuilder {
     fn default() -> Self {
         Self {
             emit_package: true,

--- a/tonic-build/src/lib.rs
+++ b/tonic-build/src/lib.rs
@@ -95,7 +95,7 @@ pub mod client;
 pub mod server;
 
 mod code_gen;
-pub use code_gen::CodeGen8uilder;
+pub use code_gen::CodeGenBuilder;
 
 /// Service generation trait.
 ///

--- a/tonic-build/src/manual.rs
+++ b/tonic-build/src/manual.rs
@@ -28,7 +28,7 @@
 //! }
 //! ```
 
-use crate::code_gen::CodeGen8uilder;
+use crate::code_gen::CodeGenBuilder;
 
 use proc_macro2::TokenStream;
 use quote::ToTokens;
@@ -352,7 +352,7 @@ struct ServiceGenerator {
 impl ServiceGenerator {
     fn generate(&mut self, service: &Service) {
         if self.builder.build_server {
-            let server = CodeGen8uilder::new()
+            let server = CodeGenBuilder::new()
                 .emit_package(true)
                 .compile_well_known_types(false)
                 .generate_server(service, "");
@@ -361,7 +361,7 @@ impl ServiceGenerator {
         }
 
         if self.builder.build_client {
-            let client = CodeGen8uilder::new()
+            let client = CodeGenBuilder::new()
                 .emit_package(true)
                 .compile_well_known_types(false)
                 .build_transport(self.builder.build_transport)

--- a/tonic-build/src/prost.rs
+++ b/tonic-build/src/prost.rs
@@ -1,4 +1,4 @@
-use crate::code_gen::CodeGen8uilder;
+use crate::code_gen::CodeGenBuilder;
 
 use super::Attributes;
 use proc_macro2::TokenStream;
@@ -161,7 +161,7 @@ impl ServiceGenerator {
 impl prost_build::ServiceGenerator for ServiceGenerator {
     fn generate(&mut self, service: prost_build::Service, _buf: &mut String) {
         if self.builder.build_server {
-            let server = CodeGen8uilder::new()
+            let server = CodeGenBuilder::new()
                 .emit_package(self.builder.emit_package)
                 .compile_well_known_types(self.builder.compile_well_known_types)
                 .attributes(self.builder.server_attributes.clone())
@@ -172,7 +172,7 @@ impl prost_build::ServiceGenerator for ServiceGenerator {
         }
 
         if self.builder.build_client {
-            let client = CodeGen8uilder::new()
+            let client = CodeGenBuilder::new()
                 .emit_package(self.builder.emit_package)
                 .compile_well_known_types(self.builder.compile_well_known_types)
                 .attributes(self.builder.client_attributes.clone())


### PR DESCRIPTION
Changes `CodeGen8uilder` to `CodeGenBuilder` in `tonic_build`. Fixes #1165.

## Motivation

While `8builder` looks super l33t, it's not consistent with the documentation.

## Solution

`sed -i 's/CodeGen8uilder/CodeGenBuilder/g'`
