### PR TITLE
chore: Use cargo-hack --no-private option instread of --ignore-private

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -79,7 +79,7 @@ jobs:
         tool: protoc@${{ env.PROTOC_VERSION }}
     - uses: Swatinem/rust-cache@v2
     - name: Check features
-      run: cargo hack check --workspace --ignore-private --each-feature --no-dev-deps
+      run: cargo hack check --workspace --no-private --each-feature --no-dev-deps
     - name: Check all targets
       run: cargo check --workspace --all-targets --all-features
 


### PR DESCRIPTION
## Motivation

Improves ci by using `cargo-hack`'s new feature.

## Solution

Uses `cargo-hack`'s more powerful `--no-private` option ([doc](https://github.com/taiki-e/cargo-hack/blob/v0.6.0/CHANGELOG.md#060---2023-08-28)) to avoid checking local crates, which is introduced recently.