### PR TITLE
chore: Improve cargo doc ci

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -70,26 +70,6 @@ jobs:
     - name: Check all targets
       run: cargo check --all --all-targets --all-features
 
-  check-docs:
-    name: check docs
-    runs-on: ubuntu-latest
-
-    env:
-      RUSTFLAGS: "-D warnings"
-
-    steps:
-    - uses: actions/checkout@v3
-    - name: Install protoc
-      uses: taiki-e/install-action@v2
-      with:
-        tool: protoc@${{ env.PROTOC_VERSION }}
-    - uses: hecrj/setup-rust-action@v1
-      with:
-        rust-version: "1.63"
-    - uses: Swatinem/rust-cache@v2
-    - name: cargo doc
-      run: cargo doc --workspace --no-deps --exclude examples
-
   deny-check:
     name: cargo-deny check
     runs-on: ubuntu-latest
@@ -110,8 +90,11 @@ jobs:
       uses: taiki-e/install-action@v2
       with:
         tool: protoc@${{ env.PROTOC_VERSION }}
-    - name: Check
-      run: cargo check --all --all-targets --all-features
+    - uses: Swatinem/rust-cache@v2
+    - run: cargo check --all --all-targets --all-features
+    - run: cargo doc --no-deps --package tonic --package tonic-build --package tonic-health --package tonic-reflection --package tonic-types --package tonic-web
+      env:
+        RUSTDOCFLAGS: "-D warnings"
 
   test:
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
## Motivation

Fixes unnecessary doc tests being executed and the redundant ci definitions, and make the doc test fail when their errors are thrown. I think we can remove doc test on test crates (they might throw unnecessary document warnings or errors as well. For example, [some warnings](https://github.com/hyperium/tonic/actions/runs/5754277946/job/15599233527#step:6:64) have been appeared).

## Solution

- Changes the doc tests to be run only against those which are aimed to be published.
- Makes the doc test fail when they throw warnings.
- Moves doc test to the msrv job as the most of the test process is same.