### PR TITLE
add example for rust-protobuf codec

### DIFF
--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -264,6 +264,14 @@ path = "src/codec_buffers/server.rs"
 name = "codec-buffers-client"
 path = "src/codec_buffers/client.rs"
 
+[[bin]]
+name = "protobuf-codec-server"
+path = "src/protobuf-codec/server.rs"
+
+[[bin]]
+name = "protobuf-codec-client"
+path = "src/protobuf-codec/client.rs"
+
 
 [features]
 gcp = ["dep:prost-types", "tonic/tls"]
@@ -324,6 +332,11 @@ hyper-rustls = { version = "0.27.0", features = ["http2", "ring", "tls12"], opti
 rustls-pemfile = { version = "2.0.0", optional = true }
 tower-http = { version = "0.5", optional = true }
 pin-project = { version = "1.0.11", optional = true }
+protobuf = "3.5.0"
 
 [build-dependencies]
 tonic-build = { path = "../tonic-build", features = ["prost"] }
+protobuf = "3.5.0"
+heck = "0.5.0"
+protobuf-parse = "3.5.0"
+protobuf-codegen = "3.5.0"

--- a/examples/src/protobuf-codec/client.rs
+++ b/examples/src/protobuf-codec/client.rs
@@ -1,0 +1,27 @@
+mod codec;
+mod protos;
+
+pub mod hello_world {
+    include!(concat!(
+        env!("OUT_DIR"),
+        "/protobuf_codec/helloworld.Greeter.rs"
+    ));
+}
+use crate::protos::helloworld::HelloRequest;
+use hello_world::greeter_client::GreeterClient;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let mut client = GreeterClient::connect("http://[::1]:50051").await?;
+
+    let request = tonic::Request::new(HelloRequest {
+        name: "Tonic".into(),
+        ..Default::default()
+    });
+
+    let response = client.say_hello(request).await?;
+
+    println!("RESPONSE={:?}", response);
+
+    Ok(())
+}

--- a/examples/src/protobuf-codec/codec.rs
+++ b/examples/src/protobuf-codec/codec.rs
@@ -1,0 +1,65 @@
+use bytes::{Buf, BufMut};
+use protobuf::Message;
+use std::marker::PhantomData;
+use tonic::codec::{Codec, DecodeBuf, Decoder, EncodeBuf, Encoder};
+use tonic::Status;
+
+pub struct ProtobufCodec<T, U>(PhantomData<(T, U)>);
+
+impl<T, U> Default for ProtobufCodec<T, U> {
+    fn default() -> Self {
+        Self(PhantomData)
+    }
+}
+
+impl<T, U> Codec for ProtobufCodec<T, U>
+where
+    T: Message,
+    U: Message,
+{
+    type Encode = T;
+    type Decode = U;
+    type Encoder = ProtobufEncoder<T>;
+    type Decoder = ProtobufDecoder<U>;
+
+    fn encoder(&mut self) -> Self::Encoder {
+        ProtobufEncoder(PhantomData)
+    }
+
+    fn decoder(&mut self) -> Self::Decoder {
+        ProtobufDecoder(PhantomData)
+    }
+}
+
+pub struct ProtobufEncoder<T>(PhantomData<T>);
+
+impl<T> Encoder for ProtobufEncoder<T>
+where
+    T: Message,
+{
+    type Item = T;
+    type Error = Status;
+
+    fn encode(&mut self, item: Self::Item, dst: &mut EncodeBuf<'_>) -> Result<(), Self::Error> {
+        Ok(item
+            .write_to_writer(&mut dst.writer())
+            .map_err(|_| Status::internal("failed to encode"))?)
+    }
+}
+
+pub struct ProtobufDecoder<U>(PhantomData<U>);
+
+impl<U> Decoder for ProtobufDecoder<U>
+where
+    U: Message,
+{
+    type Item = U;
+    type Error = Status;
+
+    fn decode(&mut self, src: &mut DecodeBuf<'_>) -> Result<Option<Self::Item>, Self::Error> {
+        Ok(Some(
+            U::parse_from_reader(&mut src.reader())
+                .map_err(|_| Status::invalid_argument("bad request"))?,
+        ))
+    }
+}

--- a/examples/src/protobuf-codec/protos.rs
+++ b/examples/src/protobuf-codec/protos.rs
@@ -1,0 +1,1 @@
+include!(concat!(env!("OUT_DIR"), "/protos/mod.rs"));

--- a/examples/src/protobuf-codec/server.rs
+++ b/examples/src/protobuf-codec/server.rs
@@ -1,0 +1,47 @@
+use tonic::{transport::Server, Request, Response, Status};
+
+mod codec;
+mod protos;
+
+pub mod hello_world {
+    include!(concat!(
+        env!("OUT_DIR"),
+        "/protobuf_codec/helloworld.Greeter.rs"
+    ));
+}
+use crate::protos::helloworld::{HelloReply, HelloRequest};
+use hello_world::greeter_server::{Greeter, GreeterServer};
+
+#[derive(Default)]
+pub struct MyGreeter {}
+
+#[tonic::async_trait]
+impl Greeter for MyGreeter {
+    async fn say_hello(
+        &self,
+        request: Request<HelloRequest>,
+    ) -> Result<Response<HelloReply>, Status> {
+        println!("Got a request from {:?}", request.remote_addr());
+
+        let reply = HelloReply {
+            message: format!("Hello {}!", request.into_inner().name),
+            ..Default::default()
+        };
+        Ok(Response::new(reply))
+    }
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let addr = "[::1]:50051".parse().unwrap();
+    let greeter = MyGreeter::default();
+
+    println!("GreeterServer listening on {}", addr);
+
+    Server::builder()
+        .add_service(GreeterServer::new(greeter))
+        .serve(addr)
+        .await?;
+
+    Ok(())
+}


### PR DESCRIPTION
## Motivation

I've found the rust-protobuf crate to have some features which prost doesn't have (namely retaining unknown fields). I want to use tonic (codegen and all) with rust-protobuf as seamlessly as with prost.

## Solution
This is an example of how I setup codgen and a codec to work as a drop in replacement for prost.

## Looking for feedback

I'm looking for feedback about whether there's a better home for this glue to live. Should this be a first party feature in tonic instead of something in the examples folder? I considered putting it in its own crate but it didn't seem to generalize well.  Should it go in rust-protobuf?