### PR TITLE
chore(tonic): Move async-stream crate to transport section

### DIFF
--- a/tonic/Cargo.toml
+++ b/tonic/Cargo.toml
@@ -67,6 +67,7 @@ prost = {version = "0.12", default-features = false, features = ["std"], optiona
 async-trait = {version = "0.1.13", optional = true}
 
 # transport
+async-stream = {version = "0.3", optional = true}
 h2 = {version = "0.3.24", optional = true}
 hyper = {version = "0.14.26", features = ["full"], optional = true}
 hyper-timeout = {version = "0.4", optional = true}
@@ -76,7 +77,6 @@ tower = {version = "0.4.7", default-features = false, features = ["balance", "bu
 axum = {version = "0.6.9", default_features = false, optional = true}
 
 # rustls
-async-stream = { version = "0.3", optional = true }
 rustls-pemfile = { version = "2.0", optional = true }
 rustls-native-certs = { version = "0.7", optional = true }
 tokio-rustls = { version = "0.26", default-features = false, features = ["logging", "tls12", "ring"], optional = true }


### PR DESCRIPTION
## Motivation

`async-stream` is now used in `transport` feature.

## Solution

Moves `async-stream` crate to `transport` section.
