### PR TITLE
chore: Update to EmbarkStudios/cargo-deny-action@v2

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -27,7 +27,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
-    - uses: EmbarkStudios/cargo-deny-action@v1
+    - uses: EmbarkStudios/cargo-deny-action@v2
 
   codegen:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Allows `workspace-duplicates` which is introduced at `cargo-deny` [0.15](https://github.com/EmbarkStudios/cargo-deny/releases/tag/0.15.0), and `BSD-2-Clause` which is newly pulled in dependencies.