### PR TITLE
feat(tls): Remove tls roots implicit configuration

### DIFF
--- a/tonic/Cargo.toml
+++ b/tonic/Cargo.toml
@@ -29,9 +29,8 @@ zstd = ["dep:zstd"]
 default = ["transport", "codegen", "prost"]
 prost = ["dep:prost"]
 tls = ["dep:rustls-pemfile", "dep:tokio-rustls", "dep:tokio", "tokio?/rt", "tokio?/macros"]
-tls-roots = ["tls-roots-common", "dep:rustls-native-certs"]
-tls-roots-common = ["tls", "channel"]
-tls-webpki-roots = ["tls-roots-common", "dep:webpki-roots"]
+tls-roots = ["tls", "channel", "dep:rustls-native-certs"]
+tls-webpki-roots = ["tls", "channel", "dep:webpki-roots"]
 router = ["dep:axum"]
 server = [
   "router",

--- a/tonic/src/transport/channel/service/connector.rs
+++ b/tonic/src/transport/channel/service/connector.rs
@@ -65,7 +65,17 @@ impl<C> Connector<C> {
             _ => return None,
         };
 
-        TlsConnector::new(Vec::new(), None, host, self.assume_http2).ok()
+        TlsConnector::new(
+            Vec::new(),
+            None,
+            host,
+            self.assume_http2,
+            #[cfg(feature = "tls-roots")]
+            true,
+            #[cfg(feature = "tls-webpki-roots")]
+            true,
+        )
+        .ok()
     }
 }
 

--- a/tonic/src/transport/channel/service/connector.rs
+++ b/tonic/src/transport/channel/service/connector.rs
@@ -33,49 +33,15 @@ pub(crate) struct Connector<C> {
     inner: C,
     #[cfg(feature = "tls")]
     tls: Option<TlsConnector>,
-    // When connecting to a URI with the https scheme, assume that the server
-    // is capable of speaking HTTP/2 even if it doesn't offer ALPN.
-    #[cfg(feature = "tls-roots-common")]
-    assume_http2: bool,
 }
 
 impl<C> Connector<C> {
-    pub(crate) fn new(
-        inner: C,
-        #[cfg(feature = "tls")] tls: Option<TlsConnector>,
-        #[cfg(feature = "tls-roots-common")] assume_http2: bool,
-    ) -> Self {
+    pub(crate) fn new(inner: C, #[cfg(feature = "tls")] tls: Option<TlsConnector>) -> Self {
         Self {
             inner,
             #[cfg(feature = "tls")]
             tls,
-            #[cfg(feature = "tls-roots-common")]
-            assume_http2,
         }
-    }
-
-    #[cfg(feature = "tls-roots-common")]
-    fn tls_or_default(&self, scheme: Option<&str>, host: Option<&str>) -> Option<TlsConnector> {
-        if self.tls.is_some() {
-            return self.tls.clone();
-        }
-
-        let host = match (scheme, host) {
-            (Some("https"), Some(host)) => host,
-            _ => return None,
-        };
-
-        TlsConnector::new(
-            Vec::new(),
-            None,
-            host,
-            self.assume_http2,
-            #[cfg(feature = "tls-roots")]
-            true,
-            #[cfg(feature = "tls-webpki-roots")]
-            true,
-        )
-        .ok()
     }
 }
 
@@ -97,11 +63,8 @@ where
     }
 
     fn call(&mut self, uri: Uri) -> Self::Future {
-        #[cfg(all(feature = "tls", not(feature = "tls-roots-common")))]
+        #[cfg(feature = "tls")]
         let tls = self.tls.clone();
-
-        #[cfg(feature = "tls-roots-common")]
-        let tls = self.tls_or_default(uri.scheme_str(), uri.host());
 
         #[cfg(feature = "tls")]
         let is_https = uri.scheme_str() == Some("https");

--- a/tonic/src/transport/channel/service/tls.rs
+++ b/tonic/src/transport/channel/service/tls.rs
@@ -26,15 +26,21 @@ impl TlsConnector {
         identity: Option<Identity>,
         domain: &str,
         assume_http2: bool,
+        #[cfg(feature = "tls-roots")] with_native_roots: bool,
+        #[cfg(feature = "tls-webpki-roots")] with_webpki_roots: bool,
     ) -> Result<Self, crate::Error> {
         let builder = ClientConfig::builder();
         let mut roots = RootCertStore::empty();
 
         #[cfg(feature = "tls-roots")]
-        roots.add_parsable_certificates(rustls_native_certs::load_native_certs()?);
+        if with_native_roots {
+            roots.add_parsable_certificates(rustls_native_certs::load_native_certs()?);
+        }
 
         #[cfg(feature = "tls-webpki-roots")]
-        roots.extend(webpki_roots::TLS_SERVER_ROOTS.iter().cloned());
+        if with_webpki_roots {
+            roots.extend(webpki_roots::TLS_SERVER_ROOTS.iter().cloned());
+        }
 
         for cert in ca_certs {
             add_certs_from_pem(&mut Cursor::new(cert), &mut roots)?;

--- a/tonic/src/transport/channel/tls.rs
+++ b/tonic/src/transport/channel/tls.rs
@@ -13,6 +13,10 @@ pub struct ClientTlsConfig {
     certs: Vec<Certificate>,
     identity: Option<Identity>,
     assume_http2: bool,
+    #[cfg(feature = "tls-roots")]
+    with_native_roots: bool,
+    #[cfg(feature = "tls-webpki-roots")]
+    with_webpki_roots: bool,
 }
 
 impl fmt::Debug for ClientTlsConfig {
@@ -33,6 +37,10 @@ impl ClientTlsConfig {
             certs: Vec::new(),
             identity: None,
             assume_http2: false,
+            #[cfg(feature = "tls-roots")]
+            with_native_roots: false,
+            #[cfg(feature = "tls-webpki-roots")]
+            with_webpki_roots: false,
         }
     }
 
@@ -75,6 +83,26 @@ impl ClientTlsConfig {
         }
     }
 
+    /// Enables the platform's trusted certs.
+    #[cfg(feature = "tls-roots")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "tls-roots")))]
+    pub fn with_native_roots(self) -> Self {
+        ClientTlsConfig {
+            with_native_roots: true,
+            ..self
+        }
+    }
+
+    /// Enables the webpki roots.
+    #[cfg(feature = "tls-webpki-roots")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "tls-webpki-roots")))]
+    pub fn with_webpki_roots(self) -> Self {
+        ClientTlsConfig {
+            with_webpki_roots: true,
+            ..self
+        }
+    }
+
     pub(crate) fn tls_connector(&self, uri: Uri) -> Result<TlsConnector, crate::Error> {
         let domain = match &self.domain {
             Some(domain) => domain,
@@ -85,6 +113,10 @@ impl ClientTlsConfig {
             self.identity.clone(),
             domain,
             self.assume_http2,
+            #[cfg(feature = "tls-roots")]
+            self.with_native_roots,
+            #[cfg(feature = "tls-webpki-roots")]
+            self.with_webpki_roots,
         )
     }
 }


### PR DESCRIPTION
Adds ability to add CA certificates and removes `tls-webpki-roots` and `tls-roots` features.