### PR TITLE
feat(transport): Add `Router::into_router`

### DIFF
--- a/tonic/src/transport/server/mod.rs
+++ b/tonic/src/transport/server/mod.rs
@@ -571,6 +571,11 @@ impl<L> Router<L> {
         self
     }
 
+    /// Convert this tonic `Router` into an axum `Router` consuming the tonic one.
+    pub fn into_router(self) -> axum::Router {
+        self.routes.into_router()
+    }
+
     /// Consume this [`Server`] creating a future that will execute the server
     /// on [tokio]'s default executor.
     ///

--- a/tonic/src/transport/service/router.rs
+++ b/tonic/src/transport/service/router.rs
@@ -60,6 +60,11 @@ impl Routes {
             router: self.router.with_state(()),
         }
     }
+
+    /// Convert this `Routes` into an [`axum::Router`].
+    pub fn into_router(self) -> axum::Router {
+        self.router
+    }
 }
 
 async fn unimplemented() -> impl axum::response::IntoResponse {


### PR DESCRIPTION
This adds `into_router` to tonic's `Router` that will convert it into an `axum::Router`.
