### PR TITLE
test: add timeout_on_sleeping_server interop test

### DIFF
--- a/interop/src/bin/client.rs
+++ b/interop/src/bin/client.rs
@@ -83,6 +83,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             Testcase::CustomMetadata => {
                 client::custom_metadata(&mut client, &mut test_results).await
             }
+            Testcase::TimeoutOnSleepingServer => {
+                client::timeout_on_sleeping_server(&mut client, &mut test_results).await
+            }
             _ => unimplemented!(),
         }
 

--- a/interop/test.sh
+++ b/interop/test.sh
@@ -17,6 +17,7 @@ TEST_CASES=(
   "custom_metadata"
   "unimplemented_method"
   "unimplemented_service"
+  "timeout_on_sleeping_server"
 )
 
 # join all test cases in one comma separated string (dropping the first one)


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/hyperium/tonic/blob/master/CONTRIBUTING.md
-->

## Motivation

I'm dealing with a conformance test that assumes that when you set (and hit) a timeout in a gRPC client, the status code you see is `DEADLINE_EXCEEDED`. Currently, when setting a timeout (say by using `request.set_timeout`), I sometimes see a `CANCELLED` code instead.

As far as I can tell, the gRPC interop test `timeout_on_sleeping_server` [checks this](https://github.com/grpc/grpc/blob/master/doc/interop-test-descriptions.md#timeout_on_sleeping_server) and asserts that the status code is `DEADLINE_EXCEEDED`. This part of the gRPC spec isn't particularly clear, but it looks like `grpc-go` sometimes converts `CANCELLED` into `DEADLINE_EXCEEDED` (see [here](https://github.com/grpc/grpc-go/pull/2906/files)).

This PR adds this particular test to the interop suite, which I believe is equivalent to this on in grpc-go [here](https://github.com/grpc/grpc-go/blob/be1d1c10a930fa0e91fc4bcd01963035011e2466/interop/test_utils.go#L240-L261).

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? If a new feature is being added, describe the intended
use case that feature fulfills.
-->

## Solution

I don't know how to solve this. It appears to me like the test case is flaky. I believe this is due to the fact that sometimes, the server is responding with `DEADLINE_EXCEED` and other times, the error is produced internally in the client as `CANCELLED`.

I'm hoping that by adding the test case, this can be nailed down.

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
