### PR TITLE
fix(examples): Use https scheme when using tls

### DIFF
--- a/examples/src/tls/client.rs
+++ b/examples/src/tls/client.rs
@@ -15,7 +15,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .ca_certificate(ca)
         .domain_name("example.com");
 
-    let channel = Channel::from_static("http://[::1]:50051")
+    let channel = Channel::from_static("https://[::1]:50051")
         .tls_config(tls)?
         .connect()
         .await?;

--- a/examples/src/tls_client_auth/client.rs
+++ b/examples/src/tls_client_auth/client.rs
@@ -19,7 +19,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .ca_certificate(server_root_ca_cert)
         .identity(client_identity);
 
-    let channel = Channel::from_static("http://[::1]:50051")
+    let channel = Channel::from_static("https://[::1]:50051")
         .tls_config(tls)?
         .connect()
         .await?;


### PR DESCRIPTION
## Motivation

Fixes examples errors.

## Solution

Uses `https` scheme when using tls.
