### PR TITLE
feat(router): Rename Routes::into_router with into_axum_router

### DIFF
--- a/tonic/src/service/router.rs
+++ b/tonic/src/service/router.rs
@@ -96,7 +96,13 @@ impl Routes {
     }
 
     /// Convert this `Routes` into an [`axum::Router`].
+    #[deprecated(since = "0.12.2", note = "Use `Routes::into_axum_router` instead.")]
     pub fn into_router(self) -> axum::Router {
+        self.into_axum_router()
+    }
+
+    /// Convert this `Routes` into an [`axum::Router`].
+    pub fn into_axum_router(self) -> axum::Router {
         self.router
     }
 }

--- a/tonic/src/transport/server/mod.rs
+++ b/tonic/src/transport/server/mod.rs
@@ -709,9 +709,9 @@ impl<L> Router<L> {
     }
 
     /// Convert this tonic `Router` into an axum `Router` consuming the tonic one.
-    #[deprecated(since = "0.12.2", note = "Use `Routes::into_router` instead.")]
+    #[deprecated(since = "0.12.2", note = "Use `Routes::into_axum_router` instead.")]
     pub fn into_router(self) -> axum::Router {
-        self.routes.into_router()
+        self.routes.into_axum_router()
     }
 
     /// Consume this [`Server`] creating a future that will execute the server


### PR DESCRIPTION
To describe what the method does more clearly, I would suppose that `Routes::into_axum_router` is more appropriate method name.