### PR TITLE
build: fix typo in documentation

### DIFF
--- a/tonic-build/src/lib.rs
+++ b/tonic-build/src/lib.rs
@@ -1,5 +1,5 @@
 //! `tonic-build` compiles `proto` files via `prost` and generates service stubs
-//! and proto definitiones for use with `tonic`.
+//! and proto definitions for use with `tonic`.
 //!
 //! # Feature flags
 //!


### PR DESCRIPTION
Single character spelling fix in lib.rs in tonic-build