### PR TITLE
chore: Replace deprecated numeric api with primitive one

### DIFF
--- a/tonic/src/codec/encode.rs
+++ b/tonic/src/codec/encode.rs
@@ -235,7 +235,7 @@ fn finish_encoding(
         ));
     }
 
-    if len > std::u32::MAX as usize {
+    if len > u32::MAX as usize {
         return Err(Status::resource_exhausted(format!(
             "Cannot return body with more than 4GB of data but got {len} bytes"
         )));


### PR DESCRIPTION
Replaces deprecated numeric API with primitive one.

https://doc.rust-lang.org/std/u32/index.html