### PR TITLE
chore(tonic): Deprecate API when they only return None

### DIFF
--- a/tonic/src/request.rs
+++ b/tonic/src/request.rs
@@ -1,8 +1,11 @@
 use crate::metadata::{MetadataMap, MetadataValue};
+#[cfg(feature = "transport")]
+use crate::transport::server::TcpConnectInfo;
 #[cfg(all(feature = "transport", feature = "tls"))]
 use crate::transport::server::TlsConnectInfo;
 #[cfg(feature = "transport")]
-use crate::transport::{server::TcpConnectInfo, Certificate};
+#[allow(deprecated)]
+use crate::transport::Certificate;
 use crate::Extensions;
 #[cfg(feature = "transport")]
 use std::sync::Arc;
@@ -207,6 +210,13 @@ impl<T> Request<T> {
     /// This will return `None` if the `IO` type used
     /// does not implement `Connected` or when using a unix domain socket.
     /// This currently only works on the server side.
+    #[cfg_attr(
+        not(feature = "transport"),
+        deprecated(
+            since = "0.10.3",
+            note = "`remote_addr` only returns `None` without transport feature. This API will require transport feature.",
+        )
+    )]
     pub fn local_addr(&self) -> Option<SocketAddr> {
         #[cfg(feature = "transport")]
         {
@@ -241,6 +251,13 @@ impl<T> Request<T> {
     /// This will return `None` if the `IO` type used
     /// does not implement `Connected` or when using a unix domain socket.
     /// This currently only works on the server side.
+    #[cfg_attr(
+        not(feature = "transport"),
+        deprecated(
+            since = "0.10.3",
+            note = "`remote_addr` only returns `None` without transport feature. This API will require transport feature.",
+        )
+    )]
     pub fn remote_addr(&self) -> Option<SocketAddr> {
         #[cfg(feature = "transport")]
         {
@@ -277,7 +294,15 @@ impl<T> Request<T> {
     /// `Some` on the server side of the `transport` server with
     /// TLS enabled connections.
     #[cfg(feature = "transport")]
+    #[cfg_attr(
+        all(feature = "transport", not(feature = "tls")),
+        deprecated(
+            since = "0.10.3",
+            note = "`peer_certs` only returns `None` without tls feature. This API will require tls feature.",
+        )
+    )]
     #[cfg_attr(docsrs, doc(cfg(feature = "transport")))]
+    #[allow(deprecated)]
     pub fn peer_certs(&self) -> Option<Arc<Vec<Certificate>>> {
         #[cfg(feature = "tls")]
         {

--- a/tonic/src/transport/mod.rs
+++ b/tonic/src/transport/mod.rs
@@ -103,6 +103,7 @@ pub use self::error::Error;
 pub use self::server::Server;
 #[doc(inline)]
 pub use self::service::grpc_timeout::TimeoutExpired;
+#[allow(deprecated)]
 pub use self::tls::Certificate;
 #[doc(inline)]
 pub use crate::server::NamedService;

--- a/tonic/src/transport/tls.rs
+++ b/tonic/src/transport/tls.rs
@@ -1,4 +1,11 @@
 /// Represents a X509 certificate.
+#[cfg_attr(
+    not(feature = "tls"),
+    deprecated(
+        since = "0.10.3",
+        note = "`Certificate` is used only by deprecated API without tls feature.",
+    )
+)]
 #[derive(Debug, Clone)]
 pub struct Certificate {
     pub(crate) pem: Vec<u8>,
@@ -13,6 +20,7 @@ pub struct Identity {
     pub(crate) key: Vec<u8>,
 }
 
+#[allow(deprecated)]
 impl Certificate {
     /// Parse a PEM encoded X509 Certificate.
     ///
@@ -38,6 +46,7 @@ impl Certificate {
     }
 }
 
+#[allow(deprecated)]
 impl AsRef<[u8]> for Certificate {
     fn as_ref(&self) -> &[u8] {
         self.pem.as_ref()


### PR DESCRIPTION
## Motivation

#1516

## Solution

Deprecates [`Request::local_addr`](https://docs.rs/tonic/0.10.0/tonic/struct.Request.html#method.local_addr), [`Request::remote_addr`](https://docs.rs/tonic/0.10.0/tonic/struct.Request.html#method.remote_addr) and [`Request::peer_certs`](https://docs.rs/tonic/0.10.0/tonic/struct.Request.html#method.peer_certs) when they only return `None`.
