### PR TITLE
chore(examples): Remove dummy echo implementation

### DIFF
--- a/examples/build.rs
+++ b/examples/build.rs
@@ -14,6 +14,8 @@ fn main() {
 
     tonic_build::compile_protos("proto/echo/echo.proto").unwrap();
 
+    tonic_build::compile_protos("proto/unaryecho/echo.proto").unwrap();
+
     tonic_build::configure()
         .server_mod_attribute("attrs", "#[cfg(feature = \"server\")]")
         .server_attribute("Echo", "#[derive(PartialEq)]")

--- a/examples/proto/unaryecho/echo.proto
+++ b/examples/proto/unaryecho/echo.proto
@@ -1,0 +1,37 @@
+/*
+ *
+ * Copyright 2018 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+ syntax = "proto3";
+
+ package grpc.examples.unaryecho;
+
+ // EchoRequest is the request for echo.
+ message EchoRequest {
+   string message = 1;
+ }
+
+ // EchoResponse is the response for echo.
+ message EchoResponse {
+   string message = 1;
+ }
+
+ // Echo is the echo service.
+ service Echo {
+   // UnaryEcho is unary echo.
+   rpc UnaryEcho(EchoRequest) returns (EchoResponse) {}
+ }

--- a/examples/src/authentication/client.rs
+++ b/examples/src/authentication/client.rs
@@ -1,5 +1,5 @@
 pub mod pb {
-    tonic::include_proto!("grpc.examples.echo");
+    tonic::include_proto!("grpc.examples.unaryecho");
 }
 
 use pb::{echo_client::EchoClient, EchoRequest};

--- a/examples/src/authentication/server.rs
+++ b/examples/src/authentication/server.rs
@@ -1,14 +1,11 @@
 pub mod pb {
-    tonic::include_proto!("grpc.examples.echo");
+    tonic::include_proto!("grpc.examples.unaryecho");
 }
 
-use futures::Stream;
 use pb::{EchoRequest, EchoResponse};
-use std::pin::Pin;
-use tonic::{metadata::MetadataValue, transport::Server, Request, Response, Status, Streaming};
+use tonic::{metadata::MetadataValue, transport::Server, Request, Response, Status};
 
 type EchoResult<T> = Result<Response<T>, Status>;
-type ResponseStream = Pin<Box<dyn Stream<Item = Result<EchoResponse, Status>> + Send>>;
 
 #[derive(Default)]
 pub struct EchoServer;
@@ -18,31 +15,6 @@ impl pb::echo_server::Echo for EchoServer {
     async fn unary_echo(&self, request: Request<EchoRequest>) -> EchoResult<EchoResponse> {
         let message = request.into_inner().message;
         Ok(Response::new(EchoResponse { message }))
-    }
-
-    type ServerStreamingEchoStream = ResponseStream;
-
-    async fn server_streaming_echo(
-        &self,
-        _: Request<EchoRequest>,
-    ) -> EchoResult<Self::ServerStreamingEchoStream> {
-        Err(Status::unimplemented("not implemented"))
-    }
-
-    async fn client_streaming_echo(
-        &self,
-        _: Request<Streaming<EchoRequest>>,
-    ) -> EchoResult<EchoResponse> {
-        Err(Status::unimplemented("not implemented"))
-    }
-
-    type BidirectionalStreamingEchoStream = ResponseStream;
-
-    async fn bidirectional_streaming_echo(
-        &self,
-        _: Request<Streaming<EchoRequest>>,
-    ) -> EchoResult<Self::BidirectionalStreamingEchoStream> {
-        Err(Status::unimplemented("not implemented"))
     }
 }
 

--- a/examples/src/dynamic_load_balance/client.rs
+++ b/examples/src/dynamic_load_balance/client.rs
@@ -1,5 +1,5 @@
 pub mod pb {
-    tonic::include_proto!("grpc.examples.echo");
+    tonic::include_proto!("grpc.examples.unaryecho");
 }
 
 use pb::{echo_client::EchoClient, EchoRequest};

--- a/examples/src/dynamic_load_balance/server.rs
+++ b/examples/src/dynamic_load_balance/server.rs
@@ -1,17 +1,14 @@
 pub mod pb {
-    tonic::include_proto!("grpc.examples.echo");
+    tonic::include_proto!("grpc.examples.unaryecho");
 }
 
-use futures::Stream;
 use std::net::SocketAddr;
-use std::pin::Pin;
 use tokio::sync::mpsc;
-use tonic::{transport::Server, Request, Response, Status, Streaming};
+use tonic::{transport::Server, Request, Response, Status};
 
 use pb::{EchoRequest, EchoResponse};
 
 type EchoResult<T> = Result<Response<T>, Status>;
-type ResponseStream = Pin<Box<dyn Stream<Item = Result<EchoResponse, Status>> + Send>>;
 
 #[derive(Debug)]
 pub struct EchoServer {
@@ -24,31 +21,6 @@ impl pb::echo_server::Echo for EchoServer {
         let message = format!("{} (from {})", request.into_inner().message, self.addr);
 
         Ok(Response::new(EchoResponse { message }))
-    }
-
-    type ServerStreamingEchoStream = ResponseStream;
-
-    async fn server_streaming_echo(
-        &self,
-        _: Request<EchoRequest>,
-    ) -> EchoResult<Self::ServerStreamingEchoStream> {
-        Err(Status::unimplemented("not implemented"))
-    }
-
-    async fn client_streaming_echo(
-        &self,
-        _: Request<Streaming<EchoRequest>>,
-    ) -> EchoResult<EchoResponse> {
-        Err(Status::unimplemented("not implemented"))
-    }
-
-    type BidirectionalStreamingEchoStream = ResponseStream;
-
-    async fn bidirectional_streaming_echo(
-        &self,
-        _: Request<Streaming<EchoRequest>>,
-    ) -> EchoResult<Self::BidirectionalStreamingEchoStream> {
-        Err(Status::unimplemented("not implemented"))
     }
 }
 

--- a/examples/src/hyper_warp_multiplex/client.rs
+++ b/examples/src/hyper_warp_multiplex/client.rs
@@ -8,7 +8,7 @@ pub mod hello_world {
 }
 
 pub mod echo {
-    tonic::include_proto!("grpc.examples.echo");
+    tonic::include_proto!("grpc.examples.unaryecho");
 }
 
 use echo::{echo_client::EchoClient, EchoRequest};

--- a/examples/src/hyper_warp_multiplex/server.rs
+++ b/examples/src/hyper_warp_multiplex/server.rs
@@ -4,7 +4,6 @@
 //! `curl localhost:50051/hello`
 
 use futures::future::{self, Either, TryFutureExt};
-use futures::Stream;
 use http::version::Version;
 use hyper::{service::make_service_fn, Server};
 use std::convert::Infallible;
@@ -23,7 +22,7 @@ pub mod hello_world {
 }
 
 pub mod echo {
-    tonic::include_proto!("grpc.examples.echo");
+    tonic::include_proto!("grpc.examples.unaryecho");
 }
 use hello_world::{
     greeter_server::{Greeter, GreeterServer},
@@ -34,8 +33,6 @@ use echo::{
     echo_server::{Echo, EchoServer},
     EchoRequest, EchoResponse,
 };
-
-type ResponseStream = Pin<Box<dyn Stream<Item = Result<EchoResponse, Status>> + Send>>;
 
 #[derive(Default)]
 pub struct MyGreeter {}
@@ -64,31 +61,6 @@ impl Echo for MyEcho {
     ) -> Result<Response<EchoResponse>, Status> {
         let message = request.into_inner().message;
         Ok(Response::new(EchoResponse { message }))
-    }
-
-    type ServerStreamingEchoStream = ResponseStream;
-
-    async fn server_streaming_echo(
-        &self,
-        _: Request<EchoRequest>,
-    ) -> Result<Response<Self::ServerStreamingEchoStream>, Status> {
-        Err(Status::unimplemented("Not yet implemented"))
-    }
-
-    async fn client_streaming_echo(
-        &self,
-        _: Request<tonic::Streaming<EchoRequest>>,
-    ) -> Result<Response<EchoResponse>, Status> {
-        Err(Status::unimplemented("Not yet implemented"))
-    }
-
-    type BidirectionalStreamingEchoStream = ResponseStream;
-
-    async fn bidirectional_streaming_echo(
-        &self,
-        _: Request<tonic::Streaming<EchoRequest>>,
-    ) -> Result<Response<Self::BidirectionalStreamingEchoStream>, Status> {
-        Err(Status::unimplemented("Not yet implemented"))
     }
 }
 

--- a/examples/src/load_balance/client.rs
+++ b/examples/src/load_balance/client.rs
@@ -1,5 +1,5 @@
 pub mod pb {
-    tonic::include_proto!("grpc.examples.echo");
+    tonic::include_proto!("grpc.examples.unaryecho");
 }
 
 use pb::{echo_client::EchoClient, EchoRequest};

--- a/examples/src/load_balance/server.rs
+++ b/examples/src/load_balance/server.rs
@@ -1,17 +1,14 @@
 pub mod pb {
-    tonic::include_proto!("grpc.examples.echo");
+    tonic::include_proto!("grpc.examples.unaryecho");
 }
 
-use futures::Stream;
 use std::net::SocketAddr;
-use std::pin::Pin;
 use tokio::sync::mpsc;
-use tonic::{transport::Server, Request, Response, Status, Streaming};
+use tonic::{transport::Server, Request, Response, Status};
 
 use pb::{EchoRequest, EchoResponse};
 
 type EchoResult<T> = Result<Response<T>, Status>;
-type ResponseStream = Pin<Box<dyn Stream<Item = Result<EchoResponse, Status>> + Send>>;
 
 #[derive(Debug)]
 pub struct EchoServer {
@@ -24,31 +21,6 @@ impl pb::echo_server::Echo for EchoServer {
         let message = format!("{} (from {})", request.into_inner().message, self.addr);
 
         Ok(Response::new(EchoResponse { message }))
-    }
-
-    type ServerStreamingEchoStream = ResponseStream;
-
-    async fn server_streaming_echo(
-        &self,
-        _: Request<EchoRequest>,
-    ) -> EchoResult<Self::ServerStreamingEchoStream> {
-        Err(Status::unimplemented("not implemented"))
-    }
-
-    async fn client_streaming_echo(
-        &self,
-        _: Request<Streaming<EchoRequest>>,
-    ) -> EchoResult<EchoResponse> {
-        Err(Status::unimplemented("not implemented"))
-    }
-
-    type BidirectionalStreamingEchoStream = ResponseStream;
-
-    async fn bidirectional_streaming_echo(
-        &self,
-        _: Request<Streaming<EchoRequest>>,
-    ) -> EchoResult<Self::BidirectionalStreamingEchoStream> {
-        Err(Status::unimplemented("not implemented"))
     }
 }
 

--- a/examples/src/multiplex/client.rs
+++ b/examples/src/multiplex/client.rs
@@ -3,7 +3,7 @@ pub mod hello_world {
 }
 
 pub mod echo {
-    tonic::include_proto!("grpc.examples.echo");
+    tonic::include_proto!("grpc.examples.unaryecho");
 }
 
 use echo::{echo_client::EchoClient, EchoRequest};

--- a/examples/src/multiplex/server.rs
+++ b/examples/src/multiplex/server.rs
@@ -1,5 +1,3 @@
-use futures::Stream;
-use std::pin::Pin;
 use tonic::{transport::Server, Request, Response, Status};
 
 pub mod hello_world {
@@ -7,7 +5,7 @@ pub mod hello_world {
 }
 
 pub mod echo {
-    tonic::include_proto!("grpc.examples.echo");
+    tonic::include_proto!("grpc.examples.unaryecho");
 }
 
 use hello_world::{
@@ -19,8 +17,6 @@ use echo::{
     echo_server::{Echo, EchoServer},
     EchoRequest, EchoResponse,
 };
-
-type ResponseStream = Pin<Box<dyn Stream<Item = Result<EchoResponse, Status>> + Send>>;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -65,30 +61,5 @@ impl Echo for MyEcho {
     ) -> Result<Response<EchoResponse>, Status> {
         let message = request.into_inner().message;
         Ok(Response::new(EchoResponse { message }))
-    }
-
-    type ServerStreamingEchoStream = ResponseStream;
-
-    async fn server_streaming_echo(
-        &self,
-        _: Request<EchoRequest>,
-    ) -> Result<Response<Self::ServerStreamingEchoStream>, Status> {
-        Err(Status::unimplemented("Not yet implemented"))
-    }
-
-    async fn client_streaming_echo(
-        &self,
-        _: Request<tonic::Streaming<EchoRequest>>,
-    ) -> Result<Response<EchoResponse>, Status> {
-        Err(Status::unimplemented("Not yet implemented"))
-    }
-
-    type BidirectionalStreamingEchoStream = ResponseStream;
-
-    async fn bidirectional_streaming_echo(
-        &self,
-        _: Request<tonic::Streaming<EchoRequest>>,
-    ) -> Result<Response<Self::BidirectionalStreamingEchoStream>, Status> {
-        Err(Status::unimplemented("Not yet implemented"))
     }
 }

--- a/examples/src/tls/client.rs
+++ b/examples/src/tls/client.rs
@@ -1,5 +1,5 @@
 pub mod pb {
-    tonic::include_proto!("/grpc.examples.echo");
+    tonic::include_proto!("/grpc.examples.unaryecho");
 }
 
 use pb::{echo_client::EchoClient, EchoRequest};

--- a/examples/src/tls/client_rustls.rs
+++ b/examples/src/tls/client_rustls.rs
@@ -2,7 +2,7 @@
 //! provide a custom `ClientConfig` for the tls configuration.
 
 pub mod pb {
-    tonic::include_proto!("/grpc.examples.echo");
+    tonic::include_proto!("/grpc.examples.unaryecho");
 }
 
 use hyper::{client::HttpConnector, Uri};

--- a/examples/src/tls/server.rs
+++ b/examples/src/tls/server.rs
@@ -1,20 +1,17 @@
 pub mod pb {
-    tonic::include_proto!("/grpc.examples.echo");
+    tonic::include_proto!("/grpc.examples.unaryecho");
 }
 
-use futures::Stream;
 use pb::{EchoRequest, EchoResponse};
-use std::pin::Pin;
 use tonic::{
     transport::{
         server::{TcpConnectInfo, TlsConnectInfo},
         Identity, Server, ServerTlsConfig,
     },
-    Request, Response, Status, Streaming,
+    Request, Response, Status,
 };
 
 type EchoResult<T> = Result<Response<T>, Status>;
-type ResponseStream = Pin<Box<dyn Stream<Item = Result<EchoResponse, Status>> + Send>>;
 
 #[derive(Default)]
 pub struct EchoServer;
@@ -34,31 +31,6 @@ impl pb::echo_server::Echo for EchoServer {
 
         let message = request.into_inner().message;
         Ok(Response::new(EchoResponse { message }))
-    }
-
-    type ServerStreamingEchoStream = ResponseStream;
-
-    async fn server_streaming_echo(
-        &self,
-        _: Request<EchoRequest>,
-    ) -> EchoResult<Self::ServerStreamingEchoStream> {
-        Err(Status::unimplemented("not implemented"))
-    }
-
-    async fn client_streaming_echo(
-        &self,
-        _: Request<Streaming<EchoRequest>>,
-    ) -> EchoResult<EchoResponse> {
-        Err(Status::unimplemented("not implemented"))
-    }
-
-    type BidirectionalStreamingEchoStream = ResponseStream;
-
-    async fn bidirectional_streaming_echo(
-        &self,
-        _: Request<Streaming<EchoRequest>>,
-    ) -> EchoResult<Self::BidirectionalStreamingEchoStream> {
-        Err(Status::unimplemented("not implemented"))
     }
 }
 

--- a/examples/src/tls/server_rustls.rs
+++ b/examples/src/tls/server_rustls.rs
@@ -1,17 +1,16 @@
 pub mod pb {
-    tonic::include_proto!("/grpc.examples.echo");
+    tonic::include_proto!("/grpc.examples.unaryecho");
 }
 
-use futures::Stream;
 use hyper::server::conn::Http;
 use pb::{EchoRequest, EchoResponse};
-use std::{pin::Pin, sync::Arc};
+use std::sync::Arc;
 use tokio::net::TcpListener;
 use tokio_rustls::{
     rustls::{Certificate, PrivateKey, ServerConfig},
     TlsAcceptor,
 };
-use tonic::{transport::Server, Request, Response, Status, Streaming};
+use tonic::{transport::Server, Request, Response, Status};
 use tower_http::ServiceBuilderExt;
 
 #[tokio::main]
@@ -98,7 +97,6 @@ struct ConnInfo {
 }
 
 type EchoResult<T> = Result<Response<T>, Status>;
-type ResponseStream = Pin<Box<dyn Stream<Item = Result<EchoResponse, Status>> + Send>>;
 
 #[derive(Default)]
 pub struct EchoServer;
@@ -114,30 +112,5 @@ impl pb::echo_server::Echo for EchoServer {
 
         let message = request.into_inner().message;
         Ok(Response::new(EchoResponse { message }))
-    }
-
-    type ServerStreamingEchoStream = ResponseStream;
-
-    async fn server_streaming_echo(
-        &self,
-        _: Request<EchoRequest>,
-    ) -> EchoResult<Self::ServerStreamingEchoStream> {
-        Err(Status::unimplemented("not implemented"))
-    }
-
-    async fn client_streaming_echo(
-        &self,
-        _: Request<Streaming<EchoRequest>>,
-    ) -> EchoResult<EchoResponse> {
-        Err(Status::unimplemented("not implemented"))
-    }
-
-    type BidirectionalStreamingEchoStream = ResponseStream;
-
-    async fn bidirectional_streaming_echo(
-        &self,
-        _: Request<Streaming<EchoRequest>>,
-    ) -> EchoResult<Self::BidirectionalStreamingEchoStream> {
-        Err(Status::unimplemented("not implemented"))
     }
 }

--- a/examples/src/tls_client_auth/client.rs
+++ b/examples/src/tls_client_auth/client.rs
@@ -1,5 +1,5 @@
 pub mod pb {
-    tonic::include_proto!("grpc.examples.echo");
+    tonic::include_proto!("grpc.examples.unaryecho");
 }
 
 use pb::{echo_client::EchoClient, EchoRequest};

--- a/examples/src/tls_client_auth/server.rs
+++ b/examples/src/tls_client_auth/server.rs
@@ -1,15 +1,12 @@
 pub mod pb {
-    tonic::include_proto!("grpc.examples.echo");
+    tonic::include_proto!("grpc.examples.unaryecho");
 }
 
-use futures::Stream;
 use pb::{EchoRequest, EchoResponse};
-use std::pin::Pin;
 use tonic::transport::{Certificate, Identity, Server, ServerTlsConfig};
 use tonic::{Request, Response, Status};
 
 type EchoResult<T> = Result<Response<T>, Status>;
-type ResponseStream = Pin<Box<dyn Stream<Item = Result<EchoResponse, Status>> + Send>>;
 
 #[derive(Default)]
 pub struct EchoServer;
@@ -25,31 +22,6 @@ impl pb::echo_server::Echo for EchoServer {
 
         let message = request.into_inner().message;
         Ok(Response::new(EchoResponse { message }))
-    }
-
-    type ServerStreamingEchoStream = ResponseStream;
-
-    async fn server_streaming_echo(
-        &self,
-        _: Request<EchoRequest>,
-    ) -> Result<Response<Self::ServerStreamingEchoStream>, Status> {
-        Err(Status::unimplemented("Not yet implemented"))
-    }
-
-    async fn client_streaming_echo(
-        &self,
-        _: Request<tonic::Streaming<EchoRequest>>,
-    ) -> Result<Response<EchoResponse>, Status> {
-        Err(Status::unimplemented("Not yet implemented"))
-    }
-
-    type BidirectionalStreamingEchoStream = ResponseStream;
-
-    async fn bidirectional_streaming_echo(
-        &self,
-        _: Request<tonic::Streaming<EchoRequest>>,
-    ) -> Result<Response<Self::BidirectionalStreamingEchoStream>, Status> {
-        Err(Status::unimplemented("Not yet implemented"))
     }
 }
 


### PR DESCRIPTION
Removes dummy echo implementations from examples as we might not need to use full echo proto in some examples.

These changes may improve its readability.