### PR TITLE
Remove unnecessary trait bounds from server

### DIFF
--- a/tonic-build/src/server.rs
+++ b/tonic-build/src/server.rs
@@ -52,7 +52,7 @@ pub(crate) fn generate_internal<T: Service>(
         generate_doc_comments(service.comment())
     };
 
-    let named = generate_named(&server_service, &server_trait, &service_name);
+    let named = generate_named(&server_service, &service_name);
     let mod_attributes = attributes.for_mod(package);
     let struct_attributes = attributes.for_struct(&service_name);
 
@@ -110,7 +110,7 @@ pub(crate) fn generate_internal<T: Service>(
             #service_doc
             #(#struct_attributes)*
             #[derive(Debug)]
-            pub struct #server_service<T: #server_trait> {
+            pub struct #server_service<T> {
                 inner: Arc<T>,
                 accept_compression_encodings: EnabledCompressionEncodings,
                 send_compression_encodings: EnabledCompressionEncodings,
@@ -118,7 +118,7 @@ pub(crate) fn generate_internal<T: Service>(
                 max_encoding_message_size: Option<usize>,
             }
 
-            impl<T: #server_trait> #server_service<T> {
+            impl<T> #server_service<T> {
                 pub fn new(inner: T) -> Self {
                     Self::from_arc(Arc::new(inner))
                 }
@@ -175,7 +175,7 @@ pub(crate) fn generate_internal<T: Service>(
                 }
             }
 
-            impl<T: #server_trait> Clone for #server_service<T> {
+            impl<T> Clone for #server_service<T> {
                 fn clone(&self) -> Self {
                     let inner = self.inner.clone();
                     Self {
@@ -352,11 +352,7 @@ fn generate_trait_methods<T: Service>(
     stream
 }
 
-fn generate_named(
-    server_service: &syn::Ident,
-    server_trait: &syn::Ident,
-    service_name: &str,
-) -> TokenStream {
+fn generate_named(server_service: &syn::Ident, service_name: &str) -> TokenStream {
     let service_name = syn::LitStr::new(service_name, proc_macro2::Span::call_site());
     let name_doc = generate_doc_comment(" Generated gRPC service name");
 
@@ -364,7 +360,7 @@ fn generate_named(
         #name_doc
         pub const SERVICE_NAME: &'static str = #service_name;
 
-        impl<T: #server_trait> tonic::server::NamedService for #server_service<T> {
+        impl<T> tonic::server::NamedService for #server_service<T> {
             const NAME: &'static str = SERVICE_NAME;
         }
     }

--- a/tonic-health/src/generated/grpc_health_v1.rs
+++ b/tonic-health/src/generated/grpc_health_v1.rs
@@ -243,14 +243,14 @@ pub mod health_server {
         ) -> std::result::Result<tonic::Response<Self::WatchStream>, tonic::Status>;
     }
     #[derive(Debug)]
-    pub struct HealthServer<T: Health> {
+    pub struct HealthServer<T> {
         inner: Arc<T>,
         accept_compression_encodings: EnabledCompressionEncodings,
         send_compression_encodings: EnabledCompressionEncodings,
         max_decoding_message_size: Option<usize>,
         max_encoding_message_size: Option<usize>,
     }
-    impl<T: Health> HealthServer<T> {
+    impl<T> HealthServer<T> {
         pub fn new(inner: T) -> Self {
             Self::from_arc(Arc::new(inner))
         }
@@ -427,7 +427,7 @@ pub mod health_server {
             }
         }
     }
-    impl<T: Health> Clone for HealthServer<T> {
+    impl<T> Clone for HealthServer<T> {
         fn clone(&self) -> Self {
             let inner = self.inner.clone();
             Self {
@@ -441,7 +441,7 @@ pub mod health_server {
     }
     /// Generated gRPC service name
     pub const SERVICE_NAME: &'static str = "grpc.health.v1.Health";
-    impl<T: Health> tonic::server::NamedService for HealthServer<T> {
+    impl<T> tonic::server::NamedService for HealthServer<T> {
         const NAME: &'static str = SERVICE_NAME;
     }
 }

--- a/tonic-reflection/src/generated/grpc_reflection_v1.rs
+++ b/tonic-reflection/src/generated/grpc_reflection_v1.rs
@@ -291,14 +291,14 @@ pub mod server_reflection_server {
         >;
     }
     #[derive(Debug)]
-    pub struct ServerReflectionServer<T: ServerReflection> {
+    pub struct ServerReflectionServer<T> {
         inner: Arc<T>,
         accept_compression_encodings: EnabledCompressionEncodings,
         send_compression_encodings: EnabledCompressionEncodings,
         max_decoding_message_size: Option<usize>,
         max_encoding_message_size: Option<usize>,
     }
-    impl<T: ServerReflection> ServerReflectionServer<T> {
+    impl<T> ServerReflectionServer<T> {
         pub fn new(inner: T) -> Self {
             Self::from_arc(Arc::new(inner))
         }
@@ -436,7 +436,7 @@ pub mod server_reflection_server {
             }
         }
     }
-    impl<T: ServerReflection> Clone for ServerReflectionServer<T> {
+    impl<T> Clone for ServerReflectionServer<T> {
         fn clone(&self) -> Self {
             let inner = self.inner.clone();
             Self {
@@ -450,7 +450,7 @@ pub mod server_reflection_server {
     }
     /// Generated gRPC service name
     pub const SERVICE_NAME: &'static str = "grpc.reflection.v1.ServerReflection";
-    impl<T: ServerReflection> tonic::server::NamedService for ServerReflectionServer<T> {
+    impl<T> tonic::server::NamedService for ServerReflectionServer<T> {
         const NAME: &'static str = SERVICE_NAME;
     }
 }

--- a/tonic-reflection/src/generated/grpc_reflection_v1alpha.rs
+++ b/tonic-reflection/src/generated/grpc_reflection_v1alpha.rs
@@ -291,14 +291,14 @@ pub mod server_reflection_server {
         >;
     }
     #[derive(Debug)]
-    pub struct ServerReflectionServer<T: ServerReflection> {
+    pub struct ServerReflectionServer<T> {
         inner: Arc<T>,
         accept_compression_encodings: EnabledCompressionEncodings,
         send_compression_encodings: EnabledCompressionEncodings,
         max_decoding_message_size: Option<usize>,
         max_encoding_message_size: Option<usize>,
     }
-    impl<T: ServerReflection> ServerReflectionServer<T> {
+    impl<T> ServerReflectionServer<T> {
         pub fn new(inner: T) -> Self {
             Self::from_arc(Arc::new(inner))
         }
@@ -436,7 +436,7 @@ pub mod server_reflection_server {
             }
         }
     }
-    impl<T: ServerReflection> Clone for ServerReflectionServer<T> {
+    impl<T> Clone for ServerReflectionServer<T> {
         fn clone(&self) -> Self {
             let inner = self.inner.clone();
             Self {
@@ -450,7 +450,7 @@ pub mod server_reflection_server {
     }
     /// Generated gRPC service name
     pub const SERVICE_NAME: &'static str = "grpc.reflection.v1alpha.ServerReflection";
-    impl<T: ServerReflection> tonic::server::NamedService for ServerReflectionServer<T> {
+    impl<T> tonic::server::NamedService for ServerReflectionServer<T> {
         const NAME: &'static str = SERVICE_NAME;
     }
 }


### PR DESCRIPTION
See #1871 for details. This is a straightforward implementation of removing the trait bounds where possible.