### PR TITLE
chore: Bump msrv to 1.65

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -88,7 +88,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: hecrj/setup-rust-action@v1
       with:
-        rust-version: "1.64"    # msrv
+        rust-version: "1.65"    # msrv
     - name: Install protoc
       uses: taiki-e/install-action@v2
       with:

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ For IntelliJ IDEA users, please refer to [this](https://github.com/intellij-rust
 
 ### Rust Version
 
-`tonic`'s MSRV is `1.64`.
+`tonic`'s MSRV is `1.65`.
 
 ```bash
 $ rustup update


### PR DESCRIPTION
`tonic-build` now depends on `regex-syntax` 0.8.0, which require Rust 1.65 as MSRV, via `prost-build`.