### PR TITLE
chore: Add regex-syntax to deny skip-tree

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -19,6 +19,7 @@ skip-tree = [
     { name = "hermit-abi" },
     { name = "base64" },
     { name = "syn" },
+    { name = "regex-syntax" },
 ]
 
 [licenses]


### PR DESCRIPTION
## Motivation

Fixes ci failure due to the duplicate version of regex-syntax.

## Solution 

Adds regex-syntax to the deny skip-tree.