### PR TITLE
chore(interop): Lock clap version to 4.0

### DIFF
--- a/interop/Cargo.toml
+++ b/interop/Cargo.toml
@@ -16,7 +16,7 @@ path = "src/bin/server.rs"
 
 [dependencies]
 async-stream = "0.3"
-clap = {version = "4.0.26", features = ["derive"]}
+clap = {version = ">=4.0.26, <4.1", features = ["derive"]}
 console = "0.15"
 futures-core = "0.3"
 futures-util = "0.3"

--- a/interop/Cargo.toml
+++ b/interop/Cargo.toml
@@ -17,6 +17,7 @@ path = "src/bin/server.rs"
 [dependencies]
 async-stream = "0.3"
 clap = {version = ">=4.0.26, <4.1", features = ["derive"]}
+clap_lex = "=0.3.0"             # keeps msrv to 1.60
 console = "0.15"
 futures-core = "0.3"
 futures-util = "0.3"


### PR DESCRIPTION
In order to fix msrv 1.60 test, locks clap version to 4.0 as clap 4.1 increased its msrv to 1.64.