### PR TITLE
feat(build): Optionally to emit `Arc<Self>` as server receiver

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,5 +23,6 @@ members = [
   "tests/compression",
   "tonic-web/tests/integration",
   "tests/service_named_result",
+  "tests/use_arc_self",
 ]
 resolver = "2"

--- a/tests/use_arc_self/Cargo.toml
+++ b/tests/use_arc_self/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+authors = ["Aurimas Blažulionis <aurimas@chorus.one>"]
+edition = "2021"
+license = "MIT"
+name = "use_arc_self"
+publish = false
+version = "0.1.0"
+
+[dependencies]
+futures = "0.3"
+prost = "0.11"
+tonic = {path = "../../tonic", features = ["gzip"]}
+
+[build-dependencies]
+tonic-build = {path = "../../tonic-build" }
+
+[package.metadata.cargo-machete]
+ignored = ["prost"]

--- a/tests/use_arc_self/LICENSE
+++ b/tests/use_arc_self/LICENSE
@@ -1,0 +1,19 @@
+Copyright (c) 2020 Lucio Franco
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/tests/use_arc_self/build.rs
+++ b/tests/use_arc_self/build.rs
@@ -1,0 +1,6 @@
+fn main() {
+    tonic_build::configure()
+        .use_arc_self(true)
+        .compile(&["proto/test.proto"], &["proto"])
+        .unwrap();
+}

--- a/tests/use_arc_self/proto/test.proto
+++ b/tests/use_arc_self/proto/test.proto
@@ -1,0 +1,12 @@
+syntax = "proto3";
+
+package test;
+
+service Test {
+  rpc TestRequest(SomeData) returns (SomeData);
+}
+
+message SomeData {
+  // include a bunch of data so there actually is something to compress
+  bytes data = 1;
+}

--- a/tests/use_arc_self/src/lib.rs
+++ b/tests/use_arc_self/src/lib.rs
@@ -1,0 +1,20 @@
+#![allow(unused_imports)]
+
+use futures::{Stream, StreamExt};
+use std::sync::Arc;
+use tonic::{Request, Response, Status};
+
+tonic::include_proto!("test");
+
+#[derive(Debug, Default)]
+struct Svc;
+
+#[tonic::async_trait]
+impl test_server::Test for Svc {
+    async fn test_request(
+        self: Arc<Self>,
+        req: Request<SomeData>,
+    ) -> Result<Response<SomeData>, Status> {
+        Ok(Response::new(req.into_inner()))
+    }
+}

--- a/tonic-build/src/code_gen.rs
+++ b/tonic-build/src/code_gen.rs
@@ -12,6 +12,7 @@ pub struct CodeGenBuilder {
     attributes: Attributes,
     build_transport: bool,
     disable_comments: HashSet<String>,
+    use_arc_self: bool,
 }
 
 impl CodeGenBuilder {
@@ -57,6 +58,12 @@ impl CodeGenBuilder {
         self
     }
 
+    /// Emit `Arc<Self>` instead of `&self` in service trait.
+    pub fn use_arc_self(&mut self, enable: bool) -> &mut Self {
+        self.use_arc_self = enable;
+        self
+    }
+
     /// Generate client code based on `Service`.
     ///
     /// This takes some `Service` and will generate a `TokenStream` that contains
@@ -85,6 +92,7 @@ impl CodeGenBuilder {
             self.compile_well_known_types,
             &self.attributes,
             &self.disable_comments,
+            self.use_arc_self,
         )
     }
 }
@@ -97,6 +105,7 @@ impl Default for CodeGenBuilder {
             attributes: Attributes::default(),
             build_transport: true,
             disable_comments: HashSet::default(),
+            use_arc_self: false,
         }
     }
 }

--- a/tonic-build/src/prost.rs
+++ b/tonic-build/src/prost.rs
@@ -37,6 +37,7 @@ pub fn configure() -> Builder {
         include_file: None,
         emit_rerun_if_changed: std::env::var_os("CARGO").is_some(),
         disable_comments: HashSet::default(),
+        use_arc_self: false,
     }
 }
 
@@ -170,6 +171,7 @@ impl prost_build::ServiceGenerator for ServiceGenerator {
                 .compile_well_known_types(self.builder.compile_well_known_types)
                 .attributes(self.builder.server_attributes.clone())
                 .disable_comments(self.builder.disable_comments.clone())
+                .use_arc_self(self.builder.use_arc_self)
                 .generate_server(&service, &self.builder.proto_path);
 
             self.servers.extend(server);
@@ -242,6 +244,7 @@ pub struct Builder {
     pub(crate) include_file: Option<PathBuf>,
     pub(crate) emit_rerun_if_changed: bool,
     pub(crate) disable_comments: HashSet<String>,
+    pub(crate) use_arc_self: bool,
 
     out_dir: Option<PathBuf>,
 }
@@ -408,6 +411,12 @@ impl Builder {
     /// Disable service and rpc comments emission.
     pub fn disable_comments(mut self, path: impl AsRef<str>) -> Self {
         self.disable_comments.insert(path.as_ref().to_string());
+        self
+    }
+
+    /// Emit `Arc<Self>` receiver type in server traits instead of `&self`.
+    pub fn use_arc_self(mut self, enable: bool) -> Self {
+        self.use_arc_self = enable;
         self
     }
 

--- a/tonic-health/src/generated/grpc.health.v1.rs
+++ b/tonic-health/src/generated/grpc.health.v1.rs
@@ -337,7 +337,9 @@ pub mod health_server {
                             request: tonic::Request<super::HealthCheckRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
-                            let fut = async move { (*inner).check(request).await };
+                            let fut = async move {
+                                <T as Health>::check(&inner, request).await
+                            };
                             Box::pin(fut)
                         }
                     }
@@ -382,7 +384,9 @@ pub mod health_server {
                             request: tonic::Request<super::HealthCheckRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
-                            let fut = async move { (*inner).watch(request).await };
+                            let fut = async move {
+                                <T as Health>::watch(&inner, request).await
+                            };
                             Box::pin(fut)
                         }
                     }

--- a/tonic-reflection/src/generated/grpc.reflection.v1alpha.rs
+++ b/tonic-reflection/src/generated/grpc.reflection.v1alpha.rs
@@ -389,7 +389,11 @@ pub mod server_reflection_server {
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                (*inner).server_reflection_info(request).await
+                                <T as ServerReflection>::server_reflection_info(
+                                        &inner,
+                                        request,
+                                    )
+                                    .await
                             };
                             Box::pin(fut)
                         }


### PR DESCRIPTION
This implements an option to emit `Arc<Self>` instead of `&self` in server traits. This enables implementor to reference `Self` data for indefinite duration, which may be useful for streaming requests.

Fixes: #1351

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/hyperium/tonic/blob/master/CONTRIBUTING.md
-->

I have a few comments about this:

This impl required me to generate a new `inner_arg` token stream for each method, because I could not find a way to easily coerce between `Arc<T>` and `&T` in a generic way that does not conflict with ambiguous function names.

Tests are very minimal, if this feature looks good otherwise, I'll add more.