### PR TITLE
chore(tls): Small refactoring

### DIFF
--- a/tonic/Cargo.toml
+++ b/tonic/Cargo.toml
@@ -27,7 +27,7 @@ codegen = ["dep:async-trait"]
 gzip = ["dep:flate2"]
 default = ["transport", "codegen", "prost"]
 prost = ["dep:prost"]
-tls = ["dep:rustls-pemfile", "transport", "dep:tokio-rustls", "dep:rustls", "tokio/rt", "tokio/macros"]
+tls = ["dep:rustls-pemfile", "transport", "dep:tokio-rustls", "tokio/rt", "tokio/macros"]
 tls-roots = ["tls-roots-common", "dep:rustls-native-certs"]
 tls-roots-common = ["tls"]
 tls-webpki-roots = ["tls-roots-common", "dep:webpki-roots"]
@@ -78,9 +78,8 @@ axum = {version = "0.6.9", default_features = false, optional = true}
 # rustls
 async-stream = { version = "0.3", optional = true }
 rustls-pemfile = { version = "1.0", optional = true }
-rustls-native-certs = { version = "0.6.1", optional = true }
+rustls-native-certs = { version = "0.6.3", optional = true }
 tokio-rustls = { version = "0.24", optional = true }
-rustls = { version = "0.21.6", optional = true }
 webpki-roots = { version = "0.25.0", optional = true }
 
 # compression


### PR DESCRIPTION
## Motivation

Small refactorings of `tonic`'s tls config.

## Solution

- Removes `rustls` crate from dependencies as it is not used.
- Updates to `rustls-native-certs` 0.6.3 from 0.6.1 and use its `AsRef<[u8]>` for `Certificate`.
- Uses `AsRef<u8>` for `tonic`'s `Certificate` struct instead of slice syntax.