### PR TITLE
Allow to duplicate `GrpcMethod` extensions

### DIFF
--- a/tonic/src/extensions.rs
+++ b/tonic/src/extensions.rs
@@ -73,7 +73,7 @@ impl fmt::Debug for Extensions {
 }
 
 /// A gRPC Method info extension.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct GrpcMethod {
     service: &'static str,
     method: &'static str,


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/hyperium/tonic/blob/master/CONTRIBUTING.md
-->

## Motivation

I have a custom middleware implementation that retries requests based on certain conditions. That requires cloning the request including all extensions. On previous tonic versions there were no extensions, so we could simply ignore them. While updating to tonic 0.9 I've noticed that an extension was added to each request. It's unfortunately not easily possible to duplicate the extension, even if the internal details are trivially clonable.

## Solution

Add a `#[derive(Clone)]` to the corresponding type
