### PR TITLE
chore: Allow 2-clause BSD licenses

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -35,7 +35,8 @@ allow = [
     "Zlib",
     "Unicode-DFS-2016",
     "MPL-2.0",
-    "BSD-3-Clause"
+    "BSD-2-Clause",
+    "BSD-3-Clause",
 ]
 
 [[licenses.clarify]]


### PR DESCRIPTION
## Motivation

cargo deny failed in https://github.com/hyperium/tonic/actions/runs/10198566819/job/28213729309?pr=1829 due to the 2-clause BSD license which is used by the zerocopy crate (via rand -> rand_chacha -> ppv-lite86).