### PR TITLE
chore: Remove base64 from deny skip-tree

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -19,7 +19,6 @@ deny = [
 skip-tree = [
     { name = "windows-sys" },
     { name = "hermit-abi" },
-    { name = "base64" },
     { name = "syn" },
     { name = "bitflags" },
     { name = "socket2" },


### PR DESCRIPTION
## Motivation

Reflects the current state.

## Solution

As `headers` 0.3.9 updated to `base64` 0.21, the duplicate version of `base64` is resolved.