### PR TITLE
tonic-reflection: re-expose v1alpha reflection server builder

### DIFF
--- a/tonic-reflection/src/server/mod.rs
+++ b/tonic-reflection/src/server/mod.rs
@@ -7,6 +7,9 @@ mod v1;
 
 pub use v1::Builder;
 
+/// `v1alpha` variant of the gRPC Reflection Service
+pub mod v1alpha;
+
 /// Represents an error in the construction of a gRPC Reflection Service.
 #[derive(Debug)]
 pub enum Error {

--- a/tonic-reflection/src/server/v1alpha.rs
+++ b/tonic-reflection/src/server/v1alpha.rs
@@ -1,8 +1,8 @@
-use crate::pb::v1::server_reflection_server::{ServerReflection, ServerReflectionServer};
+pub use crate::pb::v1alpha::server_reflection_server::{ServerReflection, ServerReflectionServer};
 
-use crate::pb::v1::server_reflection_request::MessageRequest;
-use crate::pb::v1::server_reflection_response::MessageResponse;
-use crate::pb::v1::{
+use crate::pb::v1alpha::server_reflection_request::MessageRequest;
+use crate::pb::v1alpha::server_reflection_response::MessageResponse;
+use crate::pb::v1alpha::{
     ExtensionNumberResponse, FileDescriptorResponse, ListServiceResponse, ServerReflectionRequest,
     ServerReflectionResponse, ServiceResponse,
 };
@@ -19,7 +19,7 @@ use tonic::{Request, Response, Status, Streaming};
 
 use crate::server::Error;
 
-/// A builder used to construct a gRPC Reflection Service. (`v1` protocol variant)
+/// A builder used to construct a gRPC Reflection Service. (`v1alpha` protocol variant)
 #[derive(Debug)]
 pub struct Builder<'b> {
     file_descriptor_sets: Vec<FileDescriptorSet>,
@@ -83,7 +83,8 @@ impl<'b> Builder<'b> {
     /// Build a gRPC Reflection Service to be served via Tonic.
     pub fn build(mut self) -> Result<ServerReflectionServer<impl ServerReflection>, Error> {
         if self.include_reflection_service {
-            self = self.register_encoded_file_descriptor_set(crate::pb::v1::FILE_DESCRIPTOR_SET);
+            self =
+                self.register_encoded_file_descriptor_set(crate::pb::v1alpha::FILE_DESCRIPTOR_SET);
         }
 
         for encoded in &self.encoded_file_descriptor_sets {

--- a/tonic-reflection/tests/versions.rs
+++ b/tonic-reflection/tests/versions.rs
@@ -1,0 +1,170 @@
+use std::net::SocketAddr;
+use tokio::sync::oneshot;
+use tokio_stream::{wrappers::TcpListenerStream, StreamExt};
+use tonic::{transport::Server, Request};
+
+use tonic_reflection::pb::{v1, v1alpha};
+use tonic_reflection::server::v1alpha::Builder as V1AlphaBuilder;
+use tonic_reflection::server::Builder;
+
+#[tokio::test]
+async fn test_v1() {
+    let response = make_v1_request(v1::ServerReflectionRequest {
+        host: "".to_string(),
+        message_request: Some(v1::server_reflection_request::MessageRequest::ListServices(
+            String::new(),
+        )),
+    })
+    .await;
+
+    if let v1::server_reflection_response::MessageResponse::ListServicesResponse(services) =
+        response
+    {
+        assert_eq!(
+            services.service,
+            vec![v1::ServiceResponse {
+                name: String::from("grpc.reflection.v1.ServerReflection")
+            }]
+        );
+    } else {
+        panic!("Expected a ListServicesResponse variant");
+    }
+}
+
+#[tokio::test]
+async fn test_v1alpha() {
+    let response = make_v1alpha_request(v1alpha::ServerReflectionRequest {
+        host: "".to_string(),
+        message_request: Some(
+            v1alpha::server_reflection_request::MessageRequest::ListServices(String::new()),
+        ),
+    })
+    .await;
+
+    if let v1alpha::server_reflection_response::MessageResponse::ListServicesResponse(services) =
+        response
+    {
+        assert_eq!(
+            services.service,
+            vec![v1alpha::ServiceResponse {
+                name: String::from("grpc.reflection.v1alpha.ServerReflection")
+            }]
+        );
+    } else {
+        panic!("Expected a ListServicesResponse variant");
+    }
+}
+
+async fn make_v1_request(
+    request: v1::ServerReflectionRequest,
+) -> v1::server_reflection_response::MessageResponse {
+    // Run a test server
+    let (shutdown_tx, shutdown_rx) = oneshot::channel();
+
+    let addr: SocketAddr = "127.0.0.1:0".parse().expect("SocketAddr parse");
+    let listener = tokio::net::TcpListener::bind(addr).await.expect("bind");
+    let local_addr = format!("http://{}", listener.local_addr().expect("local address"));
+    let jh = tokio::spawn(async move {
+        let service = Builder::configure().build().unwrap();
+
+        Server::builder()
+            .add_service(service)
+            .serve_with_incoming_shutdown(TcpListenerStream::new(listener), async {
+                drop(shutdown_rx.await)
+            })
+            .await
+            .unwrap();
+    });
+
+    // Give the test server a few ms to become available
+    tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+
+    // Construct client and send request, extract response
+    let conn = tonic::transport::Endpoint::new(local_addr)
+        .unwrap()
+        .connect()
+        .await
+        .unwrap();
+    let mut client = v1::server_reflection_client::ServerReflectionClient::new(conn);
+
+    let request = Request::new(tokio_stream::once(request));
+    let mut inbound = client
+        .server_reflection_info(request)
+        .await
+        .expect("request")
+        .into_inner();
+
+    let response = inbound
+        .next()
+        .await
+        .expect("steamed response")
+        .expect("successful response")
+        .message_response
+        .expect("some MessageResponse");
+
+    // We only expect one response per request
+    assert!(inbound.next().await.is_none());
+
+    // Shut down test server
+    shutdown_tx.send(()).expect("send shutdown");
+    jh.await.expect("server shutdown");
+
+    response
+}
+
+async fn make_v1alpha_request(
+    request: v1alpha::ServerReflectionRequest,
+) -> v1alpha::server_reflection_response::MessageResponse {
+    // Run a test server
+    let (shutdown_tx, shutdown_rx) = oneshot::channel();
+
+    let addr: SocketAddr = "127.0.0.1:0".parse().expect("SocketAddr parse");
+    let listener = tokio::net::TcpListener::bind(addr).await.expect("bind");
+    let local_addr = format!("http://{}", listener.local_addr().expect("local address"));
+    let jh = tokio::spawn(async move {
+        let service = V1AlphaBuilder::configure().build().unwrap();
+
+        Server::builder()
+            .add_service(service)
+            .serve_with_incoming_shutdown(TcpListenerStream::new(listener), async {
+                drop(shutdown_rx.await)
+            })
+            .await
+            .unwrap();
+    });
+
+    // Give the test server a few ms to become available
+    tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+
+    // Construct client and send request, extract response
+    let conn = tonic::transport::Endpoint::new(local_addr)
+        .unwrap()
+        .connect()
+        .await
+        .unwrap();
+    let mut client = v1alpha::server_reflection_client::ServerReflectionClient::new(conn);
+
+    let request = Request::new(tokio_stream::once(request));
+    let mut inbound = client
+        .server_reflection_info(request)
+        .await
+        .expect("request")
+        .into_inner();
+
+    let response = inbound
+        .next()
+        .await
+        .expect("steamed response")
+        .expect("successful response")
+        .message_response
+        .expect("some MessageResponse");
+
+    // We only expect one response per request
+    assert!(inbound.next().await.is_none());
+
+    // Shut down test server
+    shutdown_tx.send(()).expect("send shutdown");
+    jh.await.expect("server shutdown");
+
+    response
+}


### PR DESCRIPTION
While testing the new tonic 0.12 release, we discovered that https://github.com/hyperium/tonic/pull/1701 upgraded the reflection protocol to `v1` from `v1alpha`.

This breaks compatibility with popular gRPC debugging tools like `Postman` and `Kreya`, who only use the `v1alpha` protocol.

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/hyperium/tonic/blob/master/CONTRIBUTING.md
-->

## Motivation

Upgrading to 0.12 would potentially introduce a degradation in triaging flows since tools supporting the `v1` protocol are limited.

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? If a new feature is being added, describe the intended
use case that feature fulfills.
-->

## Solution

Following the https://github.com/hyperium/tonic/pull/1802 PR, this reintroduces the `v1alpha` protocol in a separate module.

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
