### PR TITLE
chore: Minimize cargo-deny skip tree

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -15,9 +15,9 @@ deny = [
     { name = "term" },
 ]
 skip-tree = [
-    { name = "rustls-pemfile" },
     { name = "windows-sys" },
     { name = "hermit-abi" },
+    { name = "base64" },
     { name = "syn" },
 ]
 

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -302,7 +302,7 @@ prost-types = { version = "0.11", optional = true }
 http = { version = "0.2", optional = true }
 http-body = { version = "0.4.2", optional = true }
 hyper = { version = "0.14", optional = true }
-warp = { version = "0.3", default-features = false, optional = true }
+warp = { version = "0.3.4", default-features = false, optional = true }
 listenfd = { version = "1.0", optional = true }
 bytes = { version = "1", optional = true }
 h2 = { version = "0.3", optional = true }


### PR DESCRIPTION
As warp updated to use rustls-pemfile v1 in 0.3.4, we could minimize the cargo-deny skip tree.