### PR TITLE
tonic: add hyper's `http2_max_pending_accept_reset_streams` to server

### DIFF
--- a/tonic/src/transport/server/mod.rs
+++ b/tonic/src/transport/server/mod.rs
@@ -91,6 +91,7 @@ pub struct Server<L = Identity> {
     http2_keepalive_interval: Option<Duration>,
     http2_keepalive_timeout: Option<Duration>,
     http2_adaptive_window: Option<bool>,
+    http2_max_pending_accept_reset_streams: Option<usize>,
     max_frame_size: Option<u32>,
     accept_http1: bool,
     service_builder: ServiceBuilder<L>,
@@ -112,6 +113,7 @@ impl Default for Server<Identity> {
             http2_keepalive_interval: None,
             http2_keepalive_timeout: None,
             http2_adaptive_window: None,
+            http2_max_pending_accept_reset_streams: None,
             max_frame_size: None,
             accept_http1: false,
             service_builder: Default::default(),
@@ -267,6 +269,19 @@ impl<L> Server<L> {
     pub fn http2_adaptive_window(self, enabled: Option<bool>) -> Self {
         Server {
             http2_adaptive_window: enabled,
+            ..self
+        }
+    }
+
+    /// Configures the maximum number of pending reset streams allowed before a GOAWAY will be sent.
+    ///
+    /// This will default to whatever the default in h2 is. As of v0.3.17, it is 20.
+    ///
+    /// See <https://github.com/hyperium/hyper/issues/2877> for more information.
+    #[must_use]
+    pub fn http2_max_pending_accept_reset_streams(self, max: Option<usize>) -> Self {
+        Server {
+            http2_max_pending_accept_reset_streams: max,
             ..self
         }
     }
@@ -453,6 +468,7 @@ impl<L> Server<L> {
             http2_keepalive_interval: self.http2_keepalive_interval,
             http2_keepalive_timeout: self.http2_keepalive_timeout,
             http2_adaptive_window: self.http2_adaptive_window,
+            http2_max_pending_accept_reset_streams: self.http2_max_pending_accept_reset_streams,
             max_frame_size: self.max_frame_size,
             accept_http1: self.accept_http1,
         }
@@ -491,6 +507,7 @@ impl<L> Server<L> {
             .http2_keepalive_timeout
             .unwrap_or_else(|| Duration::new(DEFAULT_HTTP2_KEEPALIVE_TIMEOUT_SECS, 0));
         let http2_adaptive_window = self.http2_adaptive_window;
+        let http2_max_pending_accept_reset_streams = self.http2_max_pending_accept_reset_streams;
 
         let svc = self.service_builder.service(svc);
 
@@ -513,6 +530,7 @@ impl<L> Server<L> {
             .http2_keep_alive_interval(http2_keepalive_interval)
             .http2_keep_alive_timeout(http2_keepalive_timeout)
             .http2_adaptive_window(http2_adaptive_window.unwrap_or_default())
+            .http2_max_pending_accept_reset_streams(http2_max_pending_accept_reset_streams)
             .http2_max_frame_size(max_frame_size);
 
         if let Some(signal) = signal {


### PR DESCRIPTION
This adds the [`http2_max_pending_accept_reset_streams`](https://docs.rs/hyper/latest/hyper/server/conn/struct.Http.html#method.http2_max_pending_accept_reset_streams) property to the server, to configure the allowed number of reset streams pending accept.

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? If a new feature is being added, describe the intended
use case that feature fulfills.
-->

In [Qdrant](https://github.com/qdrant/qdrant) we're trying to use hundreds of streams over HTTP2, all having a good chance to be dropped/reset. This makes it very easy to reach the default limit of [20](https://docs.rs/h2/latest/h2/server/struct.Builder.html#method.max_pending_accept_reset_streams) reset streams, causing internal connection errors, causing cluster consensus problems in production.

We'd like to greatly increase this limit for our internal cluster communication to prevent triggering the `GOAWAY/ENHANCE_YOUR_CALM` error. The risk of a denial of service is accepted because this is just for internal communication. The additional CPU/memory this consumes is not an issue in our case.

## Solution

To increase this limit, we need access to the property this PR implements.

For reference, this limit was implemented a month ago in <https://github.com/hyperium/h2/pull/668>.

Additionally we'd like to access [`reset_stream_duration`](https://docs.rs/h2/latest/h2/server/struct.Builder.html#method.reset_stream_duration) to further tune this. But that will be in a different PR once this is merged.