### PR TITLE
feat(build): Add `#[deprecated]` to deprecated client methods

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,5 +26,6 @@ members = [
   "tests/service_named_result",
   "tests/use_arc_self",
   "tests/default_stubs",
+  "tests/deprecated_methods",
 ]
 resolver = "2"

--- a/tests/deprecated_methods/Cargo.toml
+++ b/tests/deprecated_methods/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "deprecated_methods"
+edition = "2021"
+license = "MIT"
+publish = false
+version = "0.1.0"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+prost = "0.13"
+tonic = { path = "../../tonic" }
+
+[build-dependencies]
+prost-build = "0.13"
+tonic-build = { path = "../../tonic-build" }

--- a/tests/deprecated_methods/build.rs
+++ b/tests/deprecated_methods/build.rs
@@ -1,0 +1,3 @@
+fn main() {
+    tonic_build::compile_protos("proto/test.proto").unwrap();
+}

--- a/tests/deprecated_methods/proto/test.proto
+++ b/tests/deprecated_methods/proto/test.proto
@@ -1,0 +1,14 @@
+syntax = "proto3";
+
+package test;
+
+service Service1 {
+  rpc Deprecated(Request) returns (Response) {
+    option deprecated = true;
+  }
+  rpc NotDeprecated(Request) returns (Response);
+}
+
+message Request {}
+
+message Response {}

--- a/tests/deprecated_methods/src/lib.rs
+++ b/tests/deprecated_methods/src/lib.rs
@@ -1,0 +1,3 @@
+pub mod pb {
+    tonic::include_proto!("test");
+}

--- a/tests/deprecated_methods/tests/deprecated_methods.rs
+++ b/tests/deprecated_methods/tests/deprecated_methods.rs
@@ -3,6 +3,11 @@ use std::{fs, path::PathBuf};
 #[test]
 fn test() {
     let path = PathBuf::from(std::env::var("OUT_DIR").unwrap()).join("test.rs");
-    let s = fs::read_to_string(path).unwrap();
-    assert_eq!(s.match_indices("#[deprecated]").count(), 1);
+    let s = fs::read_to_string(path)
+        .unwrap()
+        .split_whitespace()
+        .collect::<Vec<_>>()
+        .join(" ");
+    assert!(s.contains("#[deprecated] pub async fn deprecated("));
+    assert!(!s.contains("#[deprecated] pub async fn not_deprecated("));
 }

--- a/tests/deprecated_methods/tests/deprecated_methods.rs
+++ b/tests/deprecated_methods/tests/deprecated_methods.rs
@@ -1,0 +1,8 @@
+use std::{fs, path::PathBuf};
+
+#[test]
+fn test() {
+    let path = PathBuf::from(std::env::var("OUT_DIR").unwrap()).join("test.rs");
+    let s = fs::read_to_string(path).unwrap();
+    assert_eq!(s.match_indices("#[deprecated]").count(), 1);
+}

--- a/tonic-build/src/client.rs
+++ b/tonic-build/src/client.rs
@@ -2,8 +2,8 @@ use std::collections::HashSet;
 
 use super::{Attributes, Method, Service};
 use crate::{
-    format_method_name, format_method_path, format_service_name, generate_doc_comments,
-    naive_snake_case,
+    format_method_name, format_method_path, format_service_name, generate_deprecated,
+    generate_doc_comments, naive_snake_case,
 };
 use proc_macro2::TokenStream;
 use quote::{format_ident, quote};
@@ -175,6 +175,9 @@ fn generate_methods<T: Service>(
     for method in service.methods() {
         if !disable_comments.contains(&format_method_name(service, method, emit_package)) {
             stream.extend(generate_doc_comments(method.comment()));
+        }
+        if method.deprecated() {
+            stream.extend(generate_deprecated());
         }
 
         let method = match (method.client_streaming(), method.server_streaming()) {

--- a/tonic-build/src/lib.rs
+++ b/tonic-build/src/lib.rs
@@ -144,6 +144,8 @@ pub trait Method {
     fn server_streaming(&self) -> bool;
     /// Get comments about this item.
     fn comment(&self) -> &[Self::Comment];
+    /// Method is deprecated.
+    fn deprecated(&self) -> bool;
     /// Type name of request and response.
     fn request_response_name(
         &self,
@@ -238,6 +240,19 @@ fn generate_attributes<'a>(
                 .attrs
         })
         .collect::<Vec<_>>()
+}
+
+fn generate_deprecated() -> TokenStream {
+    let mut deprecated_stream = TokenStream::new();
+    deprecated_stream.append(Ident::new("deprecated", Span::call_site()));
+
+    let group = Group::new(Delimiter::Bracket, deprecated_stream);
+
+    let mut stream = TokenStream::new();
+    stream.append(Punct::new('#', Spacing::Alone));
+    stream.append(group);
+
+    stream
 }
 
 // Generate a singular line of a doc comment

--- a/tonic-build/src/lib.rs
+++ b/tonic-build/src/lib.rs
@@ -145,7 +145,9 @@ pub trait Method {
     /// Get comments about this item.
     fn comment(&self) -> &[Self::Comment];
     /// Method is deprecated.
-    fn deprecated(&self) -> bool;
+    fn deprecated(&self) -> bool {
+        false
+    }
     /// Type name of request and response.
     fn request_response_name(
         &self,

--- a/tonic-build/src/manual.rs
+++ b/tonic-build/src/manual.rs
@@ -173,6 +173,8 @@ pub struct Method {
     client_streaming: bool,
     /// Identifies if server streams multiple server messages.
     server_streaming: bool,
+    /// Identifies if the method is deprecated.
+    deprecated: bool,
     /// The path to the codec to use for this method
     codec_path: String,
 }
@@ -209,6 +211,10 @@ impl crate::Method for Method {
 
     fn comment(&self) -> &[Self::Comment] {
         &self.comments
+    }
+
+    fn deprecated(&self) -> bool {
+        self.deprecated
     }
 
     fn request_response_name(
@@ -262,6 +268,8 @@ pub struct MethodBuilder {
     client_streaming: bool,
     /// Identifies if server streams multiple server messages.
     server_streaming: bool,
+    /// Identifies if the method is deprecated.
+    deprecated: bool,
     /// The path to the codec to use for this method
     codec_path: Option<String>,
 }
@@ -338,6 +346,7 @@ impl MethodBuilder {
             output_type: self.output_type.unwrap(),
             client_streaming: self.client_streaming,
             server_streaming: self.server_streaming,
+            deprecated: self.deprecated,
             codec_path: self.codec_path.unwrap(),
         }
     }

--- a/tonic-build/src/prost.rs
+++ b/tonic-build/src/prost.rs
@@ -156,6 +156,10 @@ impl crate::Method for TonicBuildMethod {
         &self.prost_method.comments.leading[..]
     }
 
+    fn deprecated(&self) -> bool {
+        self.prost_method.options.deprecated.unwrap_or_default()
+    }
+
     fn request_response_name(
         &self,
         proto_path: &str,


### PR DESCRIPTION
## Motivation

When an rpc method is marked as deprecated, tonic currently doesn't forward it to the user (#1512).

## Solution

This PR adds the `#[deprecated]` attribute to generated rust client methods that are marked as deprecated in a protobuf file. I've added `Method::deprecated` which returns if the method is deprecated and is checked when the client code is generated. ~~I'd consider this a breaking change, as the `Method` trait is publicly exposed and the code will now emit warnings if a deprecated generated method is called.~~ `Method::deprecated` has a default implementation which always returns `false`.
