### PR TITLE
Repair rust-analyzer for tonic files

### DIFF
--- a/tonic-build/src/prost.rs
+++ b/tonic-build/src/prost.rs
@@ -541,13 +541,9 @@ impl Builder {
         protos: &[impl AsRef<Path>],
         includes: &[impl AsRef<Path>],
     ) -> io::Result<()> {
-        let out_dir = if let Some(out_dir) = self.out_dir.as_ref() {
-            out_dir.clone()
-        } else {
-            PathBuf::from(std::env::var("OUT_DIR").unwrap())
-        };
-
-        config.out_dir(out_dir);
+        if let Some(out_dir) = self.out_dir.as_ref() {
+            config.out_dir(out_dir);
+        }
         if let Some(path) = self.file_descriptor_set_path.as_ref() {
             config.file_descriptor_set_path(path);
         }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/hyperium/tonic/blob/master/CONTRIBUTING.md
-->

## Motivation

In my codebase I have files generated by prost and by tonic. I noticed that rust-analyzer was working fine with files generated by prost but not with files generated by tonic. 



<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? If a new feature is being added, describe the intended
use case that feature fulfills.
-->

## Solution

I found out that rust-analyzer doesn't like when a generated file is included with relative path. It only works with absolute path (i.g. when using the `OUT_DIR` env variable).

I also found out that tonic always calls `prost_build::Config.out_dir`, which causes prost to always generate includes with relative paths.

My solution was to avoid setting the `out_dir` in prost when unnecessary.

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
