### PR TITLE
chore(interop): Remove unnecessary asyncronous file io to read data

### DIFF
--- a/interop/Cargo.toml
+++ b/interop/Cargo.toml
@@ -25,7 +25,7 @@ http = "0.2"
 http-body = "0.4.2"
 hyper = "0.14"
 prost = "0.11"
-tokio = {version = "1.0", features = ["rt-multi-thread", "time", "macros", "fs"]}
+tokio = {version = "1.0", features = ["rt-multi-thread", "time", "macros"]}
 tokio-stream = "0.1"
 tonic = {path = "../tonic", features = ["tls"]}
 tower = {version = "0.4"}

--- a/interop/src/bin/client.rs
+++ b/interop/src/bin/client.rs
@@ -35,7 +35,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .concurrency_limit(30);
 
     if matches.use_tls {
-        let pem = tokio::fs::read("interop/data/ca.pem").await?;
+        let pem = std::fs::read_to_string("interop/data/ca.pem")?;
         let ca = Certificate::from_pem(pem);
         endpoint = endpoint.tls_config(
             ClientTlsConfig::new()

--- a/interop/src/bin/server.rs
+++ b/interop/src/bin/server.rs
@@ -27,8 +27,8 @@ async fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
     let mut builder = Server::builder();
 
     if matches.use_tls {
-        let cert = tokio::fs::read("interop/data/server1.pem").await?;
-        let key = tokio::fs::read("interop/data/server1.key").await?;
+        let cert = std::fs::read_to_string("interop/data/server1.pem")?;
+        let key = std::fs::read_to_string("interop/data/server1.key")?;
         let identity = Identity::from_pem(cert, key);
 
         builder = builder.tls_config(ServerTlsConfig::new().identity(identity))?;


### PR DESCRIPTION
## Motivation

Simplifies implementations.

## Solution

As we do not have to read these data asynchronously, we could use std's function.