### PR TITLE
chore: Update cargo-deny config

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -21,7 +21,6 @@ skip-tree = [
     { name = "hermit-abi" },
     { name = "syn" },
     { name = "bitflags" },
-    { name = "socket2" },
     { name = "indexmap" },
 ]
 

--- a/deny.toml
+++ b/deny.toml
@@ -19,7 +19,6 @@ deny = [
 skip-tree = [
     { name = "windows-sys" },
     { name = "hermit-abi" },
-    { name = "base64" },
     { name = "syn" },
     { name = "bitflags" },
     { name = "socket2" },


### PR DESCRIPTION
## Motivation

Updates to reflect the current latest state and cargo-deny behavior.

## Solution

- Allow `dirs` and `dirs-sys` crates.
    - `prost-build` depends on `dirs` (and `dirs-sys` depended by `dirs`) because its dependency `which` 4.4.1 become to depend on `dirs`.
    - Recently these crates seem not to have a lot of dependencies.
        - https://crates.io/crates/dirs/5.0.1/dependencies
        - https://crates.io/crates/dirs-sys/0.4.1/dependencies
- Adds `redox_syscall` to cargo-deny skip-tree.
    - `dirs-sys` depends on an old version of `redox_syscall`.
- Removes `base64` from cargo-deny skip-tree
    - As headers 0.3.9 updated to base64 0.21, the duplicate version of base64 is resolved.