### PR TITLE
chore(examples): Fix blocking-server

### DIFF
--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -15,6 +15,10 @@ name = "helloworld-client"
 path = "src/helloworld/client.rs"
 
 [[bin]]
+name = "blocking-server"
+path = "src/blocking/server.rs"
+
+[[bin]]
 name = "blocking-client"
 path = "src/blocking/client.rs"
 

--- a/examples/src/blocking/server.rs
+++ b/examples/src/blocking/server.rs
@@ -32,9 +32,10 @@ fn main() {
     let addr = "[::1]:50051".parse().unwrap();
     let greeter = MyGreeter::default();
 
-    let mut rt = Runtime::new().expect("failed to obtain a new RunTime object");
+    let rt = Runtime::new().expect("failed to obtain a new RunTime object");
     let server_future = Server::builder()
-                        .add_service(GreeterServer::new(greeter))
-                        .serve(addr);
-    rt.block_on(server_future).expect("failed to successfully run the future on RunTime");
+        .add_service(GreeterServer::new(greeter))
+        .serve(addr);
+    rt.block_on(server_future)
+        .expect("failed to successfully run the future on RunTime");
 }


### PR DESCRIPTION
- Moves to the blocking directory.
- Registers the blocking server example as bin.
- Fixes lint.
- Applies rustfmt.