### PR TITLE
chore: Set all-features option true in deny config

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -1,3 +1,5 @@
+all-features = true
+
 [bans]
 multiple-versions = "deny"
 deny = [


### PR DESCRIPTION
## Motivation

Improves development experiences when running cargo-deny checking locally.

## Solution

Sets all-features option true in deny config instead of using `--all-features` command line argument.