### PR TITLE
update examples rand version

### DIFF
--- a/examples/routeguide-tutorial.md
+++ b/examples/routeguide-tutorial.md
@@ -182,7 +182,7 @@ tokio-stream = "0.1"
 async-stream = "0.2"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-rand = "0.7"
+rand = "0.8"
 
 [build-dependencies]
 tonic-build = "0.11"


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/hyperium/tonic/blob/master/CONTRIBUTING.md
-->

## Motivation

when rand = "0.7", it will occur a lot of errors.
eg:
```bash
error[E0277]: the trait bound `std::ops::Range<{integer}>: SampleBorrow<std::ops::Range<{integer}>>` is not satisfied
   --> src/route-client.rs:43:42
    |
43  |     let point_count: i32 = rng.gen_range(2..100);
    |                                --------- ^^^^^^ the trait `SampleUniform` is not implemented for `std::ops::Range<{integer}>`, which is required by `std::ops::Range<{integer}>: SampleBorrow<_>`
    |                                |
    |                                required by a bound introduced by this call
    |
    = help: the trait `SampleBorrow<Borrowed>` is implemented for `&'a Borrowed`
    = note: required for `std::ops::Range<{integer}>` to implement `SampleBorrow<std::ops::Range<{integer}>>`
note: required by a bound in `gen_range`
   --> /Users/tsingwong/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rand-0.7.3/src/lib.rs:214:13
    |
212 |     fn gen_range<T: SampleUniform, B1, B2>(&mut self, low: B1, high: B2) -> T
    |        --------- required by a bound in this associated function
213 |     where
214 |         B1: SampleBorrow<T> + Sized,
    |             ^^^^^^^^^^^^^^^ required by this bound in `Rng::gen_range`
```


So I could not complete this tutorial. 

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

And I find the version  in [examples/Cargo.toml](https://github.com/hyperium/tonic/blob/master/examples/Cargo.toml), it's `rand = { version = "0.8", optional = true }`.

Oh, It helps me complete this tutorial.
