### PR TITLE
chore(codegen): Deprecate _Inner<T>.

### DIFF
--- a/tonic-build/src/server.rs
+++ b/tonic-build/src/server.rs
@@ -111,14 +111,12 @@ pub(crate) fn generate_internal<T: Service>(
             #(#struct_attributes)*
             #[derive(Debug)]
             pub struct #server_service<T: #server_trait> {
-                inner: _Inner<T>,
+                inner: Arc<T>,
                 accept_compression_encodings: EnabledCompressionEncodings,
                 send_compression_encodings: EnabledCompressionEncodings,
                 max_decoding_message_size: Option<usize>,
                 max_encoding_message_size: Option<usize>,
             }
-
-            struct _Inner<T>(Arc<T>);
 
             impl<T: #server_trait> #server_service<T> {
                 pub fn new(inner: T) -> Self {
@@ -126,7 +124,6 @@ pub(crate) fn generate_internal<T: Service>(
                 }
 
                 pub fn from_arc(inner: Arc<T>) -> Self {
-                    let inner = _Inner(inner);
                     Self {
                         inner,
                         accept_compression_encodings: Default::default(),
@@ -163,8 +160,6 @@ pub(crate) fn generate_internal<T: Service>(
                 }
 
                 fn call(&mut self, req: http::Request<B>) -> Self::Future {
-                    let inner = self.inner.clone();
-
                     match req.uri().path() {
                         #methods
 
@@ -190,18 +185,6 @@ pub(crate) fn generate_internal<T: Service>(
                         max_decoding_message_size: self.max_decoding_message_size,
                         max_encoding_message_size: self.max_encoding_message_size,
                     }
-                }
-            }
-
-            impl<T: #server_trait> Clone for _Inner<T> {
-                fn clone(&self) -> Self {
-                    Self(Arc::clone(&self.0))
-                }
-            }
-
-            impl<T: std::fmt::Debug> std::fmt::Debug for _Inner<T> {
-                fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-                   write!(f, "{:?}", self.0)
                 }
             }
 
@@ -492,7 +475,6 @@ fn generate_unary<T: Method>(
         let max_encoding_message_size = self.max_encoding_message_size;
         let inner = self.inner.clone();
         let fut = async move {
-            let inner = inner.0;
             let method = #service_ident(inner);
             let codec = #codec_name::default();
 
@@ -560,7 +542,6 @@ fn generate_server_streaming<T: Method>(
         let max_encoding_message_size = self.max_encoding_message_size;
         let inner = self.inner.clone();
         let fut = async move {
-            let inner = inner.0;
             let method = #service_ident(inner);
             let codec = #codec_name::default();
 
@@ -619,7 +600,6 @@ fn generate_client_streaming<T: Method>(
         let max_encoding_message_size = self.max_encoding_message_size;
         let inner = self.inner.clone();
         let fut = async move {
-            let inner = inner.0;
             let method = #service_ident(inner);
             let codec = #codec_name::default();
 
@@ -688,7 +668,6 @@ fn generate_streaming<T: Method>(
         let max_encoding_message_size = self.max_encoding_message_size;
         let inner = self.inner.clone();
         let fut = async move {
-            let inner = inner.0;
             let method = #service_ident(inner);
             let codec = #codec_name::default();
 

--- a/tonic-health/src/generated/grpc_health_v1.rs
+++ b/tonic-health/src/generated/grpc_health_v1.rs
@@ -243,19 +243,17 @@ pub mod health_server {
     }
     #[derive(Debug)]
     pub struct HealthServer<T: Health> {
-        inner: _Inner<T>,
+        inner: Arc<T>,
         accept_compression_encodings: EnabledCompressionEncodings,
         send_compression_encodings: EnabledCompressionEncodings,
         max_decoding_message_size: Option<usize>,
         max_encoding_message_size: Option<usize>,
     }
-    struct _Inner<T>(Arc<T>);
     impl<T: Health> HealthServer<T> {
         pub fn new(inner: T) -> Self {
             Self::from_arc(Arc::new(inner))
         }
         pub fn from_arc(inner: Arc<T>) -> Self {
-            let inner = _Inner(inner);
             Self {
                 inner,
                 accept_compression_encodings: Default::default(),
@@ -318,7 +316,6 @@ pub mod health_server {
             Poll::Ready(Ok(()))
         }
         fn call(&mut self, req: http::Request<B>) -> Self::Future {
-            let inner = self.inner.clone();
             match req.uri().path() {
                 "/grpc.health.v1.Health/Check" => {
                     #[allow(non_camel_case_types)]
@@ -349,7 +346,6 @@ pub mod health_server {
                     let max_encoding_message_size = self.max_encoding_message_size;
                     let inner = self.inner.clone();
                     let fut = async move {
-                        let inner = inner.0;
                         let method = CheckSvc(inner);
                         let codec = tonic::codec::ProstCodec::default();
                         let mut grpc = tonic::server::Grpc::new(codec)
@@ -396,7 +392,6 @@ pub mod health_server {
                     let max_encoding_message_size = self.max_encoding_message_size;
                     let inner = self.inner.clone();
                     let fut = async move {
-                        let inner = inner.0;
                         let method = WatchSvc(inner);
                         let codec = tonic::codec::ProstCodec::default();
                         let mut grpc = tonic::server::Grpc::new(codec)
@@ -438,16 +433,6 @@ pub mod health_server {
                 max_decoding_message_size: self.max_decoding_message_size,
                 max_encoding_message_size: self.max_encoding_message_size,
             }
-        }
-    }
-    impl<T: Health> Clone for _Inner<T> {
-        fn clone(&self) -> Self {
-            Self(Arc::clone(&self.0))
-        }
-    }
-    impl<T: std::fmt::Debug> std::fmt::Debug for _Inner<T> {
-        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-            write!(f, "{:?}", self.0)
         }
     }
     impl<T: Health> tonic::server::NamedService for HealthServer<T> {

--- a/tonic-reflection/src/generated/grpc_reflection_v1alpha.rs
+++ b/tonic-reflection/src/generated/grpc_reflection_v1alpha.rs
@@ -291,19 +291,17 @@ pub mod server_reflection_server {
     }
     #[derive(Debug)]
     pub struct ServerReflectionServer<T: ServerReflection> {
-        inner: _Inner<T>,
+        inner: Arc<T>,
         accept_compression_encodings: EnabledCompressionEncodings,
         send_compression_encodings: EnabledCompressionEncodings,
         max_decoding_message_size: Option<usize>,
         max_encoding_message_size: Option<usize>,
     }
-    struct _Inner<T>(Arc<T>);
     impl<T: ServerReflection> ServerReflectionServer<T> {
         pub fn new(inner: T) -> Self {
             Self::from_arc(Arc::new(inner))
         }
         pub fn from_arc(inner: Arc<T>) -> Self {
-            let inner = _Inner(inner);
             Self {
                 inner,
                 accept_compression_encodings: Default::default(),
@@ -366,7 +364,6 @@ pub mod server_reflection_server {
             Poll::Ready(Ok(()))
         }
         fn call(&mut self, req: http::Request<B>) -> Self::Future {
-            let inner = self.inner.clone();
             match req.uri().path() {
                 "/grpc.reflection.v1alpha.ServerReflection/ServerReflectionInfo" => {
                     #[allow(non_camel_case_types)]
@@ -404,7 +401,6 @@ pub mod server_reflection_server {
                     let max_encoding_message_size = self.max_encoding_message_size;
                     let inner = self.inner.clone();
                     let fut = async move {
-                        let inner = inner.0;
                         let method = ServerReflectionInfoSvc(inner);
                         let codec = tonic::codec::ProstCodec::default();
                         let mut grpc = tonic::server::Grpc::new(codec)
@@ -446,16 +442,6 @@ pub mod server_reflection_server {
                 max_decoding_message_size: self.max_decoding_message_size,
                 max_encoding_message_size: self.max_encoding_message_size,
             }
-        }
-    }
-    impl<T: ServerReflection> Clone for _Inner<T> {
-        fn clone(&self) -> Self {
-            Self(Arc::clone(&self.0))
-        }
-    }
-    impl<T: std::fmt::Debug> std::fmt::Debug for _Inner<T> {
-        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-            write!(f, "{:?}", self.0)
         }
     }
     impl<T: ServerReflection> tonic::server::NamedService for ServerReflectionServer<T> {


### PR DESCRIPTION
Removes a redundant clone in the `tower-service::Service::call()` implementation, and reduces the amount of generated code. Does not break any user facing API.

Don't know how much the removed clone matters in practice. Perhaps it gets optimized away during compilation regardless 🙈