### PR TITLE
feat(server): Deprecate method to convert router into axum router

### DIFF
--- a/tonic/src/transport/server/mod.rs
+++ b/tonic/src/transport/server/mod.rs
@@ -709,6 +709,7 @@ impl<L> Router<L> {
     }
 
     /// Convert this tonic `Router` into an axum `Router` consuming the tonic one.
+    #[deprecated(since = "0.12.2", note = "Use `Routes::into_router` instead.")]
     pub fn into_router(self) -> axum::Router {
         self.routes.into_router()
     }


### PR DESCRIPTION
This can be obtained from Routes directly.