### PR TITLE
tonic-web: proxy any kind of Service

### DIFF
--- a/tonic-web/src/layer.rs
+++ b/tonic-web/src/layer.rs
@@ -1,35 +1,48 @@
+use std::error::Error;
+
 use super::{BoxBody, BoxError, GrpcWebService};
 
 use tower_layer::Layer;
 use tower_service::Service;
 
 /// Layer implementing the grpc-web protocol.
-#[derive(Debug, Clone)]
-pub struct GrpcWebLayer {
-    _priv: (),
+#[derive(Debug)]
+pub struct GrpcWebLayer<ResBody = BoxBody> {
+    _markers: std::marker::PhantomData<ResBody>,
 }
 
-impl GrpcWebLayer {
-    /// Create a new grpc-web layer.
-    pub fn new() -> GrpcWebLayer {
-        Self { _priv: () }
+impl<ResBody> Clone for GrpcWebLayer<ResBody> {
+    fn clone(&self) -> Self {
+        Self {
+            _markers: std::marker::PhantomData,
+        }
     }
 }
 
-impl Default for GrpcWebLayer {
+impl<ResBody> GrpcWebLayer<ResBody> {
+    /// Create a new grpc-web layer.
+    pub fn new() -> Self {
+        Self {
+            _markers: std::marker::PhantomData,
+        }
+    }
+}
+
+impl<ResBody> Default for GrpcWebLayer<ResBody> {
     fn default() -> Self {
         Self::new()
     }
 }
 
-impl<S> Layer<S> for GrpcWebLayer
+impl<S, ResBody> Layer<S> for GrpcWebLayer<ResBody>
 where
-    S: Service<http::Request<hyper::Body>, Response = http::Response<BoxBody>>,
-    S: Send + 'static,
+    S: Service<http::Request<BoxBody>, Response = http::Response<ResBody>> + Send + 'static,
     S::Future: Send + 'static,
     S::Error: Into<BoxError> + Send,
+    ResBody: http_body::Body + Send + 'static,
+    ResBody::Error: Error + Send + 'static,
 {
-    type Service = GrpcWebService<S>;
+    type Service = GrpcWebService<S, ResBody>;
 
     fn layer(&self, inner: S) -> Self::Service {
         GrpcWebService::new(inner)

--- a/tonic-web/tests/integration/Cargo.toml
+++ b/tonic-web/tests/integration/Cargo.toml
@@ -7,6 +7,7 @@ version = "0.1.0"
 license = "MIT"
 
 [dependencies]
+axum = { version = "0.6.9" }
 base64 = "0.21"
 bytes = "1.0"
 hyper = "0.14"
@@ -17,6 +18,7 @@ tonic = { path = "../../../tonic" }
 
 [dev-dependencies]
 tonic-web = { path = "../../../tonic-web" }
+tower = { version = "0.4", features = ["util"] }
 
 [build-dependencies]
 tonic-build = { path = "../../../tonic-build" }

--- a/tonic-web/tests/integration/tests/grpc_web.rs
+++ b/tonic-web/tests/integration/tests/grpc_web.rs
@@ -1,13 +1,19 @@
+use std::convert::Infallible;
 use std::net::SocketAddr;
 
+use axum::error_handling::HandleErrorLayer;
 use base64::Engine as _;
 use bytes::{Buf, BufMut, Bytes, BytesMut};
 use hyper::http::{header, StatusCode};
+use hyper::server::conn::AddrIncoming;
+use hyper::service::make_service_fn;
 use hyper::{Body, Client, Method, Request, Uri};
 use prost::Message;
 use tokio::net::TcpListener;
 use tokio_stream::wrappers::TcpListenerStream;
 use tonic::transport::Server;
+use tower::util::MapRequestLayer;
+use tower::ServiceBuilder;
 
 use integration::pb::{test_server::TestServer, Input, Output};
 use integration::Svc;
@@ -16,6 +22,29 @@ use tonic_web::GrpcWebLayer;
 #[tokio::test]
 async fn binary_request() {
     let server_url = spawn().await;
+    let client = Client::new();
+
+    let req = build_request(server_url, "grpc-web", "grpc-web");
+    let res = client.request(req).await.unwrap();
+    let content_type = res.headers().get(header::CONTENT_TYPE).unwrap().clone();
+    let content_type = content_type.to_str().unwrap();
+
+    assert_eq!(res.status(), StatusCode::OK);
+    assert_eq!(content_type, "application/grpc-web+proto");
+
+    let (message, trailers) = decode_body(res.into_body(), content_type).await;
+    let expected = Output {
+        id: 1,
+        desc: "one".to_owned(),
+    };
+
+    assert_eq!(message, expected);
+    assert_eq!(&trailers[..], b"grpc-status:0\r\n");
+}
+
+#[tokio::test]
+async fn binary_request_reverse_proxy() {
+    let server_url = spawn_reverse_proxy().await;
     let client = Client::new();
 
     let req = build_request(server_url, "grpc-web", "grpc-web");
@@ -76,6 +105,54 @@ async fn spawn() -> String {
     });
 
     url
+}
+
+/// Spawn two servers, one serving the gRPC API
+async fn spawn_reverse_proxy() -> String {
+    // Set up gRPC service
+    let addr = SocketAddr::from(([127, 0, 0, 1], 0));
+    let listener = TcpListener::bind(addr).await.expect("listener");
+    let url = format!("http://{}", listener.local_addr().unwrap());
+    let listener_stream = TcpListenerStream::new(listener);
+
+    let _ = tokio::spawn(async move {
+        Server::builder()
+            .add_service(TestServer::new(Svc))
+            .serve_with_incoming(listener_stream)
+            .await
+            .unwrap()
+    });
+
+    // Set up proxy to the above service that applies tonic-web
+    let addr2 = SocketAddr::from(([127, 0, 0, 1], 0));
+    let http_client = hyper::Client::builder().http2_only(true).build_http();
+    let listener2 = TcpListener::bind(addr2).await.expect("listener");
+    let url2 = format!("http://{}", listener2.local_addr().unwrap());
+
+    let svc = ServiceBuilder::new()
+        .layer(GrpcWebLayer::new())
+        .layer(MapRequestLayer::new(move |r: hyper::Request<_>| {
+            let (mut parts, body) = r.into_parts();
+            parts.uri = format!("{}{}", url, parts.uri).parse().unwrap();
+            Request::from_parts(parts, body)
+        }))
+        .layer(HandleErrorLayer::new(|_err| async {
+            Ok::<_, Infallible>((StatusCode::INTERNAL_SERVER_ERROR, "Internal Server Error"))
+        }))
+        .service(http_client);
+    let make_svc = make_service_fn(move |_| {
+        let svc = svc.clone();
+        async { Ok::<_, Infallible>(svc) }
+    });
+
+    let _ = tokio::spawn(async move {
+        hyper::Server::builder(AddrIncoming::from_listener(listener2).unwrap())
+            .serve(make_svc)
+            .await
+            .unwrap()
+    });
+
+    url2
 }
 
 fn encode_body() -> Bytes {


### PR DESCRIPTION
This allows applying the GrpcWebLayer to any kind of Service, not just ones that tonic generates. This makes it possible to use tonic-web as a grpc-web proxy to a gRPC server implemented in another language for example.


## Motivation

See https://github.com/hyperium/tonic/issues/1361

## Solution

I made GrpcWebService generic over the request body it receives and the body that the upstream service responds. It's mostly a lot of search and replace with a couple of changes in how we convert the body to conform to the right interface.

I've also added a test that proxies to a gRPC service over a `hyper::Client` to show it's generic over any kind of Service.

Closes https://github.com/hyperium/tonic/issues/1361
