### PR TITLE
Update Cargo.toml

### DIFF
--- a/tonic/Cargo.toml
+++ b/tonic/Cargo.toml
@@ -69,7 +69,7 @@ prost = {version = "0.12", default-features = false, features = ["std"], optiona
 async-trait = {version = "0.1.13", optional = true}
 
 # transport
-h2 = {version = "0.3.17", optional = true}
+h2 = {version = "0.3.24", optional = true}
 hyper = {version = "0.14.26", features = ["full"], optional = true}
 hyper-timeout = {version = "0.4", optional = true}
 tokio-stream = "0.1"


### PR DESCRIPTION
Updating h2 to 0.3.24 as per [advisory](https://rustsec.org/advisories/RUSTSEC-2024-0003.html). I would also consider upgrading to 0.4 at some point 