### PR TITLE
chore: Replace unit struct with ordinary struct

### DIFF
--- a/examples/src/authentication/server.rs
+++ b/examples/src/authentication/server.rs
@@ -8,7 +8,7 @@ use tonic::{metadata::MetadataValue, transport::Server, Request, Response, Statu
 type EchoResult<T> = Result<Response<T>, Status>;
 
 #[derive(Default)]
-pub struct EchoServer;
+pub struct EchoServer {}
 
 #[tonic::async_trait]
 impl pb::echo_server::Echo for EchoServer {

--- a/examples/src/multiplex/server.rs
+++ b/examples/src/multiplex/server.rs
@@ -51,7 +51,7 @@ impl Greeter for MyGreeter {
 }
 
 #[derive(Default)]
-pub struct MyEcho;
+pub struct MyEcho {}
 
 #[tonic::async_trait]
 impl Echo for MyEcho {

--- a/examples/src/tls/server.rs
+++ b/examples/src/tls/server.rs
@@ -14,7 +14,7 @@ use tonic::{
 type EchoResult<T> = Result<Response<T>, Status>;
 
 #[derive(Default)]
-pub struct EchoServer;
+pub struct EchoServer {}
 
 #[tonic::async_trait]
 impl pb::echo_server::Echo for EchoServer {

--- a/examples/src/tls_client_auth/server.rs
+++ b/examples/src/tls_client_auth/server.rs
@@ -9,7 +9,7 @@ use tonic::{Request, Response, Status};
 type EchoResult<T> = Result<Response<T>, Status>;
 
 #[derive(Default)]
-pub struct EchoServer;
+pub struct EchoServer {}
 
 #[tonic::async_trait]
 impl pb::echo_server::Echo for EchoServer {

--- a/examples/src/tls_rustls/server.rs
+++ b/examples/src/tls_rustls/server.rs
@@ -91,7 +91,7 @@ struct ConnInfo {
 type EchoResult<T> = Result<Response<T>, Status>;
 
 #[derive(Default)]
-pub struct EchoServer;
+pub struct EchoServer {}
 
 #[tonic::async_trait]
 impl pb::echo_server::Echo for EchoServer {

--- a/examples/src/tower/server.rs
+++ b/examples/src/tower/server.rs
@@ -66,7 +66,7 @@ fn intercept(req: Request<()>) -> Result<Request<()>, Status> {
 }
 
 #[derive(Debug, Clone, Default)]
-struct MyMiddlewareLayer;
+struct MyMiddlewareLayer {}
 
 impl<S> Layer<S> for MyMiddlewareLayer {
     type Service = MyMiddleware<S>;

--- a/interop/src/server.rs
+++ b/interop/src/server.rs
@@ -14,7 +14,7 @@ pub use pb::test_service_server::TestServiceServer;
 pub use pb::unimplemented_service_server::UnimplementedServiceServer;
 
 #[derive(Default, Clone)]
-pub struct TestService;
+pub struct TestService {}
 
 type Result<T> = std::result::Result<Response<T>, Status>;
 type Streaming<T> = Request<tonic::Streaming<T>>;
@@ -156,7 +156,7 @@ impl pb::test_service_server::TestService for TestService {
 }
 
 #[derive(Default)]
-pub struct UnimplementedService;
+pub struct UnimplementedService {}
 
 #[tonic::async_trait]
 impl pb::unimplemented_service_server::UnimplementedService for UnimplementedService {


### PR DESCRIPTION
Resolves clippy warnings and improves codes consistency.