### PR TITLE
chore(reflection): Remove futures-util

### DIFF
--- a/tonic-reflection/Cargo.toml
+++ b/tonic-reflection/Cargo.toml
@@ -27,4 +27,3 @@ tonic = { version = "0.9", path = "../tonic", default-features = false, features
 [dev-dependencies]
 tonic = { version = "0.9", path = "../tonic", default-features = false, features = ["transport"] }
 tonic-build = { version = "0.9", path = "../tonic-build", default-features = false, features = ["prost", "cleanup-markdown"] }
-futures-util = "0.3"

--- a/tonic-reflection/tests/server.rs
+++ b/tonic-reflection/tests/server.rs
@@ -1,4 +1,3 @@
-use futures_util::FutureExt;
 use prost::Message;
 use std::net::SocketAddr;
 use tokio::sync::oneshot;
@@ -106,7 +105,9 @@ async fn make_test_reflection_request(request: ServerReflectionRequest) -> Messa
 
         Server::builder()
             .add_service(service)
-            .serve_with_incoming_shutdown(TcpListenerStream::new(listener), shutdown_rx.map(drop))
+            .serve_with_incoming_shutdown(TcpListenerStream::new(listener), async {
+                drop(shutdown_rx.await)
+            })
             .await
             .unwrap();
     });


### PR DESCRIPTION
## Motivation

Continuing of reducing futures crates.

## Solution

Removes `futures-util` from `tonic-reflection` entirely.
