### PR TITLE
chore(examples): Remove unused pin-project from dependencies

### DIFF
--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -221,7 +221,6 @@ prost-types = "0.11"
 http = "0.2"
 http-body = "0.4.2"
 hyper = { version = "0.14", features = ["full"] }
-pin-project = "1.0"
 warp = "0.3"
 # Health example
 tonic-health = { path = "../tonic-health" }


### PR DESCRIPTION
pin-project seems not to be used in examples.