### PR TITLE
chore: Add cargo-machete to detect unused dependencies

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -27,6 +27,10 @@ jobs:
       uses: baptiste0928/cargo-install@v1
       with:
         crate: cargo-hack
+    - name: Install cargo-machete
+      uses: baptiste0928/cargo-install@v1
+      with:
+        crate: cargo-machete
     - name: Install Protoc
       uses: arduino/setup-protoc@v1
       with:
@@ -34,6 +38,8 @@ jobs:
     - uses: Swatinem/rust-cache@v2
     - name: Check fmt
       run: cargo fmt -- --check
+    - name: Check unused dependencies
+      run: cargo machete
     - name: Check features
       run: cargo hack check --all --ignore-private --each-feature --no-dev-deps
     - name: Check all targets

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -293,3 +293,6 @@ tower-http = { version = "0.3", optional = true }
 
 [build-dependencies]
 tonic-build = { path = "../tonic-build", features = ["prost"] }
+
+[package.metadata.cargo-machete]
+ignored = ["prost-types"]

--- a/interop/Cargo.toml
+++ b/interop/Cargo.toml
@@ -35,3 +35,6 @@ tracing-subscriber = {version = "0.3", features = ["env-filter"]}
 
 [build-dependencies]
 tonic-build = {path = "../tonic-build", features = ["prost"]}
+
+[package.metadata.cargo-machete]
+ignored = ["prost"]

--- a/tests/ambiguous_methods/Cargo.toml
+++ b/tests/ambiguous_methods/Cargo.toml
@@ -14,3 +14,6 @@ tonic = {path = "../../tonic"}
 
 [build-dependencies]
 tonic-build = {path = "../../tonic-build"}
+
+[package.metadata.cargo-machete]
+ignored = ["prost"]

--- a/tests/compression/Cargo.toml
+++ b/tests/compression/Cargo.toml
@@ -21,3 +21,6 @@ tower-http = {version = "0.3", features = ["map-response-body", "map-request-bod
 
 [build-dependencies]
 tonic-build = {path = "../../tonic-build" }
+
+[package.metadata.cargo-machete]
+ignored = ["prost"]

--- a/tests/disable_comments/Cargo.toml
+++ b/tests/disable_comments/Cargo.toml
@@ -15,3 +15,6 @@ tonic = { path = "../../tonic" }
 [build-dependencies]
 prost-build = "0.11.6"
 tonic-build = { path = "../../tonic-build" }
+
+[package.metadata.cargo-machete]
+ignored = ["prost"]

--- a/tests/extern_path/my_application/Cargo.toml
+++ b/tests/extern_path/my_application/Cargo.toml
@@ -15,3 +15,6 @@ uuid = {package = "uuid1", path = "../uuid"}
 
 [build-dependencies]
 tonic-build = {path = "../../../tonic-build"}
+
+[package.metadata.cargo-machete]
+ignored = ["prost"]

--- a/tests/extern_path/uuid/Cargo.toml
+++ b/tests/extern_path/uuid/Cargo.toml
@@ -12,3 +12,6 @@ version = "0.1.0"
 prost = "0.11"
 [build-dependencies]
 prost-build = "0.11.6"
+
+[package.metadata.cargo-machete]
+ignored = ["prost"]

--- a/tests/included_service/Cargo.toml
+++ b/tests/included_service/Cargo.toml
@@ -14,3 +14,6 @@ tonic = {path = "../../tonic"}
 
 [build-dependencies]
 tonic-build = {path = "../../tonic-build"}
+
+[package.metadata.cargo-machete]
+ignored = ["prost"]

--- a/tests/integration_tests/Cargo.toml
+++ b/tests/integration_tests/Cargo.toml
@@ -29,3 +29,6 @@ tracing-subscriber = {version = "0.3", features = ["env-filter"]}
 
 [build-dependencies]
 tonic-build = {path = "../../tonic-build"}
+
+[package.metadata.cargo-machete]
+ignored = ["prost"]

--- a/tests/same_name/Cargo.toml
+++ b/tests/same_name/Cargo.toml
@@ -14,3 +14,6 @@ tonic = {path = "../../tonic"}
 
 [build-dependencies]
 tonic-build = {path = "../../tonic-build"}
+
+[package.metadata.cargo-machete]
+ignored = ["prost"]

--- a/tests/service_named_result/Cargo.toml
+++ b/tests/service_named_result/Cargo.toml
@@ -12,3 +12,6 @@ tonic = {path = "../../tonic"}
 
 [build-dependencies]
 tonic-build = {path = "../../tonic-build"}
+
+[package.metadata.cargo-machete]
+ignored = ["prost"]

--- a/tests/service_named_service/Cargo.toml
+++ b/tests/service_named_service/Cargo.toml
@@ -14,3 +14,6 @@ tonic = {path = "../../tonic"}
 
 [build-dependencies]
 tonic-build = {path = "../../tonic-build"}
+
+[package.metadata.cargo-machete]
+ignored = ["prost"]

--- a/tests/stream_conflict/Cargo.toml
+++ b/tests/stream_conflict/Cargo.toml
@@ -14,3 +14,6 @@ tonic = { path = "../../tonic" }
 
 [build-dependencies]
 tonic-build = { path = "../../tonic-build" }
+
+[package.metadata.cargo-machete]
+ignored = ["prost"]

--- a/tests/wellknown-compiled/Cargo.toml
+++ b/tests/wellknown-compiled/Cargo.toml
@@ -18,3 +18,6 @@ tonic = {path = "../../tonic"}
 [build-dependencies]
 prost-build = "0.11.6"
 tonic-build = {path = "../../tonic-build"}
+
+[package.metadata.cargo-machete]
+ignored = ["prost"]

--- a/tests/wellknown/Cargo.toml
+++ b/tests/wellknown/Cargo.toml
@@ -15,3 +15,6 @@ tonic = {path = "../../tonic"}
 
 [build-dependencies]
 tonic-build = {path = "../../tonic-build"}
+
+[package.metadata.cargo-machete]
+ignored = ["prost", "prost-types"]


### PR DESCRIPTION
## Motivation

Keeps manifests not to depend on unused crates.

## Solution

Adds [cargo-machete](https://github.com/bnjbvr/cargo-machete) to detect unused dependencies.