### PR TITLE
Draft: Update to hyper 1.0 and axum 0.7

### DIFF
--- a/tonic/Cargo.toml
+++ b/tonic/Cargo.toml
@@ -28,7 +28,14 @@ gzip = ["dep:flate2"]
 zstd = ["dep:zstd"]
 default = ["transport", "codegen", "prost"]
 prost = ["dep:prost"]
-tls = ["dep:rustls-pemfile", "transport", "dep:tokio-rustls", "dep:rustls", "tokio/rt", "tokio/macros"]
+tls = [
+  "dep:rustls-pemfile",
+  "transport",
+  "dep:tokio-rustls",
+  "dep:rustls",
+  "tokio/rt",
+  "tokio/macros",
+]
 tls-roots = ["tls-roots-common", "dep:rustls-native-certs"]
 tls-roots-common = ["tls"]
 tls-webpki-roots = ["tls-roots-common", "dep:webpki-roots"]
@@ -52,29 +59,42 @@ channel = []
 [dependencies]
 base64 = "0.21"
 bytes = "1.0"
-http = "0.2"
+http = "1.0"
 tracing = "0.1"
 
 tokio = "1.0.1"
-http-body = "0.4.4"
+http-body = "1.0"
+http-body-util = "0.1"
 percent-encoding = "2.1"
 pin-project = "1.0.11"
 tower-layer = "0.3"
 tower-service = "0.3"
 
 # prost
-prost = {version = "0.12", default-features = false, features = ["std"], optional = true}
+prost = { version = "0.12", default-features = false, features = [
+  "std",
+], optional = true }
 
 # codegen
-async-trait = {version = "0.1.13", optional = true}
+async-trait = { version = "0.1.13", optional = true }
 
 # transport
-h2 = {version = "0.3.17", optional = true}
-hyper = {version = "0.14.26", features = ["full"], optional = true}
-hyper-timeout = {version = "0.4", optional = true}
+h2 = { version = "0.4", optional = true }
+hyper = { version = "1.0", features = ["full"], optional = true }
+hyper-util = { version = "0.1", features = ["full"] }
+hyper-timeout = { version = "0.5", optional = true }
 tokio-stream = "0.1"
-tower = {version = "0.4.7", default-features = false, features = ["balance", "buffer", "discover", "limit", "load", "make", "timeout", "util"], optional = true}
-axum = {version = "0.6.9", default_features = false, optional = true}
+tower = { version = "0.4.7", default-features = false, features = [
+  "balance",
+  "buffer",
+  "discover",
+  "limit",
+  "load",
+  "make",
+  "timeout",
+  "util",
+], optional = true }
+axum = { version = "0.7", default_features = false, optional = true }
 
 # rustls
 async-stream = { version = "0.3", optional = true }
@@ -85,7 +105,7 @@ rustls = { version = "0.21.7", optional = true }
 webpki-roots = { version = "0.25.0", optional = true }
 
 # compression
-flate2 = {version = "1.0", optional = true}
+flate2 = { version = "1.0", optional = true }
 zstd = { version = "0.12.3", optional = true }
 
 [dev-dependencies]
@@ -94,8 +114,8 @@ quickcheck = "1.0"
 quickcheck_macros = "1.0"
 rand = "0.8"
 static_assertions = "1.0"
-tokio = {version = "1.0", features = ["rt", "macros"]}
-tower = {version = "0.4.7", features = ["full"]}
+tokio = { version = "1.0", features = ["rt", "macros"] }
+tower = { version = "0.4.7", features = ["full"] }
 
 [package.metadata.docs.rs]
 all-features = true

--- a/tonic/src/body.rs
+++ b/tonic/src/body.rs
@@ -1,9 +1,7 @@
 //! HTTP specific body utilities.
 
-use http_body::Body;
-
 /// A type erased HTTP body used for tonic services.
-pub type BoxBody = http_body::combinators::UnsyncBoxBody<bytes::Bytes, crate::Status>;
+pub type BoxBody = http_body_util::combinators::UnsyncBoxBody<bytes::Bytes, crate::Status>;
 
 /// Convert a [`http_body::Body`] into a [`BoxBody`].
 pub(crate) fn boxed<B>(body: B) -> BoxBody
@@ -16,7 +14,7 @@ where
 
 /// Create an empty `BoxBody`
 pub fn empty_body() -> BoxBody {
-    http_body::Empty::new()
+    http_body_util::Empty::new()
         .map_err(|err| match err {})
         .boxed_unsync()
 }

--- a/tonic/src/body.rs
+++ b/tonic/src/body.rs
@@ -1,5 +1,7 @@
 //! HTTP specific body utilities.
 
+use http_body_util::BodyExt;
+
 /// A type erased HTTP body used for tonic services.
 pub type BoxBody = http_body_util::combinators::UnsyncBoxBody<bytes::Bytes, crate::Status>;
 
@@ -18,3 +20,4 @@ pub fn empty_body() -> BoxBody {
         .map_err(|err| match err {})
         .boxed_unsync()
 }
+

--- a/tonic/src/codec/encode.rs
+++ b/tonic/src/codec/encode.rs
@@ -3,7 +3,7 @@ use super::{EncodeBuf, Encoder, DEFAULT_MAX_SEND_MESSAGE_SIZE, HEADER_SIZE};
 use crate::{Code, Status};
 use bytes::{BufMut, Bytes, BytesMut};
 use http::HeaderMap;
-use http_body::Body;
+use http_body::{Body, Frame};
 use pin_project::pin_project;
 use std::{
     pin::Pin,
@@ -319,10 +319,10 @@ where
         self.state.is_end_stream
     }
 
-    fn poll_data(
+    fn poll_frame(
         self: Pin<&mut Self>,
         cx: &mut Context<'_>,
-    ) -> Poll<Option<Result<Self::Data, Self::Error>>> {
+    ) -> Poll<Option<Result<Frame<Self::Data>, Self::Error>>> {
         let self_proj = self.project();
         match ready!(self_proj.inner.poll_next(cx)) {
             Some(Ok(d)) => Some(Ok(d)).into(),
@@ -336,11 +336,5 @@ where
             None => None.into(),
         }
     }
-
-    fn poll_trailers(
-        self: Pin<&mut Self>,
-        _cx: &mut Context<'_>,
-    ) -> Poll<Result<Option<HeaderMap>, Status>> {
-        Poll::Ready(self.project().state.trailers())
-    }
 }
+

--- a/tonic/src/codec/prost.rs
+++ b/tonic/src/codec/prost.rs
@@ -268,7 +268,7 @@ mod tests {
     mod body {
         use crate::Status;
         use bytes::Bytes;
-        use http_body::Body;
+        use http_body::{Body, Frame};
         use std::{
             pin::Pin,
             task::{Context, Poll},
@@ -299,10 +299,10 @@ mod tests {
             type Data = Bytes;
             type Error = Status;
 
-            fn poll_data(
+            fn poll_frame(
                 mut self: Pin<&mut Self>,
                 cx: &mut Context<'_>,
-            ) -> Poll<Option<Result<Self::Data, Self::Error>>> {
+            ) -> Poll<Option<Result<Frame<Self::Data>, Self::Error>>> {
                 // every other call to poll_data returns data
                 let should_send = self.count % 2 == 0;
                 let data_len = self.data.len();
@@ -325,13 +325,7 @@ mod tests {
                     Poll::Ready(None)
                 }
             }
-
-            fn poll_trailers(
-                self: Pin<&mut Self>,
-                _cx: &mut Context<'_>,
-            ) -> Poll<Result<Option<http::HeaderMap>, Self::Error>> {
-                Poll::Ready(Ok(None))
-            }
         }
     }
 }
+

--- a/tonic/src/extensions.rs
+++ b/tonic/src/extensions.rs
@@ -24,7 +24,7 @@ impl Extensions {
     /// If a extension of this type already existed, it will
     /// be returned.
     #[inline]
-    pub fn insert<T: Send + Sync + 'static>(&mut self, val: T) -> Option<T> {
+    pub fn insert<T: Send + Sync + Clone + 'static>(&mut self, val: T) -> Option<T> {
         self.inner.insert(val)
     }
 
@@ -95,3 +95,4 @@ impl GrpcMethod {
         self.method
     }
 }
+

--- a/tonic/src/service/interceptor.rs
+++ b/tonic/src/service/interceptor.rs
@@ -232,7 +232,8 @@ where
 mod tests {
     #[allow(unused_imports)]
     use super::*;
-    use http::header::HeaderMap;
+    use http_body::Frame;
+    use http_body_util::Empty;
     use std::{
         pin::Pin,
         task::{Context, Poll},
@@ -246,18 +247,11 @@ mod tests {
         type Data = Bytes;
         type Error = Status;
 
-        fn poll_data(
+        fn poll_frame(
             self: Pin<&mut Self>,
             _cx: &mut Context<'_>,
-        ) -> Poll<Option<Result<Self::Data, Self::Error>>> {
+        ) -> Poll<Option<Result<Frame<Self::Data>, Self::Error>>> {
             Poll::Ready(None)
-        }
-
-        fn poll_trailers(
-            self: Pin<&mut Self>,
-            _cx: &mut Context<'_>,
-        ) -> Poll<Result<Option<HeaderMap>, Self::Error>> {
-            Poll::Ready(Ok(None))
         }
     }
 
@@ -318,19 +312,20 @@ mod tests {
 
     #[tokio::test]
     async fn doesnt_change_http_method() {
-        let svc = tower::service_fn(|request: http::Request<hyper::Body>| async move {
+        let svc = tower::service_fn(|request: http::Request<Empty>| async move {
             assert_eq!(request.method(), http::Method::OPTIONS);
 
-            Ok::<_, hyper::Error>(hyper::Response::new(hyper::Body::empty()))
+            Ok::<_, hyper::Error>(hyper::Response::new(Empty::new()))
         });
 
         let svc = InterceptedService::new(svc, Ok);
 
         let request = http::Request::builder()
             .method(http::Method::OPTIONS)
-            .body(hyper::Body::empty())
+            .body(Empty::new())
             .unwrap();
 
         svc.oneshot(request).await.unwrap();
     }
 }
+

--- a/tonic/src/status.rs
+++ b/tonic/src/status.rs
@@ -412,13 +412,7 @@ impl Status {
         // > status. Note that the frequency of PINGs is highly dependent on the network
         // > environment, implementations are free to adjust PING frequency based on network and
         // > application requirements, which is why it's mapped to unavailable here.
-        //
-        // Likewise, if we are unable to connect to the server, map this to UNAVAILABLE.  This is
-        // consistent with the behavior of a C++ gRPC client when the server is not running, and
-        // matches the spec of:
-        // > The service is currently unavailable. This is most likely a transient condition that
-        // > can be corrected if retried with a backoff.
-        if err.is_timeout() || err.is_connect() {
+        if err.is_timeout() {
             return Some(Status::unavailable(err.to_string()));
         }
 
@@ -1009,3 +1003,4 @@ mod tests {
         assert_eq!(status.details(), DETAILS);
     }
 }
+

--- a/tonic/src/transport/channel/endpoint.rs
+++ b/tonic/src/transport/channel/endpoint.rs
@@ -313,7 +313,7 @@ impl Endpoint {
 
     /// Create a channel from this config.
     pub async fn connect(&self) -> Result<Channel, Error> {
-        let mut http = hyper::client::connect::HttpConnector::new();
+        let mut http = hyper_util::client::legacy::connect::HttpConnector::new();
         http.enforce_http(false);
         http.set_nodelay(self.tcp_nodelay);
         http.set_keepalive(self.tcp_keepalive);
@@ -334,7 +334,7 @@ impl Endpoint {
     /// The channel returned by this method does not attempt to connect to the endpoint until first
     /// use.
     pub fn connect_lazy(&self) -> Channel {
-        let mut http = hyper::client::connect::HttpConnector::new();
+        let mut http = hyper_util::client::legacy::connect::HttpConnector::new();
         http.enforce_http(false);
         http.set_nodelay(self.tcp_nodelay);
         http.set_keepalive(self.tcp_keepalive);

--- a/tonic/src/transport/channel/mod.rs
+++ b/tonic/src/transport/channel/mod.rs
@@ -17,7 +17,7 @@ use http::{
     uri::{InvalidUri, Uri},
     Request, Response,
 };
-use hyper::client::connect::Connection as HyperConnection;
+use hyper_util::client::legacy::connect::Connection as HyperConnection;
 use std::{
     fmt,
     future::Future,
@@ -236,3 +236,4 @@ impl fmt::Debug for ResponseFuture {
         f.debug_struct("ResponseFuture").finish()
     }
 }
+

--- a/tonic/src/transport/mod.rs
+++ b/tonic/src/transport/mod.rs
@@ -108,8 +108,8 @@ pub use self::tls::Certificate;
 #[doc(inline)]
 /// A deprecated re-export. Please use `tonic::server::NamedService` directly.
 pub use crate::server::NamedService;
-pub use axum::{body::BoxBody as AxumBoxBody, Router as AxumRouter};
-pub use hyper::{Body, Uri};
+pub use axum::{body::Body as AxumBoxBody, Router as AxumRouter};
+pub use hyper::Uri;
 
 pub(crate) use self::service::executor::Executor;
 
@@ -124,3 +124,4 @@ pub use self::server::ServerTlsConfig;
 pub use self::tls::Identity;
 
 type BoxFuture<'a, T> = std::pin::Pin<Box<dyn std::future::Future<Output = T> + Send + 'a>>;
+

--- a/tonic/src/transport/server/conn.rs
+++ b/tonic/src/transport/server/conn.rs
@@ -1,4 +1,3 @@
-use hyper::server::conn::AddrStream;
 use std::net::SocketAddr;
 use tokio::net::TcpStream;
 
@@ -83,17 +82,6 @@ impl TcpConnectInfo {
     /// Return the remote address the IO resource is connected too.
     pub fn remote_addr(&self) -> Option<SocketAddr> {
         self.remote_addr
-    }
-}
-
-impl Connected for AddrStream {
-    type ConnectInfo = TcpConnectInfo;
-
-    fn connect_info(&self) -> Self::ConnectInfo {
-        TcpConnectInfo {
-            local_addr: Some(self.local_addr()),
-            remote_addr: Some(self.remote_addr()),
-        }
     }
 }
 

--- a/tonic/src/transport/server/incoming.rs
+++ b/tonic/src/transport/server/incoming.rs
@@ -123,7 +123,7 @@ enum SelectOutput<A> {
 /// of `AsyncRead + AsyncWrite` that communicate with clients that connect to a socket address.
 #[derive(Debug)]
 pub struct TcpIncoming {
-    inner: AddrIncoming,
+    inner: TcpListener,
 }
 
 impl TcpIncoming {
@@ -163,22 +163,16 @@ impl TcpIncoming {
         nodelay: bool,
         keepalive: Option<Duration>,
     ) -> Result<Self, crate::Error> {
-        let mut inner = AddrIncoming::bind(&addr)?;
+        let mut inner = TcpListener::bind(&addr)?;
         inner.set_nodelay(nodelay);
         inner.set_keepalive(keepalive);
         Ok(TcpIncoming { inner })
     }
+}
 
-    /// Creates a new `TcpIncoming` from an existing `tokio::net::TcpListener`.
-    pub fn from_listener(
-        listener: TcpListener,
-        nodelay: bool,
-        keepalive: Option<Duration>,
-    ) -> Result<Self, crate::Error> {
-        let mut inner = AddrIncoming::from_listener(listener)?;
-        inner.set_nodelay(nodelay);
-        inner.set_keepalive(keepalive);
-        Ok(TcpIncoming { inner })
+impl From<TcpListener> for TcpIncoming {
+    fn from(inner: TcpListener) -> Self {
+        TcpIncoming { inner }
     }
 }
 

--- a/tonic/src/transport/server/incoming.rs
+++ b/tonic/src/transport/server/incoming.rs
@@ -1,9 +1,5 @@
 use super::{Connected, Server};
 use crate::transport::service::ServerIo;
-use hyper::server::{
-    accept::Accept,
-    conn::{AddrIncoming, AddrStream},
-};
 use std::{
     net::SocketAddr,
     pin::Pin,
@@ -12,7 +8,7 @@ use std::{
 };
 use tokio::{
     io::{AsyncRead, AsyncWrite},
-    net::TcpListener,
+    net::{TcpListener, TcpStream},
 };
 use tokio_stream::{Stream, StreamExt};
 
@@ -187,7 +183,7 @@ impl TcpIncoming {
 }
 
 impl Stream for TcpIncoming {
-    type Item = Result<AddrStream, std::io::Error>;
+    type Item = Result<TcpStream, std::io::Error>;
 
     fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
         Pin::new(&mut self.inner).poll_accept(cx)
@@ -207,3 +203,4 @@ mod tests {
         let _t3 = TcpIncoming::new(addr, true, None).unwrap();
     }
 }
+

--- a/tonic/src/transport/server/mod.rs
+++ b/tonic/src/transport/server/mod.rs
@@ -43,7 +43,7 @@ use crate::body::BoxBody;
 use bytes::Bytes;
 use http::{Request, Response};
 use http_body::Body as _;
-use hyper::{server::accept, Body};
+use hyper::Body;
 use pin_project::pin_project;
 use std::{
     convert::Infallible,
@@ -57,6 +57,7 @@ use std::{
     time::Duration,
 };
 use tokio::io::{AsyncRead, AsyncWrite};
+use tokio::net::TcpStream;
 use tokio_stream::Stream;
 use tower::{
     layer::util::{Identity, Stack},
@@ -527,7 +528,7 @@ impl<L> Server<L> {
         let svc = self.service_builder.service(svc);
 
         let tcp = incoming::tcp_incoming(incoming, self);
-        let incoming = accept::from_stream::<_, _, crate::Error>(tcp);
+        let incoming = TcpStream::accept::from_stream::<_, _, crate::Error>(tcp);
 
         let svc = MakeSvc {
             inner: svc,

--- a/tonic/src/transport/server/mod.rs
+++ b/tonic/src/transport/server/mod.rs
@@ -65,7 +65,7 @@ use tower::{
     Service, ServiceBuilder,
 };
 
-type BoxHttpBody = http_body::combinators::UnsyncBoxBody<Bytes, crate::Error>;
+type BoxHttpBody = http_body_util::combinators::UnsyncBoxBody<Bytes, crate::Error>;
 type BoxService = tower::util::BoxService<Request<Body>, Response<BoxHttpBody>, crate::Error>;
 type TraceInterceptor = Arc<dyn Fn(&http::Request<()>) -> tracing::Span + Send + Sync + 'static>;
 

--- a/tonic/src/transport/server/mod.rs
+++ b/tonic/src/transport/server/mod.rs
@@ -16,6 +16,7 @@ pub use super::service::RoutesBuilder;
 /// A deprecated re-export. Please use `tonic::server::NamedService` directly.
 pub use crate::server::NamedService;
 pub use conn::{Connected, TcpConnectInfo};
+use hyper_util::rt::TokioExecutor;
 #[cfg(feature = "tls")]
 pub use tls::ServerTlsConfig;
 
@@ -536,16 +537,17 @@ impl<L> Server<L> {
             _io: PhantomData,
         };
 
-        let server = hyper::Server::builder(incoming)
-            .http2_only(http2_only)
-            .http2_initial_connection_window_size(init_connection_window_size)
-            .http2_initial_stream_window_size(init_stream_window_size)
-            .http2_max_concurrent_streams(max_concurrent_streams)
-            .http2_keep_alive_interval(http2_keepalive_interval)
-            .http2_keep_alive_timeout(http2_keepalive_timeout)
-            .http2_adaptive_window(http2_adaptive_window.unwrap_or_default())
-            .http2_max_pending_accept_reset_streams(http2_max_pending_accept_reset_streams)
-            .http2_max_frame_size(max_frame_size);
+        let server = hyper_util::server::conn::auto::Builder::new(TokioExecutor::new())
+            .http2()
+            .initial_connection_window_size(init_connection_window_size)
+            .initial_stream_window_size(init_stream_window_size)
+            .max_concurrent_streams(max_concurrent_streams)
+            .keep_alive_interval(http2_keepalive_interval)
+            .keep_alive_timeout(http2_keepalive_timeout)
+            .adaptive_window(http2_adaptive_window.unwrap_or_default())
+            // FIXME: wait for this to be added to hyper-util
+            //.max_pending_accept_reset_streams(http2_max_pending_accept_reset_streams)
+            .max_frame_size(max_frame_size);
 
         if let Some(signal) = signal {
             server
@@ -887,3 +889,4 @@ where
         future::ready(Ok(svc))
     }
 }
+

--- a/tonic/src/transport/server/recover_error.rs
+++ b/tonic/src/transport/server/recover_error.rs
@@ -98,30 +98,18 @@ where
     type Data = B::Data;
     type Error = B::Error;
 
-    fn poll_data(
+    fn poll_frame(
         self: Pin<&mut Self>,
         cx: &mut Context<'_>,
-    ) -> Poll<Option<Result<Self::Data, Self::Error>>> {
-        match self.project().inner.as_pin_mut() {
-            Some(b) => b.poll_data(cx),
-            None => Poll::Ready(None),
-        }
+    ) -> Poll<Option<Result<http_body::Frame<Self::Data>, Self::Error>>> {
+        Pin::new(&mut self.0).poll_frame(cx)
     }
 
-    fn poll_trailers(
-        self: Pin<&mut Self>,
-        cx: &mut Context<'_>,
-    ) -> Poll<Result<Option<http::HeaderMap>, Self::Error>> {
-        match self.project().inner.as_pin_mut() {
-            Some(b) => b.poll_trailers(cx),
-            None => Poll::Ready(Ok(None)),
-        }
+    fn size_hint(&self) -> http_body::SizeHint {
+        self.0.size_hint()
     }
 
     fn is_end_stream(&self) -> bool {
-        match &self.inner {
-            Some(b) => b.is_end_stream(),
-            None => true,
-        }
+        self.body.is_end_stream()
     }
 }

--- a/tonic/src/transport/service/connection.rs
+++ b/tonic/src/transport/service/connection.rs
@@ -38,15 +38,15 @@ impl Connection {
             .clone();
 
         if let Some(val) = endpoint.http2_keep_alive_timeout {
-            settings.http2_keep_alive_timeout(val);
+            settings.keep_alive_timeout(val);
         }
 
         if let Some(val) = endpoint.http2_keep_alive_while_idle {
-            settings.http2_keep_alive_while_idle(val);
+            settings.keep_alive_while_idle(val);
         }
 
         if let Some(val) = endpoint.http2_adaptive_window {
-            settings.http2_adaptive_window(val);
+            settings.adaptive_window(val);
         }
 
         let stack = ServiceBuilder::new()

--- a/tonic/src/transport/service/connection.rs
+++ b/tonic/src/transport/service/connection.rs
@@ -5,8 +5,8 @@ use crate::{
 };
 use http::Uri;
 use hyper::client::conn::Builder;
-use hyper::client::connect::Connection as HyperConnection;
 use hyper::client::service::Connect as HyperConnect;
+use hyper_util::client::legacy::connect::Connection as HyperConnection;
 use std::{
     fmt,
     task::{Context, Poll},
@@ -126,3 +126,4 @@ impl fmt::Debug for Connection {
         f.debug_struct("Connection").finish()
     }
 }
+

--- a/tonic/src/transport/service/discover.rs
+++ b/tonic/src/transport/service/discover.rs
@@ -32,7 +32,7 @@ impl<K: Hash + Eq + Clone> Stream for DynamicServiceStream<K> {
             Poll::Pending | Poll::Ready(None) => Poll::Pending,
             Poll::Ready(Some(change)) => match change {
                 Change::Insert(k, endpoint) => {
-                    let mut http = hyper::client::connect::HttpConnector::new();
+                    let mut http = hyper_util::client::legacy::connect::HttpConnector::new();
                     http.set_nodelay(endpoint.tcp_nodelay);
                     http.set_keepalive(endpoint.tcp_keepalive);
                     http.set_connect_timeout(endpoint.connect_timeout);

--- a/tonic/src/transport/service/io.rs
+++ b/tonic/src/transport/service/io.rs
@@ -1,5 +1,5 @@
 use crate::transport::server::Connected;
-use hyper::client::connect::{Connected as HyperConnected, Connection};
+use hyper_util::client::legacy::connect::{Connected as HyperConnected, Connection};
 use std::io;
 use std::io::IoSlice;
 use std::pin::Pin;


### PR DESCRIPTION
Hi, apologies for the delay.

This PR is to update `hyper` to 1.0, `http` to 1.0, `http-body` to 1.0, and `axum` to 0.7.

- [x] update imports to use `-util` crates
- [x] update `AddrStream` and `AddrIncoming`
- [ ] use axum `Request` and `Response` in transport (in-progress)
- [ ] add `poll_frame` to `impl http_body::Body`  (in-progress)
- [ ] remove `poll_trailers` from `impl http_body::Body` (in-progress)
- [ ] fix hyper-timeout connector
- [ ] fix connect, Connect (no more `hyper::client::service::Connect`)
- [ ] update version, docs
- [ ] update examples
- [ ] many more (tonic-web, etc. Some of these will be in separate PRs)

Depends on:
- [x] https://github.com/hyperium/hyper/issues/3461

Under consideration:
- rename `tonic::body::BoxBody` to `tonic::body::Body` to match axum
- now that `TcpIncoming` has `TcpListener` as the inner type instead of the deprecated `AddrIncoming`, can `TcpIncoming` be simplified?

I tried to break it up so that it is easier to review commit-by-commit.
There are some things I am still working through. Any feedback would be helpful.

Closes #1579