### PR TITLE
chore(health): Fix clippy lint

### DIFF
--- a/tonic-health/src/server.rs
+++ b/tonic-health/src/server.rs
@@ -155,7 +155,7 @@ impl Health for HealthService {
             let status = crate::pb::health_check_response::ServingStatus::from(*status_rx.borrow()) as i32;
             yield HealthCheckResponse { status };
 
-            while let Ok(_) = status_rx.changed().await {
+            while status_rx.changed().await.is_ok() {
                 let status = crate::pb::health_check_response::ServingStatus::from(*status_rx.borrow()) as i32;
                 yield HealthCheckResponse { status };
             }


### PR DESCRIPTION
Fixes a clippy lint error. It's strange that this hasn't been detected.