### PR TITLE
Add Virtio VSOCK support

### DIFF
--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -142,6 +142,16 @@ path = "src/uds/server.rs"
 required-features = ["uds"]
 
 [[bin]]
+name = "vsock-client"
+path = "src/vsock/client.rs"
+required-features = ["vsock"]
+
+[[bin]]
+name = "vsock-server"
+path = "src/vsock/server.rs"
+required-features = ["vsock"]
+
+[[bin]]
 name = "interceptor-client"
 path = "src/interceptor/client.rs"
 
@@ -264,6 +274,7 @@ tracing = ["dep:tracing", "dep:tracing-subscriber"]
 hyper-warp = ["dep:futures", "dep:tower", "dep:hyper", "dep:http", "dep:http-body", "dep:warp"]
 hyper-warp-multiplex = ["hyper-warp"]
 uds = ["tokio-stream/net", "dep:tower", "dep:hyper"]
+vsock = ["dep:vsock", "tokio-vsock", "dep:tower", "dep:hyper"]
 streaming = ["dep:futures", "tokio-stream", "dep:h2"]
 mock = ["dep:futures", "dep:tower"]
 tower = ["dep:futures", "dep:hyper", "dep:tower", "dep:http"]
@@ -283,7 +294,7 @@ default = ["full"]
 # Common dependencies
 tokio = { version = "1.0", features = ["rt-multi-thread", "macros"] }
 prost = "0.11"
-tonic = { path = "../tonic" }
+tonic = { path = "../tonic", features = ["vsock"] }
 # Optional dependencies
 tonic-web = { path = "../tonic-web", optional = true }
 tonic-health = { path = "../tonic-health", optional = true }
@@ -310,6 +321,8 @@ tokio-rustls = { version = "0.24.0", optional = true }
 hyper-rustls = { version = "0.24.0", features = ["http2"], optional = true }
 rustls-pemfile = { version = "1", optional = true }
 tower-http = { version = "0.4", optional = true }
+tokio-vsock = { version = "0.4.0", optional = true }
+vsock = { version = "0.3.0", optional = true }
 
 [build-dependencies]
 tonic-build = { path = "../tonic-build", features = ["prost"] }

--- a/examples/src/vsock/client.rs
+++ b/examples/src/vsock/client.rs
@@ -1,0 +1,47 @@
+#![cfg_attr(not(unix), allow(unused_imports))]
+
+pub mod hello_world {
+    tonic::include_proto!("helloworld");
+}
+
+use hello_world::{greeter_client::GreeterClient, HelloRequest};
+use tokio_vsock::VsockStream;
+use tonic::transport::{Endpoint, Uri};
+use tower::service_fn;
+
+// Use vsock-loopback so we don't need to spin up a VM. Must match server.
+static TEST_CID: u32 = vsock::VMADDR_CID_LOCAL;
+// Arbitrarily chosen. Must match server.
+static TEST_PORT: u32 = 8000;
+
+// Virtio VSOCK does not use URIs, hence this URI will never be used.
+// It is defined purely since in order to create a channel, since a URI has to
+// be supplied to create an `Endpoint`.
+static IGNORED_ENDPOINT_URI: &str = "file://[::]:0";
+
+#[cfg(unix)]
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let channel = Endpoint::try_from(IGNORED_ENDPOINT_URI)?
+        .connect_with_connector(service_fn(|_: Uri| {
+            VsockStream::connect(TEST_CID, TEST_PORT)
+        }))
+        .await?;
+
+    let mut client = GreeterClient::new(channel);
+
+    let request = tonic::Request::new(HelloRequest {
+        name: "Tonic".into(),
+    });
+
+    let response = client.say_hello(request).await?;
+
+    println!("RESPONSE={:?}", response);
+
+    Ok(())
+}
+
+#[cfg(not(unix))]
+fn main() {
+    panic!("The `uds` example only works on unix systems!");
+}

--- a/examples/src/vsock/server.rs
+++ b/examples/src/vsock/server.rs
@@ -1,0 +1,60 @@
+#![cfg_attr(not(unix), allow(unused_imports))]
+
+pub mod hello_world {
+    tonic::include_proto!("helloworld");
+}
+
+use hello_world::{
+    greeter_server::{Greeter, GreeterServer},
+    HelloReply, HelloRequest,
+};
+use tokio_vsock::VsockListener;
+use tonic::transport::server::VsockConnectInfo;
+use tonic::{transport::Server, Request, Response, Status};
+
+// Use vsock-loopback so we don't need to spin up a VM.
+static TEST_CID: u32 = vsock::VMADDR_CID_LOCAL;
+// Arbitrarily chosen. Must match client.
+static TEST_PORT: u32 = 8000;
+
+#[derive(Default)]
+pub struct MyGreeter {}
+
+#[tonic::async_trait]
+impl Greeter for MyGreeter {
+    async fn say_hello(
+        &self,
+        request: Request<HelloRequest>,
+    ) -> Result<Response<HelloReply>, Status> {
+        #[cfg(unix)]
+        {
+            let conn_info = request.extensions().get::<VsockConnectInfo>().unwrap();
+            println!("Got a request {:?} with info {:?}", request, conn_info);
+        }
+
+        let reply = hello_world::HelloReply {
+            message: format!("Hello {}!", request.into_inner().name),
+        };
+        Ok(Response::new(reply))
+    }
+}
+
+#[cfg(unix)]
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let greeter = MyGreeter::default();
+
+    let stream = VsockListener::bind(TEST_CID, TEST_PORT)?.incoming();
+
+    Server::builder()
+        .add_service(GreeterServer::new(greeter))
+        .serve_with_incoming(stream)
+        .await?;
+
+    Ok(())
+}
+
+#[cfg(not(unix))]
+fn main() {
+    panic!("The `uds` example only works on unix systems!");
+}

--- a/tests/integration_tests/Cargo.toml
+++ b/tests/integration_tests/Cargo.toml
@@ -13,7 +13,7 @@ bytes = "1.0"
 futures-util = "0.3"
 prost = "0.11"
 tokio = {version = "1.0", features = ["macros", "rt-multi-thread", "net"]}
-tonic = {path = "../../tonic"}
+tonic = {path = "../../tonic", features = ["vsock"]}
 tracing-subscriber = {version = "0.3"}
 
 [dev-dependencies]
@@ -26,6 +26,8 @@ tokio-stream = {version = "0.1.5", features = ["net"]}
 tower = {version = "0.4", features = []}
 tower-http = { version = "0.4", features = ["set-header", "trace"] }
 tower-service = "0.3"
+tokio-vsock = "0.4.0"
+vsock = "0.3.0"
 tracing = "0.1"
 
 [build-dependencies]

--- a/tonic/Cargo.toml
+++ b/tonic/Cargo.toml
@@ -42,6 +42,7 @@ channel = [
   "dep:tower",
   "dep:hyper-timeout",
 ]
+vsock = ["tokio-vsock"]
 
 # [[bench]]
 # name = "bench_main"
@@ -75,6 +76,7 @@ tokio = {version = "1.0.1", features = ["net", "time", "macros"], optional = tru
 tokio-stream = "0.1"
 tower = {version = "0.4.7", default-features = false, features = ["balance", "buffer", "discover", "limit", "load", "make", "timeout", "util"], optional = true}
 axum = {version = "0.6.9", default_features = false, optional = true}
+tokio-vsock = { version = "0.4.0", optional = true }
 
 # rustls
 async-stream = { version = "0.3", optional = true }

--- a/tonic/src/transport/channel/endpoint.rs
+++ b/tonic/src/transport/channel/endpoint.rs
@@ -343,6 +343,8 @@ impl Endpoint {
     /// This allows you to build a [Channel](struct.Channel.html) that uses a non-HTTP transport.
     /// See the `uds` example for an example on how to use this function to build channel that
     /// uses a Unix socket transport.
+    /// See the `vsock` example for an example on how to use this function to build channel that
+    /// uses Virtio VSOCK as transport.
     ///
     /// The [`connect_timeout`](Endpoint::connect_timeout) will still be applied.
     pub async fn connect_with_connector<C>(&self, connector: C) -> Result<Channel, Error>
@@ -374,6 +376,8 @@ impl Endpoint {
     ///
     /// See the `uds` example for an example on how to use this function to build channel that
     /// uses a Unix socket transport.
+    /// See the `vsock` example for an example on how to use this function to build channel that
+    /// uses Virtio VSOCK as transport.
     pub fn connect_with_connector_lazy<C>(&self, connector: C) -> Channel
     where
         C: MakeConnection<Uri> + Send + 'static,

--- a/tonic/src/transport/server/mod.rs
+++ b/tonic/src/transport/server/mod.rs
@@ -8,6 +8,7 @@ mod recover_error;
 mod tls;
 #[cfg(unix)]
 mod unix;
+mod vsock;
 
 pub use super::service::Routes;
 pub use crate::server::NamedService;
@@ -23,6 +24,9 @@ use super::service::TlsAcceptor;
 
 #[cfg(unix)]
 pub use unix::UdsConnectInfo;
+
+#[cfg(all(unix, feature = "vsock"))]
+pub use vsock::VsockConnectInfo;
 
 pub use incoming::TcpIncoming;
 

--- a/tonic/src/transport/server/vsock.rs
+++ b/tonic/src/transport/server/vsock.rs
@@ -1,13 +1,9 @@
 use super::Connected;
 
-/// Connection info for Unix domain socket streams.
-///
-/// This type will be accessible through [request extensions][ext] if you're using
-/// a unix stream.
+/// Connection info for VSOCK socket streams.
 ///
 /// See [Connected] for more details.
 ///
-/// [ext]: crate::Request::extensions
 /// [Connected]: crate::transport::server::Connected
 #[cfg_attr(docsrs, doc(cfg(unix)))]
 #[derive(Clone, Debug)]

--- a/tonic/src/transport/server/vsock.rs
+++ b/tonic/src/transport/server/vsock.rs
@@ -1,0 +1,30 @@
+use super::Connected;
+
+/// Connection info for Unix domain socket streams.
+///
+/// This type will be accessible through [request extensions][ext] if you're using
+/// a unix stream.
+///
+/// See [Connected] for more details.
+///
+/// [ext]: crate::Request::extensions
+/// [Connected]: crate::transport::server::Connected
+#[cfg_attr(docsrs, doc(cfg(unix)))]
+#[derive(Clone, Debug)]
+pub struct VsockConnectInfo {
+    /// Local address
+    pub local_addr: Option<tokio_vsock::VsockAddr>,
+    /// Peer address
+    pub peer_addr: Option<tokio_vsock::VsockAddr>,
+}
+
+impl Connected for tokio_vsock::VsockStream {
+    type ConnectInfo = VsockConnectInfo;
+
+    fn connect_info(&self) -> Self::ConnectInfo {
+        VsockConnectInfo {
+            local_addr: self.local_addr().ok(),
+            peer_addr: self.peer_addr().ok(),
+        }
+    }
+}


### PR DESCRIPTION
## Motivation

gRPC recently merged support for Virtio VSOCK as transport. It would be helpful for [us](https://github.com/project-oak/oak) if tonic were to match gRPC's support for it.

gRPC PR that adds VSOCK support: https://github.com/grpc/grpc/pull/32847

## Solution

Add Virtio VSOCK support, integration test, and example


cc @tiziano88
