### PR TITLE
Add a `GRPC_CONTENT_TYPE` for "application/grpc".

### DIFF
--- a/tonic-build/src/server.rs
+++ b/tonic-build/src/server.rs
@@ -171,8 +171,8 @@ pub(crate) fn generate_internal<T: Service>(
                         _ => Box::pin(async move {
                             Ok(http::Response::builder()
                                .status(200)
-                               .header("grpc-status", "12")
-                               .header("content-type", "application/grpc")
+                               .header("grpc-status", tonic::Code::Unimplemented as i32)
+                               .header(http::header::CONTENT_TYPE, tonic::metadata::GRPC_CONTENT_TYPE)
                                .body(empty_body())
                                .unwrap())
                         }),

--- a/tonic-health/src/generated/grpc_health_v1.rs
+++ b/tonic-health/src/generated/grpc_health_v1.rs
@@ -418,8 +418,11 @@ pub mod health_server {
                         Ok(
                             http::Response::builder()
                                 .status(200)
-                                .header("grpc-status", "12")
-                                .header("content-type", "application/grpc")
+                                .header("grpc-status", tonic::Code::Unimplemented as i32)
+                                .header(
+                                    http::header::CONTENT_TYPE,
+                                    tonic::metadata::GRPC_CONTENT_TYPE,
+                                )
                                 .body(empty_body())
                                 .unwrap(),
                         )

--- a/tonic-reflection/src/generated/grpc_reflection_v1alpha.rs
+++ b/tonic-reflection/src/generated/grpc_reflection_v1alpha.rs
@@ -426,8 +426,11 @@ pub mod server_reflection_server {
                         Ok(
                             http::Response::builder()
                                 .status(200)
-                                .header("grpc-status", "12")
-                                .header("content-type", "application/grpc")
+                                .header("grpc-status", tonic::Code::Unimplemented as i32)
+                                .header(
+                                    http::header::CONTENT_TYPE,
+                                    tonic::metadata::GRPC_CONTENT_TYPE,
+                                )
                                 .body(empty_body())
                                 .unwrap(),
                         )

--- a/tonic-web/src/service.rs
+++ b/tonic-web/src/service.rs
@@ -5,6 +5,7 @@ use std::task::{ready, Context, Poll};
 use http::{header, HeaderMap, HeaderValue, Method, Request, Response, StatusCode, Version};
 use hyper::Body;
 use pin_project::pin_project;
+use tonic::metadata::GRPC_CONTENT_TYPE;
 use tonic::{
     body::{empty_body, BoxBody},
     server::NamedService,
@@ -15,8 +16,6 @@ use tracing::{debug, trace};
 use crate::call::content_types::is_grpc_web;
 use crate::call::{Encoding, GrpcWebCall};
 use crate::BoxError;
-
-const GRPC: &str = "application/grpc";
 
 /// Service implementing the grpc-web protocol.
 #[derive(Debug, Clone)]
@@ -205,8 +204,10 @@ impl<'a> RequestKind<'a> {
 fn coerce_request(mut req: Request<Body>, encoding: Encoding) -> Request<Body> {
     req.headers_mut().remove(header::CONTENT_LENGTH);
 
-    req.headers_mut()
-        .insert(header::CONTENT_TYPE, HeaderValue::from_static(GRPC));
+    req.headers_mut().insert(
+        header::CONTENT_TYPE,
+        HeaderValue::from_static(GRPC_CONTENT_TYPE),
+    );
 
     req.headers_mut()
         .insert(header::TE, HeaderValue::from_static("trailers"));
@@ -376,7 +377,7 @@ mod tests {
         fn request() -> Request<Body> {
             Request::builder()
                 .version(Version::HTTP_2)
-                .header(CONTENT_TYPE, GRPC)
+                .header(CONTENT_TYPE, GRPC_CONTENT_TYPE)
                 .body(Body::empty())
                 .unwrap()
         }
@@ -396,7 +397,7 @@ mod tests {
             let mut svc = crate::enable(Svc);
 
             let req = Request::builder()
-                .header(CONTENT_TYPE, GRPC)
+                .header(CONTENT_TYPE, GRPC_CONTENT_TYPE)
                 .body(Body::empty())
                 .unwrap();
 

--- a/tonic/src/client/grpc.rs
+++ b/tonic/src/client/grpc.rs
@@ -1,4 +1,5 @@
 use crate::codec::compression::{CompressionEncoding, EnabledCompressionEncodings};
+use crate::metadata::GRPC_CONTENT_TYPE;
 use crate::{
     body::BoxBody,
     client::GrpcService,
@@ -404,7 +405,7 @@ impl GrpcConfig {
         // Set the content type
         request
             .headers_mut()
-            .insert(CONTENT_TYPE, HeaderValue::from_static("application/grpc"));
+            .insert(CONTENT_TYPE, HeaderValue::from_static(GRPC_CONTENT_TYPE));
 
         #[cfg(any(feature = "gzip", feature = "zstd"))]
         if let Some(encoding) = self.send_compression_encodings {

--- a/tonic/src/metadata/mod.rs
+++ b/tonic/src/metadata/mod.rs
@@ -33,6 +33,9 @@ pub use self::value::MetadataValue;
 
 pub(crate) use self::map::GRPC_TIMEOUT_HEADER;
 
+/// HTTP Header `content-type` value for gRPC calls.
+pub const GRPC_CONTENT_TYPE: &str = "application/grpc";
+
 /// The metadata::errors module contains types for errors that can occur
 /// while handling gRPC custom metadata.
 pub mod errors {

--- a/tonic/src/server/grpc.rs
+++ b/tonic/src/server/grpc.rs
@@ -1,6 +1,7 @@
 use crate::codec::compression::{
     CompressionEncoding, EnabledCompressionEncodings, SingleMessageCompressionOverride,
 };
+use crate::metadata::GRPC_CONTENT_TYPE;
 use crate::{
     body::BoxBody,
     codec::{encode_server, Codec, Streaming},
@@ -438,7 +439,7 @@ where
         // Set the content type
         parts.headers.insert(
             http::header::CONTENT_TYPE,
-            http::header::HeaderValue::from_static("application/grpc"),
+            http::header::HeaderValue::from_static(GRPC_CONTENT_TYPE),
         );
 
         #[cfg(any(feature = "gzip", feature = "zstd"))]

--- a/tonic/src/status.rs
+++ b/tonic/src/status.rs
@@ -1,5 +1,5 @@
-use crate::body::BoxBody;
 use crate::metadata::MetadataMap;
+use crate::{body::BoxBody, metadata::GRPC_CONTENT_TYPE};
 use base64::Engine as _;
 use bytes::Bytes;
 use http::header::{HeaderMap, HeaderValue};
@@ -582,14 +582,13 @@ impl Status {
         self
     }
 
-    #[allow(clippy::wrong_self_convention)]
     /// Build an `http::Response` from the given `Status`.
     pub fn to_http(self) -> http::Response<BoxBody> {
         let (mut parts, _body) = http::Response::new(()).into_parts();
 
         parts.headers.insert(
             http::header::CONTENT_TYPE,
-            http::header::HeaderValue::from_static("application/grpc"),
+            http::header::HeaderValue::from_static(GRPC_CONTENT_TYPE),
         );
 
         self.add_header(&mut parts.headers).unwrap();

--- a/tonic/src/transport/service/router.rs
+++ b/tonic/src/transport/service/router.rs
@@ -1,5 +1,6 @@
 use crate::{
     body::{boxed, BoxBody},
+    metadata::GRPC_CONTENT_TYPE,
     server::NamedService,
 };
 use http::{Request, Response};
@@ -99,7 +100,10 @@ impl Routes {
 
 async fn unimplemented() -> impl axum::response::IntoResponse {
     let status = http::StatusCode::OK;
-    let headers = [("grpc-status", "12"), ("content-type", "application/grpc")];
+    let headers = [
+        ("grpc-status", "12"),
+        (http::header::CONTENT_TYPE.as_str(), GRPC_CONTENT_TYPE),
+    ];
     (status, headers)
 }
 


### PR DESCRIPTION
Currently defined in `tonic::metadata`. Would need guidance from maintainers for where it might be better located.

Motivation is that I'm currently implementing my own tower-service::Service for handling gRPC calls, and it would be nice if tonic could provide a constant for the media type. (Writing my own because I need to combine multiple gRPC services using generics.)