### PR TITLE
Add support for load-shedding.

### DIFF
--- a/tonic/Cargo.toml
+++ b/tonic/Cargo.toml
@@ -73,7 +73,7 @@ h2 = {version = "0.3.17", optional = true}
 hyper = {version = "0.14.26", features = ["full"], optional = true}
 hyper-timeout = {version = "0.4", optional = true}
 tokio-stream = "0.1"
-tower = {version = "0.4.7", default-features = false, features = ["balance", "buffer", "discover", "limit", "load", "make", "timeout", "util"], optional = true}
+tower = {version = "0.4.7", default-features = false, features = ["balance", "buffer", "discover", "limit", "load", "make", "timeout", "util", "load-shed"], optional = true}
 axum = {version = "0.6.9", default_features = false, optional = true}
 
 # rustls

--- a/tonic/src/status.rs
+++ b/tonic/src/status.rs
@@ -350,6 +350,17 @@ impl Status {
             Err(err) => err,
         };
 
+        // If the load shed middleware is enabled, respond to
+        // service overloaded with an appropriate grpc status.
+        let err = match err.downcast::<tower::load_shed::error::Overloaded>() {
+            Ok(_) => {
+                return Ok(Status::resource_exhausted(
+                    "Too many active requests for the connection",
+                ));
+            }
+            Err(err) => err,
+        };
+
         if let Some(mut status) = find_status_in_source_chain(&*err) {
             status.source = Some(err.into());
             return Ok(status);


### PR DESCRIPTION
Add an option to enable load shedding for the service constructed for the connection.

## Motivation

In the server we are implementing we want to load-shed when the service is overloaded, and we want to limit the number of concurrent requests per connection. We use tower::load_shed layer for load shedding, but this only applies to the entire service.

If we additionally apply the per-connection concurrency limit the issue is that this limit is typically hit first and so the service responds with "not ready". As a result the load-shed layer of the service is never reached meaning that requests just queue up.

## Solution

The solution is to optionally add a load-shed layer to the per-connection service constructed by tonic.
