### PR TITLE
feat(grpc-web): make public some methods to enable grpc-web client proxying

### DIFF
--- a/tonic/src/codec/compression.rs
+++ b/tonic/src/codec/compression.rs
@@ -269,7 +269,7 @@ pub(crate) fn decompress(
 }
 
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
-pub(crate) enum SingleMessageCompressionOverride {
+pub enum SingleMessageCompressionOverride {
     /// Inherit whatever compression is already configured. If the stream is compressed this
     /// message will also be configured.
     ///

--- a/tonic/src/codec/decode.rs
+++ b/tonic/src/codec/decode.rs
@@ -54,7 +54,9 @@ enum Direction {
 }
 
 impl<T> Streaming<T> {
-    pub(crate) fn new_response<B, D>(
+    /// Create a new streaming response in the grpc response format for decoding a response [Body]
+    /// into message of type T
+    pub fn new_response<B, D>(
         decoder: D,
         body: B,
         status_code: StatusCode,
@@ -75,7 +77,8 @@ impl<T> Streaming<T> {
         )
     }
 
-    pub(crate) fn new_empty<B, D>(decoder: D, body: B) -> Self
+    /// Create empty response. For creating responses that have no content (headers + trailers only)
+    pub fn new_empty<B, D>(decoder: D, body: B) -> Self
     where
         B: Body + Send + 'static,
         B::Error: Into<crate::Error>,
@@ -84,7 +87,8 @@ impl<T> Streaming<T> {
         Self::new(decoder, body, Direction::EmptyResponse, None, None)
     }
 
-    #[doc(hidden)]
+    /// Create a new streaming request in the grpc response format for decoding a request [Body]
+    /// into message of type T
     pub fn new_request<B, D>(
         decoder: D,
         body: B,

--- a/tonic/src/codec/encode.rs
+++ b/tonic/src/codec/encode.rs
@@ -13,7 +13,9 @@ use std::{
 };
 use tokio_stream::{Stream, StreamExt};
 
-pub(crate) fn encode_server<T, U>(
+/// Turns a stream of grpc results (message or error status) into [EncodeBody] which is used by grpc
+/// servers for turning the messages into http frames for sending over the network.
+pub fn encode_server<T, U>(
     encoder: T,
     source: U,
     compression_encoding: Option<CompressionEncoding>,
@@ -35,7 +37,9 @@ where
     EncodeBody::new_server(stream)
 }
 
-pub(crate) fn encode_client<T, U>(
+/// Turns a stream of grpc messages into [EncodeBody] which is used by grpc clients for
+/// turning the messages into http frames for sending over the network.
+pub fn encode_client<T, U>(
     encoder: T,
     source: U,
     compression_encoding: Option<CompressionEncoding>,
@@ -266,9 +270,10 @@ enum Role {
     Server,
 }
 
+/// A specialized implementation of [Body] for encoding [Result<Bytes, Status>].
 #[pin_project]
 #[derive(Debug)]
-pub(crate) struct EncodeBody<S> {
+pub struct EncodeBody<S> {
     #[pin]
     inner: S,
     state: EncodeState,

--- a/tonic/src/codec/mod.rs
+++ b/tonic/src/codec/mod.rs
@@ -13,11 +13,10 @@ mod prost;
 use crate::Status;
 use std::io;
 
-pub(crate) use self::encode::{encode_client, encode_server};
-
 pub use self::buffer::{DecodeBuf, EncodeBuf};
 pub use self::compression::{CompressionEncoding, EnabledCompressionEncodings};
 pub use self::decode::Streaming;
+pub use self::encode::{encode_client, encode_server, EncodeBody};
 #[cfg(feature = "prost")]
 pub use self::prost::ProstCodec;
 


### PR DESCRIPTION


<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/hyperium/tonic/blob/master/CONTRIBUTING.md
-->

## Motivation

I want to create a middleware grpc service that can listen to regular grpc calls, and forward them to another service as grpc-web calls. In order to do this fully generically, there needs to be made public some internals of tonic that are normally called via the `Grpc` service that the generated service code uses.

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? If a new feature is being added, describe the intended
use case that feature fulfills.
-->

## Solution

Publish the minimal set of symbols that are required
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->


---

If there is interest, I can create a new example in the examples dir to demonstrate grpc-web proxying. I've only tested unary calls locally so far.