### PR TITLE
feat(router): Reexport axum type without server feature

### DIFF
--- a/examples/src/h2c/server.rs
+++ b/examples/src/h2c/server.rs
@@ -71,7 +71,7 @@ mod h2c {
     use http::{Request, Response};
     use hyper::body::Incoming;
     use hyper_util::{rt::TokioExecutor, service::TowerToHyperService};
-    use tonic::{body::empty_body, transport::AxumBody};
+    use tonic::{body::empty_body, service::AxumBody};
     use tower::Service;
 
     #[derive(Clone)]

--- a/tonic/src/service/mod.rs
+++ b/tonic/src/service/mod.rs
@@ -9,3 +9,5 @@ pub use self::interceptor::{interceptor, Interceptor};
 #[doc(inline)]
 #[cfg(feature = "router")]
 pub use self::router::{Routes, RoutesBuilder};
+#[cfg(feature = "router")]
+pub use axum::{body::Body as AxumBody, Router as AxumRouter};

--- a/tonic/src/transport/mod.rs
+++ b/tonic/src/transport/mod.rs
@@ -111,8 +111,6 @@ pub use self::service::grpc_timeout::TimeoutExpired;
 
 #[cfg(feature = "tls")]
 pub use self::tls::Certificate;
-#[cfg(feature = "server")]
-pub use axum::{body::Body as AxumBody, Router as AxumRouter};
 pub use hyper::{body::Body, Uri};
 #[cfg(feature = "tls")]
 pub use tokio_rustls::rustls::pki_types::CertificateDer;


### PR DESCRIPTION
Reexport axum's type without server feature. When using the axum router, there seems not need to use the transport server implementation, so I think it would be appropriate to reexport it in the same place as the tonic routes.