### PR TITLE
feat(transport): opt into TLS with servers without ALPN

### DIFF
--- a/tonic/src/transport/channel/endpoint.rs
+++ b/tonic/src/transport/channel/endpoint.rs
@@ -24,6 +24,11 @@ pub struct Endpoint {
     pub(crate) rate_limit: Option<(u64, Duration)>,
     #[cfg(feature = "tls")]
     pub(crate) tls: Option<TlsConnector>,
+    // Only applies if the tls config is not explicitly set. This allows users
+    // to connect to a server that doesn't support ALPN while using the
+    // tls-roots-common feature for setting up TLS.
+    #[cfg(feature = "tls-roots-common")]
+    pub(crate) tls_assume_http2: bool,
     pub(crate) buffer_size: Option<usize>,
     pub(crate) init_stream_window_size: Option<u32>,
     pub(crate) init_connection_window_size: Option<u32>,
@@ -250,6 +255,18 @@ impl Endpoint {
         })
     }
 
+    /// Configures TLS to assume that the server offers HTTP/2 even if it
+    /// doesn't perform ALPN negotiation. This only applies if a tls_config has
+    /// not been set.
+    #[cfg(feature = "tls-roots-common")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "tls-roots-common")))]
+    pub fn tls_assume_http2(self, assume_http2: bool) -> Self {
+        Endpoint {
+            tls_assume_http2: assume_http2,
+            ..self
+        }
+    }
+
     /// Set the value of `TCP_NODELAY` option for accepted connections. Enabled by default.
     pub fn tcp_nodelay(self, enabled: bool) -> Self {
         Endpoint {
@@ -302,8 +319,11 @@ impl Endpoint {
     }
 
     pub(crate) fn connector<C>(&self, c: C) -> service::Connector<C> {
-        #[cfg(feature = "tls")]
+        #[cfg(all(feature = "tls", not(feature = "tls-roots-common")))]
         let connector = service::Connector::new(c, self.tls.clone());
+
+        #[cfg(all(feature = "tls", feature = "tls-roots-common"))]
+        let connector = service::Connector::new(c, self.tls.clone(), self.tls_assume_http2);
 
         #[cfg(not(feature = "tls"))]
         let connector = service::Connector::new(c);
@@ -424,6 +444,8 @@ impl From<Uri> for Endpoint {
             timeout: None,
             #[cfg(feature = "tls")]
             tls: None,
+            #[cfg(feature = "tls-roots-common")]
+            tls_assume_http2: false,
             buffer_size: None,
             init_stream_window_size: None,
             init_connection_window_size: None,

--- a/tonic/src/transport/channel/tls.rs
+++ b/tonic/src/transport/channel/tls.rs
@@ -12,6 +12,7 @@ pub struct ClientTlsConfig {
     domain: Option<String>,
     cert: Option<Certificate>,
     identity: Option<Identity>,
+    assume_http2: bool,
 }
 
 impl fmt::Debug for ClientTlsConfig {
@@ -31,6 +32,7 @@ impl ClientTlsConfig {
             domain: None,
             cert: None,
             identity: None,
+            assume_http2: false,
         }
     }
 
@@ -58,11 +60,25 @@ impl ClientTlsConfig {
         }
     }
 
+    /// If true, the connector should assume that the server supports HTTP/2,
+    /// even if it doesn't provide protocol negotiation via ALPN.
+    pub fn assume_http2(self, assume_http2: bool) -> Self {
+        ClientTlsConfig {
+            assume_http2,
+            ..self
+        }
+    }
+
     pub(crate) fn tls_connector(&self, uri: Uri) -> Result<TlsConnector, crate::Error> {
         let domain = match &self.domain {
             Some(domain) => domain,
             None => uri.host().ok_or_else(Error::new_invalid_uri)?,
         };
-        TlsConnector::new(self.cert.clone(), self.identity.clone(), domain)
+        TlsConnector::new(
+            self.cert.clone(),
+            self.identity.clone(),
+            domain,
+            self.assume_http2,
+        )
     }
 }

--- a/tonic/src/transport/service/connector.rs
+++ b/tonic/src/transport/service/connector.rs
@@ -12,14 +12,24 @@ pub(crate) struct Connector<C> {
     inner: C,
     #[cfg(feature = "tls")]
     tls: Option<TlsConnector>,
+    // When connecting to a URI with the https scheme, assume that the server
+    // is capable of speaking HTTP/2 even if it doesn't offer ALPN.
+    #[cfg(feature = "tls-roots-common")]
+    assume_http2: bool,
 }
 
 impl<C> Connector<C> {
-    pub(crate) fn new(inner: C, #[cfg(feature = "tls")] tls: Option<TlsConnector>) -> Self {
+    pub(crate) fn new(
+        inner: C,
+        #[cfg(feature = "tls")] tls: Option<TlsConnector>,
+        #[cfg(feature = "tls-roots-common")] assume_http2: bool,
+    ) -> Self {
         Self {
             inner,
             #[cfg(feature = "tls")]
             tls,
+            #[cfg(feature = "tls-roots-common")]
+            assume_http2,
         }
     }
 
@@ -34,7 +44,7 @@ impl<C> Connector<C> {
             _ => return None,
         };
 
-        TlsConnector::new(None, None, host).ok()
+        TlsConnector::new(None, None, host, self.assume_http2).ok()
     }
 }
 


### PR DESCRIPTION
Sometimes servers are secured with tls and speak gRPC, but don't perform ALPN protocol negotation. Most other gRPC implementations out there, as far as I can tell will just assume that the remote server is speaking h2 if there is ALPN. Tonic is strict in this regard. This patch takes the conservative approach of allowing users to opt into assuming that the remote server is running h2. A more aggressive patch in the future might be to invert the default.

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/hyperium/tonic/blob/master/CONTRIBUTING.md
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? If a new feature is being added, describe the intended
use case that feature fulfills.
-->
This patch allows users to connect to gRPC services over TLS that don't use ALPN. The rest of the ecosystem seems to support this. See https://github.com/hyperium/tonic/issues/1427.

## Solution

The patch allows users to opt into this behavior either by configuring the TlsClientConfig or, when using `tls-roots-common` to configure the endpoint to opt into this behavior.

I have tried the patch out on https://github.com/PeterFaiman/tonic-issue-minimal-example and it fixes the problem for the public Grafana API as well as for my own server. 

Fixes #1427
