### PR TITLE
chore(examples): Remove clone on copy value

### DIFF
--- a/examples/routeguide-tutorial.md
+++ b/examples/routeguide-tutorial.md
@@ -498,7 +498,7 @@ async fn route_chat(
         while let Some(note) = stream.next().await {
             let note = note?;
 
-            let location = note.location.clone().unwrap();
+            let location = note.location.unwrap();
 
             let location_notes = notes.entry(location).or_insert(vec![]);
             location_notes.push(note);

--- a/examples/src/routeguide/server.rs
+++ b/examples/src/routeguide/server.rs
@@ -116,7 +116,7 @@ impl RouteGuide for RouteGuideService {
             while let Some(note) = stream.next().await {
                 let note = note?;
 
-                let location = note.location.clone().unwrap();
+                let location = note.location.unwrap();
 
                 let location_notes = notes.entry(location).or_insert(vec![]);
                 location_notes.push(note);


### PR DESCRIPTION
Removes clone of the value which implements copy trait.