### PR TITLE
chore: fix 0.11.0 changelog entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# [](https://github.com/hyperium/tonic/compare/v0.10.2...v0.11.0) (2024-02-08)
+# [0.11.0](https://github.com/hyperium/tonic/compare/v0.10.2...v0.11.0) (2024-02-08)
 
 BREAKING CHANGES:
 


### PR DESCRIPTION
## Motivation

The version number is missing from the latest changelog entry.

## Solution

Add the missing value.
