### PR TITLE
chore(tests): Remove futures

### DIFF
--- a/tests/default_stubs/Cargo.toml
+++ b/tests/default_stubs/Cargo.toml
@@ -7,7 +7,6 @@ publish = false
 version = "0.1.0"
 
 [dependencies]
-futures = "0.3"
 tokio = {version = "1.0", features = ["macros", "rt-multi-thread", "net"]}
 tokio-stream = {version = "0.1", features = ["net"]}
 prost = "0.11"

--- a/tests/default_stubs/src/lib.rs
+++ b/tests/default_stubs/src/lib.rs
@@ -2,8 +2,8 @@
 
 mod test_defaults;
 
-use futures::{Stream, StreamExt};
 use std::pin::Pin;
+use tokio_stream::{Stream, StreamExt};
 use tonic::{Request, Response, Status, Streaming};
 
 tonic::include_proto!("test");


### PR DESCRIPTION
## Motivation

Reduces `futures` crate.

## Solution

Uses `tokio-stream` instead of `futures`.