### PR TITLE
feat(types): Add gRPC Richer Error Model support (QuotaFailure)

### DIFF
--- a/tonic-types/src/lib.rs
+++ b/tonic-types/src/lib.rs
@@ -31,7 +31,8 @@ pub use pb::Status;
 mod richer_error;
 
 pub use richer_error::{
-    BadRequest, DebugInfo, ErrorDetail, ErrorDetails, FieldViolation, RetryInfo, StatusExt,
+    BadRequest, DebugInfo, ErrorDetail, ErrorDetails, FieldViolation, QuotaFailure, QuotaViolation,
+    RetryInfo, StatusExt,
 };
 
 mod sealed {

--- a/tonic-types/src/richer_error/error_details/mod.rs
+++ b/tonic-types/src/richer_error/error_details/mod.rs
@@ -166,23 +166,23 @@ impl ErrorDetails {
     }
 
     /// Get [`RetryInfo`] details, if any
-    pub fn retry_info(&self) -> &Option<RetryInfo> {
-        &self.retry_info
+    pub fn retry_info(&self) -> Option<RetryInfo> {
+        self.retry_info.clone()
     }
 
     /// Get [`DebugInfo`] details, if any
-    pub fn debug_info(&self) -> &Option<DebugInfo> {
-        &self.debug_info
+    pub fn debug_info(&self) -> Option<DebugInfo> {
+        self.debug_info.clone()
     }
 
     /// Get [`QuotaFailure`] details, if any
-    pub fn quota_failure(&self) -> &Option<QuotaFailure> {
-        &self.quota_failure
+    pub fn quota_failure(&self) -> Option<QuotaFailure> {
+        self.quota_failure.clone()
     }
 
     /// Get [`BadRequest`] details, if any
-    pub fn bad_request(&self) -> &Option<BadRequest> {
-        &self.bad_request
+    pub fn bad_request(&self) -> Option<BadRequest> {
+        self.bad_request.clone()
     }
 
     /// Set [`RetryInfo`] details. Can be chained with other `.set_` and

--- a/tonic-types/src/richer_error/error_details/mod.rs
+++ b/tonic-types/src/richer_error/error_details/mod.rs
@@ -166,23 +166,23 @@ impl ErrorDetails {
     }
 
     /// Get [`RetryInfo`] details, if any
-    pub fn retry_info(&self) -> Option<RetryInfo> {
-        self.retry_info.clone()
+    pub fn retry_info(&self) -> &Option<RetryInfo> {
+        &self.retry_info
     }
 
     /// Get [`DebugInfo`] details, if any
-    pub fn debug_info(&self) -> Option<DebugInfo> {
-        self.debug_info.clone()
+    pub fn debug_info(&self) -> &Option<DebugInfo> {
+        &self.debug_info
     }
 
     /// Get [`QuotaFailure`] details, if any
-    pub fn quota_failure(&self) -> Option<QuotaFailure> {
-        self.quota_failure.clone()
+    pub fn quota_failure(&self) -> &Option<QuotaFailure> {
+        &self.quota_failure
     }
 
     /// Get [`BadRequest`] details, if any
-    pub fn bad_request(&self) -> Option<BadRequest> {
-        self.bad_request.clone()
+    pub fn bad_request(&self) -> &Option<BadRequest> {
+        &self.bad_request
     }
 
     /// Set [`RetryInfo`] details. Can be chained with other `.set_` and

--- a/tonic-types/src/richer_error/error_details/mod.rs
+++ b/tonic-types/src/richer_error/error_details/mod.rs
@@ -1,6 +1,8 @@
 use std::time;
 
-use super::std_messages::{BadRequest, DebugInfo, FieldViolation, RetryInfo};
+use super::std_messages::{
+    BadRequest, DebugInfo, FieldViolation, QuotaFailure, QuotaViolation, RetryInfo,
+};
 
 pub(crate) mod vec;
 
@@ -16,6 +18,9 @@ pub struct ErrorDetails {
 
     /// This field stores [`DebugInfo`] data, if any.
     pub(crate) debug_info: Option<DebugInfo>,
+
+    /// This field stores [`QuotaFailure`] data, if any.
+    pub(crate) quota_failure: Option<QuotaFailure>,
 
     /// This field stores [`BadRequest`] data, if any.
     pub(crate) bad_request: Option<BadRequest>,
@@ -35,6 +40,7 @@ impl ErrorDetails {
         ErrorDetails {
             retry_info: None,
             debug_info: None,
+            quota_failure: None,
             bad_request: None,
         }
     }
@@ -72,6 +78,46 @@ impl ErrorDetails {
     pub fn with_debug_info(stack_entries: Vec<String>, detail: impl Into<String>) -> Self {
         ErrorDetails {
             debug_info: Some(DebugInfo::new(stack_entries, detail)),
+            ..ErrorDetails::new()
+        }
+    }
+
+    /// Generates an [`ErrorDetails`] struct with [`QuotaFailure`] details and
+    /// remaining fields set to `None`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tonic_types::{ErrorDetails, QuotaViolation};
+    ///
+    /// let err_details = ErrorDetails::with_quota_failure(vec![
+    ///     QuotaViolation::new("subject 1", "description 1"),
+    ///     QuotaViolation::new("subject 2", "description 2"),
+    /// ]);
+    /// ```
+    pub fn with_quota_failure(violations: Vec<QuotaViolation>) -> Self {
+        ErrorDetails {
+            quota_failure: Some(QuotaFailure::new(violations)),
+            ..ErrorDetails::new()
+        }
+    }
+
+    /// Generates an [`ErrorDetails`] struct with [`QuotaFailure`] details (one
+    /// [`QuotaViolation`] set) and remaining fields set to `None`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tonic_types::{ErrorDetails};
+    ///
+    /// let err_details = ErrorDetails::with_quota_failure_violation("subject", "description");
+    /// ```
+    pub fn with_quota_failure_violation(
+        subject: impl Into<String>,
+        description: impl Into<String>,
+    ) -> Self {
+        ErrorDetails {
+            quota_failure: Some(QuotaFailure::with_violation(subject, description)),
             ..ErrorDetails::new()
         }
     }
@@ -129,6 +175,11 @@ impl ErrorDetails {
         self.debug_info.clone()
     }
 
+    /// Get [`QuotaFailure`] details, if any
+    pub fn quota_failure(&self) -> Option<QuotaFailure> {
+        self.quota_failure.clone()
+    }
+
     /// Get [`BadRequest`] details, if any
     pub fn bad_request(&self) -> Option<BadRequest> {
         self.bad_request.clone()
@@ -173,6 +224,78 @@ impl ErrorDetails {
     ) -> &mut Self {
         self.debug_info = Some(DebugInfo::new(stack_entries, detail));
         self
+    }
+
+    /// Set [`QuotaFailure`] details. Can be chained with other `.set_` and
+    /// `.add_` [`ErrorDetails`] methods.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tonic_types::{ErrorDetails, QuotaViolation};
+    ///
+    /// let mut err_details = ErrorDetails::new();
+    ///
+    /// err_details.set_quota_failure(vec![
+    ///     QuotaViolation::new("subject 1", "description 1"),
+    ///     QuotaViolation::new("subject 2", "description 2"),
+    /// ]);
+    /// ```
+    pub fn set_quota_failure(&mut self, violations: Vec<QuotaViolation>) -> &mut Self {
+        self.quota_failure = Some(QuotaFailure::new(violations));
+        self
+    }
+
+    /// Adds a [`QuotaViolation`] to [`QuotaFailure`] details. Sets
+    /// [`QuotaFailure`] details if it is not set yet. Can be chained with
+    /// other `.set_` and `.add_` [`ErrorDetails`] methods.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tonic_types::{ErrorDetails};
+    ///
+    /// let mut err_details = ErrorDetails::new();
+    ///
+    /// err_details.add_quota_failure_violation("subject", "description");
+    /// ```
+    pub fn add_quota_failure_violation(
+        &mut self,
+        subject: impl Into<String>,
+        description: impl Into<String>,
+    ) -> &mut Self {
+        match &mut self.quota_failure {
+            Some(quota_failure) => {
+                quota_failure.add_violation(subject, description);
+            }
+            None => {
+                self.quota_failure = Some(QuotaFailure::with_violation(subject, description));
+            }
+        };
+        self
+    }
+
+    /// Returns `true` if [`QuotaFailure`] is set and its `violations` vector
+    /// is not empty, otherwise returns `false`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tonic_types::{ErrorDetails};
+    ///
+    /// let mut err_details = ErrorDetails::with_quota_failure(vec![]);
+    ///
+    /// assert_eq!(err_details.has_quota_failure_violations(), false);
+    ///
+    /// err_details.add_quota_failure_violation("subject", "description");
+    ///
+    /// assert_eq!(err_details.has_quota_failure_violations(), true);
+    /// ```
+    pub fn has_quota_failure_violations(&self) -> bool {
+        if let Some(quota_failure) = &self.quota_failure {
+            return !quota_failure.violations.is_empty();
+        }
+        false
     }
 
     /// Set [`BadRequest`] details. Can be chained with other `.set_` and

--- a/tonic-types/src/richer_error/error_details/vec.rs
+++ b/tonic-types/src/richer_error/error_details/vec.rs
@@ -1,4 +1,4 @@
-use super::super::std_messages::{BadRequest, DebugInfo, RetryInfo};
+use super::super::std_messages::{BadRequest, DebugInfo, QuotaFailure, RetryInfo};
 
 /// Wraps the structs corresponding to the standard error messages, allowing
 /// the implementation and handling of vectors containing any of them.
@@ -10,6 +10,9 @@ pub enum ErrorDetail {
 
     /// Wraps the [`DebugInfo`] struct.
     DebugInfo(DebugInfo),
+
+    /// Wraps the [`QuotaFailure`] struct.
+    QuotaFailure(QuotaFailure),
 
     /// Wraps the [`BadRequest`] struct.
     BadRequest(BadRequest),
@@ -24,6 +27,12 @@ impl From<RetryInfo> for ErrorDetail {
 impl From<DebugInfo> for ErrorDetail {
     fn from(err_detail: DebugInfo) -> Self {
         ErrorDetail::DebugInfo(err_detail)
+    }
+}
+
+impl From<QuotaFailure> for ErrorDetail {
+    fn from(err_detail: QuotaFailure) -> Self {
+        ErrorDetail::QuotaFailure(err_detail)
     }
 }
 

--- a/tonic-types/src/richer_error/std_messages/mod.rs
+++ b/tonic-types/src/richer_error/std_messages/mod.rs
@@ -6,6 +6,10 @@ mod debug_info;
 
 pub use debug_info::DebugInfo;
 
+mod quota_failure;
+
+pub use quota_failure::{QuotaFailure, QuotaViolation};
+
 mod bad_request;
 
 pub use bad_request::{BadRequest, FieldViolation};

--- a/tonic-types/src/richer_error/std_messages/quota_failure.rs
+++ b/tonic-types/src/richer_error/std_messages/quota_failure.rs
@@ -152,7 +152,7 @@ mod tests {
         );
 
         assert!(
-            quota_failure.is_empty() == false,
+            !quota_failure.is_empty(),
             "filled QuotaFailure returns 'true' from .is_empty()"
         );
 

--- a/tonic-types/src/richer_error/std_messages/quota_failure.rs
+++ b/tonic-types/src/richer_error/std_messages/quota_failure.rs
@@ -1,0 +1,182 @@
+use prost::{DecodeError, Message};
+use prost_types::Any;
+
+use super::super::{pb, FromAny, IntoAny};
+
+/// Used at the `violations` field of the [`QuotaFailure`] struct. Describes a
+/// single quota violation.
+#[derive(Clone, Debug)]
+pub struct QuotaViolation {
+    /// Subject on which the quota check failed.
+    pub subject: String,
+
+    /// Description of why the quota check failed.
+    pub description: String,
+}
+
+impl QuotaViolation {
+    /// Creates a new [`QuotaViolation`] struct.
+    pub fn new(subject: impl Into<String>, description: impl Into<String>) -> Self {
+        QuotaViolation {
+            subject: subject.into(),
+            description: description.into(),
+        }
+    }
+}
+
+/// Used to encode/decode the `QuotaFailure` standard error message described
+/// in [error_details.proto]. Describes how a quota check failed.
+///
+/// [error_details.proto]: https://github.com/googleapis/googleapis/blob/master/google/rpc/error_details.proto
+#[derive(Clone, Debug)]
+pub struct QuotaFailure {
+    /// Describes all quota violations.
+    pub violations: Vec<QuotaViolation>,
+}
+
+impl QuotaFailure {
+    /// Type URL of the `QuotaFailure` standard error message type.
+    pub const TYPE_URL: &'static str = "type.googleapis.com/google.rpc.QuotaFailure";
+
+    /// Creates a new [`QuotaFailure`] struct.
+    pub fn new(violations: Vec<QuotaViolation>) -> Self {
+        QuotaFailure { violations }
+    }
+
+    /// Creates a new [`QuotaFailure`] struct with a single [`QuotaViolation`]
+    /// in `violations`.
+    pub fn with_violation(subject: impl Into<String>, description: impl Into<String>) -> Self {
+        QuotaFailure {
+            violations: vec![QuotaViolation {
+                subject: subject.into(),
+                description: description.into(),
+            }],
+        }
+    }
+}
+
+impl QuotaFailure {
+    /// Adds a [`QuotaViolation`] to [`QuotaFailure`]'s `violations`.
+    pub fn add_violation(
+        &mut self,
+        subject: impl Into<String>,
+        description: impl Into<String>,
+    ) -> &mut Self {
+        self.violations.append(&mut vec![QuotaViolation {
+            subject: subject.into(),
+            description: description.into(),
+        }]);
+        self
+    }
+
+    /// Returns `true` if [`QuotaFailure`]'s `violations` vector is empty, and
+    /// `false` if it is not.
+    pub fn is_empty(&self) -> bool {
+        self.violations.is_empty()
+    }
+}
+
+impl IntoAny for QuotaFailure {
+    fn into_any(self) -> Any {
+        let detail_data = pb::QuotaFailure {
+            violations: self
+                .violations
+                .into_iter()
+                .map(|v| pb::quota_failure::Violation {
+                    subject: v.subject,
+                    description: v.description,
+                })
+                .collect(),
+        };
+
+        Any {
+            type_url: QuotaFailure::TYPE_URL.to_string(),
+            value: detail_data.encode_to_vec(),
+        }
+    }
+}
+
+impl FromAny for QuotaFailure {
+    fn from_any(any: Any) -> Result<Self, DecodeError> {
+        let buf: &[u8] = &any.value;
+        let quota_failure = pb::QuotaFailure::decode(buf)?;
+
+        let quota_failure = QuotaFailure {
+            violations: quota_failure
+                .violations
+                .into_iter()
+                .map(|v| QuotaViolation {
+                    subject: v.subject,
+                    description: v.description,
+                })
+                .collect(),
+        };
+
+        Ok(quota_failure)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::super::{FromAny, IntoAny};
+    use super::QuotaFailure;
+
+    #[test]
+    fn gen_quota_failure() {
+        let mut quota_failure = QuotaFailure::new(Vec::new());
+        let formatted = format!("{:?}", quota_failure);
+
+        let expected = "QuotaFailure { violations: [] }";
+
+        assert!(
+            formatted.eq(expected),
+            "empty QuotaFailure differs from expected result"
+        );
+
+        assert!(
+            quota_failure.is_empty(),
+            "empty QuotaFailure returns 'false' from .is_empty()"
+        );
+
+        quota_failure
+            .add_violation("clientip:<ip address>", "description a")
+            .add_violation("project:<project id>", "description b");
+
+        let formatted = format!("{:?}", quota_failure);
+
+        let expected_filled = "QuotaFailure { violations: [QuotaViolation { subject: \"clientip:<ip address>\", description: \"description a\" }, QuotaViolation { subject: \"project:<project id>\", description: \"description b\" }] }";
+
+        assert!(
+            formatted.eq(expected_filled),
+            "filled QuotaFailure differs from expected result"
+        );
+
+        assert!(
+            quota_failure.is_empty() == false,
+            "filled QuotaFailure returns 'true' from .is_empty()"
+        );
+
+        let gen_any = quota_failure.into_any();
+
+        let formatted = format!("{:?}", gen_any);
+
+        let expected = "Any { type_url: \"type.googleapis.com/google.rpc.QuotaFailure\", value: [10, 38, 10, 21, 99, 108, 105, 101, 110, 116, 105, 112, 58, 60, 105, 112, 32, 97, 100, 100, 114, 101, 115, 115, 62, 18, 13, 100, 101, 115, 99, 114, 105, 112, 116, 105, 111, 110, 32, 97, 10, 37, 10, 20, 112, 114, 111, 106, 101, 99, 116, 58, 60, 112, 114, 111, 106, 101, 99, 116, 32, 105, 100, 62, 18, 13, 100, 101, 115, 99, 114, 105, 112, 116, 105, 111, 110, 32, 98] }";
+
+        assert!(
+            formatted.eq(expected),
+            "Any from filled QuotaFailure differs from expected result"
+        );
+
+        let br_details = match QuotaFailure::from_any(gen_any) {
+            Err(error) => panic!("Error generating QuotaFailure from Any: {:?}", error),
+            Ok(from_any) => from_any,
+        };
+
+        let formatted = format!("{:?}", br_details);
+
+        assert!(
+            formatted.eq(expected_filled),
+            "QuotaFailure from Any differs from expected result"
+        );
+    }
+}


### PR DESCRIPTION
## Motivation

The [gRPC Richer Error Model][error-handling] is quite useful to send additional feedback to clients, and is supported by many gRPC libraries in other languages.

## Solution

This PR continues the work initiated in [#1068], building on the changes made in [#1179]. It adds support for the `QuotaFailure` standard error message type to `tonic-types`.

[error-handling]: https://www.grpc.io/docs/guides/error
[#1068]: https://github.com/hyperium/tonic/pull/1068
[#1179]: https://github.com/hyperium/tonic/pull/1179