### PR TITLE
chore(tonic): Remove outdated allow dead code lint annotation

### DIFF
--- a/tonic/src/transport/service/tls.rs
+++ b/tonic/src/transport/service/tls.rs
@@ -17,7 +17,6 @@ const ALPN_H2: &str = "h2";
 
 #[derive(Debug)]
 enum TlsError {
-    #[allow(dead_code)]
     H2NotNegotiated,
     CertificateParseError,
     PrivateKeyParseError,


### PR DESCRIPTION
We could remove this lint annotation.