### PR TITLE
chore(tonic): Update to webpki-roots 0.25.0

### DIFF
--- a/tonic/Cargo.toml
+++ b/tonic/Cargo.toml
@@ -79,7 +79,7 @@ async-stream = { version = "0.3", optional = true }
 rustls-pemfile = { version = "1.0", optional = true }
 rustls-native-certs = { version = "0.6.1", optional = true }
 tokio-rustls = { version = "0.24.0", optional = true }
-webpki-roots = { version = "0.24.0", optional = true }
+webpki-roots = { version = "0.25.0", optional = true }
 
 # compression
 flate2 = {version = "1.0", optional = true}

--- a/tonic/src/transport/service/tls.rs
+++ b/tonic/src/transport/service/tls.rs
@@ -51,7 +51,7 @@ impl TlsConnector {
         {
             use tokio_rustls::rustls::OwnedTrustAnchor;
 
-            roots.add_server_trust_anchors(webpki_roots::TLS_SERVER_ROOTS.0.iter().map(|ta| {
+            roots.add_server_trust_anchors(webpki_roots::TLS_SERVER_ROOTS.iter().map(|ta| {
                 OwnedTrustAnchor::from_subject_spki_name_constraints(
                     ta.subject,
                     ta.spki,


### PR DESCRIPTION
## Motivation

Updates to the latest `webpki-roots` version and fixes a deprecation warning.

## Solution

Updates to `webpki-roots` 0.25.0.