### PR TITLE
docs: fix broken doc links 

### DIFF
--- a/tonic/src/transport/channel/endpoint.rs
+++ b/tonic/src/transport/channel/endpoint.rs
@@ -208,7 +208,7 @@ impl Endpoint {
     ///
     /// Default is 65,535
     ///
-    /// [spec]: https://http2.github.io/http2-spec/#SETTINGS_INITIAL_WINDOW_SIZE
+    /// [spec]: https://httpwg.org/specs/rfc9113.html#SettingValues
     pub fn initial_stream_window_size(self, sz: impl Into<Option<u32>>) -> Self {
         Endpoint {
             init_stream_window_size: sz.into(),

--- a/tonic/src/transport/server/mod.rs
+++ b/tonic/src/transport/server/mod.rs
@@ -194,7 +194,7 @@ impl<L> Server<L> {
     ///
     /// Default is 65,535
     ///
-    /// [spec]: https://http2.github.io/http2-spec/#SETTINGS_INITIAL_WINDOW_SIZE
+    /// [spec]: https://httpwg.org/specs/rfc9113.html#SettingValues
     #[must_use]
     pub fn initial_stream_window_size(self, sz: impl Into<Option<u32>>) -> Self {
         Server {
@@ -219,7 +219,7 @@ impl<L> Server<L> {
     ///
     /// Default is no limit (`None`).
     ///
-    /// [spec]: https://http2.github.io/http2-spec/#SETTINGS_MAX_CONCURRENT_STREAMS
+    /// [spec]: https://httpwg.org/specs/rfc9113.html#SettingValues
     #[must_use]
     pub fn max_concurrent_streams(self, max: impl Into<Option<u32>>) -> Self {
         Server {
@@ -295,12 +295,13 @@ impl<L> Server<L> {
             ..self
         }
     }
-
-    /// Sets the maximum frame size to use for HTTP2.
+    /// Sets the [`SETTINGS_MAX_FRAME_SIZE`][spec] to use for HTTP2.
     ///
     /// Passing `None` will do nothing.
     ///
     /// If not set, will default from underlying transport.
+    ///
+    /// [spec]: https://httpwg.org/specs/rfc9113.html#SettingValues
     #[must_use]
     pub fn max_frame_size(self, frame_size: impl Into<Option<u32>>) -> Self {
         Server {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/hyperium/tonic/blob/master/CONTRIBUTING.md
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? If a new feature is being added, describe the intended
use case that feature fulfills.
-->
See https://github.com/hyperium/tonic/issues/1365

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

Updated the links to refer to https://httpwg.org/specs/rfc9113.html. There's no links to the individual settings, so I've just linked to the section for each. Also added a missing link for `SETTINGS_MAX_FRAME_SIZE` for consistency

