### PR TITLE
Update base64 dependency from 0.21 to 0.22

### DIFF
--- a/tonic-web/Cargo.toml
+++ b/tonic-web/Cargo.toml
@@ -15,7 +15,7 @@ repository = "https://github.com/hyperium/tonic"
 version = "0.11.0"
 
 [dependencies]
-base64 = "0.21"
+base64 = "0.22"
 bytes = "1"
 tokio-stream = "0.1"
 http = "0.2"

--- a/tonic/Cargo.toml
+++ b/tonic/Cargo.toml
@@ -49,7 +49,7 @@ channel = []
 # harness = false
 
 [dependencies]
-base64 = "0.21"
+base64 = "0.22"
 bytes = "1.0"
 http = "0.2"
 tracing = "0.1"


### PR DESCRIPTION
Tonic currently depends on two different versions of base64 - directly on 0.21, and transitively through rustls-pemfile on 0.22. Updating tonic to use 0.22 results in just a single version dependency. This is helpful for ecosystems (like Android) where keeping crates on the latest version of dependencies across various projects helps reduce memory usage and disc space.