### PR TITLE
chore: Add bitflags to deny skip

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -16,6 +16,9 @@ deny = [
     # term is not fully maintained, and termcolor is replacing it
     { name = "term" },
 ]
+skip = [
+    { name = "bitflags" },
+]
 skip-tree = [
     { name = "windows-sys" },
     { name = "hermit-abi" },


### PR DESCRIPTION
## Motivation

Fixes a `cargo-deny` error.

## Solution

Allows `bitflags` duplicate version error.
