### PR TITLE
chore: Remove socket2 version range config

### DIFF
--- a/tonic/Cargo.toml
+++ b/tonic/Cargo.toml
@@ -80,7 +80,7 @@ async-stream = {version = "0.3", optional = true}
 h2 = {version = "0.4", optional = true}
 hyper = {version = "1", features = ["http1", "http2"], optional = true}
 hyper-util = { version = ">=0.1.4, <0.2", features = ["tokio"], optional = true }
-socket2 = { version = ">=0.4.7, <0.6.0", optional = true, features = ["all"] }
+socket2 = { version = "0.5", optional = true, features = ["all"] }
 tokio = {version = "1", default-features = false, optional = true}
 tokio-stream = { version = "0.1", features = ["net"] }
 tower = {version = "0.4.7", default-features = false, optional = true}


### PR DESCRIPTION
`hyper-util` 0.1.4 has already required `socket2` 0.5.