### PR TITLE
docs(tonic-build): Fix wrong hightlight

### DIFF
--- a/tonic-build/README.md
+++ b/tonic-build/README.md
@@ -8,11 +8,11 @@ Required dependencies
 
 ```toml
 [dependencies]
-tonic = <tonic-version>
-prost = <prost-version>
+tonic = "<tonic-version>"
+prost = "<prost-version>"
 
 [build-dependencies]
-tonic-build = <tonic-version>
+tonic-build = "<tonic-version>"
 ```
 
 ## Examples


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/hyperium/tonic/blob/master/CONTRIBUTING.md
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? If a new feature is being added, describe the intended
use case that feature fulfills.
-->

The GitHub page will hightlight the `wrong` grammar in markdown, it causing unnecessary visual attraction
![图片](https://github.com/hyperium/tonic/assets/32761048/01ac44c3-f15d-464a-b287-b9039019721f)


## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

Add double quotes in yaml block, it also meets the requirements of cargo.
![图片](https://github.com/hyperium/tonic/assets/32761048/62b30c97-da34-4efb-b1e5-a65d912df98b)

