### PR TITLE
feat(types): Add gRPC Richer Error Model support (DebugInfo)

### DIFF
--- a/tonic-types/src/lib.rs
+++ b/tonic-types/src/lib.rs
@@ -31,7 +31,7 @@ pub use pb::Status;
 mod richer_error;
 
 pub use richer_error::{
-    BadRequest, ErrorDetail, ErrorDetails, FieldViolation, RetryInfo, StatusExt,
+    BadRequest, DebugInfo, ErrorDetail, ErrorDetails, FieldViolation, RetryInfo, StatusExt,
 };
 
 mod sealed {

--- a/tonic-types/src/richer_error/error_details/vec.rs
+++ b/tonic-types/src/richer_error/error_details/vec.rs
@@ -1,4 +1,4 @@
-use super::super::std_messages::{BadRequest, RetryInfo};
+use super::super::std_messages::{BadRequest, DebugInfo, RetryInfo};
 
 /// Wraps the structs corresponding to the standard error messages, allowing
 /// the implementation and handling of vectors containing any of them.
@@ -8,6 +8,9 @@ pub enum ErrorDetail {
     /// Wraps the [`RetryInfo`] struct.
     RetryInfo(RetryInfo),
 
+    /// Wraps the [`DebugInfo`] struct.
+    DebugInfo(DebugInfo),
+
     /// Wraps the [`BadRequest`] struct.
     BadRequest(BadRequest),
 }
@@ -15,6 +18,12 @@ pub enum ErrorDetail {
 impl From<RetryInfo> for ErrorDetail {
     fn from(err_detail: RetryInfo) -> Self {
         ErrorDetail::RetryInfo(err_detail)
+    }
+}
+
+impl From<DebugInfo> for ErrorDetail {
+    fn from(err_detail: DebugInfo) -> Self {
+        ErrorDetail::DebugInfo(err_detail)
     }
 }
 

--- a/tonic-types/src/richer_error/std_messages/debug_info.rs
+++ b/tonic-types/src/richer_error/std_messages/debug_info.rs
@@ -1,0 +1,112 @@
+use prost::{DecodeError, Message};
+use prost_types::Any;
+
+use super::super::{pb, FromAny, IntoAny};
+
+/// Used to encode/decode the `DebugInfo` standard error message described in
+/// [error_details.proto]. Describes additional debugging info.
+///
+/// [error_details.proto]: https://github.com/googleapis/googleapis/blob/master/google/rpc/error_details.proto
+#[derive(Clone, Debug)]
+pub struct DebugInfo {
+    /// Stack trace entries indicating where the error occurred.
+    pub stack_entries: Vec<String>,
+
+    /// Additional debugging information provided by the server.
+    pub detail: String,
+}
+
+impl DebugInfo {
+    /// Type URL of the `DebugInfo` standard error message type.
+    pub const TYPE_URL: &'static str = "type.googleapis.com/google.rpc.DebugInfo";
+
+    /// Creates a new [`DebugInfo`] struct.
+    pub fn new(stack_entries: Vec<String>, detail: impl Into<String>) -> Self {
+        DebugInfo {
+            stack_entries,
+            detail: detail.into(),
+        }
+    }
+}
+
+impl DebugInfo {
+    /// Returns `true` if [`DebugInfo`] fields are empty, and `false` if they
+    /// are not.
+    pub fn is_empty(&self) -> bool {
+        self.stack_entries.is_empty() && self.detail.is_empty()
+    }
+}
+
+impl IntoAny for DebugInfo {
+    fn into_any(self) -> Any {
+        let detail_data = pb::DebugInfo {
+            stack_entries: self.stack_entries,
+            detail: self.detail,
+        };
+
+        Any {
+            type_url: DebugInfo::TYPE_URL.to_string(),
+            value: detail_data.encode_to_vec(),
+        }
+    }
+}
+
+impl FromAny for DebugInfo {
+    fn from_any(any: Any) -> Result<Self, DecodeError> {
+        let buf: &[u8] = &any.value;
+        let debug_info = pb::DebugInfo::decode(buf)?;
+
+        let debug_info = DebugInfo {
+            stack_entries: debug_info.stack_entries,
+            detail: debug_info.detail,
+        };
+
+        Ok(debug_info)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::super::{FromAny, IntoAny};
+    use super::DebugInfo;
+
+    #[test]
+    fn gen_debug_info() {
+        let debug_info = DebugInfo::new(
+            vec!["trace 3".into(), "trace 2".into(), "trace 1".into()],
+            "details about the error",
+        );
+
+        let formatted = format!("{:?}", debug_info);
+
+        let expected_filled = "DebugInfo { stack_entries: [\"trace 3\", \"trace 2\", \"trace 1\"], detail: \"details about the error\" }";
+
+        assert!(
+            formatted.eq(expected_filled),
+            "filled DebugInfo differs from expected result"
+        );
+
+        let gen_any = debug_info.into_any();
+        let formatted = format!("{:?}", gen_any);
+
+        let expected =
+            "Any { type_url: \"type.googleapis.com/google.rpc.DebugInfo\", value: [10, 7, 116, 114, 97, 99, 101, 32, 51, 10, 7, 116, 114, 97, 99, 101, 32, 50, 10, 7, 116, 114, 97, 99, 101, 32, 49, 18, 23, 100, 101, 116, 97, 105, 108, 115, 32, 97, 98, 111, 117, 116, 32, 116, 104, 101, 32, 101, 114, 114, 111, 114] }";
+
+        assert!(
+            formatted.eq(expected),
+            "Any from filled DebugInfo differs from expected result"
+        );
+
+        let br_details = match DebugInfo::from_any(gen_any) {
+            Err(error) => panic!("Error generating DebugInfo from Any: {:?}", error),
+            Ok(from_any) => from_any,
+        };
+
+        let formatted = format!("{:?}", br_details);
+
+        assert!(
+            formatted.eq(expected_filled),
+            "DebugInfo from Any differs from expected result"
+        );
+    }
+}

--- a/tonic-types/src/richer_error/std_messages/mod.rs
+++ b/tonic-types/src/richer_error/std_messages/mod.rs
@@ -2,6 +2,10 @@ mod retry_info;
 
 pub use retry_info::RetryInfo;
 
+mod debug_info;
+
+pub use debug_info::DebugInfo;
+
 mod bad_request;
 
 pub use bad_request::{BadRequest, FieldViolation};


### PR DESCRIPTION
## Motivation

The [gRPC Richer Error Model][error-handling] is quite useful to send additional feedback to clients, and is supported by many gRPC libraries in other languages.

## Solution

This PR continues the work initiated in [#1068], building on the changes made in [#1095]. It adds support for the `DebugInfo` standard error message type to `tonic-types`.

[error-handling]: https://www.grpc.io/docs/guides/error
[#1068]: https://github.com/hyperium/tonic/pull/1068
[#1095]: https://github.com/hyperium/tonic/pull/1095