### PR TITLE
Expose Extensions::from_http to user

### DIFF
--- a/tonic/src/extensions.rs
+++ b/tonic/src/extensions.rs
@@ -55,7 +55,8 @@ impl Extensions {
     }
 
     #[inline]
-    pub(crate) fn from_http(http: http::Extensions) -> Self {
+    /// Convert from `http::Extensions`
+    pub fn from_http(http: http::Extensions) -> Self {
         Self { inner: http }
     }
 


### PR DESCRIPTION
This exposes `Extensions::from_http` to allow user to write more efficient tower's Service instead of using Interceptor as it doesn't allow to customize Response