### PR TITLE
chore(examples): Add `cancellation` example

### DIFF
--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -268,6 +268,10 @@ name = "cancellation-server"
 path = "src/cancellation/server.rs"
 required-features = ["cancellation"]
 
+[[bin]]
+name = "cancellation-client"
+path = "src/cancellation/client.rs"
+
 
 [features]
 gcp = ["dep:prost-types", "tonic/tls"]

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -263,6 +263,11 @@ name = "h2c-client"
 path = "src/h2c/client.rs"
 required-features = ["h2c"]
 
+[[bin]]
+name = "cancellation-server"
+path = "src/cancellation/server.rs"
+required-features = ["cancellation"]
+
 
 [features]
 gcp = ["dep:prost-types", "tonic/tls"]
@@ -287,8 +292,9 @@ timeout = ["tokio/time", "dep:tower"]
 tls-client-auth = ["tonic/tls"]
 types = ["dep:tonic-types"]
 h2c = ["dep:hyper", "dep:axum", "dep:tower", "dep:http"]
+cancellation = ["dep:tokio-util"]
 
-full = ["gcp", "routeguide", "reflection", "autoreload", "health", "grpc-web", "tracing", "hyper-warp", "hyper-warp-multiplex", "uds", "streaming", "mock", "tower", "json-codec", "compression", "tls", "tls-rustls", "dynamic-load-balance", "timeout", "tls-client-auth", "types"]
+full = ["gcp", "routeguide", "reflection", "autoreload", "health", "grpc-web", "tracing", "hyper-warp", "hyper-warp-multiplex", "uds", "streaming", "mock", "tower", "json-codec", "compression", "tls", "tls-rustls", "dynamic-load-balance", "timeout", "tls-client-auth", "types", "cancellation"]
 default = ["full"]
 
 [dependencies]
@@ -305,6 +311,7 @@ axum = { version = "0.6", optional = true }
 either = { version = "1.9", optional = true }
 async-stream = { version = "0.3", optional = true }
 tokio-stream = { version = "0.1", optional = true }
+tokio-util = { version = "0.7.8", optional = true }
 tower = { version = "0.4", optional = true }
 rand = { version = "0.8", optional = true }
 serde = { version = "1.0", features = ["derive"], optional = true }

--- a/examples/src/cancellation/client.rs
+++ b/examples/src/cancellation/client.rs
@@ -1,0 +1,30 @@
+use hello_world::greeter_client::GreeterClient;
+use hello_world::HelloRequest;
+
+use tokio::time::{timeout, Duration};
+
+pub mod hello_world {
+    tonic::include_proto!("helloworld");
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let mut client = GreeterClient::connect("http://[::1]:50051").await?;
+
+    let request = tonic::Request::new(HelloRequest {
+        name: "Tonic".into(),
+    });
+
+    // Cancelling the request by dropping the request future after 1 second
+    let response = match timeout(Duration::from_secs(1), client.say_hello(request)).await {
+        Ok(response) => response?,
+        Err(_) => {
+            println!("Cancelled request after 1s");
+            return Ok(());
+        }
+    };
+
+    println!("RESPONSE={:?}", response);
+
+    Ok(())
+}

--- a/examples/src/cancellation/server.rs
+++ b/examples/src/cancellation/server.rs
@@ -38,7 +38,7 @@ impl Greeter for MyGreeter {
         };
         let cancellation_future = async move {
             println!("Request from {:?} cancelled by client", remote_addr);
-            // If this future is executed it means the request future was dropped, 
+            // If this future is executed it means the request future was dropped,
             // so it doesn't actually matter what is returned here
             Err(Status::cancelled("Request cancelled by client"))
         };

--- a/examples/src/cancellation/server.rs
+++ b/examples/src/cancellation/server.rs
@@ -27,6 +27,7 @@ impl Greeter for MyGreeter {
         let request_future = async move {
             println!("Got a request from {:?}", request.remote_addr());
 
+            // Take a long time to complete request for the client to cancel early
             sleep(Duration::from_secs(10)).await;
 
             let reply = hello_world::HelloReply {
@@ -37,6 +38,8 @@ impl Greeter for MyGreeter {
         };
         let cancellation_future = async move {
             println!("Request from {:?} cancelled by client", remote_addr);
+            // If this future is executed it means the request future was dropped, 
+            // so it doesn't actually matter what is returned here
             Err(Status::cancelled("Request cancelled by client"))
         };
         with_cancellation_handler(request_future, cancellation_future).await
@@ -52,8 +55,11 @@ where
     FCancellation: Future<Output = Result<Response<HelloReply>, Status>> + Send + 'static,
 {
     let token = CancellationToken::new();
+    // Will call token.cancel() when the future is dropped, such as when the client cancels the request
     let _drop_guard = token.clone().drop_guard();
     let select_task = tokio::spawn(async move {
+        // Can select on token cancellation on any cancellable future while handling the request,
+        // allowing for custom cleanup code or monitoring
         select! {
             res = request_future => res,
             _ = token.cancelled() => cancellation_future.await,

--- a/examples/src/cancellation/server.rs
+++ b/examples/src/cancellation/server.rs
@@ -1,0 +1,79 @@
+use std::future::Future;
+
+use tokio_util::sync::CancellationToken;
+use tonic::{transport::Server, Request, Response, Status};
+
+use hello_world::greeter_server::{Greeter, GreeterServer};
+use hello_world::{HelloReply, HelloRequest};
+
+use tokio::select;
+use tokio::time::sleep;
+use tokio::time::Duration;
+
+pub mod hello_world {
+    tonic::include_proto!("helloworld");
+}
+
+#[derive(Default)]
+pub struct MyGreeter {}
+
+#[tonic::async_trait]
+impl Greeter for MyGreeter {
+    async fn say_hello(
+        &self,
+        request: Request<HelloRequest>,
+    ) -> Result<Response<HelloReply>, Status> {
+        let remote_addr = request.remote_addr();
+        let request_future = async move {
+            println!("Got a request from {:?}", request.remote_addr());
+
+            sleep(Duration::from_secs(10)).await;
+
+            let reply = hello_world::HelloReply {
+                message: format!("Hello {}!", request.into_inner().name),
+            };
+
+            Ok(Response::new(reply))
+        };
+        let cancellation_future = async move {
+            println!("Request from {:?} cancelled by client", remote_addr);
+            Err(Status::cancelled("Request cancelled by client"))
+        };
+        with_cancellation_handler(request_future, cancellation_future).await
+    }
+}
+
+async fn with_cancellation_handler<FRequest, FCancellation>(
+    request_future: FRequest,
+    cancellation_future: FCancellation,
+) -> Result<Response<HelloReply>, Status>
+where
+    FRequest: Future<Output = Result<Response<HelloReply>, Status>> + Send + 'static,
+    FCancellation: Future<Output = Result<Response<HelloReply>, Status>> + Send + 'static,
+{
+    let token = CancellationToken::new();
+    let _drop_guard = token.clone().drop_guard();
+    let select_task = tokio::spawn(async move {
+        select! {
+            res = request_future => res,
+            _ = token.cancelled() => cancellation_future.await,
+        }
+    });
+
+    select_task.await.unwrap()
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let addr = "[::1]:50051".parse().unwrap();
+    let greeter = MyGreeter::default();
+
+    println!("GreeterServer listening on {}", addr);
+
+    Server::builder()
+        .add_service(GreeterServer::new(greeter))
+        .serve(addr)
+        .await?;
+
+    Ok(())
+}

--- a/examples/src/timeout/client.rs
+++ b/examples/src/timeout/client.rs
@@ -20,7 +20,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         name: "Tonic".into(),
     });
 
-    let response = client.say_hello(request).await?;
+    let response = tokio::client.say_hello(request).await?;
 
     println!("RESPONSE={:?}", response);
 

--- a/examples/src/timeout/client.rs
+++ b/examples/src/timeout/client.rs
@@ -20,7 +20,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         name: "Tonic".into(),
     });
 
-    let response = tokio::client.say_hello(request).await?;
+    let response = client.say_hello(request).await?;
 
     println!("RESPONSE={:?}", response);
 


### PR DESCRIPTION
## Motivation

There are some valid usecases for being notified of request cancellation and executing clean up logic on client cancellation.
This can be easily done with server streaming and bidi streaming, but there doesn't seem to be a straightforward approach for unary RPCs.

## Solution

Creating a new task for unary requests (like in server/bidi streaming requests), having the unary request' future await on this new task with a CancellationToken drop guard.

Under the assumption that request futures are dropped when client cancels the request, this will notify the task through the drop guard's drop logic