### PR TITLE
chore(examples): Remove futures-util

### DIFF
--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -261,7 +261,7 @@ autoreload = ["tokio-stream/net", "dep:listenfd"]
 health = ["dep:tonic-health"]
 grpc-web = ["dep:tonic-web", "dep:bytes", "dep:http", "dep:hyper", "dep:tracing-subscriber"]
 tracing = ["dep:tracing", "dep:tracing-subscriber"]
-hyper-warp = ["dep:futures-util", "dep:tower", "dep:hyper", "dep:http", "dep:http-body", "dep:warp"]
+hyper-warp = ["dep:either", "dep:tower", "dep:hyper", "dep:http", "dep:http-body", "dep:warp"]
 hyper-warp-multiplex = ["hyper-warp"]
 uds = ["tokio-stream/net", "dep:tower", "dep:hyper"]
 streaming = ["tokio-stream", "dep:h2"]
@@ -289,8 +289,8 @@ tonic-web = { path = "../tonic-web", optional = true }
 tonic-health = { path = "../tonic-health", optional = true }
 tonic-reflection = { path = "../tonic-reflection", optional = true }
 tonic-types = { path = "../tonic-types", optional = true }
+either = { version = "1.9", optional = true }
 async-stream = { version = "0.3", optional = true }
-futures-util = { version = "0.3", optional = true }
 tokio-stream = { version = "0.1", optional = true }
 tower = { version = "0.4", optional = true }
 rand = { version = "0.8", optional = true }

--- a/examples/src/hyper_warp_multiplex/server.rs
+++ b/examples/src/hyper_warp_multiplex/server.rs
@@ -3,7 +3,7 @@
 //! To hit the warp server you can run this command:
 //! `curl localhost:50051/hello`
 
-use futures_util::future::{self, Either, TryFutureExt};
+use either::Either;
 use http::version::Version;
 use hyper::{service::make_service_fn, Server};
 use std::convert::Infallible;
@@ -80,22 +80,25 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 .add_service(echo)
                 .into_service();
 
-            future::ok::<_, Infallible>(tower::service_fn(
+            std::future::ready(Ok::<_, Infallible>(tower::service_fn(
                 move |req: hyper::Request<hyper::Body>| match req.version() {
-                    Version::HTTP_11 | Version::HTTP_10 => Either::Left(
-                        warp.call(req)
-                            .map_ok(|res| res.map(EitherBody::Left))
-                            .map_err(Error::from),
-                    ),
-                    Version::HTTP_2 => Either::Right(
-                        tonic
-                            .call(req)
-                            .map_ok(|res| res.map(EitherBody::Right))
-                            .map_err(Error::from),
-                    ),
+                    Version::HTTP_11 | Version::HTTP_10 => Either::Left({
+                        let res = warp.call(req);
+                        Box::pin(async move {
+                            let res = res.await.map(|res| res.map(EitherBody::Left))?;
+                            Ok::<_, Error>(res)
+                        })
+                    }),
+                    Version::HTTP_2 => Either::Right({
+                        let res = tonic.call(req);
+                        Box::pin(async move {
+                            let res = res.await.map(|res| res.map(EitherBody::Right))?;
+                            Ok::<_, Error>(res)
+                        })
+                    }),
                     _ => unimplemented!(),
                 },
-            ))
+            )))
         }))
         .await?;
 


### PR DESCRIPTION
## Motivation

Continuing from #1438.

## Solution

Removes `futures-util` in examples. Converts `Future` manually and uses `either` crate where `futures_util::future::Either` used.