### PR TITLE
chore: Update to actions/checkout@v4

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -15,7 +15,7 @@ jobs:
   rustfmt:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - uses: hecrj/setup-rust-action@v2
       with:
         components: rustfmt
@@ -25,13 +25,13 @@ jobs:
     name: cargo-deny check
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - uses: EmbarkStudios/cargo-deny-action@v1
 
   codegen:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - uses: hecrj/setup-rust-action@v2
     - name: Install protoc
       uses: taiki-e/install-action@v2
@@ -51,7 +51,7 @@ jobs:
         - os: windows-latest
           option: --exclude-features uds
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - uses: dtolnay/rust-toolchain@master
       with:
         toolchain: nightly-2024-02-06
@@ -70,7 +70,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, macOS-latest, windows-latest]
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - uses: hecrj/setup-rust-action@v2
     - uses: taiki-e/install-action@cargo-hack
     - name: Install protoc
@@ -87,7 +87,7 @@ jobs:
     name: Check MSRV
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - uses: hecrj/setup-rust-action@v2
       with:
         rust-version: "1.70"    # msrv
@@ -107,7 +107,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, macOS-latest, windows-latest]
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - uses: hecrj/setup-rust-action@v2
     - name: Install protoc
       uses: taiki-e/install-action@v2
@@ -125,7 +125,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, macOS-latest, windows-latest]
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - uses: hecrj/setup-rust-action@v2
     - name: Install protoc
       uses: taiki-e/install-action@v2


### PR DESCRIPTION
## Motivation

`actions/checkout@v4` is released.

https://github.com/actions/checkout/releases/tag/v4.0.0

## Solution

Updates to `actions/checkout@v4` from version 3.
