### PR TITLE
chore(examples): Remove unnecessary asyncronous file io to read data for example

### DIFF
--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -234,7 +234,7 @@ path = "src/json-codec/server.rs"
 required-features = ["json-codec"]
 
 [features]
-gcp = ["dep:prost-types", "tokio/fs", "tonic/tls"]
+gcp = ["dep:prost-types", "tonic/tls"]
 routeguide = ["dep:async-stream", "dep:futures", "tokio-stream", "dep:rand", "dep:serde", "dep:serde_json"]
 reflection = ["dep:tonic-reflection"]
 autoreload = ["tokio-stream/net", "dep:listenfd"]
@@ -243,17 +243,17 @@ grpc-web = ["dep:tonic-web", "dep:bytes", "dep:http", "hyper", "dep:tracing-subs
 tracing = ["dep:tracing", "dep:tracing-attributes", "dep:tracing-subscriber"]
 hyper-warp = ["dep:futures", "dep:tower", "hyper", "dep:http", "dep:http-body", "dep:warp"]
 hyper-warp-multiplex = ["hyper-warp"]
-uds = ["tokio-stream/net", "dep:tower", "hyper", "tokio/fs"]
+uds = ["tokio-stream/net", "dep:tower", "hyper"]
 streaming = ["dep:futures", "tokio-stream", "dep:h2"]
 mock = ["dep:futures", "dep:tower"]
 tower = ["dep:futures", "hyper", "dep:tower", "dep:http"]
 json-codec = ["dep:serde", "dep:serde_json", "dep:bytes"]
 compression = ["tonic/gzip"]
-tls = ["hyper", "tokio/fs", "tonic/tls", "dep:hyper-rustls", "dep:tower",
+tls = ["hyper", "tonic/tls", "dep:hyper-rustls", "dep:tower",
        "tower-http/add-extension", "dep:rustls-pemfile", "dep:tokio-rustls"]
 dynamic-load-balance = ["dep:tower"]
 timeout = ["tokio/time", "dep:tower"]
-tls-client-auth = ["tokio/fs", "tonic/tls"]
+tls-client-auth = ["tonic/tls"]
 
 full = ["gcp", "routeguide", "reflection", "autoreload", "health", "grpc-web", "tracing", "hyper-warp", "hyper-warp-multiplex",
         "uds", "streaming", "mock", "tower", "json-codec", "compression", "tls", "dynamic-load-balance", "timeout","tls-client-auth"]

--- a/examples/src/gcp/client.rs
+++ b/examples/src/gcp/client.rs
@@ -24,10 +24,10 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let bearer_token = format!("Bearer {}", token);
     let header_value: MetadataValue<_> = bearer_token.parse()?;
 
-    let certs = tokio::fs::read("examples/data/gcp/roots.pem").await?;
+    let certs = std::fs::read_to_string("examples/data/gcp/roots.pem")?;
 
     let tls_config = ClientTlsConfig::new()
-        .ca_certificate(Certificate::from_pem(certs.as_slice()))
+        .ca_certificate(Certificate::from_pem(certs))
         .domain_name("pubsub.googleapis.com");
 
     let channel = Channel::from_static(ENDPOINT)

--- a/examples/src/tls/client.rs
+++ b/examples/src/tls/client.rs
@@ -7,7 +7,7 @@ use tonic::transport::{Certificate, Channel, ClientTlsConfig};
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let pem = tokio::fs::read("examples/data/tls/ca.pem").await?;
+    let pem = std::fs::read_to_string("examples/data/tls/ca.pem")?;
     let ca = Certificate::from_pem(pem);
 
     let tls = ClientTlsConfig::new()

--- a/examples/src/tls/server.rs
+++ b/examples/src/tls/server.rs
@@ -36,8 +36,8 @@ impl pb::echo_server::Echo for EchoServer {
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let cert = tokio::fs::read("examples/data/tls/server.pem").await?;
-    let key = tokio::fs::read("examples/data/tls/server.key").await?;
+    let cert = std::fs::read_to_string("examples/data/tls/server.pem")?;
+    let key = std::fs::read_to_string("examples/data/tls/server.key")?;
 
     let identity = Identity::from_pem(cert, key);
 

--- a/examples/src/tls_client_auth/client.rs
+++ b/examples/src/tls_client_auth/client.rs
@@ -7,10 +7,10 @@ use tonic::transport::{Certificate, Channel, ClientTlsConfig, Identity};
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let server_root_ca_cert = tokio::fs::read("examples/data/tls/ca.pem").await?;
+    let server_root_ca_cert = std::fs::read_to_string("examples/data/tls/ca.pem")?;
     let server_root_ca_cert = Certificate::from_pem(server_root_ca_cert);
-    let client_cert = tokio::fs::read("examples/data/tls/client1.pem").await?;
-    let client_key = tokio::fs::read("examples/data/tls/client1.key").await?;
+    let client_cert = std::fs::read_to_string("examples/data/tls/client1.pem")?;
+    let client_key = std::fs::read_to_string("examples/data/tls/client1.key")?;
     let client_identity = Identity::from_pem(client_cert, client_key);
 
     let tls = ClientTlsConfig::new()

--- a/examples/src/tls_client_auth/server.rs
+++ b/examples/src/tls_client_auth/server.rs
@@ -27,11 +27,11 @@ impl pb::echo_server::Echo for EchoServer {
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let cert = tokio::fs::read("examples/data/tls/server.pem").await?;
-    let key = tokio::fs::read("examples/data/tls/server.key").await?;
+    let cert = std::fs::read_to_string("examples/data/tls/server.pem")?;
+    let key = std::fs::read_to_string("examples/data/tls/server.key")?;
     let server_identity = Identity::from_pem(cert, key);
 
-    let client_ca_cert = tokio::fs::read("examples/data/tls/client_ca.pem").await?;
+    let client_ca_cert = std::fs::read_to_string("examples/data/tls/client_ca.pem")?;
     let client_ca_cert = Certificate::from_pem(client_ca_cert);
 
     let addr = "[::1]:50051".parse().unwrap();

--- a/examples/src/uds/server.rs
+++ b/examples/src/uds/server.rs
@@ -45,7 +45,7 @@ impl Greeter for MyGreeter {
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let path = "/tmp/tonic/helloworld";
 
-    tokio::fs::create_dir_all(Path::new(path).parent().unwrap()).await?;
+    std::fs::create_dir_all(Path::new(path).parent().unwrap())?;
 
     let greeter = MyGreeter::default();
 


### PR DESCRIPTION
## Motivation

Simplifies examples.

## Solution

Uses the standard library to read data for examples instead of tokio's file api. In our examples we don't need to read the data asynchronously.