### PR TITLE
chore: Use setup-rust-action v1 to setup rust in ci

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -21,9 +21,8 @@ jobs:
     - uses: hecrj/setup-rust-action@v1
       with:
         rust-version: ${{ matrix.rust }}
+        components: rustfmt
     - uses: actions/checkout@v3
-    - name: Install rustfmt
-      run: rustup component add rustfmt
     - name: Install cargo-hack
       run: cargo install cargo-hack
     - name: Install Protoc
@@ -98,8 +97,7 @@ jobs:
     - uses: hecrj/setup-rust-action@v1
       with:
         rust-version: ${{ matrix.rust }}
-    - name: Install rustfmt
-      run: rustup component add rustfmt
+        components: rustfmt
     - name: Install Protoc
       uses: arduino/setup-protoc@v1
       with:
@@ -124,8 +122,7 @@ jobs:
     - uses: hecrj/setup-rust-action@v1
       with:
         rust-version: ${{ matrix.rust }}
-    - name: Install rustfmt
-      run: rustup component add rustfmt
+        components: rustfmt
     - uses: actions/checkout@v3
     - name: Install Protoc
       uses: arduino/setup-protoc@v1

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -18,7 +18,7 @@ jobs:
       RUSTFLAGS: "-D warnings"
 
     steps:
-    - uses: hecrj/setup-rust-action@master
+    - uses: hecrj/setup-rust-action@v1
       with:
         rust-version: ${{ matrix.rust }}
     - uses: actions/checkout@v3
@@ -47,12 +47,9 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
-    - name: Install Rust and clippy
-      uses: actions-rs/toolchain@v1
+    - uses: hecrj/setup-rust-action@v1
       with:
-        profile: minimal
-        toolchain: "1.60"
-        override: true
+        rust-version: "1.60"
         components: clippy
     - name: Install Protoc
       uses: arduino/setup-protoc@v1
@@ -75,12 +72,9 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-      - name: Install Rust
-        uses: actions-rs/toolchain@v1
+      - uses: hecrj/setup-rust-action@v1
         with:
-          profile: minimal
-          toolchain: "1.60"
-          override: true
+          rust-version: "1.60"
       - name: Install Protoc
         uses: arduino/setup-protoc@v1
         with:
@@ -101,7 +95,7 @@ jobs:
       QUICKCHECK_TESTS: 1000
 
     steps:
-    - uses: hecrj/setup-rust-action@master
+    - uses: hecrj/setup-rust-action@v1
       with:
         rust-version: ${{ matrix.rust }}
     - name: Install rustfmt
@@ -127,7 +121,7 @@ jobs:
       RUSTFLAGS: "-D warnings"
 
     steps:
-    - uses: hecrj/setup-rust-action@master
+    - uses: hecrj/setup-rust-action@v1
       with:
         rust-version: ${{ matrix.rust }}
     - name: Install rustfmt


### PR DESCRIPTION
- Uses hecrj/setup-rust-action which has been used before in tonic project as it's been updated more frequently than actions-rs/toolchain recently.
- Locks hecrj/setup-rust-action version to v1 to be safe against possible breaking changes.
- Uses hecrj/setup-rust-action's option to install components.