### PR TITLE
chore(examples): Remove relative path from reading data

### DIFF
--- a/examples/src/gcp/client.rs
+++ b/examples/src/gcp/client.rs
@@ -24,7 +24,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let bearer_token = format!("Bearer {}", token);
     let header_value: MetadataValue<_> = bearer_token.parse()?;
 
-    let certs = std::fs::read_to_string("examples/data/gcp/roots.pem")?;
+    let data_dir = std::path::PathBuf::from_iter([std::env!("CARGO_MANIFEST_DIR"), "data"]);
+    let certs = std::fs::read_to_string(data_dir.join("gcp/roots.pem"))?;
 
     let tls_config = ClientTlsConfig::new()
         .ca_certificate(Certificate::from_pem(certs))

--- a/examples/src/routeguide/data.rs
+++ b/examples/src/routeguide/data.rs
@@ -15,7 +15,8 @@ struct Location {
 
 #[allow(dead_code)]
 pub fn load() -> Vec<crate::routeguide::Feature> {
-    let file = File::open("examples/data/route_guide_db.json").expect("failed to open data file");
+    let data_dir = std::path::PathBuf::from_iter([std::env!("CARGO_MANIFEST_DIR"), "data"]);
+    let file = File::open(data_dir.join("route_guide_db.json")).expect("failed to open data file");
 
     let decoded: Vec<Feature> =
         serde_json::from_reader(&file).expect("failed to deserialize features");

--- a/examples/src/tls/client.rs
+++ b/examples/src/tls/client.rs
@@ -7,7 +7,8 @@ use tonic::transport::{Certificate, Channel, ClientTlsConfig};
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let pem = std::fs::read_to_string("examples/data/tls/ca.pem")?;
+    let data_dir = std::path::PathBuf::from_iter([std::env!("CARGO_MANIFEST_DIR"), "data"]);
+    let pem = std::fs::read_to_string(data_dir.join("tls/ca.pem"))?;
     let ca = Certificate::from_pem(pem);
 
     let tls = ClientTlsConfig::new()

--- a/examples/src/tls/client_rustls.rs
+++ b/examples/src/tls/client_rustls.rs
@@ -5,13 +5,16 @@ pub mod pb {
     tonic::include_proto!("/grpc.examples.unaryecho");
 }
 
+use std::iter::FromIterator;
+
 use hyper::{client::HttpConnector, Uri};
 use pb::{echo_client::EchoClient, EchoRequest};
 use tokio_rustls::rustls::{ClientConfig, RootCertStore};
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let fd = std::fs::File::open("examples/data/tls/ca.pem")?;
+    let data_dir = std::path::PathBuf::from_iter([std::env!("CARGO_MANIFEST_DIR"), "data"]);
+    let fd = std::fs::File::open(data_dir.join("tls/ca.pem"))?;
 
     let mut roots = RootCertStore::empty();
 

--- a/examples/src/tls/server.rs
+++ b/examples/src/tls/server.rs
@@ -36,8 +36,9 @@ impl pb::echo_server::Echo for EchoServer {
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let cert = std::fs::read_to_string("examples/data/tls/server.pem")?;
-    let key = std::fs::read_to_string("examples/data/tls/server.key")?;
+    let data_dir = std::path::PathBuf::from_iter([std::env!("CARGO_MANIFEST_DIR"), "data"]);
+    let cert = std::fs::read_to_string(data_dir.join("tls/server.pem"))?;
+    let key = std::fs::read_to_string(data_dir.join("tls/server.key"))?;
 
     let identity = Identity::from_pem(cert, key);
 

--- a/examples/src/tls/server_rustls.rs
+++ b/examples/src/tls/server_rustls.rs
@@ -15,8 +15,9 @@ use tower_http::ServiceBuilderExt;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let data_dir = std::path::PathBuf::from_iter([std::env!("CARGO_MANIFEST_DIR"), "data"]);
     let certs = {
-        let fd = std::fs::File::open("examples/data/tls/server.pem")?;
+        let fd = std::fs::File::open(data_dir.join("tls/server.pem"))?;
         let mut buf = std::io::BufReader::new(&fd);
         rustls_pemfile::certs(&mut buf)?
             .into_iter()
@@ -24,7 +25,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             .collect()
     };
     let key = {
-        let fd = std::fs::File::open("examples/data/tls/server.key")?;
+        let fd = std::fs::File::open(data_dir.join("tls/server.key"))?;
         let mut buf = std::io::BufReader::new(&fd);
         rustls_pemfile::pkcs8_private_keys(&mut buf)?
             .into_iter()
@@ -32,7 +33,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             .next()
             .unwrap()
 
-        // let key = std::fs::read("examples/data/tls/server.key")?;
+        // let key = std::fs::read(data_dir.join("tls/server.key"))?;
         // PrivateKey(key)
     };
 

--- a/examples/src/tls_client_auth/client.rs
+++ b/examples/src/tls_client_auth/client.rs
@@ -7,10 +7,11 @@ use tonic::transport::{Certificate, Channel, ClientTlsConfig, Identity};
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let server_root_ca_cert = std::fs::read_to_string("examples/data/tls/ca.pem")?;
+    let data_dir = std::path::PathBuf::from_iter([std::env!("CARGO_MANIFEST_DIR"), "data"]);
+    let server_root_ca_cert = std::fs::read_to_string(data_dir.join("tls/ca.pem"))?;
     let server_root_ca_cert = Certificate::from_pem(server_root_ca_cert);
-    let client_cert = std::fs::read_to_string("examples/data/tls/client1.pem")?;
-    let client_key = std::fs::read_to_string("examples/data/tls/client1.key")?;
+    let client_cert = std::fs::read_to_string(data_dir.join("tls/client1.pem"))?;
+    let client_key = std::fs::read_to_string(data_dir.join("tls/client1.key"))?;
     let client_identity = Identity::from_pem(client_cert, client_key);
 
     let tls = ClientTlsConfig::new()

--- a/examples/src/tls_client_auth/server.rs
+++ b/examples/src/tls_client_auth/server.rs
@@ -27,11 +27,12 @@ impl pb::echo_server::Echo for EchoServer {
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let cert = std::fs::read_to_string("examples/data/tls/server.pem")?;
-    let key = std::fs::read_to_string("examples/data/tls/server.key")?;
+    let data_dir = std::path::PathBuf::from_iter([std::env!("CARGO_MANIFEST_DIR"), "data"]);
+    let cert = std::fs::read_to_string(data_dir.join("tls/server.pem"))?;
+    let key = std::fs::read_to_string(data_dir.join("tls/server.key"))?;
     let server_identity = Identity::from_pem(cert, key);
 
-    let client_ca_cert = std::fs::read_to_string("examples/data/tls/client_ca.pem")?;
+    let client_ca_cert = std::fs::read_to_string(data_dir.join("tls/client_ca.pem"))?;
     let client_ca_cert = Certificate::from_pem(client_ca_cert);
 
     let addr = "[::1]:50051".parse().unwrap();


### PR DESCRIPTION
## Motivation

Allows to run examples in the examples directory as well as the workspace root.

## Solution

Uses an absolute path instead of a relative path when reading data for examples.