### PR TITLE
Set a connection timeout in DynamicServiceStream

### DIFF
--- a/tonic/src/transport/service/discover.rs
+++ b/tonic/src/transport/service/discover.rs
@@ -36,6 +36,7 @@ impl<K: Hash + Eq + Clone> Stream for DynamicServiceStream<K> {
                     let mut http = hyper::client::connect::HttpConnector::new();
                     http.set_nodelay(endpoint.tcp_nodelay);
                     http.set_keepalive(endpoint.tcp_keepalive);
+                    http.set_connect_timeout(endpoint.connect_timeout);
                     http.enforce_http(false);
                     #[cfg(feature = "tls")]
                     let connector = service::connector(http, endpoint.tls.clone());


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/hyperium/tonic/blob/master/CONTRIBUTING.md
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? If a new feature is being added, describe the intended
use case that feature fulfills.
-->

I'm using [ginepro](https://github.com/TrueLayer/ginepro) for client-side load balancing, and I'm seeing ~75s timeouts ([seemingly from the kernel](https://stackoverflow.com/questions/8471577/linux-tcp-connect-failure-with-etimedout)) when trying to connect to a host which doesn't respond. I'd like more control over this timeout duration.

I already set a `connection_timeout` in the `Endpoint`, which can be used here.

## Solution

Use the connection timeout value from the `endpoint` supplied.
