### PR TITLE
fix(tonic-build,tonic) Add back TLS handling in genereated `Client::connect` code

### DIFF
--- a/tests/integration_tests/tests/connection.rs
+++ b/tests/integration_tests/tests/connection.rs
@@ -22,9 +22,13 @@ impl test_server::Test for Svc {
 #[tokio::test]
 async fn connect_returns_err() {
     let res = TestClient::connect("http://thisdoesntexist").await;
-    dbg!(&res);
 
     assert!(res.is_err());
+}
+
+#[tokio::test]
+async fn connect_handles_tls() {
+    TestClient::connect("https://example.com").await.unwrap();
 }
 
 #[tokio::test]

--- a/tests/integration_tests/tests/connection.rs
+++ b/tests/integration_tests/tests/connection.rs
@@ -22,6 +22,7 @@ impl test_server::Test for Svc {
 #[tokio::test]
 async fn connect_returns_err() {
     let res = TestClient::connect("http://thisdoesntexist").await;
+    dbg!(&res);
 
     assert!(res.is_err());
 }

--- a/tonic/src/transport/channel/endpoint.rs
+++ b/tonic/src/transport/channel/endpoint.rs
@@ -50,21 +50,8 @@ impl Endpoint {
     {
         let me = dst.try_into().map_err(|e| Error::from_source(e.into()))?;
         #[cfg(feature = "tls")]
-        if let Some(tls_config) = me
-            .uri
-            .scheme()
-            .map(|s| s.as_str() == http::uri::Scheme::HTTPS.as_str())
-            .unwrap_or(false)
-            .then(|| {
-                let config = ClientTlsConfig::new();
-                #[cfg(feature = "tls-native-roots")]
-                let config = config.with_native_roots();
-                #[cfg(feature = "tls-webpki-roots")]
-                let config = config.with_webpki_roots();
-                config
-            })
-        {
-            return me.tls_config(tls_config);
+        if me.uri.scheme() == Some(&http::uri::Scheme::HTTPS) {
+            return me.tls_config(ClientTlsConfig::new().with_enabled_roots());
         }
 
         Ok(me)

--- a/tonic/src/transport/channel/tls.rs
+++ b/tonic/src/transport/channel/tls.rs
@@ -81,6 +81,16 @@ impl ClientTlsConfig {
         }
     }
 
+    /// Activates all TLS roots enabled through `tls-*-roots` feature flags
+    pub fn with_enabled_roots(self) -> Self {
+        let config = ClientTlsConfig::new();
+        #[cfg(feature = "tls-native-roots")]
+        let config = config.with_native_roots();
+        #[cfg(feature = "tls-webpki-roots")]
+        let config = config.with_webpki_roots();
+        config
+    }
+
     pub(crate) fn into_tls_connector(self, uri: &Uri) -> Result<TlsConnector, crate::Error> {
         let domain = match &self.domain {
             Some(domain) => domain,


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/hyperium/tonic/blob/master/CONTRIBUTING.md
-->

## Motivation
The recent breaking change in https://github.com/hyperium/tonic/pull/1731 removed the ability for generated client functions to connect to HTTPS endpoints through strings alone.
For example the doctest below  would fail in 0.12.x `tonic-build` connection code:
https://github.com/hyperium/tonic/blob/03913b987ea75ac6902799f0cfa36b583b5d40e1/tonic/src/transport/channel/endpoint.rs#L79-L82

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? If a new feature is being added, describe the intended
use case that feature fulfills.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
This PR introduces a best attempt at picking up tls feature flags in `Endpoint::new` to allow successfully connecting to strings that contain `https://` once more
