### PR TITLE
docs: discarded server TCP connection config

### DIFF
--- a/tonic/src/transport/server/mod.rs
+++ b/tonic/src/transport/server/mod.rs
@@ -645,8 +645,10 @@ impl<L> Router<L> {
             .await
     }
 
-    /// Consume this [`Server`] creating a future that will execute the server on
-    /// the provided incoming stream of `AsyncRead + AsyncWrite`.
+    /// Consume this [`Server`] creating a future that will execute the server
+    /// on the provided incoming stream of `AsyncRead + AsyncWrite`.
+    ///
+    /// This method discards any provided [`Server`] TCP configuration.
     ///
     /// [`Server`]: struct.Server.html
     pub async fn serve_with_incoming<I, IO, IE, ResBody>(
@@ -674,10 +676,12 @@ impl<L> Router<L> {
             .await
     }
 
-    /// Consume this [`Server`] creating a future that will execute the server on
-    /// the provided incoming stream of `AsyncRead + AsyncWrite`. Similar to
+    /// Consume this [`Server`] creating a future that will execute the server
+    /// on the provided incoming stream of `AsyncRead + AsyncWrite`. Similar to
     /// `serve_with_shutdown` this method will also take a signal future to
     /// gracefully shutdown the server.
+    ///
+    /// This method discards any provided [`Server`] TCP configuration.
     ///
     /// [`Server`]: struct.Server.html
     pub async fn serve_with_incoming_shutdown<I, IO, IE, F, ResBody>(


### PR DESCRIPTION
Some methods on the [`Router`] utilise the TCP configuration of the [`Server`], and others don't. 

It's fairly obvious why when looking at the generic bounds, but we were using `serve_with_incoming()` with a `TcpListenerStream` (which seems to be [not uncommon]) and the author hadn't made the mental leap that this would cause `TCP_NODELAY` to be disabled / default discarded.

I nearly didn't open this, because it's somewhat obvious in hindsight, but a small docs tweak might save some others a bit of confusion.

[not uncommon]: https://github.com/search?q=repo%3Ahyperium%2Ftonic%20TcpListenerStream&type=code

[`Router`]: https://docs.rs/tonic/0.9.2/tonic/transport/server/struct.Router.html#method.serve_with_incoming

[`Server`]: https://docs.rs/tonic/0.9.2/tonic/transport/server/struct.Server.html#method.tcp_nodelay


## Solution

Update the docs. Maybe it needs a comment on the `Server`'s [`tcp_keepalive()`] and [`tcp_nodelay()`] methods instead?

[`tcp_keepalive()`]: https://docs.rs/tonic/0.9.2/tonic/transport/server/struct.Server.html#method.tcp_keepalive
[`tcp_nodelay()`]: https://docs.rs/tonic/0.9.2/tonic/transport/server/struct.Server.html#method.tcp_nodelay

