### PR TITLE
chore(types): Remove unnecesarry unreachable_pub lint allowing

### DIFF
--- a/tonic-types/src/lib.rs
+++ b/tonic-types/src/lib.rs
@@ -52,6 +52,5 @@ pub use richer_error::{
 };
 
 mod sealed {
-    #[allow(unreachable_pub)]
     pub trait Sealed {}
 }


### PR DESCRIPTION
We do not need this lint allowing as with [tonic](https://github.com/hyperium/tonic/blob/v0.8.4/tonic/src/request.rs#L388-L390).