### PR TITLE
Bump nightly to 2024-04-16

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -54,7 +54,7 @@ jobs:
     - uses: actions/checkout@v4
     - uses: dtolnay/rust-toolchain@master
       with:
-        toolchain: nightly-2024-02-06
+        toolchain: nightly-2024-04-16
     - uses: taiki-e/install-action@cargo-hack
     - uses: taiki-e/install-action@cargo-udeps
     - name: Install protoc


### PR DESCRIPTION
Upgrading to hyper>=1 will reqiure that we upgrade axum to >= 0.7. Bumping nightly is required to support axum >= 0.7 on nightly, since it uses features not stabilized before this date. This is in turn reqiured to run `cargo udeps` against tonic and associated crates.
