### PR TITLE
feat: Make async_trait optional

### DIFF
--- a/examples/routeguide-tutorial.md
+++ b/examples/routeguide-tutorial.md
@@ -304,6 +304,8 @@ impl RouteGuide for RouteGuideService {
 
 **Note**: The `tonic::async_trait` attribute macro adds support for async functions in traits. It
 uses [async-trait] internally. You can learn more about `async fn` in traits in the [async book].
+This attribute is only needed for Rust 1.74 and below, as async fn in traits have been stabilized
+in Rust 1.75.
 
 
 [cargo book]: https://doc.rust-lang.org/cargo/reference/environment-variables.html#environment-variables-cargo-sets-for-build-scripts

--- a/tonic-build/Cargo.toml
+++ b/tonic-build/Cargo.toml
@@ -22,10 +22,11 @@ quote = "1.0"
 syn = "2.0"
 
 [features]
-default = ["transport", "prost"]
+default = ["transport", "prost", "async_trait"]
 prost = ["prost-build"]
 cleanup-markdown = ["prost", "prost-build/cleanup-markdown"]
 transport = []
+async_trait = []
 
 [package.metadata.docs.rs]
 all-features = true

--- a/tonic-build/src/server.rs
+++ b/tonic-build/src/server.rs
@@ -234,10 +234,18 @@ fn generate_trait<T: Service>(
         " Generated trait containing gRPC methods that should be implemented for use with {}Server.",
         service.name()
     ));
-
+    
+    #[cfg(feature = "async_trait")]
     quote! {
         #trait_doc
         #[async_trait]
+        pub trait #server_trait : Send + Sync + 'static {
+            #methods
+        }
+    }
+    #[cfg(not(feature = "async_trait"))]
+    quote! {
+        #trait_doc
         pub trait #server_trait : Send + Sync + 'static {
             #methods
         }

--- a/tonic/Cargo.toml
+++ b/tonic/Cargo.toml
@@ -23,10 +23,11 @@ repository = "https://github.com/hyperium/tonic"
 version = "0.11.0"
 
 [features]
-codegen = ["dep:async-trait"]
+codegen = []
+async_trait = ["dep:async-trait"]
 gzip = ["dep:flate2"]
 zstd = ["dep:zstd"]
-default = ["transport", "codegen", "prost"]
+default = ["transport", "codegen", "async_trait", "prost"]
 prost = ["dep:prost"]
 tls = ["dep:rustls-pki-types", "dep:rustls-pemfile", "transport", "dep:tokio-rustls", "dep:tokio", "tokio?/rt", "tokio?/macros"]
 tls-roots = ["tls-roots-common", "dep:rustls-native-certs"]

--- a/tonic/src/codegen.rs
+++ b/tonic/src/codegen.rs
@@ -1,5 +1,6 @@
 //! Codegen exports used by `tonic-build`.
 
+#[cfg(feature = "async_trait")]
 pub use async_trait::async_trait;
 pub use tokio_stream;
 

--- a/tonic/src/lib.rs
+++ b/tonic/src/lib.rs
@@ -113,8 +113,8 @@ mod status;
 mod util;
 
 /// A re-export of [`async-trait`](https://docs.rs/async-trait) for use with codegen.
-#[cfg(feature = "codegen")]
-#[cfg_attr(docsrs, doc(cfg(feature = "codegen")))]
+#[cfg(feature = "async_trait")]
+#[cfg_attr(docsrs, doc(cfg(feature = "async_trait")))]
 pub use async_trait::async_trait;
 
 #[doc(inline)]


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/hyperium/tonic/blob/master/CONTRIBUTING.md
-->

## Motivation

Using `async fn` in traits has been [stabilized in recent Rust version](https://blog.rust-lang.org/2023/12/21/async-fn-rpit-in-traits.html). Because of this, the dependency on `async_trait` is no longer necessary with recent Rust versions. Removing unneeded dependencies can reduce compile times and help reduce the risk of supply chain attacks.

## Solution

This implements a feature `async_trait` for `tonic` and `tonic_build`. To avoid breaking any existing things, this feature is enabled by default.
