### PR TITLE
chore(router): Remove wrapper type for axum router

### DIFF
--- a/tonic/Cargo.toml
+++ b/tonic/Cargo.toml
@@ -31,7 +31,7 @@ prost = ["dep:prost"]
 tls = ["dep:rustls-pemfile", "dep:tokio-rustls", "dep:tokio", "tokio?/rt", "tokio?/macros"]
 tls-roots = ["tls", "channel", "dep:rustls-native-certs"]
 tls-webpki-roots = ["tls", "channel", "dep:webpki-roots"]
-router = ["dep:axum"]
+router = ["dep:axum", "dep:tower", "tower?/util"]
 server = [
   "router",
   "dep:async-stream",


### PR DESCRIPTION
This can be implemented by using tower's map_request.