### PR TITLE
Fix RPC name conflicts with generated code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 
 * **build:** `CODEC_PATH` moved from const to fn
 * **tonic** Remove codegen depedency on `compression` feature.
+* **tonic** Remove `compression` feature in favor of `gzip` feature.
 
 # [v0.7.2](https://github.com/hyperium/tonic/compare/v0.7.1...v0.7.2) (2022-05-04)
 

--- a/examples/helloworld-tutorial.md
+++ b/examples/helloworld-tutorial.md
@@ -243,7 +243,7 @@ If you have a gRPC GUI client such as [Bloom RPC] you should be able to send req
 
 Or if you use [grpcurl] then you can simply try send requests like this:
 ```
-$ grpcurl -plaintext -import-path ./proto -proto helloworld.proto -d '{"name": "Tonic"}' [::]:50051 helloworld.Greeter/SayHello
+$ grpcurl -plaintext -import-path ./proto -proto helloworld.proto -d '{"name": "Tonic"}' '[::]:50051' helloworld.Greeter/SayHello
 ```
 And receiving responses like this:
 ```

--- a/tonic-build/Cargo.toml
+++ b/tonic-build/Cargo.toml
@@ -18,12 +18,13 @@ version = "0.8.0"
 prettyplease = {version = "0.1"}
 proc-macro2 = "1.0"
 prost-build = {version = "0.11", optional = true}
+prost-reflect-build = {version = "0.11", optional = true}
 quote = "1.0"
 syn = "1.0"
 
 [features]
 default = ["transport", "prost"]
-prost = ["prost-build"]
+prost = ["prost-build", "prost-reflect-build"]
 transport = []
 
 [package.metadata.docs.rs]

--- a/tonic-build/src/prost.rs
+++ b/tonic-build/src/prost.rs
@@ -430,7 +430,11 @@ impl Builder {
 
         config.out_dir(out_dir);
         if let Some(path) = self.file_descriptor_set_path.as_ref() {
-            config.file_descriptor_set_path(path);
+            if let Some(builder) = reflect_builder.borrow_mut() {
+                builder.file_descriptor_set_path(path);
+            } else {
+                config.file_descriptor_set_path(path);
+            }
         }
         for (proto_path, rust_path) in self.extern_path.iter() {
             config.extern_path(proto_path, rust_path);


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/hyperium/tonic/blob/master/CONTRIBUTING.md
-->

## Motivation
Issues: https://github.com/hyperium/tonic/issues/747 and https://github.com/hyperium/tonic/issues/1253

Still a draft - need to add tests

_TLDR_: Tonic adds predefined methods to codegenned structs, like `connect`. If that name conflicts with an RPC name, the resulting code fails to compile.
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? If a new feature is being added, describe the intended
use case that feature fulfills.
-->

## Solution
This is a problem for other gRPC codegenners too. The C++ one just prepends the problematic method names with a `_`.
I took the same approach here.

For example, given the RPC definition
```
syntax = "proto3";
service MyService {
  rpc Connect(ConnectRequest) returns (ConnectResponse);
}
```

Will generate the following code now
```
    impl MyServiceClient<tonic::transport::Channel> {
        /// VVVVVVV This is the tonic-provided method
        /// Attempt to create a new client by connecting to a given endpoint.
        pub async fn connect<D>(dst: D) -> Result<Self, tonic::transport::Error>
        where
            D: std::convert::TryInto<tonic::transport::Endpoint>,
            D::Error: Into<StdError>,
        {
            let conn = tonic::transport::Endpoint::new(dst)?.connect().await?;
            Ok(Self::new(conn))
        }
    }
    impl<T> MyServiceClient<T>
    where
        T: tonic::client::GrpcService<tonic::body::BoxBody>,
        T::Error: Into<StdError>,
        T::ResponseBody: Body<Data = Bytes> + Send + 'static,
        <T::ResponseBody as Body>::Error: Into<StdError> + Send,
    {
        [...]
        /// VVVVVVV This is the method generated from the .proto file
        pub async fn _connect(
            &mut self,
            request: impl tonic::IntoRequest<super::ConnectRequest>,
        ) -> Result<tonic::Response<super::ConnectResponse>, tonic::Status> {
            [...]
        }
```

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
