### PR TITLE
chore(transport): Deprecate re-exported NamedService

### DIFF
--- a/interop/src/server.rs
+++ b/interop/src/server.rs
@@ -7,7 +7,7 @@ use std::pin::Pin;
 use std::task::{Context, Poll};
 use std::time::Duration;
 use tokio_stream::StreamExt;
-use tonic::{body::BoxBody, transport::NamedService, Code, Request, Response, Status};
+use tonic::{body::BoxBody, server::NamedService, Code, Request, Response, Status};
 use tower::Service;
 
 pub use pb::test_service_server::TestServiceServer;

--- a/tests/integration_tests/tests/extensions.rs
+++ b/tests/integration_tests/tests/extensions.rs
@@ -10,7 +10,8 @@ use std::{
 use tokio::sync::oneshot;
 use tonic::{
     body::BoxBody,
-    transport::{Endpoint, NamedService, Server},
+    server::NamedService,
+    transport::{Endpoint, Server},
     Request, Response, Status,
 };
 use tower_service::Service;

--- a/tonic/src/transport/mod.rs
+++ b/tonic/src/transport/mod.rs
@@ -105,6 +105,7 @@ pub use self::server::Server;
 pub use self::service::grpc_timeout::TimeoutExpired;
 pub use self::tls::Certificate;
 #[doc(inline)]
+/// A deprecated re-export. Please use `tonic::server::NamedService` directly.
 pub use crate::server::NamedService;
 pub use axum::{body::BoxBody as AxumBoxBody, Router as AxumRouter};
 pub use hyper::{Body, Uri};

--- a/tonic/src/transport/server/mod.rs
+++ b/tonic/src/transport/server/mod.rs
@@ -12,6 +12,8 @@ mod unix;
 pub use super::service::Routes;
 pub use super::service::RoutesBuilder;
 
+#[doc(inline)]
+/// A deprecated re-export. Please use `tonic::server::NamedService` directly.
 pub use crate::server::NamedService;
 pub use conn::{Connected, TcpConnectInfo};
 #[cfg(feature = "tls")]


### PR DESCRIPTION
## Motivation

Removes old API.

## Solution

`NamedService` has been re-exported in transport module for the historical reason. The re-exporting could be removed. As `deprecated` does not handle re-export, the deprecation should be at the comment.