### PR TITLE
chore(tonic): Move TimeoutExpired out of transport

### DIFF
--- a/tonic/src/lib.rs
+++ b/tonic/src/lib.rs
@@ -120,7 +120,7 @@ pub use extensions::GrpcMethod;
 pub use http::Extensions;
 pub use request::{IntoRequest, IntoStreamingRequest, Request};
 pub use response::Response;
-pub use status::{Code, Status};
+pub use status::{Code, Status, TimeoutExpired};
 
 pub(crate) type Error = Box<dyn std::error::Error + Send + Sync>;
 

--- a/tonic/src/transport/mod.rs
+++ b/tonic/src/transport/mod.rs
@@ -106,8 +106,6 @@ pub use self::error::Error;
 #[doc(inline)]
 #[cfg(feature = "server")]
 pub use self::server::Server;
-#[doc(inline)]
-pub use self::service::grpc_timeout::TimeoutExpired;
 
 #[cfg(feature = "tls")]
 pub use self::tls::Certificate;

--- a/tonic/src/transport/service/grpc_timeout.rs
+++ b/tonic/src/transport/service/grpc_timeout.rs
@@ -1,8 +1,7 @@
-use crate::metadata::GRPC_TIMEOUT_HEADER;
+use crate::{metadata::GRPC_TIMEOUT_HEADER, TimeoutExpired};
 use http::{HeaderMap, HeaderValue, Request};
 use pin_project::pin_project;
 use std::{
-    fmt,
     future::Future,
     pin::Pin,
     task::{ready, Context, Poll},
@@ -146,26 +145,6 @@ fn try_parse_grpc_timeout(
         None => Ok(None),
     }
 }
-
-/// Error returned if a request didn't complete within the configured timeout.
-///
-/// Timeouts can be configured either with [`Endpoint::timeout`], [`Server::timeout`], or by
-/// setting the [`grpc-timeout` metadata value][spec].
-///
-/// [`Endpoint::timeout`]: crate::transport::server::Server::timeout
-/// [`Server::timeout`]: crate::transport::channel::Endpoint::timeout
-/// [spec]: https://github.com/grpc/grpc/blob/master/doc/PROTOCOL-HTTP2.md
-#[derive(Debug)]
-pub struct TimeoutExpired(());
-
-impl fmt::Display for TimeoutExpired {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "Timeout expired")
-    }
-}
-
-// std::error::Error only requires a type to impl Debug and Display
-impl std::error::Error for TimeoutExpired {}
 
 #[cfg(test)]
 mod tests {


### PR DESCRIPTION
By moving the TimeoutExpired type from the transport module to the the tonic engine proper, the type is made available to other transport implementations and tonic can be built without the "server" feature while still returning a Status indicating the timeout.

Alternative transport implementations can use the type, now that it is moved, when they want the tonic Status error handling to recognize the error as having been triggered by a timeout in the transport logic. The tonic Status error will have a code of Cancelled with a message of "Timeout expired".

There is already a test for this:

    cargo test picks_server_timeout_if_thats_sorter

which worked the original way and contines to work; but now a new transport implementation can get the same behavior.

Addresses #1825.