### PR TITLE
Fix panic in MetadataKey::from_bytes

### DIFF
--- a/tonic/src/metadata/key.rs
+++ b/tonic/src/metadata/key.rs
@@ -42,7 +42,7 @@ impl<VE: ValueEncoding> MetadataKey<VE> {
         match HeaderName::from_bytes(src) {
             Ok(name) => {
                 if !VE::is_valid_key(name.as_str()) {
-                    panic!("invalid metadata key")
+                    return Err(InvalidMetadataKey::new());
                 }
 
                 Ok(MetadataKey {
@@ -282,3 +282,19 @@ impl Default for InvalidMetadataKey {
 }
 
 impl Error for InvalidMetadataKey {}
+
+#[test]
+fn test_from_bytes_binary() {
+    assert!(BinaryMetadataKey::from_bytes(b"").is_err());
+    assert!(BinaryMetadataKey::from_bytes(b"\xFF").is_err());
+    assert!(BinaryMetadataKey::from_bytes(b"abc").is_err());
+    assert_eq!(BinaryMetadataKey::from_bytes(b"abc-bin").unwrap().as_str(), "abc-bin");
+}
+
+#[test]
+fn test_from_bytes_ascii() {
+    assert!(AsciiMetadataKey::from_bytes(b"").is_err());
+    assert!(AsciiMetadataKey::from_bytes(b"\xFF").is_err());
+    assert_eq!(AsciiMetadataKey::from_bytes(b"abc").unwrap().as_str(), "abc");
+    assert!(AsciiMetadataKey::from_bytes(b"abc-bin").is_err());
+}

--- a/tonic/src/metadata/key.rs
+++ b/tonic/src/metadata/key.rs
@@ -288,13 +288,19 @@ fn test_from_bytes_binary() {
     assert!(BinaryMetadataKey::from_bytes(b"").is_err());
     assert!(BinaryMetadataKey::from_bytes(b"\xFF").is_err());
     assert!(BinaryMetadataKey::from_bytes(b"abc").is_err());
-    assert_eq!(BinaryMetadataKey::from_bytes(b"abc-bin").unwrap().as_str(), "abc-bin");
+    assert_eq!(
+        BinaryMetadataKey::from_bytes(b"abc-bin").unwrap().as_str(),
+        "abc-bin"
+    );
 }
 
 #[test]
 fn test_from_bytes_ascii() {
     assert!(AsciiMetadataKey::from_bytes(b"").is_err());
     assert!(AsciiMetadataKey::from_bytes(b"\xFF").is_err());
-    assert_eq!(AsciiMetadataKey::from_bytes(b"abc").unwrap().as_str(), "abc");
+    assert_eq!(
+        AsciiMetadataKey::from_bytes(b"abc").unwrap().as_str(),
+        "abc"
+    );
     assert!(AsciiMetadataKey::from_bytes(b"abc-bin").is_err());
 }

--- a/tonic/src/metadata/key.rs
+++ b/tonic/src/metadata/key.rs
@@ -283,24 +283,29 @@ impl Default for InvalidMetadataKey {
 
 impl Error for InvalidMetadataKey {}
 
-#[test]
-fn test_from_bytes_binary() {
-    assert!(BinaryMetadataKey::from_bytes(b"").is_err());
-    assert!(BinaryMetadataKey::from_bytes(b"\xFF").is_err());
-    assert!(BinaryMetadataKey::from_bytes(b"abc").is_err());
-    assert_eq!(
-        BinaryMetadataKey::from_bytes(b"abc-bin").unwrap().as_str(),
-        "abc-bin"
-    );
-}
+#[cfg(test)]
+mod tests {
+    use super::{AsciiMetadataKey, BinaryMetadataKey};
 
-#[test]
-fn test_from_bytes_ascii() {
-    assert!(AsciiMetadataKey::from_bytes(b"").is_err());
-    assert!(AsciiMetadataKey::from_bytes(b"\xFF").is_err());
-    assert_eq!(
-        AsciiMetadataKey::from_bytes(b"abc").unwrap().as_str(),
-        "abc"
-    );
-    assert!(AsciiMetadataKey::from_bytes(b"abc-bin").is_err());
+    #[test]
+    fn test_from_bytes_binary() {
+        assert!(BinaryMetadataKey::from_bytes(b"").is_err());
+        assert!(BinaryMetadataKey::from_bytes(b"\xFF").is_err());
+        assert!(BinaryMetadataKey::from_bytes(b"abc").is_err());
+        assert_eq!(
+            BinaryMetadataKey::from_bytes(b"abc-bin").unwrap().as_str(),
+            "abc-bin"
+        );
+    }
+
+    #[test]
+    fn test_from_bytes_ascii() {
+        assert!(AsciiMetadataKey::from_bytes(b"").is_err());
+        assert!(AsciiMetadataKey::from_bytes(b"\xFF").is_err());
+        assert_eq!(
+            AsciiMetadataKey::from_bytes(b"abc").unwrap().as_str(),
+            "abc"
+        );
+        assert!(AsciiMetadataKey::from_bytes(b"abc-bin").is_err());
+    }
 }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/hyperium/tonic/blob/master/CONTRIBUTING.md
-->

## Motivation

I tried using `BinaryMetadataKey::from_bytes` to parse a header value, but noticed it inconveniently panics on values that don't end in `-bin`.

## Solution

I assume this is a bug since the signature of this function suggests it returns an error on failure, and the documentation makes no mention of panicking.

This PR fixes it to return an error instead.
