### PR TITLE
chore(server): Remove unnecessary trait bound from ServerIo::connect_info

### DIFF
--- a/tonic/src/transport/server/service/io.rs
+++ b/tonic/src/transport/server/service/io.rs
@@ -32,25 +32,14 @@ impl<IO> ServerIo<IO> {
         Self::TlsIo(Box::new(io))
     }
 
-    #[cfg(feature = "tls")]
     pub(in crate::transport) fn connect_info(&self) -> ServerIoConnectInfo<IO>
     where
         IO: Connected,
-        TlsStream<IO>: Connected,
     {
         match self {
             Self::Io(io) => Either::A(io.connect_info()),
+            #[cfg(feature = "tls")]
             Self::TlsIo(io) => Either::B(io.connect_info()),
-        }
-    }
-
-    #[cfg(not(feature = "tls"))]
-    pub(in crate::transport) fn connect_info(&self) -> ServerIoConnectInfo<IO>
-    where
-        IO: Connected,
-    {
-        match self {
-            Self::Io(io) => Either::A(io.connect_info()),
         }
     }
 }


### PR DESCRIPTION
This trait bound is satisfied by the IO bound.