### PR TITLE
chore: Remove resolved cargo-deny skip-tree

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -20,9 +20,6 @@ deny = [
 skip-tree = [
     { name = "windows-sys" },
     { name = "hermit-abi" },
-    { name = "syn" },
-    { name = "bitflags" },
-    { name = "indexmap" },
     { name = "examples" },
 ]
 


### PR DESCRIPTION
Removes resolved cargo-deny skip-tree.