### PR TITLE
chore(interop): Use pico-args instead of clap

### DIFF
--- a/interop/Cargo.toml
+++ b/interop/Cargo.toml
@@ -16,8 +16,8 @@ path = "src/bin/server.rs"
 
 [dependencies]
 async-stream = "0.3"
-clap = {version = ">=4.0.26, <4.1", features = ["derive"]}
-clap_lex = "=0.3.0"             # keeps msrv to 1.60
+strum = { version = "0.24", features = ["derive"] }
+pico-args = { version = "0.5", features = ["eq-separator"] }
 console = "0.15"
 futures-core = "0.3"
 futures-util = "0.3"

--- a/interop/Cargo.toml
+++ b/interop/Cargo.toml
@@ -16,8 +16,8 @@ path = "src/bin/server.rs"
 
 [dependencies]
 async-stream = "0.3"
-strum = { version = "0.24", features = ["derive"] }
-pico-args = { version = "0.5", features = ["eq-separator"] }
+strum = {version = "0.24", features = ["derive"]}
+pico-args = {version = "0.5", features = ["eq-separator"]}
 console = "0.15"
 futures-core = "0.3"
 futures-util = "0.3"

--- a/interop/src/bin/client.rs
+++ b/interop/src/bin/client.rs
@@ -14,7 +14,7 @@ impl Opts {
     fn parse() -> Result<Opts, pico_args::Error> {
         let mut pargs = pico_args::Arguments::from_env();
         Ok(Self {
-            use_tls: pargs.value_from_str("--use_tls").unwrap_or(false),
+            use_tls: pargs.contains("--use_tls"),
             test_case: pargs.value_from_fn("--test_case", |test_case| {
                 test_case.split(',').map(Testcase::from_str).collect()
             })?,

--- a/interop/src/bin/client.rs
+++ b/interop/src/bin/client.rs
@@ -14,7 +14,7 @@ impl Opts {
     fn parse() -> Result<Opts, pico_args::Error> {
         let mut pargs = pico_args::Arguments::from_env();
         Ok(Self {
-            use_tls: pargs.value_from_str("--use_tls").unwrap_or(true),
+            use_tls: pargs.value_from_str("--use_tls").unwrap_or(false),
             test_case: pargs.value_from_fn("--test_case", |test_case| {
                 test_case.split(',').map(Testcase::from_str).collect()
             })?,

--- a/interop/src/bin/client.rs
+++ b/interop/src/bin/client.rs
@@ -1,6 +1,5 @@
 use interop::client;
-use std::str::FromStr;
-use std::time::Duration;
+use std::{str::FromStr, time::Duration};
 use tonic::transport::Endpoint;
 use tonic::transport::{Certificate, ClientTlsConfig};
 
@@ -11,7 +10,7 @@ struct Opts {
 }
 
 impl Opts {
-    fn parse() -> Result<Opts, pico_args::Error> {
+    fn parse() -> Result<Self, pico_args::Error> {
         let mut pargs = pico_args::Arguments::from_env();
         Ok(Self {
             use_tls: pargs.contains("--use_tls"),

--- a/interop/src/bin/client.rs
+++ b/interop/src/bin/client.rs
@@ -1,29 +1,32 @@
-use clap::{ArgAction, Parser};
 use interop::client;
+use std::str::FromStr;
 use std::time::Duration;
 use tonic::transport::Endpoint;
 use tonic::transport::{Certificate, ClientTlsConfig};
 
-#[derive(Parser)]
+#[derive(Debug)]
 struct Opts {
-    #[clap(name = "use_tls", long, action = ArgAction::SetTrue)]
     use_tls: bool,
-
-    #[arg(
-        long = "test_case",
-        use_value_delimiter = true,
-        num_args(1..),
-        value_enum,
-        action = ArgAction::Append
-    )]
     test_case: Vec<Testcase>,
+}
+
+impl Opts {
+    fn parse() -> Result<Opts, pico_args::Error> {
+        let mut pargs = pico_args::Arguments::from_env();
+        Ok(Self {
+            use_tls: pargs.value_from_str("--use_tls")?,
+            test_case: pargs.value_from_fn("--test_case", |test_case| {
+                test_case.split(',').map(Testcase::from_str).collect()
+            })?,
+        })
+    }
 }
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     interop::trace_init();
 
-    let matches = Opts::parse();
+    let matches = Opts::parse()?;
 
     let test_cases = matches.test_case;
 
@@ -99,8 +102,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     Ok(())
 }
 
-#[derive(Debug, Copy, Clone, clap::ValueEnum)]
-#[clap(rename_all = "snake_case")]
+#[derive(Debug, strum::EnumString)]
+#[strum(serialize_all = "snake_case")]
 enum Testcase {
     EmptyUnary,
     CacheableUnary,

--- a/interop/src/bin/client.rs
+++ b/interop/src/bin/client.rs
@@ -14,7 +14,7 @@ impl Opts {
     fn parse() -> Result<Opts, pico_args::Error> {
         let mut pargs = pico_args::Arguments::from_env();
         Ok(Self {
-            use_tls: pargs.value_from_str("--use_tls")?,
+            use_tls: pargs.value_from_str("--use_tls").unwrap_or(true),
             test_case: pargs.value_from_fn("--test_case", |test_case| {
                 test_case.split(',').map(Testcase::from_str).collect()
             })?,

--- a/interop/src/bin/server.rs
+++ b/interop/src/bin/server.rs
@@ -11,7 +11,7 @@ impl Opts {
     fn parse() -> Result<Opts, pico_args::Error> {
         let mut pargs = pico_args::Arguments::from_env();
         Ok(Self {
-            use_tls: pargs.value_from_str("--use_tls")?,
+            use_tls: pargs.value_from_str("--use_tls").unwrap_or(true),
         })
     }
 }

--- a/interop/src/bin/server.rs
+++ b/interop/src/bin/server.rs
@@ -11,7 +11,7 @@ impl Opts {
     fn parse() -> Result<Opts, pico_args::Error> {
         let mut pargs = pico_args::Arguments::from_env();
         Ok(Self {
-            use_tls: pargs.value_from_str("--use_tls").unwrap_or(true),
+            use_tls: pargs.value_from_str("--use_tls").unwrap_or(false),
         })
     }
 }

--- a/interop/src/bin/server.rs
+++ b/interop/src/bin/server.rs
@@ -8,7 +8,7 @@ struct Opts {
 }
 
 impl Opts {
-    fn parse() -> Result<Opts, pico_args::Error> {
+    fn parse() -> Result<Self, pico_args::Error> {
         let mut pargs = pico_args::Arguments::from_env();
         Ok(Self {
             use_tls: pargs.contains("--use_tls"),

--- a/interop/src/bin/server.rs
+++ b/interop/src/bin/server.rs
@@ -1,19 +1,26 @@
-use clap::{ArgAction, Parser};
 use interop::server;
 use tonic::transport::Server;
 use tonic::transport::{Identity, ServerTlsConfig};
 
-#[derive(Parser)]
+#[derive(Debug)]
 struct Opts {
-    #[clap(name = "use_tls", long, action = ArgAction::SetTrue)]
     use_tls: bool,
+}
+
+impl Opts {
+    fn parse() -> Result<Opts, pico_args::Error> {
+        let mut pargs = pico_args::Arguments::from_env();
+        Ok(Self {
+            use_tls: pargs.value_from_str("--use_tls")?,
+        })
+    }
 }
 
 #[tokio::main]
 async fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
     interop::trace_init();
 
-    let matches = Opts::parse();
+    let matches = Opts::parse()?;
 
     let addr = "127.0.0.1:10000".parse().unwrap();
 

--- a/interop/src/bin/server.rs
+++ b/interop/src/bin/server.rs
@@ -11,7 +11,7 @@ impl Opts {
     fn parse() -> Result<Opts, pico_args::Error> {
         let mut pargs = pico_args::Arguments::from_env();
         Ok(Self {
-            use_tls: pargs.value_from_str("--use_tls").unwrap_or(false),
+            use_tls: pargs.contains("--use_tls"),
         })
     }
 }


### PR DESCRIPTION
## Motivation

We have used clap to parse arguments in interop. This crate provides us with a lot of great functionalities. Since clap evolves quickly, its increase of msrv is relatively rapid. As we uses clap only in test crate, we might not need most of the clap's functionality. In order to reduce effects from dependencies in our test crates, we could use the other arguments parser which is aimed to be simple.

## Solution

Uses a more lightweight arguments parser library.