### PR TITLE
chore: Remove redundant helper constructor

### DIFF
--- a/tonic/src/transport/channel/endpoint.rs
+++ b/tonic/src/transport/channel/endpoint.rs
@@ -309,10 +309,10 @@ impl Endpoint {
         http.set_keepalive(self.tcp_keepalive);
 
         #[cfg(feature = "tls")]
-        let connector = service::connector(http, self.tls.clone());
+        let connector = service::Connector::new(http, self.tls.clone());
 
         #[cfg(not(feature = "tls"))]
-        let connector = service::connector(http);
+        let connector = service::Connector::new(http);
 
         if let Some(connect_timeout) = self.connect_timeout {
             let mut connector = hyper_timeout::TimeoutConnector::new(connector);
@@ -334,10 +334,10 @@ impl Endpoint {
         http.set_keepalive(self.tcp_keepalive);
 
         #[cfg(feature = "tls")]
-        let connector = service::connector(http, self.tls.clone());
+        let connector = service::Connector::new(http, self.tls.clone());
 
         #[cfg(not(feature = "tls"))]
-        let connector = service::connector(http);
+        let connector = service::Connector::new(http);
 
         if let Some(connect_timeout) = self.connect_timeout {
             let mut connector = hyper_timeout::TimeoutConnector::new(connector);
@@ -363,10 +363,10 @@ impl Endpoint {
         crate::Error: From<C::Error> + Send + 'static,
     {
         #[cfg(feature = "tls")]
-        let connector = service::connector(connector, self.tls.clone());
+        let connector = service::Connector::new(connector, self.tls.clone());
 
         #[cfg(not(feature = "tls"))]
-        let connector = service::connector(connector);
+        let connector = service::Connector::new(connector);
 
         if let Some(connect_timeout) = self.connect_timeout {
             let mut connector = hyper_timeout::TimeoutConnector::new(connector);
@@ -392,10 +392,10 @@ impl Endpoint {
         crate::Error: From<C::Error> + Send + 'static,
     {
         #[cfg(feature = "tls")]
-        let connector = service::connector(connector, self.tls.clone());
+        let connector = service::Connector::new(connector, self.tls.clone());
 
         #[cfg(not(feature = "tls"))]
-        let connector = service::connector(connector);
+        let connector = service::Connector::new(connector);
 
         Channel::new(connector, self.clone())
     }

--- a/tonic/src/transport/service/connector.rs
+++ b/tonic/src/transport/service/connector.rs
@@ -8,16 +8,6 @@ use std::task::{Context, Poll};
 use tower::make::MakeConnection;
 use tower_service::Service;
 
-#[cfg(not(feature = "tls"))]
-pub(crate) fn connector<C>(inner: C) -> Connector<C> {
-    Connector::new(inner)
-}
-
-#[cfg(feature = "tls")]
-pub(crate) fn connector<C>(inner: C, tls: Option<TlsConnector>) -> Connector<C> {
-    Connector::new(inner, tls)
-}
-
 pub(crate) struct Connector<C> {
     inner: C,
     #[cfg(feature = "tls")]
@@ -34,7 +24,7 @@ impl<C> Connector<C> {
     }
 
     #[cfg(feature = "tls")]
-    fn new(inner: C, tls: Option<TlsConnector>) -> Self {
+    pub(crate) fn new(inner: C, tls: Option<TlsConnector>) -> Self {
         Self { inner, tls }
     }
 

--- a/tonic/src/transport/service/discover.rs
+++ b/tonic/src/transport/service/discover.rs
@@ -39,10 +39,10 @@ impl<K: Hash + Eq + Clone> Stream for DynamicServiceStream<K> {
                     http.set_connect_timeout(endpoint.connect_timeout);
                     http.enforce_http(false);
                     #[cfg(feature = "tls")]
-                    let connector = service::connector(http, endpoint.tls.clone());
+                    let connector = service::Connector::new(http, endpoint.tls.clone());
 
                     #[cfg(not(feature = "tls"))]
-                    let connector = service::connector(http);
+                    let connector = service::Connector::new(http);
                     let connection = Connection::lazy(connector, endpoint);
                     let change = Ok(Change::Insert(k, connection));
                     Poll::Ready(Some(change))

--- a/tonic/src/transport/service/discover.rs
+++ b/tonic/src/transport/service/discover.rs
@@ -1,4 +1,3 @@
-use super::super::service;
 use super::connection::Connection;
 use crate::transport::Endpoint;
 
@@ -38,12 +37,8 @@ impl<K: Hash + Eq + Clone> Stream for DynamicServiceStream<K> {
                     http.set_keepalive(endpoint.tcp_keepalive);
                     http.set_connect_timeout(endpoint.connect_timeout);
                     http.enforce_http(false);
-                    #[cfg(feature = "tls")]
-                    let connector = service::Connector::new(http, endpoint.tls.clone());
 
-                    #[cfg(not(feature = "tls"))]
-                    let connector = service::Connector::new(http);
-                    let connection = Connection::lazy(connector, endpoint);
+                    let connection = Connection::lazy(endpoint.connector(http), endpoint);
                     let change = Ok(Change::Insert(k, connection));
                     Poll::Ready(Some(change))
                 }

--- a/tonic/src/transport/service/mod.rs
+++ b/tonic/src/transport/service/mod.rs
@@ -13,7 +13,7 @@ mod user_agent;
 
 pub(crate) use self::add_origin::AddOrigin;
 pub(crate) use self::connection::Connection;
-pub(crate) use self::connector::connector;
+pub(crate) use self::connector::Connector;
 pub(crate) use self::discover::DynamicServiceStream;
 pub(crate) use self::executor::SharedExec;
 pub(crate) use self::grpc_timeout::GrpcTimeout;


### PR DESCRIPTION
## Motivation

Simplifies implementations.

## Solution

Removes the redundant helper functions which construct Connector.
