### PR TITLE
chore(tests): Remove futures-util

### DIFF
--- a/tests/integration_tests/Cargo.toml
+++ b/tests/integration_tests/Cargo.toml
@@ -10,7 +10,6 @@ version = "0.1.0"
 
 [dependencies]
 bytes = "1.0"
-futures-util = {version="0.3", default-features =false}
 prost = "0.11"
 tokio = {version = "1.0", features = ["macros", "rt-multi-thread", "net", "sync"]}
 tonic = {path = "../../tonic"}

--- a/tests/integration_tests/src/lib.rs
+++ b/tests/integration_tests/src/lib.rs
@@ -57,3 +57,5 @@ pub mod mock {
 pub fn trace_init() {
     let _ = tracing_subscriber::fmt::try_init();
 }
+
+pub type BoxFuture<'a, T> = std::pin::Pin<Box<dyn std::future::Future<Output = T> + Send + 'a>>;

--- a/tests/integration_tests/tests/client_layer.rs
+++ b/tests/integration_tests/tests/client_layer.rs
@@ -1,8 +1,6 @@
-use std::time::Duration;
-
-use futures_util::FutureExt;
 use http::{header::HeaderName, HeaderValue};
 use integration_tests::pb::{test_client::TestClient, test_server, Input, Output};
+use std::time::Duration;
 use tokio::sync::oneshot;
 use tonic::{
     transport::{Endpoint, Server},
@@ -32,7 +30,7 @@ async fn connect_supports_standard_tower_layers() {
     let jh = tokio::spawn(async move {
         Server::builder()
             .add_service(svc)
-            .serve_with_shutdown("127.0.0.1:1340".parse().unwrap(), rx.map(drop))
+            .serve_with_shutdown("127.0.0.1:1340".parse().unwrap(), async { drop(rx.await) })
             .await
             .unwrap();
     });

--- a/tests/integration_tests/tests/connect_info.rs
+++ b/tests/integration_tests/tests/connect_info.rs
@@ -1,4 +1,3 @@
-use futures_util::FutureExt;
 use integration_tests::pb::{test_client, test_server, Input, Output};
 use std::time::Duration;
 use tokio::sync::oneshot;
@@ -29,7 +28,7 @@ async fn getting_connect_info() {
     let jh = tokio::spawn(async move {
         Server::builder()
             .add_service(svc)
-            .serve_with_shutdown("127.0.0.1:1400".parse().unwrap(), rx.map(drop))
+            .serve_with_shutdown("127.0.0.1:1400".parse().unwrap(), async { drop(rx.await) })
             .await
             .unwrap();
     });
@@ -52,7 +51,6 @@ async fn getting_connect_info() {
 
 #[cfg(unix)]
 pub mod unix {
-    use futures_util::FutureExt;
     use tokio::{
         net::{UnixListener, UnixStream},
         sync::oneshot,
@@ -98,7 +96,7 @@ pub mod unix {
         let jh = tokio::spawn(async move {
             Server::builder()
                 .add_service(service)
-                .serve_with_incoming_shutdown(uds_stream, rx.map(drop))
+                .serve_with_incoming_shutdown(uds_stream, async { drop(rx.await) })
                 .await
                 .unwrap();
         });

--- a/tests/integration_tests/tests/connection.rs
+++ b/tests/integration_tests/tests/connection.rs
@@ -1,4 +1,3 @@
-use futures_util::FutureExt;
 use integration_tests::pb::{test_client::TestClient, test_server, Input, Output};
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
@@ -36,7 +35,7 @@ async fn connect_returns_err_via_call_after_connected() {
     let jh = tokio::spawn(async move {
         Server::builder()
             .add_service(svc)
-            .serve_with_shutdown("127.0.0.1:1338".parse().unwrap(), rx.map(drop))
+            .serve_with_shutdown("127.0.0.1:1338".parse().unwrap(), async { drop(rx.await) })
             .await
             .unwrap();
     });
@@ -75,7 +74,7 @@ async fn connect_lazy_reconnects_after_first_failure() {
     let jh = tokio::spawn(async move {
         Server::builder()
             .add_service(svc)
-            .serve_with_shutdown("127.0.0.1:1339".parse().unwrap(), rx.map(drop))
+            .serve_with_shutdown("127.0.0.1:1339".parse().unwrap(), async { drop(rx.await) })
             .await
             .unwrap();
     });

--- a/tests/integration_tests/tests/interceptor.rs
+++ b/tests/integration_tests/tests/interceptor.rs
@@ -1,7 +1,5 @@
-use std::time::Duration;
-
-use futures_util::FutureExt;
 use integration_tests::pb::{test_client::TestClient, test_server, Input, Output};
+use std::time::Duration;
 use tokio::sync::oneshot;
 use tonic::{
     transport::{Endpoint, Server},
@@ -28,7 +26,7 @@ async fn interceptor_retrieves_grpc_method() {
     let jh = tokio::spawn(async move {
         Server::builder()
             .add_service(svc)
-            .serve_with_shutdown("127.0.0.1:1340".parse().unwrap(), rx.map(drop))
+            .serve_with_shutdown("127.0.0.1:1340".parse().unwrap(), async { drop(rx.await) })
             .await
             .unwrap();
     });

--- a/tests/integration_tests/tests/origin.rs
+++ b/tests/integration_tests/tests/origin.rs
@@ -1,6 +1,6 @@
-use futures_util::{future::BoxFuture, FutureExt};
 use integration_tests::pb::test_client;
 use integration_tests::pb::{test_server, Input, Output};
+use integration_tests::BoxFuture;
 use std::task::Context;
 use std::task::Poll;
 use std::time::Duration;
@@ -35,7 +35,7 @@ async fn writes_origin_header() {
         Server::builder()
             .layer(OriginLayer {})
             .add_service(svc)
-            .serve_with_shutdown("127.0.0.1:1442".parse().unwrap(), rx.map(drop))
+            .serve_with_shutdown("127.0.0.1:1442".parse().unwrap(), async { drop(rx.await) })
             .await
             .unwrap();
     });

--- a/tests/integration_tests/tests/status.rs
+++ b/tests/integration_tests/tests/status.rs
@@ -1,5 +1,4 @@
 use bytes::Bytes;
-use futures_util::FutureExt;
 use http::Uri;
 use integration_tests::mock::MockStream;
 use integration_tests::pb::{
@@ -35,7 +34,7 @@ async fn status_with_details() {
     let jh = tokio::spawn(async move {
         Server::builder()
             .add_service(svc)
-            .serve_with_shutdown("127.0.0.1:1337".parse().unwrap(), rx.map(drop))
+            .serve_with_shutdown("127.0.0.1:1337".parse().unwrap(), async { drop(rx.await) })
             .await
             .unwrap();
     });
@@ -89,7 +88,7 @@ async fn status_with_metadata() {
     let jh = tokio::spawn(async move {
         Server::builder()
             .add_service(svc)
-            .serve_with_shutdown("127.0.0.1:1338".parse().unwrap(), rx.map(drop))
+            .serve_with_shutdown("127.0.0.1:1338".parse().unwrap(), async { drop(rx.await) })
             .await
             .unwrap();
     });

--- a/tests/integration_tests/tests/user_agent.rs
+++ b/tests/integration_tests/tests/user_agent.rs
@@ -1,4 +1,3 @@
-use futures_util::FutureExt;
 use integration_tests::pb::{test_client, test_server, Input, Output};
 use std::time::Duration;
 use tokio::sync::oneshot;
@@ -28,7 +27,7 @@ async fn writes_user_agent_header() {
     let jh = tokio::spawn(async move {
         Server::builder()
             .add_service(svc)
-            .serve_with_shutdown("127.0.0.1:1322".parse().unwrap(), rx.map(drop))
+            .serve_with_shutdown("127.0.0.1:1322".parse().unwrap(), async { drop(rx.await) })
             .await
             .unwrap();
     });


### PR DESCRIPTION
## Motivation

Continuing of reducing futures crates.

## Solution

Removes `futures-util` from tests entirely.
