### PR TITLE
feat(types): Add gRPC Richer Error Model support (PreconditionFailure)

### DIFF
--- a/tonic-types/src/lib.rs
+++ b/tonic-types/src/lib.rs
@@ -46,8 +46,8 @@ pub use pb::Status;
 mod richer_error;
 
 pub use richer_error::{
-    BadRequest, DebugInfo, ErrorDetail, ErrorDetails, ErrorInfo, FieldViolation, QuotaFailure,
-    QuotaViolation, RetryInfo, StatusExt,
+    BadRequest, DebugInfo, ErrorDetail, ErrorDetails, ErrorInfo, FieldViolation,
+    PreconditionFailure, PreconditionViolation, QuotaFailure, QuotaViolation, RetryInfo, StatusExt,
 };
 
 mod sealed {

--- a/tonic-types/src/richer_error/error_details/mod.rs
+++ b/tonic-types/src/richer_error/error_details/mod.rs
@@ -39,7 +39,7 @@ impl ErrorDetails {
     /// # Examples
     ///
     /// ```
-    /// use tonic_types::{ErrorDetails};
+    /// use tonic_types::ErrorDetails;
     ///
     /// let err_details = ErrorDetails::new();
     /// ```
@@ -54,7 +54,7 @@ impl ErrorDetails {
     ///
     /// ```
     /// use std::time::Duration;
-    /// use tonic_types::{ErrorDetails};
+    /// use tonic_types::ErrorDetails;
     ///
     /// let err_details = ErrorDetails::with_retry_info(Some(Duration::from_secs(5)));
     /// ```
@@ -71,7 +71,7 @@ impl ErrorDetails {
     /// # Examples
     ///
     /// ```
-    /// use tonic_types::{ErrorDetails};
+    /// use tonic_types::ErrorDetails;
     ///
     /// let err_stack = vec!["...".into(), "...".into()];
     ///
@@ -110,7 +110,7 @@ impl ErrorDetails {
     /// # Examples
     ///
     /// ```
-    /// use tonic_types::{ErrorDetails};
+    /// use tonic_types::ErrorDetails;
     ///
     /// let err_details = ErrorDetails::with_quota_failure_violation("subject", "description");
     /// ```
@@ -131,7 +131,7 @@ impl ErrorDetails {
     ///
     /// ```
     /// use std::collections::HashMap;
-    /// use tonic_types::{ErrorDetails};
+    /// use tonic_types::ErrorDetails;
     ///
     /// let mut metadata: HashMap<String, String> = HashMap::new();
     /// metadata.insert("instanceLimitPerRequest".into(), "100".into());
@@ -233,7 +233,7 @@ impl ErrorDetails {
     /// # Examples
     ///
     /// ```
-    /// use tonic_types::{ErrorDetails};
+    /// use tonic_types::ErrorDetails;
     ///
     /// let err_details = ErrorDetails::with_bad_request_violation(
     ///     "field",
@@ -250,22 +250,22 @@ impl ErrorDetails {
         }
     }
 
-    /// Get [`RetryInfo`] details, if any
+    /// Get [`RetryInfo`] details, if any.
     pub fn retry_info(&self) -> Option<RetryInfo> {
         self.retry_info.clone()
     }
 
-    /// Get [`DebugInfo`] details, if any
+    /// Get [`DebugInfo`] details, if any.
     pub fn debug_info(&self) -> Option<DebugInfo> {
         self.debug_info.clone()
     }
 
-    /// Get [`QuotaFailure`] details, if any
+    /// Get [`QuotaFailure`] details, if any.
     pub fn quota_failure(&self) -> Option<QuotaFailure> {
         self.quota_failure.clone()
     }
 
-    /// Get [`ErrorInfo`] details, if any
+    /// Get [`ErrorInfo`] details, if any.
     pub fn error_info(&self) -> Option<ErrorInfo> {
         self.error_info.clone()
     }
@@ -275,7 +275,7 @@ impl ErrorDetails {
         self.precondition_failure.clone()
     }
 
-    /// Get [`BadRequest`] details, if any
+    /// Get [`BadRequest`] details, if any.
     pub fn bad_request(&self) -> Option<BadRequest> {
         self.bad_request.clone()
     }
@@ -287,7 +287,7 @@ impl ErrorDetails {
     ///
     /// ```
     /// use std::time::Duration;
-    /// use tonic_types::{ErrorDetails};
+    /// use tonic_types::ErrorDetails;
     ///
     /// let mut err_details = ErrorDetails::new();
     ///
@@ -304,7 +304,7 @@ impl ErrorDetails {
     /// # Examples
     ///
     /// ```
-    /// use tonic_types::{ErrorDetails};
+    /// use tonic_types::ErrorDetails;
     ///
     /// let mut err_details = ErrorDetails::new();
     ///
@@ -348,7 +348,7 @@ impl ErrorDetails {
     /// # Examples
     ///
     /// ```
-    /// use tonic_types::{ErrorDetails};
+    /// use tonic_types::ErrorDetails;
     ///
     /// let mut err_details = ErrorDetails::new();
     ///
@@ -376,7 +376,7 @@ impl ErrorDetails {
     /// # Examples
     ///
     /// ```
-    /// use tonic_types::{ErrorDetails};
+    /// use tonic_types::ErrorDetails;
     ///
     /// let mut err_details = ErrorDetails::with_quota_failure(vec![]);
     ///
@@ -400,7 +400,7 @@ impl ErrorDetails {
     ///
     /// ```
     /// use std::collections::HashMap;
-    /// use tonic_types::{ErrorDetails};
+    /// use tonic_types::ErrorDetails;
     ///
     /// let mut err_details = ErrorDetails::new();
     ///
@@ -542,7 +542,7 @@ impl ErrorDetails {
     /// # Examples
     ///
     /// ```
-    /// use tonic_types::{ErrorDetails};
+    /// use tonic_types::ErrorDetails;
     ///
     /// let mut err_details = ErrorDetails::new();
     ///
@@ -570,7 +570,7 @@ impl ErrorDetails {
     /// # Examples
     ///
     /// ```
-    /// use tonic_types::{ErrorDetails};
+    /// use tonic_types::ErrorDetails;
     ///
     /// let mut err_details = ErrorDetails::with_bad_request(vec![]);
     ///

--- a/tonic-types/src/richer_error/error_details/vec.rs
+++ b/tonic-types/src/richer_error/error_details/vec.rs
@@ -1,4 +1,6 @@
-use super::super::std_messages::{BadRequest, DebugInfo, ErrorInfo, QuotaFailure, RetryInfo};
+use super::super::std_messages::{
+    BadRequest, DebugInfo, ErrorInfo, PreconditionFailure, QuotaFailure, RetryInfo,
+};
 
 /// Wraps the structs corresponding to the standard error messages, allowing
 /// the implementation and handling of vectors containing any of them.
@@ -16,6 +18,9 @@ pub enum ErrorDetail {
 
     /// Wraps the [`ErrorInfo`] struct.
     ErrorInfo(ErrorInfo),
+
+    /// Wraps the [`PreconditionFailure`] struct.
+    PreconditionFailure(PreconditionFailure),
 
     /// Wraps the [`BadRequest`] struct.
     BadRequest(BadRequest),
@@ -42,6 +47,12 @@ impl From<QuotaFailure> for ErrorDetail {
 impl From<ErrorInfo> for ErrorDetail {
     fn from(err_detail: ErrorInfo) -> Self {
         ErrorDetail::ErrorInfo(err_detail)
+    }
+}
+
+impl From<PreconditionFailure> for ErrorDetail {
+    fn from(err_detail: PreconditionFailure) -> Self {
+        ErrorDetail::PreconditionFailure(err_detail)
     }
 }
 

--- a/tonic-types/src/richer_error/mod.rs
+++ b/tonic-types/src/richer_error/mod.rs
@@ -148,7 +148,7 @@ pub trait StatusExt: crate::sealed::Sealed {
     ///
     /// ```
     /// use tonic::{Status, Response};
-    /// use tonic_types::{StatusExt};
+    /// use tonic_types::StatusExt;
     ///
     /// fn handle_request_result<T>(req_result: Result<Response<T>, Status>) {
     ///     match req_result {
@@ -173,7 +173,7 @@ pub trait StatusExt: crate::sealed::Sealed {
     ///
     /// ```
     /// use tonic::{Status, Response};
-    /// use tonic_types::{StatusExt};
+    /// use tonic_types::StatusExt;
     ///
     /// fn handle_request_result<T>(req_result: Result<Response<T>, Status>) {
     ///     match req_result {
@@ -257,7 +257,7 @@ pub trait StatusExt: crate::sealed::Sealed {
     ///
     /// ```
     /// use tonic::{Status, Response};
-    /// use tonic_types::{StatusExt};
+    /// use tonic_types::StatusExt;
     ///
     /// fn handle_request_result<T>(req_result: Result<Response<T>, Status>) {
     ///     match req_result {
@@ -279,7 +279,7 @@ pub trait StatusExt: crate::sealed::Sealed {
     ///
     /// ```
     /// use tonic::{Status, Response};
-    /// use tonic_types::{StatusExt};
+    /// use tonic_types::StatusExt;
     ///
     /// fn handle_request_result<T>(req_result: Result<Response<T>, Status>) {
     ///     match req_result {
@@ -301,7 +301,7 @@ pub trait StatusExt: crate::sealed::Sealed {
     ///
     /// ```
     /// use tonic::{Status, Response};
-    /// use tonic_types::{StatusExt};
+    /// use tonic_types::StatusExt;
     ///
     /// fn handle_request_result<T>(req_result: Result<Response<T>, Status>) {
     ///     match req_result {
@@ -323,7 +323,7 @@ pub trait StatusExt: crate::sealed::Sealed {
     ///
     /// ```
     /// use tonic::{Status, Response};
-    /// use tonic_types::{StatusExt};
+    /// use tonic_types::StatusExt;
     ///
     /// fn handle_request_result<T>(req_result: Result<Response<T>, Status>) {
     ///     match req_result {
@@ -367,7 +367,7 @@ pub trait StatusExt: crate::sealed::Sealed {
     ///
     /// ```
     /// use tonic::{Status, Response};
-    /// use tonic_types::{StatusExt};
+    /// use tonic_types::StatusExt;
     ///
     /// fn handle_request_result<T>(req_result: Result<Response<T>, Status>) {
     ///     match req_result {

--- a/tonic-types/src/richer_error/mod.rs
+++ b/tonic-types/src/richer_error/mod.rs
@@ -12,7 +12,8 @@ use super::pb;
 
 pub use error_details::{vec::ErrorDetail, ErrorDetails};
 pub use std_messages::{
-    BadRequest, DebugInfo, ErrorInfo, FieldViolation, QuotaFailure, QuotaViolation, RetryInfo,
+    BadRequest, DebugInfo, ErrorInfo, FieldViolation, PreconditionFailure, PreconditionViolation,
+    QuotaFailure, QuotaViolation, RetryInfo,
 };
 
 trait IntoAny {
@@ -337,6 +338,28 @@ pub trait StatusExt: crate::sealed::Sealed {
     /// ```
     fn get_details_error_info(&self) -> Option<ErrorInfo>;
 
+    /// Get first [`PreconditionFailure`] details found on `tonic::Status`,
+    /// if any. If some `prost::DecodeError` occurs, returns `None`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tonic::{Status, Response};
+    /// use tonic_types::StatusExt;
+    ///
+    /// fn handle_request_result<T>(req_result: Result<Response<T>, Status>) {
+    ///     match req_result {
+    ///         Ok(_) => {},
+    ///         Err(status) => {
+    ///             if let Some(precondition_failure) = status.get_details_precondition_failure() {
+    ///                 // Handle precondition_failure details
+    ///             }
+    ///         }
+    ///     };
+    /// }
+    /// ```
+    fn get_details_precondition_failure(&self) -> Option<PreconditionFailure>;
+
     /// Get first [`BadRequest`] details found on `tonic::Status`, if any. If
     /// some `prost::DecodeError` occurs, returns `None`.
     ///
@@ -389,6 +412,10 @@ impl StatusExt for tonic::Status {
             conv_details.push(error_info.into_any());
         }
 
+        if let Some(precondition_failure) = details.precondition_failure {
+            conv_details.push(precondition_failure.into_any());
+        }
+
         if let Some(bad_request) = details.bad_request {
             conv_details.push(bad_request.into_any());
         }
@@ -425,6 +452,9 @@ impl StatusExt for tonic::Status {
                 }
                 ErrorDetail::ErrorInfo(error_info) => {
                     conv_details.push(error_info.into_any());
+                }
+                ErrorDetail::PreconditionFailure(prec_failure) => {
+                    conv_details.push(prec_failure.into_any());
                 }
                 ErrorDetail::BadRequest(bad_req) => {
                     conv_details.push(bad_req.into_any());
@@ -469,6 +499,9 @@ impl StatusExt for tonic::Status {
                 ErrorInfo::TYPE_URL => {
                     details.error_info = Some(ErrorInfo::from_any(any)?);
                 }
+                PreconditionFailure::TYPE_URL => {
+                    details.precondition_failure = Some(PreconditionFailure::from_any(any)?);
+                }
                 BadRequest::TYPE_URL => {
                     details.bad_request = Some(BadRequest::from_any(any)?);
                 }
@@ -501,6 +534,9 @@ impl StatusExt for tonic::Status {
                 }
                 ErrorInfo::TYPE_URL => {
                     details.push(ErrorInfo::from_any(any)?.into());
+                }
+                PreconditionFailure::TYPE_URL => {
+                    details.push(PreconditionFailure::from_any(any)?.into());
                 }
                 BadRequest::TYPE_URL => {
                     details.push(BadRequest::from_any(any)?.into());
@@ -572,6 +608,20 @@ impl StatusExt for tonic::Status {
         None
     }
 
+    fn get_details_precondition_failure(&self) -> Option<PreconditionFailure> {
+        let status = pb::Status::decode(self.details()).ok()?;
+
+        for any in status.details.into_iter() {
+            if any.type_url.as_str() == PreconditionFailure::TYPE_URL {
+                if let Ok(detail) = PreconditionFailure::from_any(any) {
+                    return Some(detail);
+                }
+            }
+        }
+
+        None
+    }
+
     fn get_details_bad_request(&self) -> Option<BadRequest> {
         let status = pb::Status::decode(self.details()).ok()?;
 
@@ -593,7 +643,8 @@ mod tests {
     use tonic::{Code, Status};
 
     use super::{
-        BadRequest, DebugInfo, ErrorDetails, ErrorInfo, QuotaFailure, RetryInfo, StatusExt,
+        BadRequest, DebugInfo, ErrorDetails, ErrorInfo, PreconditionFailure, QuotaFailure,
+        RetryInfo, StatusExt,
     };
 
     #[test]
@@ -611,6 +662,7 @@ mod tests {
             )
             .add_quota_failure_violation("clientip:<ip address>", "description")
             .set_error_info("SOME_INFO", "example.local", metadata.clone())
+            .add_precondition_failure_violation("TOS", "example.local", "description")
             .add_bad_request_violation("field", "description");
 
         let fmt_details = format!("{:?}", err_details);
@@ -624,6 +676,7 @@ mod tests {
             .into(),
             QuotaFailure::with_violation("clientip:<ip address>", "description").into(),
             ErrorInfo::new("SOME_INFO", "example.local", metadata).into(),
+            PreconditionFailure::with_violation("TOS", "example.local", "description").into(),
             BadRequest::with_violation("field", "description").into(),
         ];
 

--- a/tonic-types/src/richer_error/std_messages/debug_info.rs
+++ b/tonic-types/src/richer_error/std_messages/debug_info.rs
@@ -27,9 +27,7 @@ impl DebugInfo {
             detail: detail.into(),
         }
     }
-}
 
-impl DebugInfo {
     /// Returns `true` if [`DebugInfo`] fields are empty, and `false` if they
     /// are not.
     pub fn is_empty(&self) -> bool {

--- a/tonic-types/src/richer_error/std_messages/error_info.rs
+++ b/tonic-types/src/richer_error/std_messages/error_info.rs
@@ -43,9 +43,7 @@ impl ErrorInfo {
             metadata: metadata.into(),
         }
     }
-}
 
-impl ErrorInfo {
     /// Returns `true` if [`ErrorInfo`] fields are empty, and `false` if they
     /// are not.
     pub fn is_empty(&self) -> bool {

--- a/tonic-types/src/richer_error/std_messages/mod.rs
+++ b/tonic-types/src/richer_error/std_messages/mod.rs
@@ -14,6 +14,10 @@ mod error_info;
 
 pub use error_info::ErrorInfo;
 
+mod prec_failure;
+
+pub use prec_failure::{PreconditionFailure, PreconditionViolation};
+
 mod bad_request;
 
 pub use bad_request::{BadRequest, FieldViolation};

--- a/tonic-types/src/richer_error/std_messages/prec_failure.rs
+++ b/tonic-types/src/richer_error/std_messages/prec_failure.rs
@@ -1,0 +1,203 @@
+use prost::{DecodeError, Message};
+use prost_types::Any;
+
+use super::super::{pb, FromAny, IntoAny};
+
+/// Used at the `violations` field of the [`PreconditionFailure`] struct.
+/// Describes a single precondition failure.
+#[derive(Clone, Debug)]
+pub struct PreconditionViolation {
+    /// Type of the PreconditionFailure. At [error_details.proto], the usage
+    /// of a service-specific enum type is recommended. For example, "TOS" for
+    /// a "Terms of Service" violation.
+    ///
+    /// [error_details.proto]: https://github.com/googleapis/googleapis/blob/master/google/rpc/error_details.proto
+    pub r#type: String,
+
+    /// Subject, relative to the type, that failed.
+    pub subject: String,
+
+    /// A description of how the precondition failed.
+    pub description: String,
+}
+
+impl PreconditionViolation {
+    /// Creates a new [`PreconditionViolation`] struct.
+    pub fn new(
+        r#type: impl Into<String>,
+        subject: impl Into<String>,
+        description: impl Into<String>,
+    ) -> Self {
+        PreconditionViolation {
+            r#type: r#type.into(),
+            subject: subject.into(),
+            description: description.into(),
+        }
+    }
+}
+
+/// Used to encode/decode the `PreconditionFailure` standard error message
+/// described in [error_details.proto]. Describes what preconditions have
+/// failed.
+///
+/// [error_details.proto]: https://github.com/googleapis/googleapis/blob/master/google/rpc/error_details.proto
+#[derive(Clone, Debug)]
+pub struct PreconditionFailure {
+    /// Describes all precondition violations of the request.
+    pub violations: Vec<PreconditionViolation>,
+}
+
+impl PreconditionFailure {
+    /// Type URL of the `PreconditionFailure` standard error message type.
+    pub const TYPE_URL: &'static str = "type.googleapis.com/google.rpc.PreconditionFailure";
+
+    /// Creates a new [`PreconditionFailure`] struct.
+    pub fn new(violations: Vec<PreconditionViolation>) -> Self {
+        PreconditionFailure { violations }
+    }
+
+    /// Creates a new [`PreconditionFailure`] struct with a single
+    /// [`PreconditionViolation`] in `violations`.
+    pub fn with_violation(
+        violation_type: impl Into<String>,
+        subject: impl Into<String>,
+        description: impl Into<String>,
+    ) -> Self {
+        PreconditionFailure {
+            violations: vec![PreconditionViolation {
+                r#type: violation_type.into(),
+                subject: subject.into(),
+                description: description.into(),
+            }],
+        }
+    }
+
+    /// Adds a [`PreconditionViolation`] to [`PreconditionFailure`]'s
+    /// `violations` vector.
+    pub fn add_violation(
+        &mut self,
+        r#type: impl Into<String>,
+        subject: impl Into<String>,
+        description: impl Into<String>,
+    ) -> &mut Self {
+        self.violations.append(&mut vec![PreconditionViolation {
+            r#type: r#type.into(),
+            subject: subject.into(),
+            description: description.into(),
+        }]);
+        self
+    }
+
+    /// Returns `true` if [`PreconditionFailure`]'s `violations` vector is
+    /// empty, and `false` if it is not.
+    pub fn is_empty(&self) -> bool {
+        self.violations.is_empty()
+    }
+}
+
+impl IntoAny for PreconditionFailure {
+    fn into_any(self) -> Any {
+        let detail_data = pb::PreconditionFailure {
+            violations: self
+                .violations
+                .into_iter()
+                .map(|v| pb::precondition_failure::Violation {
+                    r#type: v.r#type,
+                    subject: v.subject,
+                    description: v.description,
+                })
+                .collect(),
+        };
+
+        Any {
+            type_url: PreconditionFailure::TYPE_URL.to_string(),
+            value: detail_data.encode_to_vec(),
+        }
+    }
+}
+
+impl FromAny for PreconditionFailure {
+    fn from_any(any: Any) -> Result<Self, DecodeError> {
+        let buf: &[u8] = &any.value;
+        let precondition_failure = pb::PreconditionFailure::decode(buf)?;
+
+        let precondition_failure = PreconditionFailure {
+            violations: precondition_failure
+                .violations
+                .into_iter()
+                .map(|v| PreconditionViolation {
+                    r#type: v.r#type,
+                    subject: v.subject,
+                    description: v.description,
+                })
+                .collect(),
+        };
+
+        Ok(precondition_failure)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::super::{FromAny, IntoAny};
+    use super::PreconditionFailure;
+
+    #[test]
+    fn gen_prec_failure() {
+        let mut prec_failure = PreconditionFailure::new(Vec::new());
+        let formatted = format!("{:?}", prec_failure);
+
+        let expected = "PreconditionFailure { violations: [] }";
+
+        assert!(
+            formatted.eq(expected),
+            "empty PreconditionFailure differs from expected result"
+        );
+
+        assert!(
+            prec_failure.is_empty(),
+            "empty PreconditionFailure returns 'false' from .is_empty()"
+        );
+
+        prec_failure
+            .add_violation("TOS", "example.local", "Terms of service not accepted")
+            .add_violation("FNF", "example.local", "File not found");
+
+        let formatted = format!("{:?}", prec_failure);
+
+        let expected_filled = "PreconditionFailure { violations: [PreconditionViolation { type: \"TOS\", subject: \"example.local\", description: \"Terms of service not accepted\" }, PreconditionViolation { type: \"FNF\", subject: \"example.local\", description: \"File not found\" }] }";
+
+        assert!(
+            formatted.eq(expected_filled),
+            "filled PreconditionFailure differs from expected result"
+        );
+
+        assert!(
+            !prec_failure.is_empty(),
+            "filled PreconditionFailure returns 'true' from .is_empty()"
+        );
+
+        let gen_any = prec_failure.into_any();
+
+        let formatted = format!("{:?}", gen_any);
+
+        let expected = "Any { type_url: \"type.googleapis.com/google.rpc.PreconditionFailure\", value: [10, 51, 10, 3, 84, 79, 83, 18, 13, 101, 120, 97, 109, 112, 108, 101, 46, 108, 111, 99, 97, 108, 26, 29, 84, 101, 114, 109, 115, 32, 111, 102, 32, 115, 101, 114, 118, 105, 99, 101, 32, 110, 111, 116, 32, 97, 99, 99, 101, 112, 116, 101, 100, 10, 36, 10, 3, 70, 78, 70, 18, 13, 101, 120, 97, 109, 112, 108, 101, 46, 108, 111, 99, 97, 108, 26, 14, 70, 105, 108, 101, 32, 110, 111, 116, 32, 102, 111, 117, 110, 100] }";
+
+        assert!(
+            formatted.eq(expected),
+            "Any from filled PreconditionFailure differs from expected result"
+        );
+
+        let br_details = match PreconditionFailure::from_any(gen_any) {
+            Err(error) => panic!("Error generating PreconditionFailure from Any: {:?}", error),
+            Ok(from_any) => from_any,
+        };
+
+        let formatted = format!("{:?}", br_details);
+
+        assert!(
+            formatted.eq(expected_filled),
+            "PreconditionFailure from Any differs from expected result"
+        );
+    }
+}

--- a/tonic-types/src/richer_error/std_messages/quota_failure.rs
+++ b/tonic-types/src/richer_error/std_messages/quota_failure.rs
@@ -53,9 +53,7 @@ impl QuotaFailure {
             }],
         }
     }
-}
 
-impl QuotaFailure {
     /// Adds a [`QuotaViolation`] to [`QuotaFailure`]'s `violations`.
     pub fn add_violation(
         &mut self,

--- a/tonic-types/src/richer_error/std_messages/retry_info.rs
+++ b/tonic-types/src/richer_error/std_messages/retry_info.rs
@@ -42,9 +42,7 @@ impl RetryInfo {
 
         RetryInfo { retry_delay }
     }
-}
 
-impl RetryInfo {
     /// Returns `true` if [`RetryInfo`]'s `retry_delay` is set as `None`, and
     /// `false` if it is not.
     pub fn is_empty(&self) -> bool {


### PR DESCRIPTION
## Motivation

The [gRPC Richer Error Model][error-handling] is quite useful to send additional feedback to clients, and is supported by many gRPC libraries in other languages.

## Solution

This PR continues the work initiated in [#1068], building on the changes made in [#1269]. It adds support for the `PreconditionFailure` standard error message type to `tonic-types`.

[error-handling]: https://www.grpc.io/docs/guides/error
[#1068]: https://github.com/hyperium/tonic/pull/1068
[#1269]: https://github.com/hyperium/tonic/pull/1269
