### PR TITLE
chore(test): Replace unit struct with ordinary struct

### DIFF
--- a/tonic/src/codec/prost.rs
+++ b/tonic/src/codec/prost.rs
@@ -313,7 +313,7 @@ mod tests {
     }
 
     #[derive(Debug, Clone, Default)]
-    struct MockEncoder;
+    struct MockEncoder {}
 
     impl Encoder for MockEncoder {
         type Item = Vec<u8>;
@@ -330,7 +330,7 @@ mod tests {
     }
 
     #[derive(Debug, Clone, Default)]
-    struct MockDecoder;
+    struct MockDecoder {}
 
     impl Decoder for MockDecoder {
         type Item = Vec<u8>;


### PR DESCRIPTION
Replaces unit struct with ordinary struct.