### PR TITLE
chore(tonic): Remove duplicate tls feature gate and re-export http crate instead of using wildcard importing

### DIFF
--- a/tonic/src/codegen.rs
+++ b/tonic/src/codegen.rs
@@ -13,14 +13,11 @@ pub type StdError = Box<dyn std::error::Error + Send + Sync + 'static>;
 pub use crate::codec::{CompressionEncoding, EnabledCompressionEncodings};
 pub use crate::service::interceptor::InterceptedService;
 pub use bytes::Bytes;
+pub use http;
 pub use http_body::Body;
 
 pub type BoxFuture<T, E> = self::Pin<Box<dyn self::Future<Output = Result<T, E>> + Send + 'static>>;
 pub type BoxStream<T> =
     self::Pin<Box<dyn futures_core::Stream<Item = Result<T, crate::Status>> + Send + 'static>>;
-
-pub mod http {
-    pub use http::*;
-}
 
 pub use crate::body::empty_body;

--- a/tonic/src/transport/channel/tls.rs
+++ b/tonic/src/transport/channel/tls.rs
@@ -7,8 +7,6 @@ use http::Uri;
 use std::fmt;
 
 /// Configures TLS settings for endpoints.
-#[cfg(feature = "tls")]
-#[cfg_attr(docsrs, doc(cfg(feature = "tls")))]
 #[derive(Clone, Default)]
 pub struct ClientTlsConfig {
     domain: Option<String>,
@@ -16,7 +14,6 @@ pub struct ClientTlsConfig {
     identity: Option<Identity>,
 }
 
-#[cfg(feature = "tls")]
 impl fmt::Debug for ClientTlsConfig {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("ClientTlsConfig")
@@ -27,7 +24,6 @@ impl fmt::Debug for ClientTlsConfig {
     }
 }
 
-#[cfg(feature = "tls")]
 impl ClientTlsConfig {
     /// Creates a new `ClientTlsConfig` using Rustls.
     pub fn new() -> Self {

--- a/tonic/src/transport/server/tls.rs
+++ b/tonic/src/transport/server/tls.rs
@@ -5,8 +5,6 @@ use crate::transport::{
 use std::fmt;
 
 /// Configures TLS settings for servers.
-#[cfg(feature = "tls")]
-#[cfg_attr(docsrs, doc(cfg(feature = "tls")))]
 #[derive(Clone, Default)]
 pub struct ServerTlsConfig {
     identity: Option<Identity>,
@@ -14,14 +12,12 @@ pub struct ServerTlsConfig {
     client_auth_optional: bool,
 }
 
-#[cfg(feature = "tls")]
 impl fmt::Debug for ServerTlsConfig {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("ServerTlsConfig").finish()
     }
 }
 
-#[cfg(feature = "tls")]
 impl ServerTlsConfig {
     /// Creates a new `ServerTlsConfig`.
     pub fn new() -> Self {


### PR DESCRIPTION
## Motivation

Simplifies the codes.

## Solution

Removes duplicated tls feature gate and re-exports http crate instead of using wildcard importing.