### PR TITLE
Add timer to hyper server for http2_keepalive_interval

### DIFF
--- a/tests/integration_tests/tests/http2_keep_alive.rs
+++ b/tests/integration_tests/tests/http2_keep_alive.rs
@@ -1,18 +1,15 @@
-use integration_tests::pb::{test_client::TestClient, test_server, Input, Output};
-use std::sync::{Arc, Mutex};
 use std::time::Duration;
+
 use tokio::sync::oneshot;
-use tonic::{
-    transport::{Endpoint, Server},
-    Code, Request, Response, Status,
-};
+
+use integration_tests::pb::{test_client::TestClient, test_server, Input, Output};
+use tonic::{transport::Server, Request, Response, Status};
 
 struct Svc;
 
 #[tonic::async_trait]
 impl test_server::Test for Svc {
     async fn unary_call(&self, _: Request<Input>) -> Result<Response<Output>, Status> {
-
         Ok(Response::new(Output {}))
     }
 }

--- a/tests/integration_tests/tests/http2_keep_alive.rs
+++ b/tests/integration_tests/tests/http2_keep_alive.rs
@@ -18,7 +18,7 @@ impl test_server::Test for Svc {
 }
 
 #[tokio::test]
-async fn connect_returns_err_via_call_after_connected() {
+async fn http2_keepalive_does_not_cause_panics() {
     let svc = test_server::TestServer::new(Svc {});
     let (tx, rx) = oneshot::channel::<()>();
     let jh = tokio::spawn(async move {

--- a/tests/integration_tests/tests/http2_keep_alive.rs
+++ b/tests/integration_tests/tests/http2_keep_alive.rs
@@ -1,0 +1,43 @@
+use integration_tests::pb::{test_client::TestClient, test_server, Input, Output};
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+use tokio::sync::oneshot;
+use tonic::{
+    transport::{Endpoint, Server},
+    Code, Request, Response, Status,
+};
+
+struct Svc;
+
+#[tonic::async_trait]
+impl test_server::Test for Svc {
+    async fn unary_call(&self, _: Request<Input>) -> Result<Response<Output>, Status> {
+
+        Ok(Response::new(Output {}))
+    }
+}
+
+#[tokio::test]
+async fn connect_returns_err_via_call_after_connected() {
+    let svc = test_server::TestServer::new(Svc {});
+    let (tx, rx) = oneshot::channel::<()>();
+    let jh = tokio::spawn(async move {
+        Server::builder()
+            .http2_keepalive_interval(Some(Duration::from_secs(10)))
+            .add_service(svc)
+            .serve_with_shutdown("127.0.0.1:5432".parse().unwrap(), async { drop(rx.await) })
+            .await
+            .unwrap();
+    });
+
+    tokio::time::sleep(Duration::from_millis(100)).await;
+
+    let mut client = TestClient::connect("http://127.0.0.1:5432").await.unwrap();
+
+    let res = client.unary_call(Request::new(Input {})).await;
+
+    assert!(res.is_ok());
+
+    tx.send(()).unwrap();
+    jh.await.unwrap();
+}

--- a/tonic/src/transport/server/mod.rs
+++ b/tonic/src/transport/server/mod.rs
@@ -16,7 +16,7 @@ use tracing::{debug, trace};
 pub use crate::service::{Routes, RoutesBuilder};
 
 pub use conn::{Connected, TcpConnectInfo};
-use hyper_util::rt::{TokioExecutor, TokioIo};
+use hyper_util::rt::{TokioExecutor, TokioIo, TokioTimer};
 #[cfg(feature = "tls")]
 pub use tls::ServerTlsConfig;
 
@@ -548,6 +548,7 @@ impl<L> Server<L> {
 
             builder
                 .http2()
+                .timer(TokioTimer::new())
                 .initial_connection_window_size(init_connection_window_size)
                 .initial_stream_window_size(init_stream_window_size)
                 .max_concurrent_streams(max_concurrent_streams)


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/hyperium/tonic/blob/master/CONTRIBUTING.md
-->

## Motivation

As described in this issue: https://github.com/hyperium/tonic/issues/1725 the recent upgrade to hyper 1 has broken services that use http2_keepalive_interval. This was due to a missing timer, resulting in panics with the message `You must supply a timer.` See here: https://github.com/hyperium/hyper/blob/master/src/common/time.rs#L36


## Solution

This solution adds in a timer to the server via this method: https://docs.rs/hyper-util/0.1.5/hyper_util/server/conn/auto/struct.Http2Builder.html#method.timer

The timer is a standard tokio timer: https://docs.rs/hyper-util/0.1.5/hyper_util/rt/tokio/struct.TokioTimer.html

Fixes https://github.com/hyperium/tonic/issues/1725