### PR TITLE
fix(web): fix empty trailer parsing causing infinite parser loop

### DIFF
--- a/tonic-web/src/call.rs
+++ b/tonic-web/src/call.rs
@@ -304,9 +304,10 @@ where
                         }
                     }
                     FindTrailers::IncompleteBuf => continue,
-                    FindTrailers::Done(len) => {
-                        Poll::Ready(Some(Ok(Frame::data(buf.split_to(len).freeze()))))
-                    }
+                    FindTrailers::Done(len) => Poll::Ready(match len {
+                        0 => None,
+                        _ => Some(Ok(Frame::data(buf.split_to(len).freeze()))),
+                    }),
                 };
             }
         }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/hyperium/tonic/blob/master/CONTRIBUTING.md
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? If a new feature is being added, describe the intended
use case that feature fulfills.
-->

Attempting to parse a grpc response from an envoy proxy that inserts trailers causes an infinite loop

## Solution
Digging in to the code I found that there was an attempt to read more data after parsing trailers but the buffer was empty, ending up in the same place again. Guarding this fixes the issue and I can successfully fetch a message.

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

Note this fix needs to be combined with #1880 to get a valid grpc response back (otherwise it panics earlier).
