### PR TITLE
chore: Refactor ci

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -21,6 +21,13 @@ jobs:
         components: rustfmt
     - run: cargo fmt --all --check
 
+  deny-check:
+    name: cargo-deny check
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - uses: EmbarkStudios/cargo-deny-action@v1
+
   udeps:
     name: Check unused dependencies
     runs-on: ${{ matrix.os }}
@@ -60,13 +67,6 @@ jobs:
       run: cargo hack check --workspace --ignore-private --each-feature --no-dev-deps
     - name: Check all targets
       run: cargo check --workspace --all-targets --all-features
-
-  deny-check:
-    name: cargo-deny check
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v3
-    - uses: EmbarkStudios/cargo-deny-action@v1
 
   msrv:
     name: Check MSRV

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -8,6 +8,7 @@ on:
 
 env:
   PROTOC_VERSION: 3.23.4
+  RUSTFLAGS: "-D warnings"
 
 jobs:
 
@@ -47,10 +48,6 @@ jobs:
       matrix:
         os: [ubuntu-latest, macOS-latest, windows-latest]
         rust: [stable]
-
-    env:
-      RUSTFLAGS: "-D warnings"
-
     steps:
     - uses: hecrj/setup-rust-action@v1
       with:
@@ -99,12 +96,6 @@ jobs:
       matrix:
         os: [ubuntu-latest, macOS-latest, windows-latest]
         rust: [stable]
-
-    env:
-      RUSTFLAGS: "-D warnings"
-      # run a lot of quickcheck iterations
-      QUICKCHECK_TESTS: 1000
-
     steps:
     - uses: hecrj/setup-rust-action@v1
       with:
@@ -117,6 +108,8 @@ jobs:
     - uses: actions/checkout@v3
     - name: Run tests
       run: cargo test --all --all-features
+      env:
+        QUICKCHECK_TESTS: 1000  # run a lot of quickcheck iterations
 
   interop:
     name: Interop Tests
@@ -125,10 +118,6 @@ jobs:
       matrix:
         os: [ubuntu-latest, macOS-latest, windows-latest]
         rust: [stable]
-
-    env:
-      RUSTFLAGS: "-D warnings"
-
     steps:
     - uses: hecrj/setup-rust-action@v1
       with:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -47,11 +47,8 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macOS-latest, windows-latest]
-        rust: [stable]
     steps:
     - uses: hecrj/setup-rust-action@v1
-      with:
-        rust-version: ${{ matrix.rust }}
     - uses: actions/checkout@v3
     - uses: taiki-e/install-action@cargo-hack
     - name: Install protoc
@@ -95,11 +92,8 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macOS-latest, windows-latest]
-        rust: [stable]
     steps:
     - uses: hecrj/setup-rust-action@v1
-      with:
-        rust-version: ${{ matrix.rust }}
     - name: Install protoc
       uses: taiki-e/install-action@v2
       with:
@@ -117,11 +111,8 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macOS-latest, windows-latest]
-        rust: [stable]
     steps:
     - uses: hecrj/setup-rust-action@v1
-      with:
-        rust-version: ${{ matrix.rust }}
     - uses: actions/checkout@v3
     - name: Install protoc
       uses: taiki-e/install-action@v2

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -57,9 +57,9 @@ jobs:
         tool: protoc@${{ env.PROTOC_VERSION }}
     - uses: Swatinem/rust-cache@v2
     - name: Check features
-      run: cargo hack check --all --ignore-private --each-feature --no-dev-deps
+      run: cargo hack check --workspace --ignore-private --each-feature --no-dev-deps
     - name: Check all targets
-      run: cargo check --all --all-targets --all-features
+      run: cargo check --workspace --all-targets --all-features
 
   deny-check:
     name: cargo-deny check
@@ -81,7 +81,7 @@ jobs:
       with:
         tool: protoc@${{ env.PROTOC_VERSION }}
     - uses: Swatinem/rust-cache@v2
-    - run: cargo check --all --all-targets --all-features
+    - run: cargo check --workspace --all-targets --all-features
     - run: cargo doc --no-deps --package tonic --package tonic-build --package tonic-health --package tonic-reflection --package tonic-types --package tonic-web
       env:
         RUSTDOCFLAGS: "-D warnings"
@@ -99,7 +99,7 @@ jobs:
       with:
         tool: protoc@${{ env.PROTOC_VERSION }}
     - uses: Swatinem/rust-cache@v2
-    - run: cargo test --all --all-features
+    - run: cargo test --workspace --all-features
       env:
         QUICKCHECK_TESTS: 1000  # run a lot of quickcheck iterations
 

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -75,7 +75,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: hecrj/setup-rust-action@v1
       with:
-        rust-version: "1.63"
+        rust-version: "1.63"    # msrv
     - name: Install protoc
       uses: taiki-e/install-action@v2
       with:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -48,8 +48,8 @@ jobs:
       matrix:
         os: [ubuntu-latest, macOS-latest, windows-latest]
     steps:
-    - uses: hecrj/setup-rust-action@v1
     - uses: actions/checkout@v3
+    - uses: hecrj/setup-rust-action@v1
     - uses: taiki-e/install-action@cargo-hack
     - name: Install protoc
       uses: taiki-e/install-action@v2
@@ -72,8 +72,7 @@ jobs:
     name: Check MSRV
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout
-      uses: actions/checkout@v3
+    - uses: actions/checkout@v3
     - uses: hecrj/setup-rust-action@v1
       with:
         rust-version: "1.63"
@@ -93,15 +92,14 @@ jobs:
       matrix:
         os: [ubuntu-latest, macOS-latest, windows-latest]
     steps:
+    - uses: actions/checkout@v3
     - uses: hecrj/setup-rust-action@v1
     - name: Install protoc
       uses: taiki-e/install-action@v2
       with:
         tool: protoc@${{ env.PROTOC_VERSION }}
     - uses: Swatinem/rust-cache@v2
-    - uses: actions/checkout@v3
-    - name: Run tests
-      run: cargo test --all --all-features
+    - run: cargo test --all --all-features
       env:
         QUICKCHECK_TESTS: 1000  # run a lot of quickcheck iterations
 
@@ -112,8 +110,8 @@ jobs:
       matrix:
         os: [ubuntu-latest, macOS-latest, windows-latest]
     steps:
-    - uses: hecrj/setup-rust-action@v1
     - uses: actions/checkout@v3
+    - uses: hecrj/setup-rust-action@v1
     - name: Install protoc
       uses: taiki-e/install-action@v2
       with:


### PR DESCRIPTION
## Motivation

Improves readability and maintainability.

## Solution

- Defines `RUSTFLAGS` environment variables at one place which are aimed to use every jobs.
- Moves `QUICKCHECK_TESTS` environment variable at the place to be used.
- Removes redundant matrix variable `rust`, which is only `stable`.
- Reorders steps for the uniform order.
- Updates deprecated cargo option `--all` to `--workspace`.
- Adds msrv comment to be easily found by command like grep.
- Makes `check` and `msrv` job next to each other as they have similar structure.