### PR TITLE
chore(codec): Use as_str method to implement display for CompressionEncoding

### DIFF
--- a/tonic/src/codec/compression.rs
+++ b/tonic/src/codec/compression.rs
@@ -184,14 +184,8 @@ impl CompressionEncoding {
 }
 
 impl fmt::Display for CompressionEncoding {
-    #[allow(unused_variables)]
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match *self {
-            #[cfg(feature = "gzip")]
-            CompressionEncoding::Gzip => write!(f, "gzip"),
-            #[cfg(feature = "zstd")]
-            CompressionEncoding::Zstd => write!(f, "zstd"),
-        }
+        f.write_str(self.as_str())
     }
 }
 


### PR DESCRIPTION
Reduces duplicate similar implementations for the similar purpose.