### PR TITLE
tonic-build: use unified syntax to clone `Arc`s

### DIFF
--- a/tonic-build/src/server.rs
+++ b/tonic-build/src/server.rs
@@ -179,7 +179,7 @@ pub(crate) fn generate_internal<T: Service>(
 
             impl<T: #server_trait> Clone for _Inner<T> {
                 fn clone(&self) -> Self {
-                    Self(self.0.clone())
+                    Self(Arc::clone(&self.0))
                 }
             }
 
@@ -404,7 +404,7 @@ fn generate_unary<T: Method>(
             type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
 
             fn call(&mut self, request: tonic::Request<#request>) -> Self::Future {
-                let inner = self.0.clone();
+                let inner = Arc::clone(&self.0);
                 let fut = async move {
                     (*inner).#method_ident(request).await
                 };
@@ -456,7 +456,7 @@ fn generate_server_streaming<T: Method>(
             type Future = BoxFuture<tonic::Response<Self::ResponseStream>, tonic::Status>;
 
             fn call(&mut self, request: tonic::Request<#request>) -> Self::Future {
-                let inner = self.0.clone();
+                let inner = Arc::clone(&self.0);
                 let fut = async move {
                     (*inner).#method_ident(request).await
                 };
@@ -505,7 +505,7 @@ fn generate_client_streaming<T: Method>(
             type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
 
             fn call(&mut self, request: tonic::Request<tonic::Streaming<#request>>) -> Self::Future {
-                let inner = self.0.clone();
+                let inner = Arc::clone(&self.0);
                 let fut = async move {
                     (*inner).#method_ident(request).await
 
@@ -559,7 +559,7 @@ fn generate_streaming<T: Method>(
             type Future = BoxFuture<tonic::Response<Self::ResponseStream>, tonic::Status>;
 
             fn call(&mut self, request: tonic::Request<tonic::Streaming<#request>>) -> Self::Future {
-                let inner = self.0.clone();
+                let inner = Arc::clone(&self.0);
                 let fut = async move {
                     (*inner).#method_ident(request).await
                 };

--- a/tonic-health/src/generated/grpc.health.v1.rs
+++ b/tonic-health/src/generated/grpc.health.v1.rs
@@ -278,7 +278,7 @@ pub mod health_server {
                             &mut self,
                             request: tonic::Request<super::HealthCheckRequest>,
                         ) -> Self::Future {
-                            let inner = self.0.clone();
+                            let inner = Arc::clone(&self.0);
                             let fut = async move { (*inner).check(request).await };
                             Box::pin(fut)
                         }
@@ -317,7 +317,7 @@ pub mod health_server {
                             &mut self,
                             request: tonic::Request<super::HealthCheckRequest>,
                         ) -> Self::Future {
-                            let inner = self.0.clone();
+                            let inner = Arc::clone(&self.0);
                             let fut = async move { (*inner).watch(request).await };
                             Box::pin(fut)
                         }
@@ -366,7 +366,7 @@ pub mod health_server {
     }
     impl<T: Health> Clone for _Inner<T> {
         fn clone(&self) -> Self {
-            Self(self.0.clone())
+            Self(Arc::clone(&self.0))
         }
     }
     impl<T: std::fmt::Debug> std::fmt::Debug for _Inner<T> {

--- a/tonic-reflection/src/generated/grpc.reflection.v1alpha.rs
+++ b/tonic-reflection/src/generated/grpc.reflection.v1alpha.rs
@@ -337,7 +337,7 @@ pub mod server_reflection_server {
                                 tonic::Streaming<super::ServerReflectionRequest>,
                             >,
                         ) -> Self::Future {
-                            let inner = self.0.clone();
+                            let inner = Arc::clone(&self.0);
                             let fut = async move {
                                 (*inner).server_reflection_info(request).await
                             };
@@ -388,7 +388,7 @@ pub mod server_reflection_server {
     }
     impl<T: ServerReflection> Clone for _Inner<T> {
         fn clone(&self) -> Self {
-            Self(self.0.clone())
+            Self(Arc::clone(&self.0))
         }
     }
     impl<T: std::fmt::Debug> std::fmt::Debug for _Inner<T> {

--- a/tonic/benches-disabled/benchmarks/compiled_protos/helloworld.rs
+++ b/tonic/benches-disabled/benchmarks/compiled_protos/helloworld.rs
@@ -139,7 +139,7 @@ pub mod server {
                             &mut self,
                             request: tonic::Request<super::HelloRequest>,
                         ) -> Self::Future {
-                            let inner = self.0.clone();
+                            let inner = Arc::clone(&self.0);
                             let fut = async move { inner.say_hello(request).await };
                             Box::pin(fut)
                         }


### PR DESCRIPTION
This PR changes the generated code to use the unified function syntax for cloning `Arc` values (`Arc::clone(foo)` instead of `foo.clone()`).

## Motivation

In https://github.com/MaterializeInc/materialize, we use tonic, and we also enforce the clippy lint [`clone_on_ref_ptr`](https://rust-lang.github.io/rust-clippy/stable/index.html#clone_on_ref_ptr). This lint currently triggers on code generated by tonic, which forces us to disable it for modules that import tonic-generated code.

The main motivation for this PR is that we don't have to disable the lint anymore. Using unified function syntax when cloning `Arc`s also makes the code more obvious, which is nice.

## Solution

Adjust the generated code to conform with the style clippy proposes.
