### PR TITLE
chore(lib): Remove re-exported NamedService

### DIFF
--- a/tonic/src/transport/mod.rs
+++ b/tonic/src/transport/mod.rs
@@ -105,9 +105,6 @@ pub use self::server::Server;
 pub use self::service::grpc_timeout::TimeoutExpired;
 #[allow(deprecated)]
 pub use self::tls::Certificate;
-#[doc(inline)]
-/// A deprecated re-export. Please use `tonic::server::NamedService` directly.
-pub use crate::server::NamedService;
 pub use axum::{body::BoxBody as AxumBoxBody, Router as AxumRouter};
 pub use hyper::{Body, Uri};
 

--- a/tonic/src/transport/server/mod.rs
+++ b/tonic/src/transport/server/mod.rs
@@ -12,9 +12,6 @@ mod unix;
 pub use super::service::Routes;
 pub use super::service::RoutesBuilder;
 
-#[doc(inline)]
-/// A deprecated re-export. Please use `tonic::server::NamedService` directly.
-pub use crate::server::NamedService;
 pub use conn::{Connected, TcpConnectInfo};
 #[cfg(feature = "tls")]
 pub use tls::ServerTlsConfig;
@@ -39,6 +36,7 @@ use crate::transport::Error;
 use self::recover_error::RecoverError;
 use super::service::{GrpcTimeout, ServerIo};
 use crate::body::BoxBody;
+use crate::server::NamedService;
 use bytes::Bytes;
 use http::{Request, Response};
 use http_body::Body as _;


### PR DESCRIPTION
## Motivation

Continues  #1521.

## Solution

> [!warning]
> This proposal includes breaking changes.

Removes deprecated re-exported `NamedService`.