### PR TITLE
Add client feature flag to support connect_with_connector in wasm32 targets

### DIFF
--- a/tonic/Cargo.toml
+++ b/tonic/Cargo.toml
@@ -38,8 +38,19 @@ transport = [
   "channel",
   "dep:h2",
   "dep:hyper",
+  "hyper/full",
+  "dep:tokio",
   "tokio/net",
   "tokio/time",
+  "dep:tower",
+  "tower/balance",
+  "dep:hyper-timeout",
+]
+client = [
+  "dep:h2",
+  "hyper/client",
+  "hyper/http2",
+  "dep:tokio",
   "dep:tower",
   "dep:hyper-timeout",
 ]
@@ -55,7 +66,7 @@ bytes = "1.0"
 http = "0.2"
 tracing = "0.1"
 
-tokio = "1.0.1"
+tokio = { version = "1.0.1", default-features = false, optional = true }
 http-body = "0.4.4"
 percent-encoding = "2.1"
 pin-project = "1.0.11"
@@ -70,7 +81,7 @@ async-trait = {version = "0.1.13", optional = true}
 
 # transport
 h2 = {version = "0.3.17", optional = true}
-hyper = {version = "0.14.26", features = ["full"], optional = true}
+hyper = {version = "0.14.26", default-features = false, optional = true}
 hyper-timeout = {version = "0.4", optional = true}
 tokio-stream = "0.1"
 tower = {version = "0.4.7", default-features = false, features = ["balance", "buffer", "discover", "limit", "load", "make", "timeout", "util"], optional = true}
@@ -87,6 +98,9 @@ webpki-roots = { version = "0.25.0", optional = true }
 # compression
 flate2 = {version = "1.0", optional = true}
 zstd = { version = "0.12.3", optional = true }
+
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+wasm-bindgen-futures = "0.4.38"
 
 [dev-dependencies]
 bencher = "0.1.5"

--- a/tonic/Cargo.toml
+++ b/tonic/Cargo.toml
@@ -39,7 +39,6 @@ transport = [
   "dep:h2",
   "dep:hyper",
   "hyper/full",
-  "dep:tokio",
   "tokio/net",
   "tokio/time",
   "dep:tower",
@@ -47,10 +46,10 @@ transport = [
   "dep:hyper-timeout",
 ]
 client = [
+  "channel",
   "dep:h2",
   "hyper/client",
   "hyper/http2",
-  "dep:tokio",
   "dep:tower",
   "dep:hyper-timeout",
 ]
@@ -66,7 +65,7 @@ bytes = "1.0"
 http = "0.2"
 tracing = "0.1"
 
-tokio = { version = "1.0.1", default-features = false, optional = true }
+tokio = { version = "1.0.1" }
 http-body = "0.4.4"
 percent-encoding = "2.1"
 pin-project = "1.0.11"

--- a/tonic/src/lib.rs
+++ b/tonic/src/lib.rs
@@ -101,7 +101,7 @@ pub mod metadata;
 pub mod server;
 pub mod service;
 
-#[cfg(feature = "transport")]
+#[cfg(any(feature = "transport", feature = "client"))]
 #[cfg_attr(docsrs, doc(cfg(feature = "transport")))]
 pub mod transport;
 

--- a/tonic/src/transport/channel/endpoint.rs
+++ b/tonic/src/transport/channel/endpoint.rs
@@ -27,10 +27,15 @@ pub struct Endpoint {
     pub(crate) buffer_size: Option<usize>,
     pub(crate) init_stream_window_size: Option<u32>,
     pub(crate) init_connection_window_size: Option<u32>,
+    #[cfg(feature = "transport")]
     pub(crate) tcp_keepalive: Option<Duration>,
+    #[cfg(feature = "transport")]
     pub(crate) tcp_nodelay: bool,
+    #[cfg(feature = "transport")]
     pub(crate) http2_keep_alive_interval: Option<Duration>,
+    #[cfg(feature = "transport")]
     pub(crate) http2_keep_alive_timeout: Option<Duration>,
+    #[cfg(feature = "transport")]
     pub(crate) http2_keep_alive_while_idle: Option<bool>,
     pub(crate) connect_timeout: Option<Duration>,
     pub(crate) http2_adaptive_window: Option<bool>,
@@ -167,6 +172,7 @@ impl Endpoint {
     ///
     /// Default is no keepalive (`None`)
     ///
+    #[cfg(feature = "transport")]
     pub fn tcp_keepalive(self, tcp_keepalive: Option<Duration>) -> Self {
         Endpoint {
             tcp_keepalive,
@@ -251,6 +257,7 @@ impl Endpoint {
     }
 
     /// Set the value of `TCP_NODELAY` option for accepted connections. Enabled by default.
+    #[cfg(feature = "transport")]
     pub fn tcp_nodelay(self, enabled: bool) -> Self {
         Endpoint {
             tcp_nodelay: enabled,
@@ -259,6 +266,7 @@ impl Endpoint {
     }
 
     /// Set http2 KEEP_ALIVE_INTERVAL. Uses `hyper`'s default otherwise.
+    #[cfg(feature = "transport")]
     pub fn http2_keep_alive_interval(self, interval: Duration) -> Self {
         Endpoint {
             http2_keep_alive_interval: Some(interval),
@@ -267,6 +275,7 @@ impl Endpoint {
     }
 
     /// Set http2 KEEP_ALIVE_TIMEOUT. Uses `hyper`'s default otherwise.
+    #[cfg(feature = "transport")]
     pub fn keep_alive_timeout(self, duration: Duration) -> Self {
         Endpoint {
             http2_keep_alive_timeout: Some(duration),
@@ -275,6 +284,7 @@ impl Endpoint {
     }
 
     /// Set http2 KEEP_ALIVE_WHILE_IDLE. Uses `hyper`'s default otherwise.
+    #[cfg(feature = "transport")]
     pub fn keep_alive_while_idle(self, enabled: bool) -> Self {
         Endpoint {
             http2_keep_alive_while_idle: Some(enabled),
@@ -423,10 +433,15 @@ impl From<Uri> for Endpoint {
             buffer_size: None,
             init_stream_window_size: None,
             init_connection_window_size: None,
+            #[cfg(feature = "transport")]
             tcp_keepalive: None,
+            #[cfg(feature = "transport")]
             tcp_nodelay: true,
+            #[cfg(feature = "transport")]
             http2_keep_alive_interval: None,
+            #[cfg(feature = "transport")]
             http2_keep_alive_timeout: None,
+            #[cfg(feature = "transport")]
             http2_keep_alive_while_idle: None,
             connect_timeout: None,
             http2_adaptive_window: None,

--- a/tonic/src/transport/channel/endpoint.rs
+++ b/tonic/src/transport/channel/endpoint.rs
@@ -312,6 +312,7 @@ impl Endpoint {
     }
 
     /// Create a channel from this config.
+    #[cfg(feature = "transport")]
     pub async fn connect(&self) -> Result<Channel, Error> {
         let mut http = hyper::client::connect::HttpConnector::new();
         http.enforce_http(false);
@@ -333,6 +334,7 @@ impl Endpoint {
     ///
     /// The channel returned by this method does not attempt to connect to the endpoint until first
     /// use.
+    #[cfg(feature = "transport")]
     pub fn connect_lazy(&self) -> Channel {
         let mut http = hyper::client::connect::HttpConnector::new();
         http.enforce_http(false);
@@ -428,7 +430,7 @@ impl From<Uri> for Endpoint {
             http2_keep_alive_while_idle: None,
             connect_timeout: None,
             http2_adaptive_window: None,
-            executor: SharedExec::tokio(),
+            executor: SharedExec::default_exec(),
         }
     }
 }

--- a/tonic/src/transport/channel/mod.rs
+++ b/tonic/src/transport/channel/mod.rs
@@ -9,7 +9,9 @@ pub use endpoint::Endpoint;
 #[cfg(feature = "tls")]
 pub use tls::ClientTlsConfig;
 
-use super::service::{Connection, DynamicServiceStream, SharedExec};
+use super::service::{Connection};
+#[cfg(feature = "transport")]
+use super::service::{DynamicServiceStream, SharedExec};
 use crate::body::BoxBody;
 use crate::transport::Executor;
 use bytes::Bytes;
@@ -109,6 +111,7 @@ impl Channel {
     ///
     /// This creates a [`Channel`] that will load balance across all the
     /// provided endpoints.
+    #[cfg(feature = "transport")]
     pub fn balance_list(list: impl Iterator<Item = Endpoint>) -> Self {
         let (channel, tx) = Self::balance_channel(DEFAULT_BUFFER_SIZE);
         list.for_each(|endpoint| {
@@ -122,11 +125,12 @@ impl Channel {
     /// Balance a list of [`Endpoint`]'s.
     ///
     /// This creates a [`Channel`] that will listen to a stream of change events and will add or remove provided endpoints.
+    #[cfg(feature = "transport")]
     pub fn balance_channel<K>(capacity: usize) -> (Self, Sender<Change<K, Endpoint>>)
     where
         K: Hash + Eq + Send + Clone + 'static,
     {
-        Self::balance_channel_with_executor(capacity, SharedExec::tokio())
+        Self::balance_channel_with_executor(capacity, SharedExec::default_exec())
     }
 
     /// Balance a list of [`Endpoint`]'s.
@@ -134,6 +138,7 @@ impl Channel {
     /// This creates a [`Channel`] that will listen to a stream of change events and will add or remove provided endpoints.
     ///
     /// The [`Channel`] will use the given executor to spawn async tasks.
+    #[cfg(feature = "transport")]
     pub fn balance_channel_with_executor<K, E>(
         capacity: usize,
         executor: E,

--- a/tonic/src/transport/mod.rs
+++ b/tonic/src/transport/mod.rs
@@ -88,6 +88,7 @@
 //! [rustls]: https://docs.rs/rustls/0.16.0/rustls/
 
 pub mod channel;
+#[cfg(feature = "transport")]
 pub mod server;
 
 mod error;
@@ -100,6 +101,7 @@ mod tls;
 #[cfg_attr(docsrs, doc(cfg(feature = "channel")))]
 pub use self::channel::{Channel, Endpoint};
 pub use self::error::Error;
+#[cfg(feature = "transport")]
 #[doc(inline)]
 pub use self::server::Server;
 #[doc(inline)]
@@ -107,6 +109,7 @@ pub use self::service::grpc_timeout::TimeoutExpired;
 #[cfg(feature = "tls")]
 #[cfg_attr(docsrs, doc(cfg(feature = "tls")))]
 pub use self::tls::Certificate;
+#[cfg(feature = "transport")]
 pub use axum::{body::BoxBody as AxumBoxBody, Router as AxumRouter};
 pub use hyper::{Body, Uri};
 

--- a/tonic/src/transport/service/executor.rs
+++ b/tonic/src/transport/service/executor.rs
@@ -29,7 +29,9 @@ where
     F::Output: 'static,
 {
     fn execute(&self, fut: F) {
-        wasm_bindgen_futures::spawn_local(async move {fut.await;});
+        wasm_bindgen_futures::spawn_local(async move {
+            fut.await;
+        });
     }
 }
 

--- a/tonic/src/transport/service/io.rs
+++ b/tonic/src/transport/service/io.rs
@@ -84,12 +84,12 @@ impl AsyncWrite for BoxedIo {
 
 #[cfg(feature = "transport")]
 mod server {
-    use tower::util::Either;
     use crate::transport::server::Connected;
     use std::io;
     use std::io::IoSlice;
     use std::pin::Pin;
     use std::task::{Context, Poll};
+    use tower::util::Either;
 
     #[cfg(feature = "tls")]
     use tokio_rustls::server::TlsStream;
@@ -104,7 +104,7 @@ mod server {
 
     #[cfg(feature = "tls")]
     type ServerIoConnectInfo<IO> =
-    Either<<IO as Connected>::ConnectInfo, <TlsStream<IO> as Connected>::ConnectInfo>;
+        Either<<IO as Connected>::ConnectInfo, <TlsStream<IO> as Connected>::ConnectInfo>;
 
     #[cfg(not(feature = "tls"))]
     type ServerIoConnectInfo<IO> = Either<<IO as Connected>::ConnectInfo, ()>;
@@ -121,9 +121,9 @@ mod server {
 
         #[cfg(feature = "tls")]
         pub(in crate::transport) fn connect_info(&self) -> ServerIoConnectInfo<IO>
-            where
-                IO: Connected,
-                TlsStream<IO>: Connected,
+        where
+            IO: Connected,
+            TlsStream<IO>: Connected,
         {
             match self {
                 Self::Io(io) => Either::A(io.connect_info()),
@@ -133,8 +133,8 @@ mod server {
 
         #[cfg(not(feature = "tls"))]
         pub(in crate::transport) fn connect_info(&self) -> ServerIoConnectInfo<IO>
-            where
-                IO: Connected,
+        where
+            IO: Connected,
         {
             match self {
                 Self::Io(io) => Either::A(io.connect_info()),
@@ -143,8 +143,8 @@ mod server {
     }
 
     impl<IO> AsyncRead for ServerIo<IO>
-        where
-            IO: AsyncWrite + AsyncRead + Unpin,
+    where
+        IO: AsyncWrite + AsyncRead + Unpin,
     {
         fn poll_read(
             mut self: Pin<&mut Self>,
@@ -160,8 +160,8 @@ mod server {
     }
 
     impl<IO> AsyncWrite for ServerIo<IO>
-        where
-            IO: AsyncWrite + AsyncRead + Unpin,
+    where
+        IO: AsyncWrite + AsyncRead + Unpin,
     {
         fn poll_write(
             mut self: Pin<&mut Self>,

--- a/tonic/src/transport/service/mod.rs
+++ b/tonic/src/transport/service/mod.rs
@@ -1,11 +1,13 @@
 mod add_origin;
 mod connection;
 mod connector;
+#[cfg(feature = "transport")]
 mod discover;
 pub(crate) mod executor;
 pub(crate) mod grpc_timeout;
 mod io;
 mod reconnect;
+#[cfg(feature = "transport")]
 mod router;
 #[cfg(feature = "tls")]
 mod tls;
@@ -14,13 +16,17 @@ mod user_agent;
 pub(crate) use self::add_origin::AddOrigin;
 pub(crate) use self::connection::Connection;
 pub(crate) use self::connector::Connector;
+#[cfg(feature = "transport")]
 pub(crate) use self::discover::DynamicServiceStream;
 pub(crate) use self::executor::SharedExec;
 pub(crate) use self::grpc_timeout::GrpcTimeout;
+#[cfg(feature = "transport")]
 pub(crate) use self::io::ServerIo;
 #[cfg(feature = "tls")]
 pub(crate) use self::tls::{TlsAcceptor, TlsConnector};
 pub(crate) use self::user_agent::UserAgent;
 
+#[cfg(feature = "transport")]
 pub use self::router::Routes;
+#[cfg(feature = "transport")]
 pub use self::router::RoutesBuilder;

--- a/tonic/src/transport/service/mod.rs
+++ b/tonic/src/transport/service/mod.rs
@@ -19,6 +19,7 @@ pub(crate) use self::connector::Connector;
 #[cfg(feature = "transport")]
 pub(crate) use self::discover::DynamicServiceStream;
 pub(crate) use self::executor::SharedExec;
+#[cfg(feature = "transport")]
 pub(crate) use self::grpc_timeout::GrpcTimeout;
 #[cfg(feature = "transport")]
 pub(crate) use self::io::ServerIo;


### PR DESCRIPTION
This is an updated version of @boxdot's PR #693. The main purpose is to allow compiling tonic for wasm32-unknown-unknown with the connect_with_connector function, so you could use custom connectors in wasm. 

## Motivation

The main motivation is to allow using something like https://github.com/boxdot/tonic-ws-transport to use tonic in browsers over websockets. grpc-web has a limit on concurrent conections that are open and doesn't allow for client streaming. There is also a related issue for this, #491.

## Solution

The connect_with_connector function, as well as the Endpoint and Channel structs, are gated behind the transport feature. Enabling this feature also enables things that are impossible to compile for wasm. This PR introduces a `client` feature that that enables everything necessary to make connect_with_connector work in wasm and disables anything that fails to compile for wasm. 

An alternative to adding a new `client` feature could also be to gate everything that doesn't compile for wasm behind a #[cfg()] attribute that is disabled for wasm. 

I could also add a test that checks whether compilation to wasm works with the client feature, so this won't break in the future.
