### PR TITLE
chore: Bump msrv to 1.66

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -88,7 +88,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: hecrj/setup-rust-action@v2
       with:
-        rust-version: "1.65"    # msrv
+        rust-version: "1.66"    # msrv
     - name: Install protoc
       uses: taiki-e/install-action@v2
       with:

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ For IntelliJ IDEA users, please refer to [this](https://github.com/intellij-rust
 
 ### Rust Version
 
-`tonic`'s MSRV is `1.65`.
+`tonic`'s MSRV is `1.66`.
 
 ```bash
 $ rustup update


### PR DESCRIPTION
`jobserver` 0.1.27, which `tonic` depends on as transitive dependency, requires Rust 1.66.