### PR TITLE
chore: Remove BSD-2-Clause from cargo-deny config

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -35,7 +35,6 @@ allow = [
     "Zlib",
     "Unicode-DFS-2016",
     "MPL-2.0",
-    "BSD-2-Clause",
     "BSD-3-Clause",
 ]
 


### PR DESCRIPTION
BSD-2-Clause seems not to be needed.