### PR TITLE
chore(interop): Update to strum 0.25

### DIFF
--- a/interop/Cargo.toml
+++ b/interop/Cargo.toml
@@ -16,7 +16,7 @@ path = "src/bin/server.rs"
 
 [dependencies]
 async-stream = "0.3"
-strum = {version = "0.24", features = ["derive"]}
+strum = {version = "0.25", features = ["derive"]}
 pico-args = {version = "0.5", features = ["eq-separator"]}
 console = "0.15"
 futures-core = "0.3"


### PR DESCRIPTION
## Motivation

Updates to [`strum` 0.25](https://github.com/Peternator7/strum/blob/2bcf86d0ca5cb5c733031d41aacce881643433da/CHANGELOG.md#L3).

## Solution

Updates to use it.