### PR TITLE
[tonic-web] Fix CORS trait issue when using tonic_web::enable

### DIFF
--- a/examples/src/grpc-web/server.rs
+++ b/examples/src/grpc-web/server.rs
@@ -2,7 +2,6 @@ use tonic::{transport::Server, Request, Response, Status};
 
 use hello_world::greeter_server::{Greeter, GreeterServer};
 use hello_world::{HelloReply, HelloRequest};
-use tonic_web::GrpcWebLayer;
 
 pub mod hello_world {
     tonic::include_proto!("helloworld");
@@ -39,8 +38,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     Server::builder()
         .accept_http1(true)
-        .layer(GrpcWebLayer::new())
-        .add_service(greeter)
+        .add_service(tonic_web::enable(greeter))
         .serve(addr)
         .await?;
 

--- a/tonic/Cargo.toml
+++ b/tonic/Cargo.toml
@@ -60,6 +60,7 @@ percent-encoding = "2.1"
 pin-project = "1.0.11"
 tower-layer = "0.3"
 tower-service = "0.3"
+tower-http = { version = "0.3", features = ["cors"] }
 
 # prost
 prost = {version = "0.11", default-features = false, features = ["std"], optional = true}

--- a/tonic/src/service/interceptor.rs
+++ b/tonic/src/service/interceptor.rs
@@ -188,6 +188,13 @@ where
     }
 }
 
+impl<S: crate::server::NamedService> crate::server::NamedService for tower_http::cors::Cors<S>
+where
+    S: crate::server::NamedService,
+{
+    const NAME: &'static str = S::NAME;
+}
+
 // required to use `InterceptedService` with `Router`
 impl<S, F> crate::server::NamedService for InterceptedService<S, F>
 where


### PR DESCRIPTION
## Motivation

The grpc-web README example doesn't compile due to an unimplemented trait in `tower_http::cors::Cors`.  
It seems related to [this PR](https://github.com/hyperium/tonic/pull/1123), which added the tower_http Cors layer wrapper to `tonic_web::enable`. 

## The error
```bash
error[E0277]: the trait bound `tower_http::cors::Cors<GrpcWebService<GreeterServer<MyGreeter>>>: NamedService` is not satisfied
   --> examples/src/grpc-web/server.rs:44:22
    |
44  |         .add_service(tonic_web::enable(greeter))
    |          ----------- ^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `NamedService` is not implemented for `tower_http::cors::Cors<GrpcWebService<GreeterServer<MyGreeter>>>`
    |          |
    |          required by a bound introduced by this call
    |
    = help: the following other types implement trait `NamedService`:
              GreeterServer<T>
              GrpcWebService<S>
              tonic::service::interceptor::InterceptedService<S, F>
              tower::util::either::Either<S, T>
note: required by a bound in `Server::<L>::add_service`
   --> /home/ubuntu/repos/tonic/tonic/src/transport/server/mod.rs:347:15
    |
347 |             + NamedService
    |               ^^^^^^^^^^^^ required by this bound in `Server::<L>::add_service`

For more information about this error, try `rustc --explain E0277`.
```


### Reproducing the error
You can repro the issue by cloning the tonic repo and modifying the code in [this example](https://github.com/hyperium/tonic/blob/9f716d841184b8521720c6ed941af137ca2ee6a0/examples/src/grpc-web/server.rs#L30).
```diff
...
    Server::builder()
        .accept_http1(true)
-        .layer(GrpcWebLayer::new())
-        .add_service(greeter)
+        .add_service(tonic_web::enable(greeter))
        .serve(addr)
        .await?;
...
```
Then run `cargo run -p examples --bin grpc-web-server`



## Solution

Added `NamedService` impl for `tower_http::cors::Cors<S>`.  Open to feedback on where exactly this should live.

Also made the grpc-web server example consistent with the README.  It now uses the `tonic_web::enable` helper which enables CORS support by default.  As stated in [this issue](https://github.com/hyperium/tonic/issues/270), CORS support is needed for a browser client to talk to a tonic server without a proxy.  I imagine this is what the typical tonic-web user wants.

After making this change, a grpc-web client running in my browser is able to talk to my tonic-web server without issue.