### PR TITLE
tonic-reflection: Restructure module to prep reintroducing v1alpha

### DIFF
--- a/tonic-reflection/src/server/mod.rs
+++ b/tonic-reflection/src/server/mod.rs
@@ -1,0 +1,36 @@
+pub use crate::pb::v1::server_reflection_server::{ServerReflection, ServerReflectionServer};
+
+use prost::DecodeError;
+use std::fmt::{Display, Formatter};
+
+mod v1;
+
+pub use v1::Builder;
+
+/// Represents an error in the construction of a gRPC Reflection Service.
+#[derive(Debug)]
+pub enum Error {
+    /// An error was encountered decoding a `prost_types::FileDescriptorSet` from a buffer.
+    DecodeError(prost::DecodeError),
+    /// An invalid `prost_types::FileDescriptorProto` was encountered.
+    InvalidFileDescriptorSet(String),
+}
+
+impl From<DecodeError> for Error {
+    fn from(e: DecodeError) -> Self {
+        Error::DecodeError(e)
+    }
+}
+
+impl std::error::Error for Error {}
+
+impl Display for Error {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Error::DecodeError(_) => f.write_str("error decoding FileDescriptorSet from buffer"),
+            Error::InvalidFileDescriptorSet(s) => {
+                write!(f, "invalid FileDescriptorSet - {}", s)
+            }
+        }
+    }
+}

--- a/tonic-reflection/src/server/v1.rs
+++ b/tonic-reflection/src/server/v1.rs
@@ -1,4 +1,4 @@
-pub use crate::pb::v1::server_reflection_server::{ServerReflection, ServerReflectionServer};
+use crate::pb::v1::server_reflection_server::{ServerReflection, ServerReflectionServer};
 
 use crate::pb::v1::server_reflection_request::MessageRequest;
 use crate::pb::v1::server_reflection_response::MessageResponse;
@@ -6,45 +6,18 @@ use crate::pb::v1::{
     ExtensionNumberResponse, FileDescriptorResponse, ListServiceResponse, ServerReflectionRequest,
     ServerReflectionResponse, ServiceResponse,
 };
-use prost::{DecodeError, Message};
+use prost::Message;
 use prost_types::{
     DescriptorProto, EnumDescriptorProto, FieldDescriptorProto, FileDescriptorProto,
     FileDescriptorSet,
 };
 use std::collections::HashMap;
-use std::fmt::{Display, Formatter};
 use std::sync::Arc;
 use tokio::sync::mpsc;
 use tokio_stream::{wrappers::ReceiverStream, StreamExt};
 use tonic::{Request, Response, Status, Streaming};
 
-/// Represents an error in the construction of a gRPC Reflection Service.
-#[derive(Debug)]
-pub enum Error {
-    /// An error was encountered decoding a `prost_types::FileDescriptorSet` from a buffer.
-    DecodeError(prost::DecodeError),
-    /// An invalid `prost_types::FileDescriptorProto` was encountered.
-    InvalidFileDescriptorSet(String),
-}
-
-impl From<DecodeError> for Error {
-    fn from(e: DecodeError) -> Self {
-        Error::DecodeError(e)
-    }
-}
-
-impl std::error::Error for Error {}
-
-impl Display for Error {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Error::DecodeError(_) => f.write_str("error decoding FileDescriptorSet from buffer"),
-            Error::InvalidFileDescriptorSet(s) => {
-                write!(f, "invalid FileDescriptorSet - {}", s)
-            }
-        }
-    }
-}
+use crate::server::Error;
 
 /// A builder used to construct a gRPC Reflection Service.
 #[derive(Debug)]


### PR DESCRIPTION
To simplify API verification, this is a prepatory change to shift around the v1 support to allow for a cleaner v1alpha reintroduction.

* Created a multi-file version of the server.rs module
  * Added mod.rs containing the base `Error` with associated imports / exports
  * Added v1.rs containing the v1 version of the reflection server

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/hyperium/tonic/blob/master/CONTRIBUTING.md
-->

## Motivation

The current `v1` reflection API support is lacking in various existing tools (like *Postman* and *Kreya*).

From feedback in https://github.com/hyperium/tonic/pull/1787, we should split the change into multiple PRs.

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? If a new feature is being added, describe the intended
use case that feature fulfills.
-->

## Solution

This change splits the server module to enable us to re-add the `v1alpha` support in a later PR a cleaner fashion.

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
