### PR TITLE
chore: Use baptiste0928/cargo-install@v1 to install cargo-hack

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -24,7 +24,9 @@ jobs:
         components: rustfmt
     - uses: actions/checkout@v3
     - name: Install cargo-hack
-      run: cargo install cargo-hack
+      uses: baptiste0928/cargo-install@v1
+      with:
+        crate: cargo-hack
     - name: Install Protoc
       uses: arduino/setup-protoc@v1
       with:


### PR DESCRIPTION
In every check ci jobs, it takes about 3 (in ubuntu-latest), 4 (in windows-latest), 5 (in macOS-latest) minutes to install cargo-hack. This pull request tries to speed up the jobs by introducing [baptiste0928/cargo-install](https://github.com/baptiste0928/cargo-install) action using cache.