### PR TITLE
chore(test): Use http crate directly

### DIFF
--- a/tests/integration_tests/Cargo.toml
+++ b/tests/integration_tests/Cargo.toml
@@ -19,7 +19,6 @@ tracing-subscriber = {version = "0.3"}
 async-stream = "0.3"
 http = "1"
 http-body = "1"
-hyper = "1"
 hyper-util = "0.1"
 tokio-stream = {version = "0.1.5", features = ["net"]}
 tower = {version = "0.4", features = []}

--- a/tests/integration_tests/tests/extensions.rs
+++ b/tests/integration_tests/tests/extensions.rs
@@ -1,4 +1,3 @@
-use hyper::{Request as HyperRequest, Response as HyperResponse};
 use integration_tests::{
     pb::{test_client, test_server, Input, Output},
     BoxFuture,
@@ -113,9 +112,9 @@ struct InterceptedService<S> {
     inner: S,
 }
 
-impl<S> Service<HyperRequest<BoxBody>> for InterceptedService<S>
+impl<S> Service<http::Request<BoxBody>> for InterceptedService<S>
 where
-    S: Service<HyperRequest<BoxBody>, Response = HyperResponse<BoxBody>>
+    S: Service<http::Request<BoxBody>, Response = http::Response<BoxBody>>
         + NamedService
         + Clone
         + Send
@@ -130,7 +129,7 @@ where
         self.inner.poll_ready(cx)
     }
 
-    fn call(&mut self, mut req: HyperRequest<BoxBody>) -> Self::Future {
+    fn call(&mut self, mut req: http::Request<BoxBody>) -> Self::Future {
         let clone = self.inner.clone();
         let mut inner = std::mem::replace(&mut self.inner, clone);
 


### PR DESCRIPTION
Uses `http` crate directly.