### PR TITLE
chore(tonic): Remove API when they only return None

### DIFF
--- a/tonic/src/request.rs
+++ b/tonic/src/request.rs
@@ -212,24 +212,19 @@ impl<T> Request<T> {
     #[cfg(feature = "transport")]
     #[cfg_attr(docsrs, doc(cfg(feature = "transport")))]
     pub fn local_addr(&self) -> Option<SocketAddr> {
-        #[cfg(feature = "tls")]
-        {
-            self.extensions()
-                .get::<TcpConnectInfo>()
-                .and_then(|i| i.local_addr())
-                .or_else(|| {
-                    self.extensions()
-                        .get::<TlsConnectInfo<TcpConnectInfo>>()
-                        .and_then(|i| i.get_ref().local_addr())
-                })
-        }
+        let addr = self
+            .extensions()
+            .get::<TcpConnectInfo>()
+            .and_then(|i| i.local_addr());
 
-        #[cfg(not(feature = "tls"))]
-        {
+        #[cfg(feature = "tls")]
+        let addr = addr.or_else(|| {
             self.extensions()
-                .get::<TcpConnectInfo>()
-                .and_then(|i| i.local_addr())
-        }
+                .get::<TlsConnectInfo<TcpConnectInfo>>()
+                .and_then(|i| i.get_ref().local_addr())
+        });
+
+        addr
     }
 
     /// Get the remote address of this connection.
@@ -240,24 +235,19 @@ impl<T> Request<T> {
     #[cfg(feature = "transport")]
     #[cfg_attr(docsrs, doc(cfg(feature = "transport")))]
     pub fn remote_addr(&self) -> Option<SocketAddr> {
-        #[cfg(feature = "tls")]
-        {
-            self.extensions()
-                .get::<TcpConnectInfo>()
-                .and_then(|i| i.remote_addr())
-                .or_else(|| {
-                    self.extensions()
-                        .get::<TlsConnectInfo<TcpConnectInfo>>()
-                        .and_then(|i| i.get_ref().remote_addr())
-                })
-        }
+        let addr = self
+            .extensions()
+            .get::<TcpConnectInfo>()
+            .and_then(|i| i.remote_addr());
 
-        #[cfg(not(feature = "tls"))]
-        {
+        #[cfg(feature = "tls")]
+        let addr = addr.or_else(|| {
             self.extensions()
-                .get::<TcpConnectInfo>()
-                .and_then(|i| i.remote_addr())
-        }
+                .get::<TlsConnectInfo<TcpConnectInfo>>()
+                .and_then(|i| i.get_ref().remote_addr())
+        });
+
+        addr
     }
 
     /// Get the peer certificates of the connected client.

--- a/tonic/src/transport/mod.rs
+++ b/tonic/src/transport/mod.rs
@@ -92,6 +92,7 @@ pub mod server;
 
 mod error;
 mod service;
+#[cfg(feature = "tls")]
 mod tls;
 
 #[doc(inline)]
@@ -103,7 +104,8 @@ pub use self::error::Error;
 pub use self::server::Server;
 #[doc(inline)]
 pub use self::service::grpc_timeout::TimeoutExpired;
-#[allow(deprecated)]
+#[cfg(feature = "tls")]
+#[cfg_attr(docsrs, doc(cfg(feature = "tls")))]
 pub use self::tls::Certificate;
 #[doc(inline)]
 /// A deprecated re-export. Please use `tonic::server::NamedService` directly.

--- a/tonic/src/transport/tls.rs
+++ b/tonic/src/transport/tls.rs
@@ -1,26 +1,16 @@
 /// Represents a X509 certificate.
-#[cfg_attr(
-    not(feature = "tls"),
-    deprecated(
-        since = "0.10.3",
-        note = "`Certificate` is used only by deprecated API without tls feature.",
-    )
-)]
 #[derive(Debug, Clone)]
 pub struct Certificate {
     pub(crate) pem: Vec<u8>,
 }
 
 /// Represents a private key and X509 certificate.
-#[cfg(feature = "tls")]
-#[cfg_attr(docsrs, doc(cfg(feature = "tls")))]
 #[derive(Debug, Clone)]
 pub struct Identity {
     pub(crate) cert: Certificate,
     pub(crate) key: Vec<u8>,
 }
 
-#[allow(deprecated)]
 impl Certificate {
     /// Parse a PEM encoded X509 Certificate.
     ///
@@ -46,14 +36,12 @@ impl Certificate {
     }
 }
 
-#[allow(deprecated)]
 impl AsRef<[u8]> for Certificate {
     fn as_ref(&self) -> &[u8] {
         self.pem.as_ref()
     }
 }
 
-#[cfg(feature = "tls")]
 impl Identity {
     /// Parse a PEM encoded certificate and private key.
     ///


### PR DESCRIPTION
## Motivation

Continues  #1520 and resolves #1516.

## Solution

> [!WARNING] 
> This proposal includes breaking changes.

Removes APIs when they only return `None`.
