### PR TITLE
feat(types): Add gRPC Richer Error Model support (RequestInfo)

### DIFF
--- a/tonic-types/src/lib.rs
+++ b/tonic-types/src/lib.rs
@@ -47,7 +47,8 @@ mod richer_error;
 
 pub use richer_error::{
     BadRequest, DebugInfo, ErrorDetail, ErrorDetails, ErrorInfo, FieldViolation,
-    PreconditionFailure, PreconditionViolation, QuotaFailure, QuotaViolation, RetryInfo, StatusExt,
+    PreconditionFailure, PreconditionViolation, QuotaFailure, QuotaViolation, RequestInfo,
+    RetryInfo, StatusExt,
 };
 
 mod sealed {

--- a/tonic-types/src/richer_error/error_details/mod.rs
+++ b/tonic-types/src/richer_error/error_details/mod.rs
@@ -2,7 +2,7 @@ use std::{collections::HashMap, time};
 
 use super::std_messages::{
     BadRequest, DebugInfo, ErrorInfo, FieldViolation, PreconditionFailure, PreconditionViolation,
-    QuotaFailure, QuotaViolation, RetryInfo,
+    QuotaFailure, QuotaViolation, RequestInfo, RetryInfo,
 };
 
 pub(crate) mod vec;
@@ -31,6 +31,9 @@ pub struct ErrorDetails {
 
     /// This field stores [`BadRequest`] data, if any.
     pub(crate) bad_request: Option<BadRequest>,
+
+    /// This field stores [`RequestInfo`] data, if any.
+    pub(crate) request_info: Option<RequestInfo>,
 }
 
 impl ErrorDetails {
@@ -250,6 +253,29 @@ impl ErrorDetails {
         }
     }
 
+    /// Generates an [`ErrorDetails`] struct with [`RequestInfo`] details and
+    /// remaining fields set to `None`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tonic_types::ErrorDetails;
+    ///
+    /// let err_details = ErrorDetails::with_request_info(
+    ///     "request_id",
+    ///     "serving_data",
+    /// );
+    /// ```
+    pub fn with_request_info(
+        request_id: impl Into<String>,
+        serving_data: impl Into<String>,
+    ) -> Self {
+        ErrorDetails {
+            request_info: Some(RequestInfo::new(request_id, serving_data)),
+            ..ErrorDetails::new()
+        }
+    }
+
     /// Get [`RetryInfo`] details, if any.
     pub fn retry_info(&self) -> Option<RetryInfo> {
         self.retry_info.clone()
@@ -278,6 +304,11 @@ impl ErrorDetails {
     /// Get [`BadRequest`] details, if any.
     pub fn bad_request(&self) -> Option<BadRequest> {
         self.bad_request.clone()
+    }
+
+    /// Get [`RequestInfo`] details, if any.
+    pub fn request_info(&self) -> Option<RequestInfo> {
+        self.request_info.clone()
     }
 
     /// Set [`RetryInfo`] details. Can be chained with other `.set_` and
@@ -585,5 +616,26 @@ impl ErrorDetails {
             return !bad_request.field_violations.is_empty();
         }
         false
+    }
+
+    /// Set [`RequestInfo`] details. Can be chained with other `.set_` and
+    /// `.add_` [`ErrorDetails`] methods.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tonic_types::ErrorDetails;
+    ///
+    /// let mut err_details = ErrorDetails::new();
+    ///
+    /// err_details.set_request_info("request_id", "serving_data");
+    /// ```
+    pub fn set_request_info(
+        &mut self,
+        request_id: impl Into<String>,
+        serving_data: impl Into<String>,
+    ) -> &mut Self {
+        self.request_info = Some(RequestInfo::new(request_id, serving_data));
+        self
     }
 }

--- a/tonic-types/src/richer_error/error_details/vec.rs
+++ b/tonic-types/src/richer_error/error_details/vec.rs
@@ -1,5 +1,5 @@
 use super::super::std_messages::{
-    BadRequest, DebugInfo, ErrorInfo, PreconditionFailure, QuotaFailure, RetryInfo,
+    BadRequest, DebugInfo, ErrorInfo, PreconditionFailure, QuotaFailure, RequestInfo, RetryInfo,
 };
 
 /// Wraps the structs corresponding to the standard error messages, allowing
@@ -24,6 +24,9 @@ pub enum ErrorDetail {
 
     /// Wraps the [`BadRequest`] struct.
     BadRequest(BadRequest),
+
+    /// Wraps the [`RequestInfo`] struct.
+    RequestInfo(RequestInfo),
 }
 
 impl From<RetryInfo> for ErrorDetail {
@@ -59,5 +62,11 @@ impl From<PreconditionFailure> for ErrorDetail {
 impl From<BadRequest> for ErrorDetail {
     fn from(err_detail: BadRequest) -> Self {
         ErrorDetail::BadRequest(err_detail)
+    }
+}
+
+impl From<RequestInfo> for ErrorDetail {
+    fn from(err_detail: RequestInfo) -> Self {
+        ErrorDetail::RequestInfo(err_detail)
     }
 }

--- a/tonic-types/src/richer_error/std_messages/mod.rs
+++ b/tonic-types/src/richer_error/std_messages/mod.rs
@@ -21,3 +21,7 @@ pub use prec_failure::{PreconditionFailure, PreconditionViolation};
 mod bad_request;
 
 pub use bad_request::{BadRequest, FieldViolation};
+
+mod request_info;
+
+pub use request_info::RequestInfo;

--- a/tonic-types/src/richer_error/std_messages/request_info.rs
+++ b/tonic-types/src/richer_error/std_messages/request_info.rs
@@ -1,0 +1,112 @@
+use prost::{DecodeError, Message};
+use prost_types::Any;
+
+use super::super::{pb, FromAny, IntoAny};
+
+/// Used to encode/decode the `RequestInfo` standard error message described
+/// in [error_details.proto]. Contains metadata about the request that
+/// clients can attach when providing feedback.
+///
+/// [error_details.proto]: https://github.com/googleapis/googleapis/blob/master/google/rpc/error_details.proto
+#[derive(Clone, Debug)]
+pub struct RequestInfo {
+    /// An opaque string that should only be interpreted by the service that
+    /// generated it. For example, an id used to identify requests in the logs.
+    pub request_id: String,
+
+    /// Any data used to serve this request. For example, an encrypted stack
+    /// trace that can be sent back to the service provider for debugging.
+    pub serving_data: String,
+}
+
+impl RequestInfo {
+    /// Type URL of the `RequestInfo` standard error message type.
+    pub const TYPE_URL: &'static str = "type.googleapis.com/google.rpc.RequestInfo";
+
+    /// Creates a new [`RequestInfo`] struct.
+    pub fn new(request_id: impl Into<String>, serving_data: impl Into<String>) -> Self {
+        RequestInfo {
+            request_id: request_id.into(),
+            serving_data: serving_data.into(),
+        }
+    }
+
+    /// Returns `true` if [`RequestInfo`] fields are empty, and `false` if they
+    /// are not.
+    pub fn is_empty(&self) -> bool {
+        self.request_id.is_empty() && self.serving_data.is_empty()
+    }
+}
+
+impl IntoAny for RequestInfo {
+    fn into_any(self) -> Any {
+        let detail_data = pb::RequestInfo {
+            request_id: self.request_id,
+            serving_data: self.serving_data,
+        };
+
+        Any {
+            type_url: RequestInfo::TYPE_URL.to_string(),
+            value: detail_data.encode_to_vec(),
+        }
+    }
+}
+
+impl FromAny for RequestInfo {
+    fn from_any(any: Any) -> Result<Self, DecodeError> {
+        let buf: &[u8] = &any.value;
+        let req_info = pb::RequestInfo::decode(buf)?;
+
+        let debug_info = RequestInfo {
+            request_id: req_info.request_id,
+            serving_data: req_info.serving_data,
+        };
+
+        Ok(debug_info)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::super::{FromAny, IntoAny};
+    use super::RequestInfo;
+
+    #[test]
+    fn gen_error_info() {
+        let error_info = RequestInfo::new("some-id", "some-data");
+
+        let formatted = format!("{:?}", error_info);
+
+        let expected_filled =
+            "RequestInfo { request_id: \"some-id\", serving_data: \"some-data\" }";
+
+        assert!(
+            formatted.eq(expected_filled),
+            "filled RequestInfo differs from expected result"
+        );
+
+        let gen_any = error_info.into_any();
+
+        let formatted = format!("{:?}", gen_any);
+
+        let expected =
+            "Any { type_url: \"type.googleapis.com/google.rpc.RequestInfo\", value: [10, 7, 115, 111, 109, 101, 45, 105, 100, 18, 9, 115, 111, 109, 101, 45, 100, 97, 116, 97] }";
+
+        assert!(
+            formatted.eq(expected),
+            "Any from filled RequestInfo differs from expected result"
+        );
+
+        let br_details = match RequestInfo::from_any(gen_any) {
+            Err(error) => panic!("Error generating RequestInfo from Any: {:?}", error),
+            Ok(from_any) => from_any,
+        };
+
+        let formatted = format!("{:?}", br_details);
+
+        assert!(
+            formatted.eq(expected_filled),
+            "RequestInfo from Any differs from expected result"
+        );
+    }
+}


### PR DESCRIPTION
## Motivation

The [gRPC Richer Error Model][error-handling] is quite useful to send additional feedback to clients, and is supported by many gRPC libraries in other languages.

## Solution

This PR continues the work initiated in [#1068], building on the changes made in [#1276]. It adds support for the `RequestInfo` standard error message type to `tonic-types`.

[error-handling]: https://www.grpc.io/docs/guides/error
[#1068]: https://github.com/hyperium/tonic/pull/1068
[#1276]: https://github.com/hyperium/tonic/pull/1276