### PR TITLE
chore(doc): Enable doc_auto_cfg

### DIFF
--- a/tonic-build/src/lib.rs
+++ b/tonic-build/src/lib.rs
@@ -73,18 +73,16 @@
 #![doc(html_root_url = "https://docs.rs/tonic-build/0.11.0")]
 #![doc(issue_tracker_base_url = "https://github.com/hyperium/tonic/issues/")]
 #![doc(test(no_crate_inject, attr(deny(rust_2018_idioms))))]
-#![cfg_attr(docsrs, feature(doc_cfg))]
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 
 use proc_macro2::{Delimiter, Group, Ident, Literal, Punct, Spacing, Span, TokenStream};
 use quote::TokenStreamExt;
 
 /// Prost generator
 #[cfg(feature = "prost")]
-#[cfg_attr(docsrs, doc(cfg(feature = "prost")))]
 mod prost;
 
 #[cfg(feature = "prost")]
-#[cfg_attr(docsrs, doc(cfg(feature = "prost")))]
 pub use prost::{compile_protos, configure, Builder};
 
 pub mod manual;

--- a/tonic-health/src/lib.rs
+++ b/tonic-health/src/lib.rs
@@ -19,7 +19,7 @@
 #![doc(html_root_url = "https://docs.rs/tonic-health/0.11.0")]
 #![doc(issue_tracker_base_url = "https://github.com/hyperium/tonic/issues/")]
 #![doc(test(no_crate_inject, attr(deny(rust_2018_idioms))))]
-#![cfg_attr(docsrs, feature(doc_cfg))]
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 
 use std::fmt::{Display, Formatter};
 

--- a/tonic-health/src/server.rs
+++ b/tonic-health/src/server.rs
@@ -51,7 +51,6 @@ impl HealthReporter {
     /// Sets the status of the service implemented by `S` to `Serving`. This notifies any watchers
     /// if there is a change in status.
     #[cfg(feature = "transport")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "transport")))]
     pub async fn set_serving<S>(&mut self)
     where
         S: NamedService,
@@ -64,7 +63,6 @@ impl HealthReporter {
     /// Sets the status of the service implemented by `S` to `NotServing`. This notifies any watchers
     /// if there is a change in status.
     #[cfg(feature = "transport")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "transport")))]
     pub async fn set_not_serving<S>(&mut self)
     where
         S: NamedService,

--- a/tonic-reflection/src/lib.rs
+++ b/tonic-reflection/src/lib.rs
@@ -13,7 +13,7 @@
 #![doc(html_root_url = "https://docs.rs/tonic-reflection/0.11.0")]
 #![doc(issue_tracker_base_url = "https://github.com/hyperium/tonic/issues/")]
 #![doc(test(no_crate_inject, attr(deny(rust_2018_idioms))))]
-#![cfg_attr(docsrs, feature(doc_cfg))]
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 
 mod generated {
     #![allow(unreachable_pub)]
@@ -69,5 +69,4 @@ pub mod pb {
 
 /// Implementation of the server component of gRPC Server Reflection.
 #[cfg(feature = "server")]
-#[cfg_attr(docsrs, doc(cfg(feature = "server")))]
 pub mod server;

--- a/tonic/src/codec/compression.rs
+++ b/tonic/src/codec/compression.rs
@@ -83,11 +83,9 @@ pub(crate) struct CompressionSettings {
 pub enum CompressionEncoding {
     #[allow(missing_docs)]
     #[cfg(feature = "gzip")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "gzip")))]
     Gzip,
     #[allow(missing_docs)]
     #[cfg(feature = "zstd")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "zstd")))]
     Zstd,
 }
 

--- a/tonic/src/codec/mod.rs
+++ b/tonic/src/codec/mod.rs
@@ -19,7 +19,6 @@ pub use self::buffer::{DecodeBuf, EncodeBuf};
 pub use self::compression::{CompressionEncoding, EnabledCompressionEncodings};
 pub use self::decode::Streaming;
 #[cfg(feature = "prost")]
-#[cfg_attr(docsrs, doc(cfg(feature = "prost")))]
 pub use self::prost::ProstCodec;
 
 /// Unless overridden, this is the buffer size used for encoding requests.

--- a/tonic/src/lib.rs
+++ b/tonic/src/lib.rs
@@ -92,7 +92,7 @@
 #![doc(html_root_url = "https://docs.rs/tonic/0.11.0")]
 #![doc(issue_tracker_base_url = "https://github.com/hyperium/tonic/issues/")]
 #![doc(test(no_crate_inject, attr(deny(rust_2018_idioms))))]
-#![cfg_attr(docsrs, feature(doc_cfg))]
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 
 pub mod body;
 pub mod client;
@@ -102,7 +102,6 @@ pub mod server;
 pub mod service;
 
 #[cfg(any(feature = "server", feature = "channel"))]
-#[cfg_attr(docsrs, doc(cfg(any(feature = "server", feature = "channel"))))]
 pub mod transport;
 
 mod extensions;
@@ -114,7 +113,6 @@ mod util;
 
 /// A re-export of [`async-trait`](https://docs.rs/async-trait) for use with codegen.
 #[cfg(feature = "codegen")]
-#[cfg_attr(docsrs, doc(cfg(feature = "codegen")))]
 pub use async_trait::async_trait;
 
 #[doc(inline)]
@@ -129,7 +127,6 @@ pub(crate) type Error = Box<dyn std::error::Error + Send + Sync>;
 
 #[doc(hidden)]
 #[cfg(feature = "codegen")]
-#[cfg_attr(docsrs, doc(cfg(feature = "codegen")))]
 pub mod codegen;
 
 /// `Result` is a type that represents either success ([`Ok`]) or failure ([`Err`]).

--- a/tonic/src/request.rs
+++ b/tonic/src/request.rs
@@ -212,7 +212,6 @@ impl<T> Request<T> {
     /// does not implement `Connected` or when using a unix domain socket.
     /// This currently only works on the server side.
     #[cfg(feature = "server")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "server")))]
     pub fn local_addr(&self) -> Option<SocketAddr> {
         let addr = self
             .extensions()
@@ -235,7 +234,6 @@ impl<T> Request<T> {
     /// does not implement `Connected` or when using a unix domain socket.
     /// This currently only works on the server side.
     #[cfg(feature = "server")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "server")))]
     pub fn remote_addr(&self) -> Option<SocketAddr> {
         let addr = self
             .extensions()
@@ -259,7 +257,6 @@ impl<T> Request<T> {
     /// `Some` on the server side of the `transport` server with
     /// TLS enabled connections.
     #[cfg(all(feature = "server", feature = "tls"))]
-    #[cfg_attr(docsrs, doc(all(feature = "server", feature = "tls")))]
     pub fn peer_certs(&self) -> Option<Arc<Vec<CertificateDer<'static>>>> {
         self.extensions()
             .get::<TlsConnectInfo<TcpConnectInfo>>()

--- a/tonic/src/response.rs
+++ b/tonic/src/response.rs
@@ -121,7 +121,6 @@ impl<T> Response<T> {
     /// server streams. Response streams (server to client stream and bidirectional streams) will
     /// still be compressed according to the configuration of the server.
     #[cfg(feature = "gzip")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "gzip")))]
     pub fn disable_compression(&mut self) {
         self.extensions_mut()
             .insert(crate::codec::compression::SingleMessageCompressionOverride::Disable);

--- a/tonic/src/transport/channel/endpoint.rs
+++ b/tonic/src/transport/channel/endpoint.rs
@@ -239,7 +239,6 @@ impl Endpoint {
 
     /// Configures TLS for the endpoint.
     #[cfg(feature = "tls")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "tls")))]
     pub fn tls_config(self, tls_config: ClientTlsConfig) -> Result<Self, Error> {
         Ok(Endpoint {
             tls: Some(

--- a/tonic/src/transport/channel/mod.rs
+++ b/tonic/src/transport/channel/mod.rs
@@ -3,7 +3,6 @@
 mod endpoint;
 pub(crate) mod service;
 #[cfg(feature = "tls")]
-#[cfg_attr(docsrs, doc(cfg(feature = "tls")))]
 mod tls;
 
 pub use endpoint::Endpoint;

--- a/tonic/src/transport/channel/tls.rs
+++ b/tonic/src/transport/channel/tls.rs
@@ -85,7 +85,6 @@ impl ClientTlsConfig {
 
     /// Enables the platform's trusted certs.
     #[cfg(feature = "tls-roots")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "tls-roots")))]
     pub fn with_native_roots(self) -> Self {
         ClientTlsConfig {
             with_native_roots: true,
@@ -95,7 +94,6 @@ impl ClientTlsConfig {
 
     /// Enables the webpki roots.
     #[cfg(feature = "tls-webpki-roots")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "tls-webpki-roots")))]
     pub fn with_webpki_roots(self) -> Self {
         ClientTlsConfig {
             with_webpki_roots: true,

--- a/tonic/src/transport/mod.rs
+++ b/tonic/src/transport/mod.rs
@@ -101,7 +101,6 @@ mod tls;
 
 #[doc(inline)]
 #[cfg(feature = "channel")]
-#[cfg_attr(docsrs, doc(cfg(feature = "channel")))]
 pub use self::channel::{Channel, Endpoint};
 pub use self::error::Error;
 #[doc(inline)]
@@ -111,21 +110,16 @@ pub use self::server::Server;
 pub use self::service::grpc_timeout::TimeoutExpired;
 
 #[cfg(feature = "tls")]
-#[cfg_attr(docsrs, doc(cfg(feature = "tls")))]
 pub use self::tls::Certificate;
 #[cfg(feature = "server")]
-#[cfg_attr(docsrs, doc(cfg(feature = "server")))]
 pub use axum::{body::Body as AxumBoxBody, Router as AxumRouter};
 pub use hyper::{body::Body, Uri};
 #[cfg(feature = "tls")]
 pub use tokio_rustls::rustls::pki_types::CertificateDer;
 
 #[cfg(all(feature = "channel", feature = "tls"))]
-#[cfg_attr(docsrs, doc(cfg(all(feature = "channel", feature = "tls"))))]
 pub use self::channel::ClientTlsConfig;
 #[cfg(all(feature = "server", feature = "tls"))]
-#[cfg_attr(docsrs, doc(all(feature = "server", feature = "tls")))]
 pub use self::server::ServerTlsConfig;
 #[cfg(feature = "tls")]
-#[cfg_attr(docsrs, doc(cfg(feature = "tls")))]
 pub use self::tls::Identity;

--- a/tonic/src/transport/server/conn.rs
+++ b/tonic/src/transport/server/conn.rs
@@ -129,7 +129,6 @@ where
 ///
 /// [ext]: crate::Request::extensions
 #[cfg(feature = "tls")]
-#[cfg_attr(docsrs, doc(cfg(feature = "tls")))]
 #[derive(Debug, Clone)]
 pub struct TlsConnectInfo<T> {
     inner: T,
@@ -137,7 +136,6 @@ pub struct TlsConnectInfo<T> {
 }
 
 #[cfg(feature = "tls")]
-#[cfg_attr(docsrs, doc(cfg(feature = "tls")))]
 impl<T> TlsConnectInfo<T> {
     /// Get a reference to the underlying connection info.
     pub fn get_ref(&self) -> &T {

--- a/tonic/src/transport/server/mod.rs
+++ b/tonic/src/transport/server/mod.rs
@@ -5,7 +5,6 @@ mod incoming;
 mod recover_error;
 mod service;
 #[cfg(feature = "tls")]
-#[cfg_attr(docsrs, doc(cfg(feature = "tls")))]
 mod tls;
 #[cfg(unix)]
 mod unix;
@@ -156,7 +155,6 @@ impl Server {
 impl<L> Server<L> {
     /// Configure TLS for this server.
     #[cfg(feature = "tls")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "tls")))]
     pub fn tls_config(self, tls_config: ServerTlsConfig) -> Result<Self, Error> {
         Ok(Server {
             tls: Some(tls_config.tls_acceptor().map_err(Error::from_source)?),

--- a/tonic/src/transport/server/unix.rs
+++ b/tonic/src/transport/server/unix.rs
@@ -10,7 +10,6 @@ use std::sync::Arc;
 ///
 /// [ext]: crate::Request::extensions
 /// [Connected]: crate::transport::server::Connected
-#[cfg_attr(docsrs, doc(cfg(unix)))]
 #[derive(Clone, Debug)]
 pub struct UdsConnectInfo {
     /// Peer address. This will be "unnamed" for client unix sockets.


### PR DESCRIPTION
Uses `doc_auto_cfg` instead of manual implementation.