### PR TITLE
chore: Update deprecated manifest style

### DIFF
--- a/tests/root-crate-path/Cargo.toml
+++ b/tests/root-crate-path/Cargo.toml
@@ -10,5 +10,5 @@ version = "0.1.0"
 prost = "0.12"
 tonic = {path = "../../tonic"}
 
-[build_dependencies]
+[build-dependencies]
 tonic-build = {path = "../../tonic-build"}

--- a/tonic/Cargo.toml
+++ b/tonic/Cargo.toml
@@ -73,7 +73,7 @@ hyper-timeout = {version = "0.4", optional = true}
 tokio = {version = "1.0.1", optional = true}
 tokio-stream = "0.1"
 tower = {version = "0.4.7", default-features = false, features = ["balance", "buffer", "discover", "limit", "load", "make", "timeout", "util"], optional = true}
-axum = {version = "0.6.9", default_features = false, optional = true}
+axum = {version = "0.6.9", default-features = false, optional = true}
 
 # rustls
 async-stream = { version = "0.3", optional = true }


### PR DESCRIPTION
Updates deprecated manifest field style, which will be removed in 2024 edition.

https://github.com/rust-lang/cargo/pull/13804