### PR TITLE
skip debug

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ members = [
   "codegen",
   "interop", # Tests
   "tests/disable_comments",
+  "tests/manual_debug",
   "tests/included_service",
   "tests/same_name",
   "tests/service_named_service",

--- a/tests/manual_debug/Cargo.toml
+++ b/tests/manual_debug/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+edition = "2021"
+license = "MIT"
+name = "manual_debug"
+publish = false
+version = "0.1.0"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+prost = "0.12"
+tonic = { path = "../../tonic" }
+
+[build-dependencies]
+tonic-build = { path = "../../tonic-build" }

--- a/tests/manual_debug/build.rs
+++ b/tests/manual_debug/build.rs
@@ -1,0 +1,8 @@
+fn main() {
+    tonic_build::configure()
+        .build_client(false)
+        .build_server(false)
+        .skip_debug("ManualDebug")
+        .compile(&["proto/test.proto"], &["proto"])
+        .unwrap();
+}

--- a/tests/manual_debug/proto/test.proto
+++ b/tests/manual_debug/proto/test.proto
@@ -1,0 +1,11 @@
+syntax = "proto3";
+
+package test;
+
+message ManualDebug {
+    string manual = 1;
+}
+
+message DeriveDebug {
+    string derive = 1;
+}

--- a/tests/manual_debug/src/lib.rs
+++ b/tests/manual_debug/src/lib.rs
@@ -1,0 +1,9 @@
+pub mod pb {
+    tonic::include_proto!("test");
+
+    impl std::fmt::Debug for ManualDebug {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            write!(f, "ManualDebug manual implementation")
+        }
+    }
+}

--- a/tests/manual_debug/tests/manual_debug.rs
+++ b/tests/manual_debug/tests/manual_debug.rs
@@ -1,0 +1,15 @@
+use manual_debug::pb::{ManualDebug, DeriveDebug};
+
+#[test]
+fn test() {
+    let manual = ManualDebug {
+        manual: "helloWorld".into(),
+    };
+    assert_eq!(format!("{manual:?}"), "ManualDebug manual implementation");
+
+    let derived = DeriveDebug {
+        derive: "helloWorld".into(),
+    };
+    assert_eq!(format!("{derived:?}"), r#"DeriveDebug { derive: "helloWorld" }"#
+    )
+}

--- a/tonic-build/src/prost.rs
+++ b/tonic-build/src/prost.rs
@@ -28,6 +28,7 @@ pub fn configure() -> Builder {
         enum_attributes: Vec::new(),
         type_attributes: Vec::new(),
         boxed: Vec::new(),
+        skip_debug: Vec::new(),
         btree_map: None,
         bytes: None,
         server_attributes: Attributes::default(),
@@ -239,6 +240,7 @@ pub struct Builder {
     pub(crate) message_attributes: Vec<(String, String)>,
     pub(crate) enum_attributes: Vec<(String, String)>,
     pub(crate) boxed: Vec<String>,
+    pub(crate) skip_debug: Vec<String>,
     pub(crate) btree_map: Option<Vec<String>>,
     pub(crate) bytes: Option<Vec<String>>,
     pub(crate) server_attributes: Attributes,
@@ -359,6 +361,12 @@ impl Builder {
     /// Passed directly to `prost_build::Config.boxed`.
     pub fn boxed<P: AsRef<str>>(mut self, path: P) -> Self {
         self.boxed.push(path.as_ref().to_string());
+        self
+    }
+
+    /// Add path to type that should not have a generated implementation of Debug
+    pub fn skip_debug<P: AsRef<str>>(mut self, path: P) -> Self {
+        self.skip_debug.push(path.as_ref().to_string());
         self
     }
 
@@ -572,6 +580,7 @@ impl Builder {
         for prost_path in self.boxed.iter() {
             config.boxed(prost_path);
         }
+        config.skip_debug(&self.skip_debug);
         if let Some(ref paths) = self.btree_map {
             config.btree_map(paths);
         }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/hyperium/tonic/blob/master/CONTRIBUTING.md
-->

## Motivation

A recent version of prost-build added a `skip_debug` method to let users
manually implement debug for types generated from protobuf messages. While it
was possible to use this from tonic-build, it was a bit awkward and required an
additional direct dev-dependency on prost-build as well as additional steps to
create a config instance, configure properties of that, then do the same with
tonic's configuration before calling `compile_with_config` to combine them.

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? If a new feature is being added, describe the intended
use case that feature fulfills.
-->

## Solution

This adds a new `skip_debug` method to the configuration Builder to handle the
prost config instance for the user.

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
