### PR TITLE
chore: update h2 to fix RUSTSEC-2024-0332

### DIFF
--- a/tonic/Cargo.toml
+++ b/tonic/Cargo.toml
@@ -67,7 +67,7 @@ prost = {version = "0.12", default-features = false, features = ["std"], optiona
 async-trait = {version = "0.1.13", optional = true}
 
 # transport
-h2 = {version = "0.3.24", optional = true}
+h2 = {version = "0.3.26", optional = true}
 hyper = {version = "0.14.26", features = ["full"], optional = true}
 hyper-timeout = {version = "0.4", optional = true}
 tokio = {version = "1.0.1", optional = true}


### PR DESCRIPTION
Update h2 crate to 0.3.26 to fix [RUSTSEC-2024-0332](https://rustsec.org/advisories/RUSTSEC-2024-0332) advisory.