### PR TITLE
chore: Bump msrv to 1.64

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -75,7 +75,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: hecrj/setup-rust-action@v1
       with:
-        rust-version: "1.63"    # msrv
+        rust-version: "1.64"    # msrv
     - name: Install protoc
       uses: taiki-e/install-action@v2
       with:

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ For IntelliJ IDEA users, please refer to [this](https://github.com/intellij-rust
 
 ### Rust Version
 
-`tonic`'s MSRV is `1.63`.
+`tonic`'s MSRV is `1.64`.
 
 ```bash
 $ rustup update

--- a/deny.toml
+++ b/deny.toml
@@ -23,6 +23,7 @@ skip-tree = [
     { name = "syn" },
     { name = "bitflags" },
     { name = "socket2" },
+    { name = "indexmap" },
 ]
 
 [licenses]


### PR DESCRIPTION
`tonic-build` now depends on `indexmap 2.0.0` (whose MSRV is 1.64) via `prost-build`.