### PR TITLE
chore: Prepare `0.9.1` release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# [v0.9.1](https://github.com/hyperium/tonic/compare/v0.9.0...v0.9.1) (2023-04-03)
+
+### Features
+
+- **transport:** Update `rustls` to `0.21` ([#1340](https://github.com/hyperium/tonic/pull/1340))
+
 # [v0.9.0](https://github.com/hyperium/tonic/compare/v0.8.4...v0.9.0) (2023-03-31)
 
 All tonic-* crates owned by this repository will now be versioned together to

--- a/examples/helloworld-tutorial.md
+++ b/examples/helloworld-tutorial.md
@@ -112,12 +112,12 @@ name = "helloworld-client"
 path = "src/client.rs"
 
 [dependencies]
-tonic = "0.8"
+tonic = "0.9"
 prost = "0.11"
 tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
 
 [build-dependencies]
-tonic-build = "0.8"
+tonic-build = "0.9"
 ```
 
 We include `tonic-build` as a useful way to incorporate the generation of our client and server gRPC code into the build process of our application. We will setup this build process now:

--- a/examples/routeguide-tutorial.md
+++ b/examples/routeguide-tutorial.md
@@ -174,7 +174,7 @@ Edit `Cargo.toml` and add all the dependencies we'll need for this example:
 
 ```toml
 [dependencies]
-tonic = "0.8"
+tonic = "0.9"
 prost = "0.11"
 futures-core = "0.3"
 futures-util = "0.3"
@@ -187,7 +187,7 @@ serde_json = "1.0"
 rand = "0.7"
 
 [build-dependencies]
-tonic-build = "0.8"
+tonic-build = "0.9"
 ```
 
 Create a `build.rs` file at the root of your crate:

--- a/prepare-release.sh
+++ b/prepare-release.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+
+# Script which automates modifying source version fields, and creating a release
+# commit and tag. The commit and tag are not automatically pushed, nor are the
+# crates published (see publish-release.sh).
+
+set -ex
+
+if [ "$#" -ne 1 ]
+then
+  echo "Usage: $0 <version>"
+  exit 1
+fi
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+VERSION="$1"
+MINOR="$( echo ${VERSION} | cut -d\. -f1-2 )"
+
+VERSION_MATCHER="([a-z0-9\\.-]+)"
+TONIC_CRATE_MATCHER="(tonic|tonic-[a-z]+)"
+
+# Update the README.md.
+sed -i -E "s/${TONIC_CRATE_MATCHER} = \"${VERSION_MATCHER}\"/\1 = \"${MINOR}\"/" "$DIR/examples/helloworld-tutorial.md"
+sed -i -E "s/${TONIC_CRATE_MATCHER} = \"${VERSION_MATCHER}\"/\1 = \"${MINOR}\"/" "$DIR/examples/routeguide-tutorial.md"
+
+CRATES=( \
+  "tonic" \
+  "tonic-build" \
+  "tonic-types" \
+  "tonic-reflection" \
+  "tonic-health" \
+  "tonic-web" \
+)
+
+for CRATE in "${CRATES[@]}"; do
+  # Update html_root_url attributes.
+  sed -i -E "s~html_root_url = \"https://docs\.rs/${TONIC_CRATE_MATCHER}/$VERSION_MATCHER\"~html_root_url = \"https://docs.rs/\1/${VERSION}\"~" \
+    "$DIR/$CRATE/src/lib.rs"
+
+  # Update documentation url in Cargo.toml
+  sed -i -E "s~documentation = \"https://docs\.rs/$CRATE/$VERSION_MATCHER\"~documentation = \"https://docs.rs/${CRATE}/${VERSION}\"~" \
+    "$DIR/$CRATE/Cargo.toml"
+
+  # Update Cargo.toml version fields.
+  sed -i -E "s/^version = \"${VERSION_MATCHER}\"$/version = \"${VERSION}\"/" \
+    "$DIR/$CRATE/Cargo.toml"
+done

--- a/publish-release.sh
+++ b/publish-release.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+# Script which automates publishing a crates.io release of the prost crates.
+
+set -ex
+
+if [ "$#" -ne 0 ]
+then
+  echo "Usage: $0"
+  exit 1
+fi
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+
+CRATES=( \
+  "tonic" \
+  "tonic-build" \
+  "tonic-types" \
+  "tonic-reflection" \
+  "tonic-health" \
+  "tonic-web" \
+)
+
+for CRATE in "${CRATES[@]}"; do
+  pushd "$DIR/$CRATE"
+
+  echo "Publishing $CRATE"
+
+  cargo publish
+
+  popd
+done

--- a/tonic-build/Cargo.toml
+++ b/tonic-build/Cargo.toml
@@ -4,7 +4,7 @@ categories = ["network-programming", "asynchronous"]
 description = """
 Codegen module of `tonic` gRPC implementation.
 """
-documentation = "https://docs.rs/tonic-build/0.9.0/tonic_build/"
+documentation = "https://docs.rs/tonic-build/0.9.0"
 edition = "2021"
 homepage = "https://github.com/hyperium/tonic"
 keywords = ["rpc", "grpc", "async", "codegen", "protobuf"]

--- a/tonic-build/Cargo.toml
+++ b/tonic-build/Cargo.toml
@@ -4,7 +4,7 @@ categories = ["network-programming", "asynchronous"]
 description = """
 Codegen module of `tonic` gRPC implementation.
 """
-documentation = "https://docs.rs/tonic-build/0.9.0"
+documentation = "https://docs.rs/tonic-build/0.9.1"
 edition = "2021"
 homepage = "https://github.com/hyperium/tonic"
 keywords = ["rpc", "grpc", "async", "codegen", "protobuf"]
@@ -12,7 +12,7 @@ license = "MIT"
 name = "tonic-build"
 readme = "README.md"
 repository = "https://github.com/hyperium/tonic"
-version = "0.9.0"
+version = "0.9.1"
 
 [dependencies]
 prettyplease = { version = "0.1" }

--- a/tonic-build/src/lib.rs
+++ b/tonic-build/src/lib.rs
@@ -70,7 +70,7 @@
     html_logo_url = "https://raw.githubusercontent.com/tokio-rs/website/master/public/img/icons/tonic.svg"
 )]
 #![deny(rustdoc::broken_intra_doc_links)]
-#![doc(html_root_url = "https://docs.rs/tonic-build/0.9.0")]
+#![doc(html_root_url = "https://docs.rs/tonic-build/0.9.1")]
 #![doc(issue_tracker_base_url = "https://github.com/hyperium/tonic/issues/")]
 #![doc(test(no_crate_inject, attr(deny(rust_2018_idioms))))]
 #![cfg_attr(docsrs, feature(doc_cfg))]

--- a/tonic-health/Cargo.toml
+++ b/tonic-health/Cargo.toml
@@ -4,7 +4,7 @@ categories = ["network-programming", "asynchronous"]
 description = """
 Health Checking module of `tonic` gRPC implementation.
 """
-documentation = "https://docs.rs/tonic-health/0.7.0"
+documentation = "https://docs.rs/tonic-health/0.9.1"
 edition = "2021"
 homepage = "https://github.com/hyperium/tonic"
 keywords = ["rpc", "grpc", "async", "healthcheck"]
@@ -12,7 +12,7 @@ license = "MIT"
 name = "tonic-health"
 readme = "README.md"
 repository = "https://github.com/hyperium/tonic"
-version = "0.9.0"
+version = "0.9.1"
 
 [features]
 default = ["transport"]

--- a/tonic-health/Cargo.toml
+++ b/tonic-health/Cargo.toml
@@ -4,7 +4,7 @@ categories = ["network-programming", "asynchronous"]
 description = """
 Health Checking module of `tonic` gRPC implementation.
 """
-documentation = "https://docs.rs/tonic-health/0.7.0/tonic-health/"
+documentation = "https://docs.rs/tonic-health/0.7.0"
 edition = "2021"
 homepage = "https://github.com/hyperium/tonic"
 keywords = ["rpc", "grpc", "async", "healthcheck"]

--- a/tonic-health/src/lib.rs
+++ b/tonic-health/src/lib.rs
@@ -16,7 +16,7 @@
     html_logo_url = "https://raw.githubusercontent.com/tokio-rs/website/master/public/img/icons/tonic.svg"
 )]
 #![deny(rustdoc::broken_intra_doc_links)]
-#![doc(html_root_url = "https://docs.rs/tonic-health/0.9.0")]
+#![doc(html_root_url = "https://docs.rs/tonic-health/0.9.1")]
 #![doc(issue_tracker_base_url = "https://github.com/hyperium/tonic/issues/")]
 #![doc(test(no_crate_inject, attr(deny(rust_2018_idioms))))]
 #![cfg_attr(docsrs, feature(doc_cfg))]

--- a/tonic-reflection/Cargo.toml
+++ b/tonic-reflection/Cargo.toml
@@ -9,7 +9,7 @@ Server Reflection module of `tonic` gRPC implementation.
 """
 edition = "2021"
 homepage = "https://github.com/hyperium/tonic"
-documentation = "https://docs.rs/tonic-reflection/0.9.0/tonic-reflection/"
+documentation = "https://docs.rs/tonic-reflection/0.9.0"
 keywords = ["rpc", "grpc", "async", "reflection"]
 license = "MIT"
 name = "tonic-reflection"

--- a/tonic-reflection/Cargo.toml
+++ b/tonic-reflection/Cargo.toml
@@ -9,13 +9,13 @@ Server Reflection module of `tonic` gRPC implementation.
 """
 edition = "2021"
 homepage = "https://github.com/hyperium/tonic"
-documentation = "https://docs.rs/tonic-reflection/0.9.0"
+documentation = "https://docs.rs/tonic-reflection/0.9.1"
 keywords = ["rpc", "grpc", "async", "reflection"]
 license = "MIT"
 name = "tonic-reflection"
 readme = "README.md"
 repository = "https://github.com/hyperium/tonic"
-version = "0.9.0"
+version = "0.9.1"
 
 [dependencies]
 prost = "0.11"

--- a/tonic-reflection/src/lib.rs
+++ b/tonic-reflection/src/lib.rs
@@ -10,7 +10,7 @@
     html_logo_url = "https://github.com/hyperium/tonic/raw/master/.github/assets/tonic-docs.png"
 )]
 #![deny(rustdoc::broken_intra_doc_links)]
-#![doc(html_root_url = "https://docs.rs/tonic-reflection/0.9.0")]
+#![doc(html_root_url = "https://docs.rs/tonic-reflection/0.9.1")]
 #![doc(issue_tracker_base_url = "https://github.com/hyperium/tonic/issues/")]
 #![doc(test(no_crate_inject, attr(deny(rust_2018_idioms))))]
 #![cfg_attr(docsrs, feature(doc_cfg))]

--- a/tonic-types/Cargo.toml
+++ b/tonic-types/Cargo.toml
@@ -7,7 +7,7 @@ categories = ["web-programming", "network-programming", "asynchronous"]
 description = """
 A collection of useful protobuf types that can be used with `tonic`.
 """
-documentation = "https://docs.rs/tonic-types/0.9.0/tonic_types/"
+documentation = "https://docs.rs/tonic-types/0.9.0"
 edition = "2021"
 homepage = "https://github.com/hyperium/tonic"
 keywords = ["rpc", "grpc", "protobuf"]

--- a/tonic-types/Cargo.toml
+++ b/tonic-types/Cargo.toml
@@ -7,7 +7,7 @@ categories = ["web-programming", "network-programming", "asynchronous"]
 description = """
 A collection of useful protobuf types that can be used with `tonic`.
 """
-documentation = "https://docs.rs/tonic-types/0.9.0"
+documentation = "https://docs.rs/tonic-types/0.9.1"
 edition = "2021"
 homepage = "https://github.com/hyperium/tonic"
 keywords = ["rpc", "grpc", "protobuf"]
@@ -15,7 +15,7 @@ license = "MIT"
 name = "tonic-types"
 readme = "README.md"
 repository = "https://github.com/hyperium/tonic"
-version = "0.9.0"
+version = "0.9.1"
 
 [dependencies]
 prost = "0.11"

--- a/tonic-types/src/lib.rs
+++ b/tonic-types/src/lib.rs
@@ -150,7 +150,7 @@
     html_logo_url = "https://raw.githubusercontent.com/tokio-rs/website/master/public/img/icons/tonic.svg"
 )]
 #![deny(rustdoc::broken_intra_doc_links)]
-#![doc(html_root_url = "https://docs.rs/tonic-types/0.9.0")]
+#![doc(html_root_url = "https://docs.rs/tonic-types/0.9.1")]
 #![doc(issue_tracker_base_url = "https://github.com/hyperium/tonic/issues/")]
 
 /// Useful protobuf types

--- a/tonic-web/Cargo.toml
+++ b/tonic-web/Cargo.toml
@@ -4,7 +4,7 @@ categories = ["network-programming", "asynchronous"]
 description = """
 grpc-web protocol translation for tonic services.
 """
-documentation = "https://docs.rs/tonic-web/0.9.0/tonic-web/"
+documentation = "https://docs.rs/tonic-web/0.9.0"
 edition = "2021"
 homepage = "https://github.com/hyperium/tonic"
 keywords = ["rpc", "grpc", "grpc-web"]

--- a/tonic-web/Cargo.toml
+++ b/tonic-web/Cargo.toml
@@ -4,7 +4,7 @@ categories = ["network-programming", "asynchronous"]
 description = """
 grpc-web protocol translation for tonic services.
 """
-documentation = "https://docs.rs/tonic-web/0.9.0"
+documentation = "https://docs.rs/tonic-web/0.9.1"
 edition = "2021"
 homepage = "https://github.com/hyperium/tonic"
 keywords = ["rpc", "grpc", "grpc-web"]
@@ -12,7 +12,7 @@ license = "MIT"
 name = "tonic-web"
 readme = "README.md"
 repository = "https://github.com/hyperium/tonic"
-version = "0.9.0"
+version = "0.9.1"
 
 [dependencies]
 base64 = "0.21"

--- a/tonic-web/src/lib.rs
+++ b/tonic-web/src/lib.rs
@@ -94,7 +94,7 @@
     rust_2018_idioms,
     unreachable_pub
 )]
-#![doc(html_root_url = "https://docs.rs/tonic-web/0.9.0")]
+#![doc(html_root_url = "https://docs.rs/tonic-web/0.9.1")]
 #![doc(issue_tracker_base_url = "https://github.com/hyperium/tonic/issues/")]
 
 pub use layer::GrpcWebLayer;

--- a/tonic/Cargo.toml
+++ b/tonic/Cargo.toml
@@ -13,14 +13,14 @@ categories = ["web-programming", "network-programming", "asynchronous"]
 description = """
 A gRPC over HTTP/2 implementation focused on high performance, interoperability, and flexibility.
 """
-documentation = "https://docs.rs/tonic/0.9.0"
+documentation = "https://docs.rs/tonic/0.9.1"
 edition = "2021"
 homepage = "https://github.com/hyperium/tonic"
 keywords = ["rpc", "grpc", "async", "futures", "protobuf"]
 license = "MIT"
 readme = "../README.md"
 repository = "https://github.com/hyperium/tonic"
-version = "0.9.0"
+version = "0.9.1"
 
 [features]
 codegen = ["dep:async-trait"]

--- a/tonic/Cargo.toml
+++ b/tonic/Cargo.toml
@@ -13,7 +13,7 @@ categories = ["web-programming", "network-programming", "asynchronous"]
 description = """
 A gRPC over HTTP/2 implementation focused on high performance, interoperability, and flexibility.
 """
-documentation = "https://docs.rs/tonic/0.9.0/tonic/"
+documentation = "https://docs.rs/tonic/0.9.0"
 edition = "2021"
 homepage = "https://github.com/hyperium/tonic"
 keywords = ["rpc", "grpc", "async", "futures", "protobuf"]

--- a/tonic/src/lib.rs
+++ b/tonic/src/lib.rs
@@ -89,7 +89,7 @@
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/tokio-rs/website/master/public/img/icons/tonic.svg"
 )]
-#![doc(html_root_url = "https://docs.rs/tonic/0.9.0")]
+#![doc(html_root_url = "https://docs.rs/tonic/0.9.1")]
 #![doc(issue_tracker_base_url = "https://github.com/hyperium/tonic/issues/")]
 #![doc(test(no_crate_inject, attr(deny(rust_2018_idioms))))]
 #![cfg_attr(docsrs, feature(doc_cfg))]


### PR DESCRIPTION
# [v0.9.1](https://github.com/hyperium/tonic/compare/v0.9.0...v0.9.1) (2023-04-03)

### Features

- **transport:** Update `rustls` to `0.21` ([#1340](https://github.com/hyperium/tonic/pull/1340))
