### PR TITLE
chore(codec): Use method chain style

### DIFF
--- a/tonic/src/codec/compression.rs
+++ b/tonic/src/codec/compression.rs
@@ -205,7 +205,7 @@ pub(crate) fn compress(
     out_buf.reserve(capacity);
 
     #[cfg(any(feature = "gzip", feature = "zstd"))]
-    let mut out_writer = bytes::BufMut::writer(out_buf);
+    let mut out_writer = out_buf.writer();
 
     match settings.encoding {
         #[cfg(feature = "gzip")]
@@ -248,7 +248,7 @@ pub(crate) fn decompress(
     out_buf.reserve(capacity);
 
     #[cfg(any(feature = "gzip", feature = "zstd"))]
-    let mut out_writer = bytes::BufMut::writer(out_buf);
+    let mut out_writer = out_buf.writer();
 
     match settings.encoding {
         #[cfg(feature = "gzip")]


### PR DESCRIPTION
Seems not to be needed to use fully qualified syntax.