### PR TITLE
Fixes: #1156 Prevent error when "Result" is used as name of service in proto 

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "rust-analyzer.cargo.buildScripts.enable": true
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-    "rust-analyzer.cargo.buildScripts.enable": true
-}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,4 +22,5 @@ members = [
   "tests/root-crate-path",
   "tests/compression",
   "tonic-web/tests/integration",
+  "tests/service_named_result",
 ]

--- a/tests/service_named_result/Cargo.toml
+++ b/tests/service_named_result/Cargo.toml
@@ -2,6 +2,7 @@
 name = "service_named_result"
 version = "0.1.0"
 edition = "2021"
+publish = false
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/tests/service_named_result/Cargo.toml
+++ b/tests/service_named_result/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "service_named_result"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+prost = "0.11"
+tonic = {path = "../../tonic"}
+
+[build-dependencies]
+tonic-build = {path = "../../tonic-build"}

--- a/tests/service_named_result/LICENSE
+++ b/tests/service_named_result/LICENSE
@@ -1,0 +1,19 @@
+Copyright (c) 2020 Lucio Franco
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/tests/service_named_result/build.rs
+++ b/tests/service_named_result/build.rs
@@ -1,0 +1,3 @@
+fn main() {
+    tonic_build::compile_protos("proto/result.proto").unwrap();
+}

--- a/tests/service_named_result/proto/result.proto
+++ b/tests/service_named_result/proto/result.proto
@@ -1,0 +1,13 @@
+syntax = "proto3";
+
+import "google/protobuf/empty.proto";
+
+package result;
+
+service Result {
+  rpc Listen(google.protobuf.Empty) returns (Reply) {}
+}
+
+message Reply {
+  int32 step = 1;
+}

--- a/tests/service_named_result/src/lib.rs
+++ b/tests/service_named_result/src/lib.rs
@@ -1,0 +1,3 @@
+pub mod pb {
+    tonic::include_proto!("result");
+}

--- a/tonic-build/src/client.rs
+++ b/tonic-build/src/client.rs
@@ -225,7 +225,7 @@ fn generate_unary<T: Method>(
         pub async fn #ident(
             &mut self,
             request: impl tonic::IntoRequest<#request>,
-        ) -> Result<tonic::Response<#response>, tonic::Status> {
+        ) -> std::result::Result<tonic::Response<#response>, tonic::Status> {
            self.inner.ready().await.map_err(|e| {
                tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
            })?;
@@ -251,7 +251,7 @@ fn generate_server_streaming<T: Method>(
         pub async fn #ident(
             &mut self,
             request: impl tonic::IntoRequest<#request>,
-        ) -> Result<tonic::Response<tonic::codec::Streaming<#response>>, tonic::Status> {
+        ) -> std::result::Result<tonic::Response<tonic::codec::Streaming<#response>>, tonic::Status> {
             self.inner.ready().await.map_err(|e| {
                         tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
             })?;
@@ -277,7 +277,7 @@ fn generate_client_streaming<T: Method>(
         pub async fn #ident(
             &mut self,
             request: impl tonic::IntoStreamingRequest<Message = #request>
-        ) -> Result<tonic::Response<#response>, tonic::Status> {
+        ) -> std::result::Result<tonic::Response<#response>, tonic::Status> {
             self.inner.ready().await.map_err(|e| {
                         tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
             })?;
@@ -303,7 +303,7 @@ fn generate_streaming<T: Method>(
         pub async fn #ident(
             &mut self,
             request: impl tonic::IntoStreamingRequest<Message = #request>
-        ) -> Result<tonic::Response<tonic::codec::Streaming<#response>>, tonic::Status> {
+        ) -> std::result::Result<tonic::Response<tonic::codec::Streaming<#response>>, tonic::Status> {
             self.inner.ready().await.map_err(|e| {
                         tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
             })?;

--- a/tonic-build/src/server.rs
+++ b/tonic-build/src/server.rs
@@ -144,7 +144,7 @@ pub(crate) fn generate_internal<T: Service>(
                 type Error = std::convert::Infallible;
                 type Future = BoxFuture<Self::Response, Self::Error>;
 
-                fn poll_ready(&mut self, _cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+                fn poll_ready(&mut self, _cx: &mut Context<'_>) -> Poll<std::result::Result<(), Self::Error>> {
                     Poll::Ready(Ok(()))
                 }
 

--- a/tonic-build/src/server.rs
+++ b/tonic-build/src/server.rs
@@ -251,14 +251,14 @@ fn generate_trait_methods<T: Service>(
                 quote! {
                     #method_doc
                     async fn #name(&self, request: tonic::Request<#req_message>)
-                        -> Result<tonic::Response<#res_message>, tonic::Status>;
+                        -> std::result::Result<tonic::Response<#res_message>, tonic::Status>;
                 }
             }
             (true, false) => {
                 quote! {
                     #method_doc
                     async fn #name(&self, request: tonic::Request<tonic::Streaming<#req_message>>)
-                        -> Result<tonic::Response<#res_message>, tonic::Status>;
+                        -> std::result::Result<tonic::Response<#res_message>, tonic::Status>;
                 }
             }
             (false, true) => {
@@ -270,11 +270,11 @@ fn generate_trait_methods<T: Service>(
 
                 quote! {
                     #stream_doc
-                    type #stream: futures_core::Stream<Item = Result<#res_message, tonic::Status>> + Send + 'static;
+                    type #stream: futures_core::Stream<Item = std::result::Result<#res_message, tonic::Status>> + Send + 'static;
 
                     #method_doc
                     async fn #name(&self, request: tonic::Request<#req_message>)
-                        -> Result<tonic::Response<Self::#stream>, tonic::Status>;
+                        -> std::result::Result<tonic::Response<Self::#stream>, tonic::Status>;
                 }
             }
             (true, true) => {
@@ -286,11 +286,11 @@ fn generate_trait_methods<T: Service>(
 
                 quote! {
                     #stream_doc
-                    type #stream: futures_core::Stream<Item = Result<#res_message, tonic::Status>> + Send + 'static;
+                    type #stream: futures_core::Stream<Item = std::result::Result<#res_message, tonic::Status>> + Send + 'static;
 
                     #method_doc
                     async fn #name(&self, request: tonic::Request<tonic::Streaming<#req_message>>)
-                        -> Result<tonic::Response<Self::#stream>, tonic::Status>;
+                        -> std::result::Result<tonic::Response<Self::#stream>, tonic::Status>;
                 }
             }
         };

--- a/tonic-health/src/generated/grpc.health.v1.rs
+++ b/tonic-health/src/generated/grpc.health.v1.rs
@@ -109,7 +109,10 @@ pub mod health_client {
         pub async fn check(
             &mut self,
             request: impl tonic::IntoRequest<super::HealthCheckRequest>,
-        ) -> Result<tonic::Response<super::HealthCheckResponse>, tonic::Status> {
+        ) -> std::result::Result<
+            tonic::Response<super::HealthCheckResponse>,
+            tonic::Status,
+        > {
             self.inner
                 .ready()
                 .await
@@ -143,7 +146,7 @@ pub mod health_client {
         pub async fn watch(
             &mut self,
             request: impl tonic::IntoRequest<super::HealthCheckRequest>,
-        ) -> Result<
+        ) -> std::result::Result<
             tonic::Response<tonic::codec::Streaming<super::HealthCheckResponse>>,
             tonic::Status,
         > {
@@ -176,10 +179,13 @@ pub mod health_server {
         async fn check(
             &self,
             request: tonic::Request<super::HealthCheckRequest>,
-        ) -> Result<tonic::Response<super::HealthCheckResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::HealthCheckResponse>,
+            tonic::Status,
+        >;
         /// Server streaming response type for the Watch method.
         type WatchStream: futures_core::Stream<
-                Item = Result<super::HealthCheckResponse, tonic::Status>,
+                Item = std::result::Result<super::HealthCheckResponse, tonic::Status>,
             >
             + Send
             + 'static;
@@ -201,7 +207,7 @@ pub mod health_server {
         async fn watch(
             &self,
             request: tonic::Request<super::HealthCheckRequest>,
-        ) -> Result<tonic::Response<Self::WatchStream>, tonic::Status>;
+        ) -> std::result::Result<tonic::Response<Self::WatchStream>, tonic::Status>;
     }
     #[derive(Debug)]
     pub struct HealthServer<T: Health> {

--- a/tonic-health/src/generated/grpc.health.v1.rs
+++ b/tonic-health/src/generated/grpc.health.v1.rs
@@ -262,7 +262,7 @@ pub mod health_server {
         fn poll_ready(
             &mut self,
             _cx: &mut Context<'_>,
-        ) -> Poll<Result<(), Self::Error>> {
+        ) -> Poll<std::result::Result<(), Self::Error>> {
             Poll::Ready(Ok(()))
         }
         fn call(&mut self, req: http::Request<B>) -> Self::Future {

--- a/tonic-reflection/src/generated/grpc.reflection.v1alpha.rs
+++ b/tonic-reflection/src/generated/grpc.reflection.v1alpha.rs
@@ -218,7 +218,7 @@ pub mod server_reflection_client {
             request: impl tonic::IntoStreamingRequest<
                 Message = super::ServerReflectionRequest,
             >,
-        ) -> Result<
+        ) -> std::result::Result<
             tonic::Response<tonic::codec::Streaming<super::ServerReflectionResponse>>,
             tonic::Status,
         > {
@@ -248,7 +248,10 @@ pub mod server_reflection_server {
     pub trait ServerReflection: Send + Sync + 'static {
         /// Server streaming response type for the ServerReflectionInfo method.
         type ServerReflectionInfoStream: futures_core::Stream<
-                Item = Result<super::ServerReflectionResponse, tonic::Status>,
+                Item = std::result::Result<
+                    super::ServerReflectionResponse,
+                    tonic::Status,
+                >,
             >
             + Send
             + 'static;
@@ -257,7 +260,10 @@ pub mod server_reflection_server {
         async fn server_reflection_info(
             &self,
             request: tonic::Request<tonic::Streaming<super::ServerReflectionRequest>>,
-        ) -> Result<tonic::Response<Self::ServerReflectionInfoStream>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<Self::ServerReflectionInfoStream>,
+            tonic::Status,
+        >;
     }
     #[derive(Debug)]
     pub struct ServerReflectionServer<T: ServerReflection> {

--- a/tonic-reflection/src/generated/grpc.reflection.v1alpha.rs
+++ b/tonic-reflection/src/generated/grpc.reflection.v1alpha.rs
@@ -318,7 +318,7 @@ pub mod server_reflection_server {
         fn poll_ready(
             &mut self,
             _cx: &mut Context<'_>,
-        ) -> Poll<Result<(), Self::Error>> {
+        ) -> Poll<std::result::Result<(), Self::Error>> {
             Poll::Ready(Ok(()))
         }
         fn call(&mut self, req: http::Request<B>) -> Self::Future {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/hyperium/tonic/blob/master/CONTRIBUTING.md
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? If a new feature is being added, describe the intended
use case that feature fulfills.
-->

Fixes a name conflict when the service itself is named as `Result`. The conflict occurs with the `std::result::Result` included in the prelude. Issue described in #1156.

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
To prevent the conflict, the generated code will now refer to the `Result` in a qualified manner viz, `std::result::Result`.


### Test Sample

**result.proto**

```protobuf
syntax = "proto3";

import "google/protobuf/any.proto";
import "google/protobuf/empty.proto";

option go_package = "github.com/stevenhansel/binus-logbook/scraper/internal/grpc/proto/result";

package result;

service Result {
  rpc Listen(google.protobuf.Empty) returns (Reply) {}
}

message Reply {
  int32 step = 1;
  string name = 2;
}
```

**server.rs**

```rust
use tonic::{transport::Server, Request, Response, Status};

pub mod pb {
    tonic::include_proto!("result");
}

use pb::{Reply, result_server};


#[derive(Debug, Default)]
pub struct ResultAPI {}

#[tonic::async_trait]
impl result_server::Result for ResultAPI {
    async fn listen(&self, _request: Request<()>) -> Result<Response<Reply>, Status> {
        return Ok(Response::new(Reply { step: 1, name: "23".to_string() }))
    }
}

#[tokio::main]
async fn main() -> Result<(), Box<dyn std::error::Error>> {
    let addr = "[::1]:50051".parse()?;
    let api = ResultAPI::default();

    Server::builder()
        .add_service(result_server::ResultServer::new(api))
        .serve(addr)
        .await?;

    Ok(())
}
```

**client.rs**

```rust
pub mod pb {
    tonic::include_proto!("result");
}

use pb::{result_client};

#[tokio::main]
async fn main() -> Result<(), Box<dyn std::error::Error>> {
    let mut client = result_client::ResultClient::connect("http://[::1]:50051").await?;

    let request = tonic::Request::new(());

    let response = client.listen(request).await?;

    println!("RESPONSE={:?}", response);

    Ok(())
}
```