### PR TITLE
chore: Rename Status to_http method to into_http

### DIFF
--- a/tonic/src/server/grpc.rs
+++ b/tonic/src/server/grpc.rs
@@ -15,7 +15,7 @@ macro_rules! t {
     ($result:expr) => {
         match $result {
             Ok(value) => value,
-            Err(status) => return status.to_http(),
+            Err(status) => return status.into_http(),
         }
     };
 }

--- a/tonic/src/service/interceptor.rs
+++ b/tonic/src/service/interceptor.rs
@@ -219,7 +219,7 @@ where
                 let response = status
                     .take()
                     .unwrap()
-                    .to_http()
+                    .into_http()
                     .map(|_| B::default())
                     .map(boxed);
                 Poll::Ready(Ok(response))
@@ -288,7 +288,7 @@ mod tests {
     #[tokio::test]
     async fn handles_intercepted_status_as_response() {
         let message = "Blocked by the interceptor";
-        let expected = Status::permission_denied(message).to_http();
+        let expected = Status::permission_denied(message).into_http();
 
         let svc = tower::service_fn(|_: http::Request<TestBody>| async {
             Ok::<_, Status>(http::Response::new(TestBody))

--- a/tonic/src/status.rs
+++ b/tonic/src/status.rs
@@ -580,9 +580,8 @@ impl Status {
         self
     }
 
-    #[allow(clippy::wrong_self_convention)]
     /// Build an `http::Response` from the given `Status`.
-    pub fn to_http(self) -> http::Response<BoxBody> {
+    pub fn into_http(self) -> http::Response<BoxBody> {
         let mut response = http::Response::new(crate::body::empty_body());
         response.headers_mut().insert(
             http::header::CONTENT_TYPE,


### PR DESCRIPTION
Follows to the naming convention.

https://rust-lang.github.io/api-guidelines/naming.html#ad-hoc-conversions-follow-as_-to_-into_-conventions-c-conv
