### PR TITLE
chore(examples): Call Routes::prepare

### DIFF
--- a/examples/src/h2c/server.rs
+++ b/examples/src/h2c/server.rs
@@ -39,7 +39,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!("GreeterServer listening on {}", addr);
 
     let incoming = TcpListener::bind(addr).await?;
-    let svc = Routes::new(GreeterServer::new(greeter));
+    let svc = Routes::new(GreeterServer::new(greeter)).prepare();
 
     let h2c = h2c::H2c { s: svc };
 

--- a/examples/src/tls_rustls/server.rs
+++ b/examples/src/tls_rustls/server.rs
@@ -39,7 +39,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let server = EchoServer::default();
 
-    let svc = Routes::new(pb::echo_server::EchoServer::new(server));
+    let svc = Routes::new(pb::echo_server::EchoServer::new(server)).prepare();
 
     let http = Builder::new(TokioExecutor::new());
 


### PR DESCRIPTION
Calls `Routes::prepare` in examples.