### PR TITLE
Fix http2_keepalive panics on the client side

### DIFF
--- a/tests/integration_tests/tests/http2_keep_alive.rs
+++ b/tests/integration_tests/tests/http2_keep_alive.rs
@@ -3,7 +3,8 @@ use std::time::Duration;
 use tokio::sync::oneshot;
 
 use integration_tests::pb::{test_client::TestClient, test_server, Input, Output};
-use tonic::{transport::Server, Request, Response, Status};
+use tonic::transport::{Channel, Server};
+use tonic::{Request, Response, Status};
 
 struct Svc;
 
@@ -30,6 +31,36 @@ async fn http2_keepalive_does_not_cause_panics() {
     tokio::time::sleep(Duration::from_millis(100)).await;
 
     let mut client = TestClient::connect("http://127.0.0.1:5432").await.unwrap();
+
+    let res = client.unary_call(Request::new(Input {})).await;
+
+    assert!(res.is_ok());
+
+    tx.send(()).unwrap();
+    jh.await.unwrap();
+}
+
+#[tokio::test]
+async fn http2_keepalive_does_not_cause_panics_on_client_side() {
+    let svc = test_server::TestServer::new(Svc {});
+    let (tx, rx) = oneshot::channel::<()>();
+    let jh = tokio::spawn(async move {
+        Server::builder()
+            .http2_keepalive_interval(Some(Duration::from_secs(5)))
+            .add_service(svc)
+            .serve_with_shutdown("127.0.0.1:5431".parse().unwrap(), async { drop(rx.await) })
+            .await
+            .unwrap();
+    });
+
+    tokio::time::sleep(Duration::from_millis(100)).await;
+
+    let channel = Channel::from_static("http://127.0.0.1:5431")
+        .http2_keep_alive_interval(Duration::from_secs(5))
+        .connect()
+        .await
+        .unwrap();
+    let mut client = TestClient::new(channel);
 
     let res = client.unary_call(Request::new(Input {})).await;
 

--- a/tonic/src/transport/service/connection.rs
+++ b/tonic/src/transport/service/connection.rs
@@ -7,11 +7,11 @@ use crate::{
 use http::Uri;
 use hyper::rt;
 use hyper::{client::conn::http2::Builder, rt::Executor};
+use hyper_util::rt::TokioTimer;
 use std::{
     fmt,
     task::{Context, Poll},
 };
-use hyper_util::rt::TokioTimer;
 use tower::load::Load;
 use tower::{
     layer::Layer,

--- a/tonic/src/transport/service/connection.rs
+++ b/tonic/src/transport/service/connection.rs
@@ -11,6 +11,7 @@ use std::{
     fmt,
     task::{Context, Poll},
 };
+use hyper_util::rt::TokioTimer;
 use tower::load::Load;
 use tower::{
     layer::Layer,
@@ -39,6 +40,7 @@ impl Connection {
             .initial_stream_window_size(endpoint.init_stream_window_size)
             .initial_connection_window_size(endpoint.init_connection_window_size)
             .keep_alive_interval(endpoint.http2_keep_alive_interval)
+            .timer(TokioTimer::new())
             .clone();
 
         if let Some(val) = endpoint.http2_keep_alive_timeout {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/hyperium/tonic/blob/master/CONTRIBUTING.md
-->

## Motivation

https://github.com/hyperium/tonic/pull/1726 fixed http2_keepalive on the server side, but panics were still present when using http2_keepalive on the client side. 

## Solution

Add the necessary timer to the SharedExec when constructing it via `tonic::transport::service::Connection`.
