### PR TITLE
chore: prepare 0.12.2 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,26 @@
+# [0.12.2](https://github.com/hyperium/tonic/compare/v0.12.1...v0.12.2) (2024-08-23)
+
+### Features
+
+* Move TimeoutExpired out of transport (#1826)
+* Move ConnectError type from transport (#1828)
+* **channel:** allow setting max_header_list_size (#1835)
+* **router:** Add RoutesBuilder constructor (#1855)
+* **tls:** Rename tls-roots feature with tls-native-roots (#1860)
+* **router:** Rename Routes::into_router with into_axum_router (#1862)
+* **router:** Implement from axum::Router for Routes (#1863)
+* **channel:** Re-enable TLS based on Cargo features in generated clients (#1866)
+* **server:** allow setting max_header_list_size (#1870)
+* **build:** Expose formatted service name (#1684)
+* **reflection:** add back support for v1alpha reflection protocol (#1888)
+
+### Bug Fixes
+
+* **router:** Add missing unimplemented fallback to RoutesBuilder (#1864)
+* **server:** Prevent server from exiting on ECONNABORTED (#1874)
+* **web:** fix panic in trailer parsing on multiple trailers (#1880)
+* **web:** fix empty trailer parsing causing infinite parser loop (#1883)
+
 # [0.12.1](https://github.com/hyperium/tonic/compare/v0.12.0...v0.12.1) (2024-07-17)
 
 ### Bug Fixes

--- a/tonic-build/Cargo.toml
+++ b/tonic-build/Cargo.toml
@@ -4,7 +4,7 @@ categories = ["network-programming", "asynchronous"]
 description = """
 Codegen module of `tonic` gRPC implementation.
 """
-documentation = "https://docs.rs/tonic-build/0.12.1"
+documentation = "https://docs.rs/tonic-build/0.12.2"
 edition = "2021"
 homepage = "https://github.com/hyperium/tonic"
 keywords = ["rpc", "grpc", "async", "codegen", "protobuf"]
@@ -12,7 +12,7 @@ license = "MIT"
 name = "tonic-build"
 readme = "README.md"
 repository = "https://github.com/hyperium/tonic"
-version = "0.12.1"
+version = "0.12.2"
 
 [dependencies]
 prettyplease = { version = "0.2" }

--- a/tonic-build/src/lib.rs
+++ b/tonic-build/src/lib.rs
@@ -70,7 +70,7 @@
     html_logo_url = "https://raw.githubusercontent.com/tokio-rs/website/master/public/img/icons/tonic.svg"
 )]
 #![deny(rustdoc::broken_intra_doc_links)]
-#![doc(html_root_url = "https://docs.rs/tonic-build/0.12.1")]
+#![doc(html_root_url = "https://docs.rs/tonic-build/0.12.2")]
 #![doc(issue_tracker_base_url = "https://github.com/hyperium/tonic/issues/")]
 #![doc(test(no_crate_inject, attr(deny(rust_2018_idioms))))]
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]

--- a/tonic-health/Cargo.toml
+++ b/tonic-health/Cargo.toml
@@ -4,7 +4,7 @@ categories = ["network-programming", "asynchronous"]
 description = """
 Health Checking module of `tonic` gRPC implementation.
 """
-documentation = "https://docs.rs/tonic-health/0.12.1"
+documentation = "https://docs.rs/tonic-health/0.12.2"
 edition = "2021"
 homepage = "https://github.com/hyperium/tonic"
 keywords = ["rpc", "grpc", "async", "healthcheck"]
@@ -12,7 +12,7 @@ license = "MIT"
 name = "tonic-health"
 readme = "README.md"
 repository = "https://github.com/hyperium/tonic"
-version = "0.12.1"
+version = "0.12.2"
 
 [features]
 default = ["transport"]

--- a/tonic-health/src/lib.rs
+++ b/tonic-health/src/lib.rs
@@ -16,7 +16,7 @@
     html_logo_url = "https://raw.githubusercontent.com/tokio-rs/website/master/public/img/icons/tonic.svg"
 )]
 #![deny(rustdoc::broken_intra_doc_links)]
-#![doc(html_root_url = "https://docs.rs/tonic-health/0.12.1")]
+#![doc(html_root_url = "https://docs.rs/tonic-health/0.12.2")]
 #![doc(issue_tracker_base_url = "https://github.com/hyperium/tonic/issues/")]
 #![doc(test(no_crate_inject, attr(deny(rust_2018_idioms))))]
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]

--- a/tonic-reflection/Cargo.toml
+++ b/tonic-reflection/Cargo.toml
@@ -9,13 +9,13 @@ Server Reflection module of `tonic` gRPC implementation.
 """
 edition = "2021"
 homepage = "https://github.com/hyperium/tonic"
-documentation = "https://docs.rs/tonic-reflection/0.12.1"
+documentation = "https://docs.rs/tonic-reflection/0.12.2"
 keywords = ["rpc", "grpc", "async", "reflection"]
 license = "MIT"
 name = "tonic-reflection"
 readme = "README.md"
 repository = "https://github.com/hyperium/tonic"
-version = "0.12.1"
+version = "0.12.2"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/tonic-reflection/src/lib.rs
+++ b/tonic-reflection/src/lib.rs
@@ -10,7 +10,7 @@
     html_logo_url = "https://github.com/hyperium/tonic/raw/master/.github/assets/tonic-docs.png"
 )]
 #![deny(rustdoc::broken_intra_doc_links)]
-#![doc(html_root_url = "https://docs.rs/tonic-reflection/0.12.1")]
+#![doc(html_root_url = "https://docs.rs/tonic-reflection/0.12.2")]
 #![doc(issue_tracker_base_url = "https://github.com/hyperium/tonic/issues/")]
 #![doc(test(no_crate_inject, attr(deny(rust_2018_idioms))))]
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]

--- a/tonic-types/Cargo.toml
+++ b/tonic-types/Cargo.toml
@@ -7,7 +7,7 @@ categories = ["web-programming", "network-programming", "asynchronous"]
 description = """
 A collection of useful protobuf types that can be used with `tonic`.
 """
-documentation = "https://docs.rs/tonic-types/0.12.1"
+documentation = "https://docs.rs/tonic-types/0.12.2"
 edition = "2021"
 homepage = "https://github.com/hyperium/tonic"
 keywords = ["rpc", "grpc", "protobuf"]
@@ -15,7 +15,7 @@ license = "MIT"
 name = "tonic-types"
 readme = "README.md"
 repository = "https://github.com/hyperium/tonic"
-version = "0.12.1"
+version = "0.12.2"
 
 [dependencies]
 prost = "0.13"

--- a/tonic-types/src/lib.rs
+++ b/tonic-types/src/lib.rs
@@ -150,7 +150,7 @@
     html_logo_url = "https://raw.githubusercontent.com/tokio-rs/website/master/public/img/icons/tonic.svg"
 )]
 #![deny(rustdoc::broken_intra_doc_links)]
-#![doc(html_root_url = "https://docs.rs/tonic-types/0.12.1")]
+#![doc(html_root_url = "https://docs.rs/tonic-types/0.12.2")]
 #![doc(issue_tracker_base_url = "https://github.com/hyperium/tonic/issues/")]
 
 mod generated {

--- a/tonic-web/Cargo.toml
+++ b/tonic-web/Cargo.toml
@@ -4,7 +4,7 @@ categories = ["network-programming", "asynchronous"]
 description = """
 grpc-web protocol translation for tonic services.
 """
-documentation = "https://docs.rs/tonic-web/0.12.1"
+documentation = "https://docs.rs/tonic-web/0.12.2"
 edition = "2021"
 homepage = "https://github.com/hyperium/tonic"
 keywords = ["rpc", "grpc", "grpc-web"]
@@ -12,7 +12,7 @@ license = "MIT"
 name = "tonic-web"
 readme = "README.md"
 repository = "https://github.com/hyperium/tonic"
-version = "0.12.1"
+version = "0.12.2"
 
 [dependencies]
 base64 = "0.22"

--- a/tonic-web/src/lib.rs
+++ b/tonic-web/src/lib.rs
@@ -94,7 +94,7 @@
     rust_2018_idioms,
     unreachable_pub
 )]
-#![doc(html_root_url = "https://docs.rs/tonic-web/0.12.1")]
+#![doc(html_root_url = "https://docs.rs/tonic-web/0.12.2")]
 #![doc(issue_tracker_base_url = "https://github.com/hyperium/tonic/issues/")]
 
 pub use call::GrpcWebCall;

--- a/tonic/Cargo.toml
+++ b/tonic/Cargo.toml
@@ -13,14 +13,14 @@ categories = ["web-programming", "network-programming", "asynchronous"]
 description = """
 A gRPC over HTTP/2 implementation focused on high performance, interoperability, and flexibility.
 """
-documentation = "https://docs.rs/tonic/0.12.1"
+documentation = "https://docs.rs/tonic/0.12.2"
 edition = "2021"
 homepage = "https://github.com/hyperium/tonic"
 keywords = ["rpc", "grpc", "async", "futures", "protobuf"]
 license = "MIT"
 readme = "../README.md"
 repository = "https://github.com/hyperium/tonic"
-version = "0.12.1"
+version = "0.12.2"
 
 [features]
 codegen = ["dep:async-trait"]

--- a/tonic/src/lib.rs
+++ b/tonic/src/lib.rs
@@ -94,7 +94,7 @@
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/tokio-rs/website/master/public/img/icons/tonic.svg"
 )]
-#![doc(html_root_url = "https://docs.rs/tonic/0.12.1")]
+#![doc(html_root_url = "https://docs.rs/tonic/0.12.2")]
 #![doc(issue_tracker_base_url = "https://github.com/hyperium/tonic/issues/")]
 #![doc(test(no_crate_inject, attr(deny(rust_2018_idioms))))]
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]


### PR DESCRIPTION
Prepare release for #1866, which fixes a regression from #1731.

Would like to get this merged before releasing:

- [ ] #1888