### PR TITLE
feat(tls): Use rustls_pki_types::CertificateDer to describe DER encoded certificate

### DIFF
--- a/tonic/src/request.rs
+++ b/tonic/src/request.rs
@@ -2,13 +2,15 @@ use crate::metadata::{MetadataMap, MetadataValue};
 #[cfg(feature = "transport")]
 use crate::transport::server::TcpConnectInfo;
 #[cfg(feature = "tls")]
-use crate::transport::{server::TlsConnectInfo, CertificateDer};
+use crate::transport::server::TlsConnectInfo;
 use crate::Extensions;
 #[cfg(feature = "transport")]
 use std::net::SocketAddr;
 #[cfg(feature = "tls")]
 use std::sync::Arc;
 use std::time::Duration;
+#[cfg(feature = "tls")]
+use tokio_rustls::rustls::pki_types::CertificateDer;
 use tokio_stream::Stream;
 
 /// A gRPC request and metadata from an RPC call.
@@ -258,7 +260,7 @@ impl<T> Request<T> {
     /// TLS enabled connections.
     #[cfg(feature = "tls")]
     #[cfg_attr(docsrs, doc(cfg(feature = "tls")))]
-    pub fn peer_certs(&self) -> Option<Arc<Vec<CertificateDer>>> {
+    pub fn peer_certs(&self) -> Option<Arc<Vec<CertificateDer<'static>>>> {
         self.extensions()
             .get::<TlsConnectInfo<TcpConnectInfo>>()
             .and_then(|i| i.peer_certs())

--- a/tonic/src/request.rs
+++ b/tonic/src/request.rs
@@ -2,7 +2,7 @@ use crate::metadata::{MetadataMap, MetadataValue};
 #[cfg(feature = "transport")]
 use crate::transport::server::TcpConnectInfo;
 #[cfg(feature = "tls")]
-use crate::transport::{server::TlsConnectInfo, Certificate};
+use crate::transport::{server::TlsConnectInfo, CertificateDer};
 use crate::Extensions;
 #[cfg(feature = "transport")]
 use std::net::SocketAddr;
@@ -258,7 +258,7 @@ impl<T> Request<T> {
     /// TLS enabled connections.
     #[cfg(feature = "tls")]
     #[cfg_attr(docsrs, doc(cfg(feature = "tls")))]
-    pub fn peer_certs(&self) -> Option<Arc<Vec<Certificate>>> {
+    pub fn peer_certs(&self) -> Option<Arc<Vec<CertificateDer>>> {
         self.extensions()
             .get::<TlsConnectInfo<TcpConnectInfo>>()
             .and_then(|i| i.peer_certs())

--- a/tonic/src/transport/mod.rs
+++ b/tonic/src/transport/mod.rs
@@ -106,7 +106,7 @@ pub use self::server::Server;
 pub use self::service::grpc_timeout::TimeoutExpired;
 #[cfg(feature = "tls")]
 #[cfg_attr(docsrs, doc(cfg(feature = "tls")))]
-pub use self::tls::Certificate;
+pub use self::tls::{Certificate, CertificateDer};
 pub use axum::{body::BoxBody as AxumBoxBody, Router as AxumRouter};
 pub use hyper::{Body, Uri};
 

--- a/tonic/src/transport/mod.rs
+++ b/tonic/src/transport/mod.rs
@@ -106,9 +106,11 @@ pub use self::server::Server;
 pub use self::service::grpc_timeout::TimeoutExpired;
 #[cfg(feature = "tls")]
 #[cfg_attr(docsrs, doc(cfg(feature = "tls")))]
-pub use self::tls::{Certificate, CertificateDer};
+pub use self::tls::Certificate;
 pub use axum::{body::BoxBody as AxumBoxBody, Router as AxumRouter};
 pub use hyper::{Body, Uri};
+#[cfg(feature = "tls")]
+pub use tokio_rustls::rustls::pki_types::CertificateDer;
 
 pub(crate) use self::service::executor::Executor;
 

--- a/tonic/src/transport/server/conn.rs
+++ b/tonic/src/transport/server/conn.rs
@@ -3,9 +3,9 @@ use std::net::SocketAddr;
 use tokio::net::TcpStream;
 
 #[cfg(feature = "tls")]
-use crate::transport::CertificateDer;
-#[cfg(feature = "tls")]
 use std::sync::Arc;
+#[cfg(feature = "tls")]
+use tokio_rustls::rustls::pki_types::CertificateDer;
 #[cfg(feature = "tls")]
 use tokio_rustls::server::TlsStream;
 
@@ -126,8 +126,7 @@ where
         let inner = inner.connect_info();
 
         let certs = if let Some(certs) = session.peer_certificates() {
-            let certs = certs.iter().map(CertificateDer::new).collect();
-            Some(Arc::new(certs))
+            Some(Arc::new(certs.to_owned()))
         } else {
             None
         };
@@ -148,7 +147,7 @@ where
 #[derive(Debug, Clone)]
 pub struct TlsConnectInfo<T> {
     inner: T,
-    certs: Option<Arc<Vec<CertificateDer>>>,
+    certs: Option<Arc<Vec<CertificateDer<'static>>>>,
 }
 
 #[cfg(feature = "tls")]
@@ -165,7 +164,7 @@ impl<T> TlsConnectInfo<T> {
     }
 
     /// Return the set of connected peer TLS certificates.
-    pub fn peer_certs(&self) -> Option<Arc<Vec<CertificateDer>>> {
+    pub fn peer_certs(&self) -> Option<Arc<Vec<CertificateDer<'static>>>> {
         self.certs.clone()
     }
 }

--- a/tonic/src/transport/server/conn.rs
+++ b/tonic/src/transport/server/conn.rs
@@ -3,7 +3,7 @@ use std::net::SocketAddr;
 use tokio::net::TcpStream;
 
 #[cfg(feature = "tls")]
-use crate::transport::Certificate;
+use crate::transport::CertificateDer;
 #[cfg(feature = "tls")]
 use std::sync::Arc;
 #[cfg(feature = "tls")]
@@ -126,7 +126,7 @@ where
         let inner = inner.connect_info();
 
         let certs = if let Some(certs) = session.peer_certificates() {
-            let certs = certs.iter().map(Certificate::from_pem).collect();
+            let certs = certs.iter().map(CertificateDer::new).collect();
             Some(Arc::new(certs))
         } else {
             None
@@ -148,7 +148,7 @@ where
 #[derive(Debug, Clone)]
 pub struct TlsConnectInfo<T> {
     inner: T,
-    certs: Option<Arc<Vec<Certificate>>>,
+    certs: Option<Arc<Vec<CertificateDer>>>,
 }
 
 #[cfg(feature = "tls")]
@@ -165,7 +165,7 @@ impl<T> TlsConnectInfo<T> {
     }
 
     /// Return the set of connected peer TLS certificates.
-    pub fn peer_certs(&self) -> Option<Arc<Vec<Certificate>>> {
+    pub fn peer_certs(&self) -> Option<Arc<Vec<CertificateDer>>> {
         self.certs.clone()
     }
 }

--- a/tonic/src/transport/server/conn.rs
+++ b/tonic/src/transport/server/conn.rs
@@ -125,11 +125,9 @@ where
         let (inner, session) = self.get_ref();
         let inner = inner.connect_info();
 
-        let certs = if let Some(certs) = session.peer_certificates() {
-            Some(Arc::new(certs.to_owned()))
-        } else {
-            None
-        };
+        let certs = session
+            .peer_certificates()
+            .map(|certs| certs.to_owned().into());
 
         TlsConnectInfo { inner, certs }
     }

--- a/tonic/src/transport/tls.rs
+++ b/tonic/src/transport/tls.rs
@@ -11,12 +11,6 @@ pub struct Identity {
     pub(crate) key: Vec<u8>,
 }
 
-/// Reprensents a DER encoded certificate.
-#[derive(Debug, Clone)]
-pub struct CertificateDer {
-    bytes: Vec<u8>,
-}
-
 impl Certificate {
     /// Parse a PEM encoded X509 Certificate.
     ///
@@ -62,29 +56,5 @@ impl Identity {
         let cert = Certificate::from_pem(cert);
         let key = key.as_ref().into();
         Self { cert, key }
-    }
-}
-
-impl CertificateDer {
-    pub(crate) fn new(bytes: impl AsRef<[u8]>) -> Self {
-        let bytes = bytes.as_ref().into();
-        Self { bytes }
-    }
-
-    /// Consumes `self`, returning the underlying DER encoded certificate
-    pub fn into_bytes(self) -> Vec<u8> {
-        self.bytes
-    }
-}
-
-impl AsRef<[u8]> for CertificateDer {
-    fn as_ref(&self) -> &[u8] {
-        self.bytes.as_ref()
-    }
-}
-
-impl AsMut<[u8]> for CertificateDer {
-    fn as_mut(&mut self) -> &mut [u8] {
-        self.bytes.as_mut()
     }
 }

--- a/tonic/src/transport/tls.rs
+++ b/tonic/src/transport/tls.rs
@@ -11,6 +11,12 @@ pub struct Identity {
     pub(crate) key: Vec<u8>,
 }
 
+/// Reprensents a DER encoded certificate.
+#[derive(Debug, Clone)]
+pub struct CertificateDer {
+    bytes: Vec<u8>,
+}
+
 impl Certificate {
     /// Parse a PEM encoded X509 Certificate.
     ///
@@ -56,5 +62,29 @@ impl Identity {
         let cert = Certificate::from_pem(cert);
         let key = key.as_ref().into();
         Self { cert, key }
+    }
+}
+
+impl CertificateDer {
+    pub(crate) fn new(bytes: impl AsRef<[u8]>) -> Self {
+        let bytes = bytes.as_ref().into();
+        Self { bytes }
+    }
+
+    /// Consumes `self`, returning the underlying DER encoded certificate
+    pub fn into_bytes(self) -> Vec<u8> {
+        self.bytes
+    }
+}
+
+impl AsRef<[u8]> for CertificateDer {
+    fn as_ref(&self) -> &[u8] {
+        self.bytes.as_ref()
+    }
+}
+
+impl AsMut<[u8]> for CertificateDer {
+    fn as_mut(&mut self) -> &mut [u8] {
+        self.bytes.as_mut()
     }
 }


### PR DESCRIPTION
## Motivation

Although `Certificate` is for PEM encoded certificate, it is used by `Request::peer_certs`'s return type, which is DER encoded certificate.

## Solution

Adds `CertificateDer` type and changes `Request::peer_certs` to use it.

This is a breaking change.