### PR TITLE
examples: add client example for `tonic-reflection`

### DIFF
--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -165,6 +165,11 @@ path = "src/health/server.rs"
 required-features = ["health"]
 
 [[bin]]
+name = "reflection-client"
+path = "src/reflection/client.rs"
+required-features = ["reflection"]
+
+[[bin]]
 name = "reflection-server"
 path = "src/reflection/server.rs"
 required-features = ["reflection"]

--- a/examples/src/reflection/client.rs
+++ b/examples/src/reflection/client.rs
@@ -1,0 +1,44 @@
+use tokio_stream::StreamExt;
+use tonic_reflection::pb::{
+    server_reflection_client::ServerReflectionClient, server_reflection_request::MessageRequest,
+    server_reflection_response::MessageResponse, ServerReflectionRequest, ServerReflectionResponse,
+};
+
+fn parse_response(resp: ServerReflectionResponse) {
+    let message_response = resp.message_response.expect("message response");
+
+    if let MessageResponse::ListServicesResponse(list_response) = message_response {
+        for svc in list_response.service {
+            println!("\tfound service: `{}`", svc.name);
+        }
+    }
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let conn = tonic::transport::Endpoint::new("http://[::1]:50052")?
+        .connect()
+        .await?;
+
+    let mut client = ServerReflectionClient::new(conn);
+
+    let list_services_request = ServerReflectionRequest {
+        host: "host".into(),
+        message_request: Some(MessageRequest::ListServices("list".into())),
+    };
+
+    let request_stream = tokio_stream::once(list_services_request);
+    let mut inbound = client
+        .server_reflection_info(request_stream)
+        .await?
+        .into_inner();
+
+    while let Some(recv) = inbound.next().await {
+        match recv {
+            Ok(resp) => parse_response(resp),
+            Err(e) => println!("\tdid not receive response due to error: `{}`", e),
+        }
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
This adds an example usage of the `ServerReflectionClient` using a `ListServices` request.

Fixes: #1600

## Motivation

Took awhile to figure out how to set up the reflection client, so thought I would provide an example.

## Solution

This example includes everything needed to communicate with a server providing reflection:
- setting up the client with an `Endpoint` (since the codegen doesn't provide the `connect` method most clients have as `transport` is an optional feature for `tonic-reflection`)
- configuring a `ServerReflectionRequest` using one of the provided `MessageRequest` options
- putting the request into a stream since reflection is a bidi-streaming procedure
- parsing the response received from the server
