### PR TITLE
Mark Service created by into_service as Sync

### DIFF
--- a/tonic/src/transport/server/mod.rs
+++ b/tonic/src/transport/server/mod.rs
@@ -684,7 +684,7 @@ impl<L> Router<L> {
     pub fn into_service<ResBody>(self) -> L::Service
     where
         L: Layer<Routes>,
-        L::Service: Service<Request<Body>, Response = Response<ResBody>> + Clone + Send + 'static,
+        L::Service: Service<Request<Body>, Response = Response<ResBody>> + Clone + Send + Sync + 'static,
         <<L as Layer<Routes>>::Service as Service<Request<Body>>>::Future: Send + 'static,
         <<L as Layer<Routes>>::Service as Service<Request<Body>>>::Error: Into<crate::Error> + Send,
         ResBody: http_body::Body<Data = Bytes> + Send + 'static,


### PR DESCRIPTION
## Motivation
In other projects in the "Tower ecosystem", it is required that the service be Sync. For example, in Poem: https://github.com/poem-web/poem/issues/536. As far as I can tell, there is no reason why the Service 

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
