### PR TITLE
chore: Add socket2 to cargo deny skip-tree config

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -22,6 +22,7 @@ skip-tree = [
     { name = "base64" },
     { name = "syn" },
     { name = "bitflags" },
+    { name = "socket2" },
 ]
 
 [licenses]


### PR DESCRIPTION
## Motivation

`tokio` bumped its MSRV to `1.63` and changed to use `socket2` 0.5, which bumped its MSRV to `1.63` as well. As `hyper`'s MSRV is 1.56, `tonic` became to depend on multiple versions of `socket2`. This pull request allows to use them to fix ci.

## Solution

Adds `socket2` to cargo deny skip-tree config.