### PR TITLE
chore: Use cargo-udeps to check unused dependencies

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -23,6 +23,9 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macOS-latest, windows-latest]
+        include:
+        - os: windows-latest
+          option: --exclude-features uds
     steps:
     - uses: actions/checkout@v3
     - uses: dtolnay/rust-toolchain@nightly
@@ -33,7 +36,7 @@ jobs:
       with:
         tool: protoc@3.20.3
     - uses: Swatinem/rust-cache@v2
-    - run: cargo hack udeps --workspace --ignore-private --each-feature
+    - run: cargo hack udeps --workspace --each-feature ${{ matrix.option }}
 
   check:
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -17,6 +17,24 @@ jobs:
         components: rustfmt
     - run: cargo fmt --all --check
 
+  udeps:
+    name: Check unused dependencies
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macOS-latest, windows-latest]
+    steps:
+    - uses: actions/checkout@v3
+    - uses: dtolnay/rust-toolchain@nightly
+    - uses: taiki-e/install-action@cargo-hack
+    - uses: taiki-e/install-action@cargo-udeps
+    - name: Install protoc
+      uses: taiki-e/install-action@v2
+      with:
+        tool: protoc@3.20.3
+    - uses: Swatinem/rust-cache@v2
+    - run: cargo hack udeps --workspace --ignore-private --each-feature
+
   check:
     runs-on: ${{ matrix.os }}
     strategy:
@@ -36,17 +54,11 @@ jobs:
       uses: baptiste0928/cargo-install@v1
       with:
         crate: cargo-hack
-    - name: Install cargo-machete
-      uses: baptiste0928/cargo-install@v1
-      with:
-        crate: cargo-machete
     - name: Install protoc
       uses: taiki-e/install-action@v2
       with:
         tool: protoc@3.20.3
     - uses: Swatinem/rust-cache@v2
-    - name: Check unused dependencies
-      run: cargo machete
     - name: Check features
       run: cargo hack check --all --ignore-private --each-feature --no-dev-deps
     - name: Check all targets

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -255,18 +255,18 @@ required-features = ["types"]
 
 [features]
 gcp = ["dep:prost-types", "tonic/tls"]
-routeguide = ["dep:async-stream", "dep:futures", "tokio-stream", "dep:rand", "dep:serde", "dep:serde_json"]
+routeguide = ["dep:async-stream", "tokio-stream", "dep:rand", "dep:serde", "dep:serde_json"]
 reflection = ["dep:tonic-reflection"]
 autoreload = ["tokio-stream/net", "dep:listenfd"]
 health = ["dep:tonic-health"]
 grpc-web = ["dep:tonic-web", "dep:bytes", "dep:http", "dep:hyper", "dep:tracing-subscriber"]
 tracing = ["dep:tracing", "dep:tracing-subscriber"]
-hyper-warp = ["dep:futures", "dep:tower", "dep:hyper", "dep:http", "dep:http-body", "dep:warp"]
+hyper-warp = ["dep:futures-util", "dep:tower", "dep:hyper", "dep:http", "dep:http-body", "dep:warp"]
 hyper-warp-multiplex = ["hyper-warp"]
 uds = ["tokio-stream/net", "dep:tower", "dep:hyper"]
-streaming = ["dep:futures", "tokio-stream", "dep:h2"]
-mock = ["dep:futures", "dep:tower"]
-tower = ["dep:futures", "dep:hyper", "dep:tower", "dep:http"]
+streaming = ["tokio-stream", "dep:h2"]
+mock = ["tokio-stream", "dep:tower"]
+tower = ["dep:hyper", "dep:tower", "dep:http"]
 json-codec = ["dep:serde", "dep:serde_json", "dep:bytes"]
 compression = ["tonic/gzip"]
 tls = ["tonic/tls"]
@@ -290,7 +290,7 @@ tonic-health = { path = "../tonic-health", optional = true }
 tonic-reflection = { path = "../tonic-reflection", optional = true }
 tonic-types = { path = "../tonic-types", optional = true }
 async-stream = { version = "0.3", optional = true }
-futures = { version = "0.3", default-features = false, optional = true }
+futures-util = { version = "0.3", optional = true }
 tokio-stream = { version = "0.1", optional = true }
 tower = { version = "0.4", optional = true }
 rand = { version = "0.8", optional = true }

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -313,6 +313,3 @@ tower-http = { version = "0.4", optional = true }
 
 [build-dependencies]
 tonic-build = { path = "../tonic-build", features = ["prost"] }
-
-[package.metadata.cargo-machete]
-ignored = ["prost-types"]

--- a/examples/src/hyper_warp/server.rs
+++ b/examples/src/hyper_warp/server.rs
@@ -3,7 +3,7 @@
 //! To hit the warp server you can run this command:
 //! `curl localhost:50051/hello`
 
-use futures::future::{self, Either, TryFutureExt};
+use futures_util::future::{self, Either, TryFutureExt};
 use http::version::Version;
 use hyper::{service::make_service_fn, Server};
 use std::convert::Infallible;

--- a/examples/src/hyper_warp_multiplex/server.rs
+++ b/examples/src/hyper_warp_multiplex/server.rs
@@ -3,7 +3,7 @@
 //! To hit the warp server you can run this command:
 //! `curl localhost:50051/hello`
 
-use futures::future::{self, Either, TryFutureExt};
+use futures_util::future::{self, Either, TryFutureExt};
 use http::version::Version;
 use hyper::{service::make_service_fn, Server};
 use std::convert::Infallible;

--- a/examples/src/mock/mock.rs
+++ b/examples/src/mock/mock.rs
@@ -23,7 +23,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     tokio::spawn(async move {
         Server::builder()
             .add_service(GreeterServer::new(greeter))
-            .serve_with_incoming(futures::stream::iter(vec![Ok::<_, std::io::Error>(server)]))
+            .serve_with_incoming(tokio_stream::iter(vec![Ok::<_, std::io::Error>(server)]))
             .await
     });
 

--- a/examples/src/routeguide/client.rs
+++ b/examples/src/routeguide/client.rs
@@ -1,7 +1,6 @@
 use std::error::Error;
 use std::time::Duration;
 
-use futures::stream;
 use rand::rngs::ThreadRng;
 use rand::Rng;
 use tokio::time;
@@ -49,7 +48,7 @@ async fn run_record_route(client: &mut RouteGuideClient<Channel>) -> Result<(), 
     }
 
     println!("Traversing {} points", points.len());
-    let request = Request::new(stream::iter(points));
+    let request = Request::new(tokio_stream::iter(points));
 
     match client.record_route(request).await {
         Ok(response) => println!("SUMMARY: {:?}", response.into_inner()),

--- a/examples/src/routeguide/server.rs
+++ b/examples/src/routeguide/server.rs
@@ -3,9 +3,8 @@ use std::pin::Pin;
 use std::sync::Arc;
 use std::time::Instant;
 
-use futures::{Stream, StreamExt};
 use tokio::sync::mpsc;
-use tokio_stream::wrappers::ReceiverStream;
+use tokio_stream::{wrappers::ReceiverStream, Stream, StreamExt};
 use tonic::transport::Server;
 use tonic::{Request, Response, Status};
 

--- a/examples/src/streaming/client.rs
+++ b/examples/src/streaming/client.rs
@@ -2,9 +2,8 @@ pub mod pb {
     tonic::include_proto!("grpc.examples.echo");
 }
 
-use futures::stream::Stream;
 use std::time::Duration;
-use tokio_stream::StreamExt;
+use tokio_stream::{Stream, StreamExt};
 use tonic::transport::Channel;
 
 use pb::{echo_client::EchoClient, EchoRequest};

--- a/examples/src/streaming/server.rs
+++ b/examples/src/streaming/server.rs
@@ -2,10 +2,9 @@ pub mod pb {
     tonic::include_proto!("grpc.examples.echo");
 }
 
-use futures::Stream;
 use std::{error::Error, io::ErrorKind, net::ToSocketAddrs, pin::Pin, time::Duration};
 use tokio::sync::mpsc;
-use tokio_stream::{wrappers::ReceiverStream, StreamExt};
+use tokio_stream::{wrappers::ReceiverStream, Stream, StreamExt};
 use tonic::{transport::Server, Request, Response, Status, Streaming};
 
 use pb::{EchoRequest, EchoResponse};

--- a/interop/Cargo.toml
+++ b/interop/Cargo.toml
@@ -35,6 +35,3 @@ tracing-subscriber = {version = "0.3", features = ["env-filter"]}
 
 [build-dependencies]
 tonic-build = {path = "../tonic-build", features = ["prost"]}
-
-[package.metadata.cargo-machete]
-ignored = ["prost"]

--- a/tests/ambiguous_methods/Cargo.toml
+++ b/tests/ambiguous_methods/Cargo.toml
@@ -14,6 +14,3 @@ tonic = {path = "../../tonic"}
 
 [build-dependencies]
 tonic-build = {path = "../../tonic-build"}
-
-[package.metadata.cargo-machete]
-ignored = ["prost"]

--- a/tests/compression/Cargo.toml
+++ b/tests/compression/Cargo.toml
@@ -21,6 +21,3 @@ tower-http = {version = "0.4", features = ["map-response-body", "map-request-bod
 
 [build-dependencies]
 tonic-build = {path = "../../tonic-build" }
-
-[package.metadata.cargo-machete]
-ignored = ["prost"]

--- a/tests/disable_comments/Cargo.toml
+++ b/tests/disable_comments/Cargo.toml
@@ -15,6 +15,3 @@ tonic = { path = "../../tonic" }
 [build-dependencies]
 prost-build = "0.11.6"
 tonic-build = { path = "../../tonic-build" }
-
-[package.metadata.cargo-machete]
-ignored = ["prost"]

--- a/tests/extern_path/my_application/Cargo.toml
+++ b/tests/extern_path/my_application/Cargo.toml
@@ -15,6 +15,3 @@ uuid = {package = "uuid1", path = "../uuid"}
 
 [build-dependencies]
 tonic-build = {path = "../../../tonic-build"}
-
-[package.metadata.cargo-machete]
-ignored = ["prost"]

--- a/tests/extern_path/uuid/Cargo.toml
+++ b/tests/extern_path/uuid/Cargo.toml
@@ -12,6 +12,3 @@ version = "0.1.0"
 prost = "0.11"
 [build-dependencies]
 prost-build = "0.11.6"
-
-[package.metadata.cargo-machete]
-ignored = ["prost"]

--- a/tests/included_service/Cargo.toml
+++ b/tests/included_service/Cargo.toml
@@ -14,6 +14,3 @@ tonic = {path = "../../tonic"}
 
 [build-dependencies]
 tonic-build = {path = "../../tonic-build"}
-
-[package.metadata.cargo-machete]
-ignored = ["prost"]

--- a/tests/integration_tests/Cargo.toml
+++ b/tests/integration_tests/Cargo.toml
@@ -30,6 +30,3 @@ tracing = "0.1"
 
 [build-dependencies]
 tonic-build = {path = "../../tonic-build"}
-
-[package.metadata.cargo-machete]
-ignored = ["prost"]

--- a/tests/same_name/Cargo.toml
+++ b/tests/same_name/Cargo.toml
@@ -14,6 +14,3 @@ tonic = {path = "../../tonic"}
 
 [build-dependencies]
 tonic-build = {path = "../../tonic-build"}
-
-[package.metadata.cargo-machete]
-ignored = ["prost"]

--- a/tests/service_named_result/Cargo.toml
+++ b/tests/service_named_result/Cargo.toml
@@ -12,6 +12,3 @@ tonic = {path = "../../tonic"}
 
 [build-dependencies]
 tonic-build = {path = "../../tonic-build"}
-
-[package.metadata.cargo-machete]
-ignored = ["prost"]

--- a/tests/service_named_service/Cargo.toml
+++ b/tests/service_named_service/Cargo.toml
@@ -14,6 +14,3 @@ tonic = {path = "../../tonic"}
 
 [build-dependencies]
 tonic-build = {path = "../../tonic-build"}
-
-[package.metadata.cargo-machete]
-ignored = ["prost"]

--- a/tests/stream_conflict/Cargo.toml
+++ b/tests/stream_conflict/Cargo.toml
@@ -14,6 +14,3 @@ tonic = { path = "../../tonic" }
 
 [build-dependencies]
 tonic-build = { path = "../../tonic-build" }
-
-[package.metadata.cargo-machete]
-ignored = ["prost"]

--- a/tests/wellknown-compiled/Cargo.toml
+++ b/tests/wellknown-compiled/Cargo.toml
@@ -18,6 +18,3 @@ tonic = {path = "../../tonic"}
 [build-dependencies]
 prost-build = "0.11.6"
 tonic-build = {path = "../../tonic-build"}
-
-[package.metadata.cargo-machete]
-ignored = ["prost"]

--- a/tests/wellknown/Cargo.toml
+++ b/tests/wellknown/Cargo.toml
@@ -15,6 +15,3 @@ tonic = {path = "../../tonic"}
 
 [build-dependencies]
 tonic-build = {path = "../../tonic-build"}
-
-[package.metadata.cargo-machete]
-ignored = ["prost", "prost-types"]

--- a/tonic-build/Cargo.toml
+++ b/tonic-build/Cargo.toml
@@ -23,8 +23,8 @@ syn = "1.0"
 
 [features]
 default = ["transport", "prost"]
-cleanup-markdown = ["prost-build/cleanup-markdown"]
 prost = ["prost-build"]
+cleanup-markdown = ["prost", "prost-build/cleanup-markdown"]
 transport = []
 
 [package.metadata.docs.rs]

--- a/tonic-build/src/server.rs
+++ b/tonic-build/src/server.rs
@@ -295,7 +295,7 @@ fn generate_trait_methods<T: Service>(
 
                 quote! {
                     #stream_doc
-                    type #stream: futures_core::Stream<Item = std::result::Result<#res_message, tonic::Status>> + Send + 'static;
+                    type #stream: tokio_stream::Stream<Item = std::result::Result<#res_message, tonic::Status>> + Send + 'static;
 
                     #method_doc
                     async fn #name(&self, request: tonic::Request<#req_message>)
@@ -311,7 +311,7 @@ fn generate_trait_methods<T: Service>(
 
                 quote! {
                     #stream_doc
-                    type #stream: futures_core::Stream<Item = std::result::Result<#res_message, tonic::Status>> + Send + 'static;
+                    type #stream: tokio_stream::Stream<Item = std::result::Result<#res_message, tonic::Status>> + Send + 'static;
 
                     #method_doc
                     async fn #name(&self, request: tonic::Request<tonic::Streaming<#req_message>>)

--- a/tonic-health/Cargo.toml
+++ b/tonic-health/Cargo.toml
@@ -21,11 +21,12 @@ transport = []
 [dependencies]
 async-stream = "0.3"
 prost = "0.11"
+futures-core = {version = "0.3"}
 tokio = {version = "1.0", features = ["sync"]}
-tokio-stream = "0.1"
 tonic = { version = "0.9", path = "../tonic", default-features = false, features = ["codegen", "prost"] }
 
 [dev-dependencies]
 tokio = {version = "1.0", features = ["rt-multi-thread", "macros"]}
+tokio-stream = "0.1"
 tonic-build = { version = "0.9", path = "../tonic-build", default-features = false, features = ["prost"] }
 prost-types = "0.11"

--- a/tonic-health/Cargo.toml
+++ b/tonic-health/Cargo.toml
@@ -21,8 +21,8 @@ transport = []
 [dependencies]
 async-stream = "0.3"
 prost = "0.11"
-futures-core = {version = "0.3"}
 tokio = {version = "1.0", features = ["sync"]}
+tokio-stream = "0.1"
 tonic = { version = "0.9", path = "../tonic", default-features = false, features = ["codegen", "prost"] }
 
 [dev-dependencies]

--- a/tonic-health/src/generated/grpc.health.v1.rs
+++ b/tonic-health/src/generated/grpc.health.v1.rs
@@ -216,7 +216,7 @@ pub mod health_server {
             tonic::Status,
         >;
         /// Server streaming response type for the Watch method.
-        type WatchStream: futures_core::Stream<
+        type WatchStream: tokio_stream::Stream<
                 Item = std::result::Result<super::HealthCheckResponse, tonic::Status>,
             >
             + Send

--- a/tonic-health/src/server.rs
+++ b/tonic-health/src/server.rs
@@ -3,11 +3,11 @@
 use crate::pb::health_server::{Health, HealthServer};
 use crate::pb::{HealthCheckRequest, HealthCheckResponse};
 use crate::ServingStatus;
-use futures_core::Stream;
 use std::collections::HashMap;
 use std::pin::Pin;
 use std::sync::Arc;
 use tokio::sync::{watch, RwLock};
+use tokio_stream::Stream;
 #[cfg(feature = "transport")]
 use tonic::server::NamedService;
 use tonic::{Request, Response, Status};

--- a/tonic-health/src/server.rs
+++ b/tonic-health/src/server.rs
@@ -3,11 +3,11 @@
 use crate::pb::health_server::{Health, HealthServer};
 use crate::pb::{HealthCheckRequest, HealthCheckResponse};
 use crate::ServingStatus;
+use futures_core::Stream;
 use std::collections::HashMap;
 use std::pin::Pin;
 use std::sync::Arc;
 use tokio::sync::{watch, RwLock};
-use tokio_stream::Stream;
 #[cfg(feature = "transport")]
 use tonic::server::NamedService;
 use tonic::{Request, Response, Status};

--- a/tonic-reflection/Cargo.toml
+++ b/tonic-reflection/Cargo.toml
@@ -27,5 +27,4 @@ tonic = { version = "0.9", path = "../tonic", default-features = false, features
 [dev-dependencies]
 tonic = { version = "0.9", path = "../tonic", default-features = false, features = ["transport"] }
 tonic-build = { version = "0.9", path = "../tonic-build", default-features = false, features = ["prost", "cleanup-markdown"] }
-futures = "0.3"
 futures-util = "0.3"

--- a/tonic-reflection/src/generated/grpc.reflection.v1alpha.rs
+++ b/tonic-reflection/src/generated/grpc.reflection.v1alpha.rs
@@ -271,7 +271,7 @@ pub mod server_reflection_server {
     #[async_trait]
     pub trait ServerReflection: Send + Sync + 'static {
         /// Server streaming response type for the ServerReflectionInfo method.
-        type ServerReflectionInfoStream: futures_core::Stream<
+        type ServerReflectionInfoStream: tokio_stream::Stream<
                 Item = std::result::Result<
                     super::ServerReflectionResponse,
                     tonic::Status,

--- a/tonic-reflection/tests/server.rs
+++ b/tonic-reflection/tests/server.rs
@@ -1,4 +1,3 @@
-use futures::stream;
 use futures_util::FutureExt;
 use prost::Message;
 use std::net::SocketAddr;
@@ -123,7 +122,7 @@ async fn make_test_reflection_request(request: ServerReflectionRequest) -> Messa
         .unwrap();
     let mut client = ServerReflectionClient::new(conn);
 
-    let request = Request::new(stream::iter(vec![request]));
+    let request = Request::new(tokio_stream::iter(vec![request]));
     let mut inbound = client
         .server_reflection_info(request)
         .await

--- a/tonic-web/Cargo.toml
+++ b/tonic-web/Cargo.toml
@@ -17,6 +17,7 @@ version = "0.9.2"
 [dependencies]
 base64 = "0.21"
 bytes = "1.0"
+futures-core = "0.3"
 tokio-stream = "0.1"
 http = "0.2"
 http-body = "0.4"

--- a/tonic-web/Cargo.toml
+++ b/tonic-web/Cargo.toml
@@ -18,6 +18,7 @@ version = "0.9.2"
 base64 = "0.21"
 bytes = "1.0"
 futures-core = "0.3"
+tokio-stream = "0.1"
 http = "0.2"
 http-body = "0.4"
 hyper = {version = "0.14", default-features = false, features = ["stream"]}

--- a/tonic-web/Cargo.toml
+++ b/tonic-web/Cargo.toml
@@ -17,7 +17,6 @@ version = "0.9.2"
 [dependencies]
 base64 = "0.21"
 bytes = "1.0"
-futures-core = "0.3"
 tokio-stream = "0.1"
 http = "0.2"
 http-body = "0.4"

--- a/tonic-web/src/call.rs
+++ b/tonic-web/src/call.rs
@@ -1,9 +1,10 @@
 use std::error::Error;
 use std::pin::Pin;
-use std::task::{ready, Context, Poll};
+use std::task::{Context, Poll};
 
 use base64::Engine as _;
 use bytes::{Buf, BufMut, Bytes, BytesMut};
+use futures_core::ready;
 use http::{header, HeaderMap, HeaderValue};
 use http_body::{Body, SizeHint};
 use pin_project::pin_project;

--- a/tonic-web/src/call.rs
+++ b/tonic-web/src/call.rs
@@ -1,10 +1,9 @@
 use std::error::Error;
 use std::pin::Pin;
-use std::task::{Context, Poll};
+use std::task::{ready, Context, Poll};
 
 use base64::Engine as _;
 use bytes::{Buf, BufMut, Bytes, BytesMut};
-use futures_core::ready;
 use http::{header, HeaderMap, HeaderValue};
 use http_body::{Body, SizeHint};
 use pin_project::pin_project;

--- a/tonic-web/src/call.rs
+++ b/tonic-web/src/call.rs
@@ -4,10 +4,11 @@ use std::task::{Context, Poll};
 
 use base64::Engine as _;
 use bytes::{Buf, BufMut, Bytes, BytesMut};
-use futures_core::{ready, Stream};
+use futures_core::ready;
 use http::{header, HeaderMap, HeaderValue};
 use http_body::{Body, SizeHint};
 use pin_project::pin_project;
+use tokio_stream::Stream;
 use tonic::Status;
 
 use self::content_types::*;

--- a/tonic-web/src/service.rs
+++ b/tonic-web/src/service.rs
@@ -1,7 +1,6 @@
-use futures_core::ready;
 use std::future::Future;
 use std::pin::Pin;
-use std::task::{Context, Poll};
+use std::task::{ready, Context, Poll};
 
 use http::{header, HeaderMap, HeaderValue, Method, Request, Response, StatusCode, Version};
 use hyper::Body;

--- a/tonic-web/src/service.rs
+++ b/tonic-web/src/service.rs
@@ -1,6 +1,7 @@
+use futures_core::ready;
 use std::future::Future;
 use std::pin::Pin;
-use std::task::{ready, Context, Poll};
+use std::task::{Context, Poll};
 
 use http::{header, HeaderMap, HeaderValue, Method, Request, Response, StatusCode, Version};
 use hyper::Body;

--- a/tonic-web/tests/integration/Cargo.toml
+++ b/tonic-web/tests/integration/Cargo.toml
@@ -14,6 +14,8 @@ prost = "0.11"
 tokio = { version = "1", features = ["macros", "rt", "net"] }
 tokio-stream = { version = "0.1", features = ["net"] }
 tonic = { path = "../../../tonic" }
+
+[dev-dependencies]
 tonic-web = { path = "../../../tonic-web" }
 
 [build-dependencies]

--- a/tonic/Cargo.toml
+++ b/tonic/Cargo.toml
@@ -71,6 +71,7 @@ h2 = {version = "0.3", optional = true}
 hyper = {version = "0.14.14", features = ["full"], optional = true}
 hyper-timeout = {version = "0.4", optional = true}
 tokio = {version = "1.0.1", features = ["net", "time", "macros"], optional = true}
+tokio-stream = "0.1"
 tower = {version = "0.4.7", default-features = false, features = ["balance", "buffer", "discover", "limit", "load", "make", "timeout", "util"], optional = true}
 axum = {version = "0.6.9", default_features = false, optional = true}
 

--- a/tonic/Cargo.toml
+++ b/tonic/Cargo.toml
@@ -49,7 +49,6 @@ channel = []
 [dependencies]
 base64 = "0.21"
 bytes = "1.0"
-futures-core = {version = "0.3", default-features = false}
 futures-util = {version = "0.3", default-features = false}
 http = "0.2"
 tracing = "0.1"

--- a/tonic/Cargo.toml
+++ b/tonic/Cargo.toml
@@ -33,15 +33,14 @@ tls-roots-common = ["tls"]
 tls-webpki-roots = ["tls-roots-common", "dep:webpki-roots"]
 transport = [
   "dep:axum",
-  "channel"
-]
-channel = [
+  "channel",
   "dep:h2",
   "dep:hyper",
   "dep:tokio",
   "dep:tower",
   "dep:hyper-timeout",
 ]
+channel = []
 
 # [[bench]]
 # name = "bench_main"
@@ -72,7 +71,6 @@ h2 = {version = "0.3", optional = true}
 hyper = {version = "0.14.14", features = ["full"], optional = true}
 hyper-timeout = {version = "0.4", optional = true}
 tokio = {version = "1.0.1", features = ["net", "time", "macros"], optional = true}
-tokio-stream = "0.1"
 tower = {version = "0.4.7", default-features = false, features = ["balance", "buffer", "discover", "limit", "load", "make", "timeout", "util"], optional = true}
 axum = {version = "0.6.9", default_features = false, optional = true}
 

--- a/tonic/src/client/grpc.rs
+++ b/tonic/src/client/grpc.rs
@@ -6,7 +6,6 @@ use crate::{
     request::SanitizeHeaders,
     Code, Request, Response, Status,
 };
-use futures_core::Stream;
 use futures_util::{future, stream, TryStreamExt};
 use http::{
     header::{HeaderValue, CONTENT_TYPE, TE},
@@ -14,6 +13,7 @@ use http::{
 };
 use http_body::Body;
 use std::fmt;
+use tokio_stream::Stream;
 
 /// A gRPC client dispatcher.
 ///

--- a/tonic/src/codec/decode.rs
+++ b/tonic/src/codec/decode.rs
@@ -2,7 +2,6 @@ use super::compression::{decompress, CompressionEncoding};
 use super::{DecodeBuf, Decoder, DEFAULT_MAX_RECV_MESSAGE_SIZE, HEADER_SIZE};
 use crate::{body::BoxBody, metadata::MetadataMap, Code, Status};
 use bytes::{Buf, BufMut, BytesMut};
-use futures_core::Stream;
 use futures_util::{future, ready};
 use http::StatusCode;
 use http_body::Body;
@@ -11,6 +10,7 @@ use std::{
     pin::Pin,
     task::{Context, Poll},
 };
+use tokio_stream::Stream;
 use tracing::{debug, trace};
 
 const BUFFER_SIZE: usize = 8 * 1024;

--- a/tonic/src/codec/encode.rs
+++ b/tonic/src/codec/encode.rs
@@ -2,7 +2,7 @@ use super::compression::{compress, CompressionEncoding, SingleMessageCompression
 use super::{EncodeBuf, Encoder, DEFAULT_MAX_SEND_MESSAGE_SIZE, HEADER_SIZE};
 use crate::{Code, Status};
 use bytes::{BufMut, Bytes, BytesMut};
-use futures_core::{Stream, TryStream};
+use futures_core::TryStream;
 use futures_util::{ready, StreamExt, TryStreamExt};
 use http::HeaderMap;
 use http_body::Body;
@@ -11,6 +11,7 @@ use std::{
     pin::Pin,
     task::{Context, Poll},
 };
+use tokio_stream::Stream;
 
 pub(super) const BUFFER_SIZE: usize = 8 * 1024;
 

--- a/tonic/src/codec/encode.rs
+++ b/tonic/src/codec/encode.rs
@@ -2,8 +2,7 @@ use super::compression::{compress, CompressionEncoding, SingleMessageCompression
 use super::{EncodeBuf, Encoder, DEFAULT_MAX_SEND_MESSAGE_SIZE, HEADER_SIZE};
 use crate::{Code, Status};
 use bytes::{BufMut, Bytes, BytesMut};
-use futures_core::TryStream;
-use futures_util::{ready, StreamExt, TryStreamExt};
+use futures_util::{ready, StreamExt, TryStream, TryStreamExt};
 use http::HeaderMap;
 use http_body::Body;
 use pin_project::pin_project;

--- a/tonic/src/codec/prost.rs
+++ b/tonic/src/codec/prost.rs
@@ -155,7 +155,7 @@ mod tests {
         let msg = Vec::from(&[0u8; 1024][..]);
 
         let messages = std::iter::repeat_with(move || Ok::<_, Status>(msg.clone())).take(10000);
-        let source = futures_util::stream::iter(messages);
+        let source = tokio_stream::iter(messages);
 
         let body = encode_server(
             encoder,
@@ -179,7 +179,7 @@ mod tests {
         let msg = vec![0u8; MAX_MESSAGE_SIZE + 1];
 
         let messages = std::iter::once(Ok::<_, Status>(msg));
-        let source = futures_util::stream::iter(messages);
+        let source = tokio_stream::iter(messages);
 
         let body = encode_server(
             encoder,
@@ -213,7 +213,7 @@ mod tests {
         let msg = vec![0u8; u32::MAX as usize + 1];
 
         let messages = std::iter::once(Ok::<_, Status>(msg));
-        let source = futures_util::stream::iter(messages);
+        let source = tokio_stream::iter(messages);
 
         let body = encode_server(
             encoder,

--- a/tonic/src/codegen.rs
+++ b/tonic/src/codegen.rs
@@ -1,8 +1,8 @@
 //! Codegen exports used by `tonic-build`.
 
 pub use async_trait::async_trait;
-pub use futures_core;
 pub use futures_util::future::{ok, poll_fn, Ready};
+pub use tokio_stream;
 
 pub use std::future::Future;
 pub use std::pin::Pin;
@@ -19,6 +19,6 @@ pub use http_body::Body;
 
 pub type BoxFuture<T, E> = self::Pin<Box<dyn self::Future<Output = Result<T, E>> + Send + 'static>>;
 pub type BoxStream<T> =
-    self::Pin<Box<dyn futures_core::Stream<Item = Result<T, crate::Status>> + Send + 'static>>;
+    self::Pin<Box<dyn tokio_stream::Stream<Item = Result<T, crate::Status>> + Send + 'static>>;
 
 pub use crate::body::empty_body;

--- a/tonic/src/request.rs
+++ b/tonic/src/request.rs
@@ -4,10 +4,10 @@ use crate::transport::server::TlsConnectInfo;
 #[cfg(feature = "transport")]
 use crate::transport::{server::TcpConnectInfo, Certificate};
 use crate::Extensions;
-use futures_core::Stream;
 #[cfg(feature = "transport")]
 use std::sync::Arc;
 use std::{net::SocketAddr, time::Duration};
+use tokio_stream::Stream;
 
 /// A gRPC request and metadata from an RPC call.
 #[derive(Debug)]

--- a/tonic/src/server/grpc.rs
+++ b/tonic/src/server/grpc.rs
@@ -7,8 +7,7 @@ use crate::{
     server::{ClientStreamingService, ServerStreamingService, StreamingService, UnaryService},
     Code, Request, Status,
 };
-use futures_core::TryStream;
-use futures_util::{future, stream, TryStreamExt};
+use futures_util::{future, stream, TryStream, TryStreamExt};
 use http_body::Body;
 use std::fmt;
 

--- a/tonic/src/server/service.rs
+++ b/tonic/src/server/service.rs
@@ -1,6 +1,6 @@
 use crate::{Request, Response, Status, Streaming};
-use futures_core::Stream;
 use std::future::Future;
+use tokio_stream::Stream;
 use tower_service::Service;
 
 /// A specialization of tower_service::Service.

--- a/tonic/src/transport/channel/mod.rs
+++ b/tonic/src/transport/channel/mod.rs
@@ -188,7 +188,7 @@ impl Channel {
         D: Discover<Service = Connection> + Unpin + Send + 'static,
         D::Error: Into<crate::Error>,
         D::Key: Hash + Send + Clone,
-        E: Executor<futures_core::future::BoxFuture<'static, ()>> + Send + Sync + 'static,
+        E: Executor<futures_util::future::BoxFuture<'static, ()>> + Send + Sync + 'static,
     {
         let svc = Balance::new(discover);
 

--- a/tonic/src/transport/server/incoming.rs
+++ b/tonic/src/transport/server/incoming.rs
@@ -1,6 +1,5 @@
 use super::{Connected, Server};
 use crate::transport::service::ServerIo;
-use futures_core::Stream;
 use futures_util::stream::TryStreamExt;
 use hyper::server::{
     accept::Accept,
@@ -16,6 +15,7 @@ use tokio::{
     io::{AsyncRead, AsyncWrite},
     net::TcpListener,
 };
+use tokio_stream::Stream;
 
 #[cfg(not(feature = "tls"))]
 pub(crate) fn tcp_incoming<IO, IE, L>(

--- a/tonic/src/transport/server/mod.rs
+++ b/tonic/src/transport/server/mod.rs
@@ -36,7 +36,6 @@ use self::recover_error::RecoverError;
 use super::service::{GrpcTimeout, ServerIo};
 use crate::body::BoxBody;
 use bytes::Bytes;
-use futures_core::Stream;
 use futures_util::{future, ready};
 use http::{Request, Response};
 use http_body::Body as _;
@@ -54,6 +53,7 @@ use std::{
     time::Duration,
 };
 use tokio::io::{AsyncRead, AsyncWrite};
+use tokio_stream::Stream;
 use tower::{
     layer::util::{Identity, Stack},
     layer::Layer,

--- a/tonic/src/transport/service/add_origin.rs
+++ b/tonic/src/transport/service/add_origin.rs
@@ -1,4 +1,4 @@
-use futures_core::future::BoxFuture;
+use futures_util::future::BoxFuture;
 use http::uri::Authority;
 use http::uri::Scheme;
 use http::{Request, Uri};

--- a/tonic/src/transport/service/discover.rs
+++ b/tonic/src/transport/service/discover.rs
@@ -9,7 +9,7 @@ use std::{
 };
 use tokio::sync::mpsc::Receiver;
 
-use futures_core::Stream;
+use tokio_stream::Stream;
 use tower::discover::Change;
 
 type DiscoverResult<K, S, E> = Result<Change<K, S>, E>;

--- a/tonic/src/transport/service/discover.rs
+++ b/tonic/src/transport/service/discover.rs
@@ -9,7 +9,7 @@ use std::{
 };
 use tokio::sync::mpsc::Receiver;
 
-use tokio_stream::Stream;
+use futures_core::Stream;
 use tower::discover::Change;
 
 type DiscoverResult<K, S, E> = Result<Change<K, S>, E>;

--- a/tonic/src/transport/service/executor.rs
+++ b/tonic/src/transport/service/executor.rs
@@ -1,4 +1,4 @@
-use futures_core::future::BoxFuture;
+use futures_util::future::BoxFuture;
 use std::{future::Future, sync::Arc};
 
 pub(crate) use hyper::rt::Executor;


### PR DESCRIPTION
## Motivation

Checks unused dependencies more strictly.

## Solution

Replaces cargo-machete with cargo-udeps, and fixes detected dependencies and features.
