### PR TITLE
chore(transport): Replace axum with matchit

### DIFF
--- a/examples/src/h2c/server.rs
+++ b/examples/src/h2c/server.rs
@@ -61,7 +61,7 @@ mod h2c {
 
     impl<S> Service<Request<Body>> for H2c<S>
     where
-        S: Service<Request<Body>, Response = Response<tonic::transport::AxumBoxBody>>
+        S: Service<Request<Body>, Response = Response<tonic::body::BoxBody>>
             + Clone
             + Send
             + 'static,

--- a/tonic/Cargo.toml
+++ b/tonic/Cargo.toml
@@ -33,7 +33,7 @@ tls-roots-common = ["tls"]
 tls-webpki-roots = ["tls-roots-common", "dep:webpki-roots"]
 transport = [
   "dep:async-stream",
-  "dep:axum",
+  "dep:matchit",
   "channel",
   "dep:h2",
   "dep:hyper",
@@ -73,7 +73,7 @@ hyper = {version = "0.14.26", features = ["full"], optional = true}
 hyper-timeout = {version = "0.4", optional = true}
 tokio-stream = "0.1"
 tower = {version = "0.4.7", default-features = false, features = ["balance", "buffer", "discover", "limit", "load", "make", "timeout", "util"], optional = true}
-axum = {version = "0.6.9", default_features = false, optional = true}
+matchit = {version = "0.7.3", optional = true}
 
 # rustls
 async-stream = { version = "0.3", optional = true }

--- a/tonic/src/transport/mod.rs
+++ b/tonic/src/transport/mod.rs
@@ -106,7 +106,6 @@ pub use self::service::grpc_timeout::TimeoutExpired;
 pub use self::tls::Certificate;
 #[doc(inline)]
 pub use crate::server::NamedService;
-pub use axum::{body::BoxBody as AxumBoxBody, Router as AxumRouter};
 pub use hyper::{Body, Uri};
 
 pub(crate) use self::service::executor::Executor;

--- a/tonic/src/transport/server/mod.rs
+++ b/tonic/src/transport/server/mod.rs
@@ -601,9 +601,9 @@ impl<L> Router<L> {
         self
     }
 
-    /// Convert this tonic `Router` into an axum `Router` consuming the tonic one.
-    pub fn into_router(self) -> axum::Router {
-        self.routes.into_router()
+    /// Convert this tonic `Router` into [`Routes`] consuming the tonic one.
+    pub fn into_router(self) -> Routes {
+        self.routes
     }
 
     /// Consume this [`Server`] creating a future that will execute the server
@@ -624,7 +624,7 @@ impl<L> Router<L> {
             .map_err(super::Error::from_source)?;
         self.server
             .serve_with_shutdown::<_, _, future::Ready<()>, _, _, ResBody>(
-                self.routes.prepare(),
+                self.routes,
                 incoming,
                 None,
             )
@@ -653,7 +653,7 @@ impl<L> Router<L> {
         let incoming = TcpIncoming::new(addr, self.server.tcp_nodelay, self.server.tcp_keepalive)
             .map_err(super::Error::from_source)?;
         self.server
-            .serve_with_shutdown(self.routes.prepare(), incoming, Some(signal))
+            .serve_with_shutdown(self.routes, incoming, Some(signal))
             .await
     }
 
@@ -681,7 +681,7 @@ impl<L> Router<L> {
     {
         self.server
             .serve_with_shutdown::<_, _, future::Ready<()>, _, _, ResBody>(
-                self.routes.prepare(),
+                self.routes,
                 incoming,
                 None,
             )
@@ -715,7 +715,7 @@ impl<L> Router<L> {
         ResBody::Error: Into<crate::Error>,
     {
         self.server
-            .serve_with_shutdown(self.routes.prepare(), incoming, Some(signal))
+            .serve_with_shutdown(self.routes, incoming, Some(signal))
             .await
     }
 
@@ -729,7 +729,7 @@ impl<L> Router<L> {
         ResBody: http_body::Body<Data = Bytes> + Send + 'static,
         ResBody::Error: Into<crate::Error>,
     {
-        self.server.service_builder.service(self.routes.prepare())
+        self.server.service_builder.service(self.routes)
     }
 }
 


### PR DESCRIPTION
## Motivation

Simplifies dependency tree, and implementations. `axum` seems to be a relatively too large library for the purpose of implementing `tonic`'s router. Directly using `matchit`, which is a crate used in `axum` seems to be simple for `tonic`.

## Solution

> **warning**
> This proposal contains breaking changes.

Replaces `axum` with `matchit` to implement the router.