### PR TITLE
chore(tls): Remove redundant reexport of TlsStream

### DIFF
--- a/tonic/src/transport/server/mod.rs
+++ b/tonic/src/transport/server/mod.rs
@@ -34,9 +34,6 @@ pub use unix::UdsConnectInfo;
 pub use incoming::TcpIncoming;
 
 #[cfg(feature = "tls")]
-pub(crate) use tokio_rustls::server::TlsStream;
-
-#[cfg(feature = "tls")]
 use crate::transport::Error;
 
 use self::service::{RecoverError, ServerIo};

--- a/tonic/src/transport/server/service/tls.rs
+++ b/tonic/src/transport/server/service/tls.rs
@@ -3,11 +3,12 @@ use std::{fmt, io::Cursor, sync::Arc};
 use tokio::io::{AsyncRead, AsyncWrite};
 use tokio_rustls::{
     rustls::{server::WebPkiClientVerifier, RootCertStore, ServerConfig},
+    server::TlsStream,
     TlsAcceptor as RustlsAcceptor,
 };
 
 use crate::transport::{
-    server::{Connected, TlsStream},
+    server::Connected,
     service::tls::{add_certs_from_pem, load_identity, ALPN_H2},
     Certificate, Identity,
 };


### PR DESCRIPTION
This reexport seems to be redundant.