### PR TITLE
chore(tonic): Remove outdated allow lint

### DIFF
--- a/tonic/src/transport/error.rs
+++ b/tonic/src/transport/error.rs
@@ -1,8 +1,3 @@
-// TODO: remove this when we use errors throughout,
-// there are some that are only used under the TLS feature
-// these probably should be scoped to a `TLSError` enum.
-#![allow(dead_code)]
-
 use std::{error::Error as StdError, fmt};
 
 type Source = Box<dyn StdError + Send + Sync + 'static>;


### PR DESCRIPTION
This lint annotation seems not to be needed now.