### PR TITLE
chore: Bump msrv to 1.63

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -82,7 +82,7 @@ jobs:
         tool: protoc@3.20.3
     - uses: hecrj/setup-rust-action@v1
       with:
-        rust-version: "1.60"
+        rust-version: "1.63"
     - uses: Swatinem/rust-cache@v2
     - name: cargo doc
       run: cargo doc --workspace --no-deps --exclude examples
@@ -102,7 +102,7 @@ jobs:
       uses: actions/checkout@v3
     - uses: hecrj/setup-rust-action@v1
       with:
-        rust-version: "1.60"
+        rust-version: "1.63"
     - name: Install protoc
       uses: taiki-e/install-action@v2
       with:

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ For IntelliJ IDEA users, please refer to [this](https://github.com/intellij-rust
 
 ### Rust Version
 
-`tonic`'s MSRV is `1.60`.
+`tonic`'s MSRV is `1.63`.
 
 ```bash
 $ rustup update


### PR DESCRIPTION
Tonic requires Rust 1.63 due to [axum 0.6.19](https://github.com/tokio-rs/axum/blob/axum-v0.6.19/axum/CHANGELOG.md#0619-17-july-2023) and [tempfile 3.7.0](https://github.com/Stebalien/tempfile/blob/v3.7.0/CHANGELOG.md#370).