### PR TITLE
chore: Use actions/checkout@v3 in ci

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -21,7 +21,7 @@ jobs:
     - uses: hecrj/setup-rust-action@master
       with:
         rust-version: ${{ matrix.rust }}
-    - uses: actions/checkout@master
+    - uses: actions/checkout@v3
     - name: Install rustfmt
       run: rustup component add rustfmt
     - name: Install cargo-hack
@@ -70,7 +70,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v1
+        uses: actions/checkout@v3
       - name: Install Rust
         uses: actions-rs/toolchain@v1
         with:
@@ -107,7 +107,7 @@ jobs:
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
     - uses: Swatinem/rust-cache@v1
-    - uses: actions/checkout@master
+    - uses: actions/checkout@v3
     - name: Run tests
       run: cargo test --all --all-features
 
@@ -128,7 +128,7 @@ jobs:
         rust-version: ${{ matrix.rust }}
     - name: Install rustfmt
       run: rustup component add rustfmt
-    - uses: actions/checkout@master
+    - uses: actions/checkout@v3
     - name: Install Protoc
       uses: arduino/setup-protoc@v1
       with:


### PR DESCRIPTION
Updates to actions/checkout version 3 and uses it instead of master branch version.