### PR TITLE
chore: Add test to check FILE_DESCRIPTOR_SET is valid

### DIFF
--- a/tonic-health/Cargo.toml
+++ b/tonic-health/Cargo.toml
@@ -28,3 +28,4 @@ tonic = { version = "0.8", path = "../tonic", default-features = false, features
 [dev-dependencies]
 tokio = {version = "1.0", features = ["rt-multi-thread", "macros"]}
 tonic-build = { version = "0.8", path = "../tonic-build", default-features = false, features = ["prost"] }
+prost-types = "0.11"

--- a/tonic-health/src/lib.rs
+++ b/tonic-health/src/lib.rs
@@ -31,6 +31,17 @@ pub mod proto {
 
     pub const GRPC_HEALTH_V1_FILE_DESCRIPTOR_SET: &[u8] =
         include_bytes!("generated/grpc_health_v1.bin");
+
+    #[cfg(test)]
+    mod tests {
+        use super::GRPC_HEALTH_V1_FILE_DESCRIPTOR_SET;
+        use prost::Message as _;
+
+        #[test]
+        fn file_descriptor_set_is_valid() {
+            prost_types::FileDescriptorSet::decode(GRPC_HEALTH_V1_FILE_DESCRIPTOR_SET).unwrap();
+        }
+    }
 }
 
 pub mod server;

--- a/tonic-reflection/src/lib.rs
+++ b/tonic-reflection/src/lib.rs
@@ -22,6 +22,17 @@ pub mod proto {
     include!("generated/grpc.reflection.v1alpha.rs");
 
     pub const FILE_DESCRIPTOR_SET: &[u8] = include_bytes!("generated/reflection_v1alpha1.bin");
+
+    #[cfg(test)]
+    mod tests {
+        use super::FILE_DESCRIPTOR_SET;
+        use prost::Message as _;
+
+        #[test]
+        fn file_descriptor_set_is_valid() {
+            prost_types::FileDescriptorSet::decode(FILE_DESCRIPTOR_SET).unwrap();
+        }
+    }
 }
 
 /// Implementation of the server component of gRPC Server Reflection.

--- a/tonic-types/src/lib.rs
+++ b/tonic-types/src/lib.rs
@@ -27,6 +27,17 @@ pub mod pb {
 
     /// Byte encoded FILE_DESCRIPTOR_SET.
     pub const FILE_DESCRIPTOR_SET: &[u8] = include_bytes!("generated/types.bin");
+
+    #[cfg(test)]
+    mod tests {
+        use super::FILE_DESCRIPTOR_SET;
+        use prost::Message as _;
+
+        #[test]
+        fn file_descriptor_set_is_valid() {
+            prost_types::FileDescriptorSet::decode(FILE_DESCRIPTOR_SET).unwrap();
+        }
+    }
 }
 
 pub use pb::Status;


### PR DESCRIPTION
## Motivation

Improves tests.

## Solution

Add tests to try decode the byte encoded file descriptor set.
