### PR TITLE
Add support for zstd compression

### DIFF
--- a/tests/compression/Cargo.toml
+++ b/tests/compression/Cargo.toml
@@ -16,7 +16,7 @@ pin-project = "1.0"
 prost = "0.11"
 tokio = {version = "1.0", features = ["macros", "rt-multi-thread", "net"]}
 tokio-stream = "0.1"
-tonic = {path = "../../tonic", features = ["gzip"]}
+tonic = {path = "../../tonic", features = ["gzip", "zstd"]}
 tower = {version = "0.4", features = []}
 tower-http = {version = "0.4", features = ["map-response-body", "map-request-body"]}
 

--- a/tests/compression/src/bidirectional_stream.rs
+++ b/tests/compression/src/bidirectional_stream.rs
@@ -3,75 +3,90 @@ use tonic::codec::CompressionEncoding;
 
 #[tokio::test(flavor = "multi_thread")]
 async fn client_enabled_server_enabled() {
-    let (client, server) = tokio::io::duplex(UNCOMPRESSED_MIN_BODY_SIZE * 10);
+    for compression_encoding in vec![CompressionEncoding::Gzip, CompressionEncoding::Zstd] {
+        let (client, server) = tokio::io::duplex(UNCOMPRESSED_MIN_BODY_SIZE * 10);
 
-    let svc = test_server::TestServer::new(Svc::default())
-        .accept_compressed(CompressionEncoding::Gzip)
-        .send_compressed(CompressionEncoding::Gzip);
+        let svc = test_server::TestServer::new(Svc::default())
+            .accept_compressed(compression_encoding)
+            .send_compressed(compression_encoding);
 
-    let request_bytes_counter = Arc::new(AtomicUsize::new(0));
-    let response_bytes_counter = Arc::new(AtomicUsize::new(0));
+        let request_bytes_counter = Arc::new(AtomicUsize::new(0));
+        let response_bytes_counter = Arc::new(AtomicUsize::new(0));
 
-    fn assert_right_encoding<B>(req: http::Request<B>) -> http::Request<B> {
-        assert_eq!(req.headers().get("grpc-encoding").unwrap(), "gzip");
-        req
-    }
+        fn assert_right_encoding<B>(req: http::Request<B>, compression_encoding: &CompressionEncoding) -> http::Request<B> {
+            let encoding = req.headers().get("grpc-encoding").unwrap();
 
-    tokio::spawn({
-        let request_bytes_counter = request_bytes_counter.clone();
-        let response_bytes_counter = response_bytes_counter.clone();
-        async move {
-            Server::builder()
-                .layer(
-                    ServiceBuilder::new()
-                        .map_request(assert_right_encoding)
-                        .layer(measure_request_body_size_layer(
-                            request_bytes_counter.clone(),
-                        ))
-                        .layer(MapResponseBodyLayer::new(move |body| {
-                            util::CountBytesBody {
-                                inner: body,
-                                counter: response_bytes_counter.clone(),
-                            }
-                        }))
-                        .into_inner(),
-                )
-                .add_service(svc)
-                .serve_with_incoming(tokio_stream::iter(vec![Ok::<_, std::io::Error>(server)]))
-                .await
-                .unwrap();
+            match compression_encoding {
+                CompressionEncoding::Gzip => assert_eq!(encoding, "gzip"),
+                CompressionEncoding::Zstd => assert_eq!(encoding, "zstd"),
+                _ => unimplemented!(),
+            }
+
+            req
         }
-    });
 
-    let mut client = test_client::TestClient::new(mock_io_channel(client).await)
-        .send_compressed(CompressionEncoding::Gzip)
-        .accept_compressed(CompressionEncoding::Gzip);
+        tokio::spawn({
+            let request_bytes_counter = request_bytes_counter.clone();
+            let response_bytes_counter = response_bytes_counter.clone();
+            async move {
+                Server::builder()
+                    .layer(
+                        ServiceBuilder::new()
+                            .map_request(move |req| assert_right_encoding(req, &compression_encoding))
+                            .layer(measure_request_body_size_layer(
+                                request_bytes_counter.clone(),
+                            ))
+                            .layer(MapResponseBodyLayer::new(move |body| {
+                                util::CountBytesBody {
+                                    inner: body,
+                                    counter: response_bytes_counter.clone(),
+                                }
+                            }))
+                            .into_inner(),
+                    )
+                    .add_service(svc)
+                    .serve_with_incoming(tokio_stream::iter(vec![Ok::<_, std::io::Error>(server)]))
+                    .await
+                    .unwrap();
+            }
+        });
 
-    let data = [0_u8; UNCOMPRESSED_MIN_BODY_SIZE].to_vec();
-    let stream = tokio_stream::iter(vec![SomeData { data: data.clone() }, SomeData { data }]);
-    let req = Request::new(stream);
+        let mut client = test_client::TestClient::new(mock_io_channel(client).await)
+            .send_compressed(compression_encoding)
+            .accept_compressed(compression_encoding);
 
-    let res = client
-        .compress_input_output_bidirectional_stream(req)
-        .await
-        .unwrap();
+        let data = [0_u8; UNCOMPRESSED_MIN_BODY_SIZE].to_vec();
+        let stream = tokio_stream::iter(vec![SomeData { data: data.clone() }, SomeData { data }]);
+        let req = Request::new(stream);
 
-    assert_eq!(res.metadata().get("grpc-encoding").unwrap(), "gzip");
+        let res = client
+            .compress_input_output_bidirectional_stream(req)
+            .await
+            .unwrap();
 
-    let mut stream: Streaming<SomeData> = res.into_inner();
+        let encoding = res.metadata().get("grpc-encoding").unwrap();
 
-    stream
-        .next()
-        .await
-        .expect("stream empty")
-        .expect("item was error");
+        match compression_encoding {
+            CompressionEncoding::Gzip => assert_eq!(encoding, "gzip"),
+            CompressionEncoding::Zstd => assert_eq!(encoding, "zstd"),
+            _ => unimplemented!()
+        }
 
-    stream
-        .next()
-        .await
-        .expect("stream empty")
-        .expect("item was error");
+        let mut stream: Streaming<SomeData> = res.into_inner();
 
-    assert!(request_bytes_counter.load(SeqCst) < UNCOMPRESSED_MIN_BODY_SIZE);
-    assert!(response_bytes_counter.load(SeqCst) < UNCOMPRESSED_MIN_BODY_SIZE);
+        stream
+            .next()
+            .await
+            .expect("stream empty")
+            .expect("item was error");
+
+        stream
+            .next()
+            .await
+            .expect("stream empty")
+            .expect("item was error");
+
+        assert!(request_bytes_counter.load(SeqCst) < UNCOMPRESSED_MIN_BODY_SIZE);
+        assert!(response_bytes_counter.load(SeqCst) < UNCOMPRESSED_MIN_BODY_SIZE);
+    }
 }

--- a/tests/compression/src/compressing_request.rs
+++ b/tests/compression/src/compressing_request.rs
@@ -4,51 +4,61 @@ use tonic::codec::CompressionEncoding;
 
 #[tokio::test(flavor = "multi_thread")]
 async fn client_enabled_server_enabled() {
-    let (client, server) = tokio::io::duplex(UNCOMPRESSED_MIN_BODY_SIZE * 10);
+    for compression_encoding in vec![CompressionEncoding::Gzip, CompressionEncoding::Zstd] {
+        let (client, server) = tokio::io::duplex(UNCOMPRESSED_MIN_BODY_SIZE * 10);
 
-    let svc =
-        test_server::TestServer::new(Svc::default()).accept_compressed(CompressionEncoding::Gzip);
+        let svc = test_server::TestServer::new(Svc::default())
+            .accept_compressed(compression_encoding);
 
-    let request_bytes_counter = Arc::new(AtomicUsize::new(0));
+        let request_bytes_counter = Arc::new(AtomicUsize::new(0));
 
-    fn assert_right_encoding<B>(req: http::Request<B>) -> http::Request<B> {
-        assert_eq!(req.headers().get("grpc-encoding").unwrap(), "gzip");
-        req
-    }
+        fn assert_right_encoding<B>(req: http::Request<B>, compression_encoding: &CompressionEncoding) -> http::Request<B> {
+            let encoding = req.headers().get("grpc-encoding").unwrap();
 
-    tokio::spawn({
-        let request_bytes_counter = request_bytes_counter.clone();
-        async move {
-            Server::builder()
-                .layer(
-                    ServiceBuilder::new()
-                        .layer(
-                            ServiceBuilder::new()
-                                .map_request(assert_right_encoding)
-                                .layer(measure_request_body_size_layer(request_bytes_counter))
-                                .into_inner(),
-                        )
-                        .into_inner(),
-                )
-                .add_service(svc)
-                .serve_with_incoming(tokio_stream::iter(vec![Ok::<_, std::io::Error>(server)]))
+            match compression_encoding {
+                CompressionEncoding::Gzip => assert_eq!(encoding, "gzip"),
+                CompressionEncoding::Zstd => assert_eq!(encoding, "zstd"),
+                _ => unimplemented!(),
+            }
+
+            req
+        }
+
+        tokio::spawn({
+            let compression_encoding = compression_encoding.clone();
+            let request_bytes_counter = request_bytes_counter.clone();
+            async move {
+                Server::builder()
+                    .layer(
+                        ServiceBuilder::new()
+                            .layer(
+                                ServiceBuilder::new()
+                                    .map_request(move |req| assert_right_encoding(req, &compression_encoding))
+                                    .layer(measure_request_body_size_layer(request_bytes_counter))
+                                    .into_inner(),
+                            )
+                            .into_inner(),
+                    )
+                    .add_service(svc)
+                    .serve_with_incoming(tokio_stream::iter(vec![Ok::<_, std::io::Error>(server)]))
+                    .await
+                    .unwrap();
+            }
+        });
+
+        let mut client = test_client::TestClient::new(mock_io_channel(client).await)
+            .send_compressed(compression_encoding);
+
+        for _ in 0..3 {
+            client
+                .compress_input_unary(SomeData {
+                    data: [0_u8; UNCOMPRESSED_MIN_BODY_SIZE].to_vec(),
+                })
                 .await
                 .unwrap();
+            let bytes_sent = request_bytes_counter.load(SeqCst);
+            assert!(bytes_sent < UNCOMPRESSED_MIN_BODY_SIZE);
         }
-    });
-
-    let mut client = test_client::TestClient::new(mock_io_channel(client).await)
-        .send_compressed(CompressionEncoding::Gzip);
-
-    for _ in 0..3 {
-        client
-            .compress_input_unary(SomeData {
-                data: [0_u8; UNCOMPRESSED_MIN_BODY_SIZE].to_vec(),
-            })
-            .await
-            .unwrap();
-        let bytes_sent = request_bytes_counter.load(SeqCst);
-        assert!(bytes_sent < UNCOMPRESSED_MIN_BODY_SIZE);
     }
 }
 

--- a/tonic/Cargo.toml
+++ b/tonic/Cargo.toml
@@ -25,6 +25,7 @@ version = "0.9.2"
 [features]
 codegen = ["dep:async-trait"]
 gzip = ["dep:flate2"]
+zstd = ["dep:zstd"]
 default = ["transport", "codegen", "prost"]
 prost = ["dep:prost"]
 tls = ["dep:rustls-pemfile", "transport", "dep:tokio-rustls", "dep:rustls", "tokio/rt", "tokio/macros"]
@@ -85,6 +86,7 @@ webpki-roots = { version = "0.25.0", optional = true }
 
 # compression
 flate2 = {version = "1.0", optional = true}
+zstd = {version = "0.12.4", optional = true}
 
 [dev-dependencies]
 bencher = "0.1.5"


### PR DESCRIPTION
## Motivation

Fixes #1236

## Solution

- Added `zstd` as a compression method using the `zstd` crate
- Updated compression integration tests to test both `gzip` and `zstd`
- Handle the case when both the `gzip` and `zstd` features are enabled