### PR TITLE
chore(web): Update to base64 0.21

### DIFF
--- a/tonic-web/tests/integration/Cargo.toml
+++ b/tonic-web/tests/integration/Cargo.toml
@@ -7,7 +7,7 @@ version = "0.1.0"
 license = "MIT"
 
 [dependencies]
-base64 = "0.13"
+base64 = "0.21"
 bytes = "1.0"
 hyper = "0.14"
 prost = "0.11"

--- a/tonic-web/tests/integration/src/lib.rs
+++ b/tonic-web/tests/integration/src/lib.rs
@@ -67,3 +67,22 @@ impl Test for Svc {
         ))
     }
 }
+
+pub mod util {
+    pub mod base64 {
+        use base64::{
+            alphabet,
+            engine::{
+                general_purpose::{GeneralPurpose, GeneralPurposeConfig},
+                DecodePaddingMode,
+            },
+        };
+
+        pub const STANDARD: GeneralPurpose = GeneralPurpose::new(
+            &alphabet::STANDARD,
+            GeneralPurposeConfig::new()
+                .with_encode_padding(true)
+                .with_decode_padding_mode(DecodePaddingMode::Indifferent),
+        );
+    }
+}


### PR DESCRIPTION
I overlooked the integration test of tonic-web in #1228.