### PR TITLE
feat(build): Add optional default unimplemented stubs

### DIFF
--- a/tonic-build/src/code_gen.rs
+++ b/tonic-build/src/code_gen.rs
@@ -12,6 +12,7 @@ pub struct CodeGenBuilder {
     attributes: Attributes,
     build_transport: bool,
     disable_comments: HashSet<String>,
+    default_impl: bool
 }
 
 impl CodeGenBuilder {
@@ -57,6 +58,12 @@ impl CodeGenBuilder {
         self
     }
 
+    /// Enable or disable returning automatic unimplemented gRPC error code for generated traits.
+    pub fn default_impl(&mut self, default_impl: bool) -> &mut Self {
+        self.default_impl = default_impl;
+        self
+    }
+
     /// Generate client code based on `Service`.
     ///
     /// This takes some `Service` and will generate a `TokenStream` that contains
@@ -85,6 +92,7 @@ impl CodeGenBuilder {
             self.compile_well_known_types,
             &self.attributes,
             &self.disable_comments,
+            self.default_impl
         )
     }
 }
@@ -97,6 +105,7 @@ impl Default for CodeGenBuilder {
             attributes: Attributes::default(),
             build_transport: true,
             disable_comments: HashSet::default(),
+            default_impl: false
         }
     }
 }

--- a/tonic-build/src/prost.rs
+++ b/tonic-build/src/prost.rs
@@ -36,6 +36,7 @@ pub fn configure() -> Builder {
         include_file: None,
         emit_rerun_if_changed: std::env::var_os("CARGO").is_some(),
         disable_comments: HashSet::default(),
+        default_impl: false
     }
 }
 
@@ -169,6 +170,7 @@ impl prost_build::ServiceGenerator for ServiceGenerator {
                 .compile_well_known_types(self.builder.compile_well_known_types)
                 .attributes(self.builder.server_attributes.clone())
                 .disable_comments(self.builder.disable_comments.clone())
+                .default_impl(self.builder.default_impl)
                 .generate_server(&service, &self.builder.proto_path);
 
             self.servers.extend(server);
@@ -240,6 +242,7 @@ pub struct Builder {
     pub(crate) include_file: Option<PathBuf>,
     pub(crate) emit_rerun_if_changed: bool,
     pub(crate) disable_comments: HashSet<String>,
+    pub(crate) default_impl: bool,
 
     out_dir: Option<PathBuf>,
 }
@@ -444,6 +447,15 @@ impl Builder {
     /// explicitly.
     pub fn emit_rerun_if_changed(mut self, enable: bool) -> Self {
         self.emit_rerun_if_changed = enable;
+        self
+    }
+
+    /// When generating services enables or disables the default implementation stubs of returning 'unimplemented' gRPC error code.
+    /// When this is false all gRPC methods must be explicitly implemented.
+    ///
+    /// This defaults to `false`.
+    pub fn default_impl(mut self, enable: bool) -> Self {
+        self.default_impl = enable;
         self
     }
 


### PR DESCRIPTION
## Motivation

Enables functionality pre https://github.com/hyperium/tonic/issues/221 without changing the current default functionality

## Solution

Add it as a builder option.

## Other notes

I agree that by default unimplemented stubs should not be added due to Rust being a strict language. However I think the option should still be available for backwards-compatibility.