### PR TITLE
feat(tonic): Use NamedService without transport feature

### DIFF
--- a/tonic/src/service/interceptor.rs
+++ b/tonic/src/service/interceptor.rs
@@ -189,10 +189,9 @@ where
 }
 
 // required to use `InterceptedService` with `Router`
-#[cfg(feature = "transport")]
-impl<S, F> crate::transport::NamedService for InterceptedService<S, F>
+impl<S, F> crate::server::NamedService for InterceptedService<S, F>
 where
-    S: crate::transport::NamedService,
+    S: crate::server::NamedService,
 {
     const NAME: &'static str = S::NAME;
 }

--- a/tonic/src/transport/mod.rs
+++ b/tonic/src/transport/mod.rs
@@ -63,7 +63,7 @@
 //! #       unimplemented!()
 //! #   }
 //! # }
-//! # impl tonic::transport::NamedService for Svc {
+//! # impl tonic::server::NamedService for Svc {
 //! # const NAME: &'static str = "some_svc";
 //! # }
 //! # let my_svc = Svc;
@@ -99,10 +99,12 @@ mod tls;
 pub use self::channel::{Channel, Endpoint};
 pub use self::error::Error;
 #[doc(inline)]
-pub use self::server::{NamedService, Server};
+pub use self::server::Server;
 #[doc(inline)]
 pub use self::service::grpc_timeout::TimeoutExpired;
 pub use self::tls::Certificate;
+#[doc(inline)]
+pub use crate::server::NamedService;
 pub use hyper::{Body, Uri};
 
 pub(crate) use self::service::executor::Executor;

--- a/tonic/src/transport/server/incoming.rs
+++ b/tonic/src/transport/server/incoming.rs
@@ -142,7 +142,7 @@ impl TcpIncoming {
     /// ```no_run
     /// # use tower_service::Service;
     /// # use http::{request::Request, response::Response};
-    /// # use tonic::{body::BoxBody, transport::{Body, NamedService, Server, server::TcpIncoming}};
+    /// # use tonic::{body::BoxBody, server::NamedService, transport::{Body, Server, server::TcpIncoming}};
     /// # use core::convert::Infallible;
     /// # use std::error::Error;
     /// # fn main() { }  // Cannot have type parameters, hence instead define:

--- a/tonic/src/transport/service/router.rs
+++ b/tonic/src/transport/service/router.rs
@@ -1,6 +1,6 @@
 use crate::{
     body::{boxed, BoxBody},
-    transport::NamedService,
+    server::NamedService,
 };
 use http::{Request, Response};
 use hyper::Body;


### PR DESCRIPTION
We can use `NamedService` without the transport feature.