### PR TITLE
Add example axum-share-tcp-port

### DIFF
--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -260,6 +260,11 @@ path = "src/codec_buffers/server.rs"
 name = "codec-buffers-client"
 path = "src/codec_buffers/client.rs"
 
+[[bin]]
+name = "axum-share-tcp-port"
+path = "src/axum-share-tcp-port/server.rs"
+required-features = ["axum"]
+
 
 [features]
 gcp = ["dep:prost-types", "tonic/tls"]
@@ -284,7 +289,7 @@ types = ["dep:tonic-types"]
 h2c = ["dep:hyper", "dep:tower", "dep:http", "dep:hyper-util"]
 cancellation = ["dep:tokio-util"]
 
-full = ["gcp", "routeguide", "reflection", "autoreload", "health", "grpc-web", "tracing", "uds", "streaming", "mock", "tower", "json-codec", "compression", "tls", "tls-rustls", "dynamic-load-balance", "timeout", "tls-client-auth", "types", "cancellation", "h2c"]
+full = ["gcp", "routeguide", "reflection", "autoreload", "health", "grpc-web", "tracing", "uds", "streaming", "mock", "tower", "json-codec", "compression", "tls", "tls-rustls", "dynamic-load-balance", "timeout", "tls-client-auth", "types", "cancellation", "h2c", "axum"]
 default = ["full"]
 
 [dependencies]
@@ -320,6 +325,7 @@ hyper-rustls = { version = "0.27.0", features = ["http2", "ring", "tls12"], opti
 rustls-pemfile = { version = "2.0.0", optional = true }
 tower-http = { version = "0.5", optional = true }
 pin-project = { version = "1.0.11", optional = true }
+axum = { version = "0.7", optional = true }
 
 [build-dependencies]
 tonic-build = { path = "../tonic-build", features = ["prost"] }

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -265,7 +265,6 @@ name = "axum-share-tcp-port"
 path = "src/axum-share-tcp-port/server.rs"
 required-features = ["axum"]
 
-
 [features]
 gcp = ["dep:prost-types", "tonic/tls"]
 routeguide = ["dep:async-stream", "tokio-stream", "dep:rand", "dep:serde", "dep:serde_json"]

--- a/examples/src/axum-share-tcp-port/server.rs
+++ b/examples/src/axum-share-tcp-port/server.rs
@@ -1,6 +1,6 @@
 //! Example of combining tonic grpc routes with regular axum http routes served
 //! on a single tcp port.
-//! 
+//!
 //! `GreeterServer` is served and also route `/foo` which returns "bar" for
 //! http GET requests.
 //!

--- a/examples/src/axum-share-tcp-port/server.rs
+++ b/examples/src/axum-share-tcp-port/server.rs
@@ -1,0 +1,68 @@
+//! Example of combining tonic grpc routes with regular axum http routes served
+//! on a single tcp port.
+//! 
+//! `GreeterServer` is served and also route `/foo` which returns "bar" for
+//! http GET requests.
+//!
+//! The downside of this approach is the tonic server configuration, e.g.
+//! [`tonic::transport::server::Server::http2_keepalive_interval`], cannot
+//! be used as we don't use the built in tonic server implementation.
+//!
+//! To configure these, or apply similar defaults to tonic, replace
+//! [`axum::serve`] with your own impl or use a crate that allows this.
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let addr: std::net::SocketAddr = "[::1]:50051".parse()?;
+
+    // get grpc routes
+    let router = grpc::routes()
+        .prepare()
+        // convert into an axum router
+        .into_axum_router()
+        // add additional http routes
+        .route("/foo", axum::routing::get(|| async { "bar" }));
+
+    println!("GreeterServer & /foo listening on {addr}");
+
+    // serve grpc & http using axum
+    //
+    // Note: To configure things like tcp_nodelay implement
+    //       own `serve` logic or use another crate.
+    let listener = tokio::net::TcpListener::bind(addr).await?;
+    axum::serve(listener, router).await?;
+
+    Ok(())
+}
+
+mod grpc {
+    use hello_world::greeter_server::{Greeter, GreeterServer};
+    use hello_world::{HelloReply, HelloRequest};
+    use tonic::{Request, Response, Status};
+
+    pub mod hello_world {
+        tonic::include_proto!("helloworld");
+    }
+
+    pub fn routes() -> tonic::service::Routes {
+        tonic::service::Routes::new(GreeterServer::new(MyGreeter::default()))
+    }
+
+    #[derive(Default)]
+    pub struct MyGreeter {}
+
+    #[tonic::async_trait]
+    impl Greeter for MyGreeter {
+        async fn say_hello(
+            &self,
+            request: Request<HelloRequest>,
+        ) -> Result<Response<HelloReply>, Status> {
+            println!("Got a request from {:?}", request.remote_addr());
+
+            let reply = hello_world::HelloReply {
+                message: format!("Hello {}!", request.into_inner().name),
+            };
+            Ok(Response::new(reply))
+        }
+    }
+}


### PR DESCRIPTION
Add example of combining tonic grpc routes with regular axum http routes served on a single tcp port.

I also added notes around the downsides of not using the tonic server impl & how another server could be similarly configured.

## Motivation
Resolves #1878
