### PR TITLE
tonic-reflection: add back support for v1alpha reflection protocol

### DIFF
--- a/examples/src/reflection/server.rs
+++ b/examples/src/reflection/server.rs
@@ -30,7 +30,7 @@ impl proto::greeter_server::Greeter for MyGreeter {
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let service = tonic_reflection::server::Builder::configure()
         .register_encoded_file_descriptor_set(proto::FILE_DESCRIPTOR_SET)
-        .build()
+        .build_v1()
         .unwrap();
 
     let addr = "[::1]:50052".parse().unwrap();

--- a/tonic-reflection/src/server/mod.rs
+++ b/tonic-reflection/src/server/mod.rs
@@ -1,10 +1,10 @@
-pub use crate::pb::v1::server_reflection_server::{ServerReflection, ServerReflectionServer};
-
-use prost::DecodeError;
 use std::fmt::{Display, Formatter};
 
-mod v1;
+use prost::DecodeError;
 
+pub use crate::pb::v1::server_reflection_server::{ServerReflection, ServerReflectionServer};
+
+mod v1;
 pub use v1::Builder;
 
 /// Represents an error in the construction of a gRPC Reflection Service.

--- a/tonic-reflection/src/server/mod.rs
+++ b/tonic-reflection/src/server/mod.rs
@@ -76,7 +76,15 @@ impl<'b> Builder<'b> {
     }
 
     /// Build a v1 gRPC Reflection Service to be served via Tonic.
-    pub fn build(mut self) -> Result<v1::ServerReflectionServer<impl v1::ServerReflection>, Error> {
+    #[deprecated(since = "0.12.2", note = "use `build_v1()` instead")]
+    pub fn build(self) -> Result<v1::ServerReflectionServer<impl v1::ServerReflection>, Error> {
+        self.build_v1()
+    }
+
+    /// Build a v1 gRPC Reflection Service to be served via Tonic.
+    pub fn build_v1(
+        mut self,
+    ) -> Result<v1::ServerReflectionServer<impl v1::ServerReflection>, Error> {
         if self.include_reflection_service {
             self = self.register_encoded_file_descriptor_set(crate::pb::v1::FILE_DESCRIPTOR_SET);
         }

--- a/tonic-reflection/src/server/mod.rs
+++ b/tonic-reflection/src/server/mod.rs
@@ -1,11 +1,281 @@
+use std::collections::HashMap;
 use std::fmt::{Display, Formatter};
+use std::sync::Arc;
 
-use prost::DecodeError;
+use prost::{DecodeError, Message};
+use prost_types::{
+    DescriptorProto, EnumDescriptorProto, FieldDescriptorProto, FileDescriptorProto,
+    FileDescriptorSet,
+};
+use tonic::Status;
 
-pub use crate::pb::v1::server_reflection_server::{ServerReflection, ServerReflectionServer};
+/// v1 interface for the gRPC Reflection Service server.
+pub mod v1;
+/// Deprecated; access these via `v1` instead.
+pub use v1::{ServerReflection, ServerReflectionServer}; // For backwards compatibility
 
-mod v1;
-pub use v1::Builder;
+/// A builder used to construct a gRPC Reflection Service.
+#[derive(Debug)]
+pub struct Builder<'b> {
+    file_descriptor_sets: Vec<FileDescriptorSet>,
+    encoded_file_descriptor_sets: Vec<&'b [u8]>,
+    include_reflection_service: bool,
+
+    service_names: Vec<String>,
+    use_all_service_names: bool,
+}
+
+impl<'b> Builder<'b> {
+    /// Create a new builder that can configure a gRPC Reflection Service.
+    pub fn configure() -> Self {
+        Builder {
+            file_descriptor_sets: Vec::new(),
+            encoded_file_descriptor_sets: Vec::new(),
+            include_reflection_service: true,
+
+            service_names: Vec::new(),
+            use_all_service_names: true,
+        }
+    }
+
+    /// Registers an instance of `prost_types::FileDescriptorSet` with the gRPC Reflection
+    /// Service builder.
+    pub fn register_file_descriptor_set(mut self, file_descriptor_set: FileDescriptorSet) -> Self {
+        self.file_descriptor_sets.push(file_descriptor_set);
+        self
+    }
+
+    /// Registers a byte slice containing an encoded `prost_types::FileDescriptorSet` with
+    /// the gRPC Reflection Service builder.
+    pub fn register_encoded_file_descriptor_set(
+        mut self,
+        encoded_file_descriptor_set: &'b [u8],
+    ) -> Self {
+        self.encoded_file_descriptor_sets
+            .push(encoded_file_descriptor_set);
+        self
+    }
+
+    /// Serve the gRPC Reflection Service descriptor via the Reflection Service. This is enabled
+    /// by default - set `include` to false to disable.
+    pub fn include_reflection_service(mut self, include: bool) -> Self {
+        self.include_reflection_service = include;
+        self
+    }
+
+    /// Advertise a fully-qualified gRPC service name.
+    ///
+    /// If not called, then all services present in the registered file descriptor sets
+    /// will be advertised.
+    pub fn with_service_name(mut self, name: impl Into<String>) -> Self {
+        self.use_all_service_names = false;
+        self.service_names.push(name.into());
+        self
+    }
+
+    /// Build a gRPC Reflection Service to be served via Tonic.
+    pub fn build(mut self) -> Result<v1::ServerReflectionServer<impl v1::ServerReflection>, Error> {
+        if self.include_reflection_service {
+            self = self.register_encoded_file_descriptor_set(crate::pb::v1::FILE_DESCRIPTOR_SET);
+        }
+
+        Ok(v1::ServerReflectionServer::new(
+            v1::ReflectionService::from(ReflectionServiceState::new(
+                self.service_names,
+                self.encoded_file_descriptor_sets,
+                self.file_descriptor_sets,
+                self.use_all_service_names,
+            )?),
+        ))
+    }
+}
+
+#[derive(Debug)]
+struct ReflectionServiceState {
+    service_names: Vec<String>,
+    files: HashMap<String, Arc<FileDescriptorProto>>,
+    symbols: HashMap<String, Arc<FileDescriptorProto>>,
+}
+
+impl ReflectionServiceState {
+    fn new(
+        service_names: Vec<String>,
+        encoded_file_descriptor_sets: Vec<&[u8]>,
+        mut file_descriptor_sets: Vec<FileDescriptorSet>,
+        use_all_service_names: bool,
+    ) -> Result<Self, Error> {
+        for encoded in encoded_file_descriptor_sets {
+            file_descriptor_sets.push(FileDescriptorSet::decode(encoded)?);
+        }
+
+        let mut state = ReflectionServiceState {
+            service_names,
+            files: HashMap::new(),
+            symbols: HashMap::new(),
+        };
+
+        for fds in file_descriptor_sets {
+            for fd in fds.file {
+                let name = match fd.name.clone() {
+                    None => {
+                        return Err(Error::InvalidFileDescriptorSet("missing name".to_string()));
+                    }
+                    Some(n) => n,
+                };
+
+                if state.files.contains_key(&name) {
+                    continue;
+                }
+
+                let fd = Arc::new(fd);
+                state.files.insert(name, fd.clone());
+                state.process_file(fd, use_all_service_names)?;
+            }
+        }
+
+        Ok(state)
+    }
+
+    fn process_file(
+        &mut self,
+        fd: Arc<FileDescriptorProto>,
+        use_all_service_names: bool,
+    ) -> Result<(), Error> {
+        let prefix = &fd.package.clone().unwrap_or_default();
+
+        for msg in &fd.message_type {
+            self.process_message(fd.clone(), prefix, msg)?;
+        }
+
+        for en in &fd.enum_type {
+            self.process_enum(fd.clone(), prefix, en)?;
+        }
+
+        for service in &fd.service {
+            let service_name = extract_name(prefix, "service", service.name.as_ref())?;
+            if use_all_service_names {
+                self.service_names.push(service_name.clone());
+            }
+            self.symbols.insert(service_name.clone(), fd.clone());
+
+            for method in &service.method {
+                let method_name = extract_name(&service_name, "method", method.name.as_ref())?;
+                self.symbols.insert(method_name, fd.clone());
+            }
+        }
+
+        Ok(())
+    }
+
+    fn process_message(
+        &mut self,
+        fd: Arc<FileDescriptorProto>,
+        prefix: &str,
+        msg: &DescriptorProto,
+    ) -> Result<(), Error> {
+        let message_name = extract_name(prefix, "message", msg.name.as_ref())?;
+        self.symbols.insert(message_name.clone(), fd.clone());
+
+        for nested in &msg.nested_type {
+            self.process_message(fd.clone(), &message_name, nested)?;
+        }
+
+        for en in &msg.enum_type {
+            self.process_enum(fd.clone(), &message_name, en)?;
+        }
+
+        for field in &msg.field {
+            self.process_field(fd.clone(), &message_name, field)?;
+        }
+
+        for oneof in &msg.oneof_decl {
+            let oneof_name = extract_name(&message_name, "oneof", oneof.name.as_ref())?;
+            self.symbols.insert(oneof_name, fd.clone());
+        }
+
+        Ok(())
+    }
+
+    fn process_enum(
+        &mut self,
+        fd: Arc<FileDescriptorProto>,
+        prefix: &str,
+        en: &EnumDescriptorProto,
+    ) -> Result<(), Error> {
+        let enum_name = extract_name(prefix, "enum", en.name.as_ref())?;
+        self.symbols.insert(enum_name.clone(), fd.clone());
+
+        for value in &en.value {
+            let value_name = extract_name(&enum_name, "enum value", value.name.as_ref())?;
+            self.symbols.insert(value_name, fd.clone());
+        }
+
+        Ok(())
+    }
+
+    fn process_field(
+        &mut self,
+        fd: Arc<FileDescriptorProto>,
+        prefix: &str,
+        field: &FieldDescriptorProto,
+    ) -> Result<(), Error> {
+        let field_name = extract_name(prefix, "field", field.name.as_ref())?;
+        self.symbols.insert(field_name, fd);
+        Ok(())
+    }
+
+    fn list_services(&self) -> &[String] {
+        &self.service_names
+    }
+
+    fn symbol_by_name(&self, symbol: &str) -> Result<Vec<u8>, Status> {
+        match self.symbols.get(symbol) {
+            None => Err(Status::not_found(format!("symbol '{}' not found", symbol))),
+            Some(fd) => {
+                let mut encoded_fd = Vec::new();
+                if fd.clone().encode(&mut encoded_fd).is_err() {
+                    return Err(Status::internal("encoding error"));
+                };
+
+                Ok(encoded_fd)
+            }
+        }
+    }
+
+    fn file_by_filename(&self, filename: &str) -> Result<Vec<u8>, Status> {
+        match self.files.get(filename) {
+            None => Err(Status::not_found(format!("file '{}' not found", filename))),
+            Some(fd) => {
+                let mut encoded_fd = Vec::new();
+                if fd.clone().encode(&mut encoded_fd).is_err() {
+                    return Err(Status::internal("encoding error"));
+                }
+
+                Ok(encoded_fd)
+            }
+        }
+    }
+}
+
+fn extract_name(
+    prefix: &str,
+    name_type: &str,
+    maybe_name: Option<&String>,
+) -> Result<String, Error> {
+    match maybe_name {
+        None => Err(Error::InvalidFileDescriptorSet(format!(
+            "missing {} name",
+            name_type
+        ))),
+        Some(name) => {
+            if prefix.is_empty() {
+                Ok(name.to_string())
+            } else {
+                Ok(format!("{}.{}", prefix, name))
+            }
+        }
+    }
+}
 
 /// Represents an error in the construction of a gRPC Reflection Service.
 #[derive(Debug)]

--- a/tonic-reflection/src/server/mod.rs
+++ b/tonic-reflection/src/server/mod.rs
@@ -13,6 +13,8 @@ use tonic::Status;
 pub mod v1;
 /// Deprecated; access these via `v1` instead.
 pub use v1::{ServerReflection, ServerReflectionServer}; // For backwards compatibility
+/// v1alpha interface for the gRPC Reflection Service server.
+pub mod v1alpha;
 
 /// A builder used to construct a gRPC Reflection Service.
 #[derive(Debug)]
@@ -73,7 +75,7 @@ impl<'b> Builder<'b> {
         self
     }
 
-    /// Build a gRPC Reflection Service to be served via Tonic.
+    /// Build a v1 gRPC Reflection Service to be served via Tonic.
     pub fn build(mut self) -> Result<v1::ServerReflectionServer<impl v1::ServerReflection>, Error> {
         if self.include_reflection_service {
             self = self.register_encoded_file_descriptor_set(crate::pb::v1::FILE_DESCRIPTOR_SET);
@@ -81,6 +83,25 @@ impl<'b> Builder<'b> {
 
         Ok(v1::ServerReflectionServer::new(
             v1::ReflectionService::from(ReflectionServiceState::new(
+                self.service_names,
+                self.encoded_file_descriptor_sets,
+                self.file_descriptor_sets,
+                self.use_all_service_names,
+            )?),
+        ))
+    }
+
+    /// Build a v1alpha gRPC Reflection Service to be served via Tonic.
+    pub fn build_v1alpha(
+        mut self,
+    ) -> Result<v1alpha::ServerReflectionServer<impl v1alpha::ServerReflection>, Error> {
+        if self.include_reflection_service {
+            self =
+                self.register_encoded_file_descriptor_set(crate::pb::v1alpha::FILE_DESCRIPTOR_SET);
+        }
+
+        Ok(v1alpha::ServerReflectionServer::new(
+            v1alpha::ReflectionService::from(ReflectionServiceState::new(
                 self.service_names,
                 self.encoded_file_descriptor_sets,
                 self.file_descriptor_sets,

--- a/tonic-reflection/src/server/v1.rs
+++ b/tonic-reflection/src/server/v1.rs
@@ -1,22 +1,22 @@
-use crate::pb::v1::server_reflection_server::{ServerReflection, ServerReflectionServer};
+use std::collections::HashMap;
+use std::sync::Arc;
 
-use crate::pb::v1::server_reflection_request::MessageRequest;
-use crate::pb::v1::server_reflection_response::MessageResponse;
-use crate::pb::v1::{
-    ExtensionNumberResponse, FileDescriptorResponse, ListServiceResponse, ServerReflectionRequest,
-    ServerReflectionResponse, ServiceResponse,
-};
 use prost::Message;
 use prost_types::{
     DescriptorProto, EnumDescriptorProto, FieldDescriptorProto, FileDescriptorProto,
     FileDescriptorSet,
 };
-use std::collections::HashMap;
-use std::sync::Arc;
 use tokio::sync::mpsc;
 use tokio_stream::{wrappers::ReceiverStream, StreamExt};
 use tonic::{Request, Response, Status, Streaming};
 
+use crate::pb::v1::server_reflection_request::MessageRequest;
+use crate::pb::v1::server_reflection_response::MessageResponse;
+use crate::pb::v1::server_reflection_server::{ServerReflection, ServerReflectionServer};
+use crate::pb::v1::{
+    ExtensionNumberResponse, FileDescriptorResponse, ListServiceResponse, ServerReflectionRequest,
+    ServerReflectionResponse, ServiceResponse,
+};
 use crate::server::Error;
 
 /// A builder used to construct a gRPC Reflection Service.

--- a/tonic-reflection/src/server/v1.rs
+++ b/tonic-reflection/src/server/v1.rs
@@ -1,289 +1,20 @@
-use std::collections::HashMap;
 use std::sync::Arc;
 
-use prost::Message;
-use prost_types::{
-    DescriptorProto, EnumDescriptorProto, FieldDescriptorProto, FileDescriptorProto,
-    FileDescriptorSet,
-};
 use tokio::sync::mpsc;
 use tokio_stream::{wrappers::ReceiverStream, StreamExt};
 use tonic::{Request, Response, Status, Streaming};
 
+use super::ReflectionServiceState;
 use crate::pb::v1::server_reflection_request::MessageRequest;
 use crate::pb::v1::server_reflection_response::MessageResponse;
-use crate::pb::v1::server_reflection_server::{ServerReflection, ServerReflectionServer};
+pub use crate::pb::v1::server_reflection_server::{ServerReflection, ServerReflectionServer};
 use crate::pb::v1::{
     ExtensionNumberResponse, FileDescriptorResponse, ListServiceResponse, ServerReflectionRequest,
     ServerReflectionResponse, ServiceResponse,
 };
-use crate::server::Error;
-
-/// A builder used to construct a gRPC Reflection Service.
-#[derive(Debug)]
-pub struct Builder<'b> {
-    file_descriptor_sets: Vec<FileDescriptorSet>,
-    encoded_file_descriptor_sets: Vec<&'b [u8]>,
-    include_reflection_service: bool,
-
-    service_names: Vec<String>,
-    use_all_service_names: bool,
-}
-
-impl<'b> Builder<'b> {
-    /// Create a new builder that can configure a gRPC Reflection Service.
-    pub fn configure() -> Self {
-        Builder {
-            file_descriptor_sets: Vec::new(),
-            encoded_file_descriptor_sets: Vec::new(),
-            include_reflection_service: true,
-
-            service_names: Vec::new(),
-            use_all_service_names: true,
-        }
-    }
-
-    /// Registers an instance of `prost_types::FileDescriptorSet` with the gRPC Reflection
-    /// Service builder.
-    pub fn register_file_descriptor_set(mut self, file_descriptor_set: FileDescriptorSet) -> Self {
-        self.file_descriptor_sets.push(file_descriptor_set);
-        self
-    }
-
-    /// Registers a byte slice containing an encoded `prost_types::FileDescriptorSet` with
-    /// the gRPC Reflection Service builder.
-    pub fn register_encoded_file_descriptor_set(
-        mut self,
-        encoded_file_descriptor_set: &'b [u8],
-    ) -> Self {
-        self.encoded_file_descriptor_sets
-            .push(encoded_file_descriptor_set);
-        self
-    }
-
-    /// Serve the gRPC Reflection Service descriptor via the Reflection Service. This is enabled
-    /// by default - set `include` to false to disable.
-    pub fn include_reflection_service(mut self, include: bool) -> Self {
-        self.include_reflection_service = include;
-        self
-    }
-
-    /// Advertise a fully-qualified gRPC service name.
-    ///
-    /// If not called, then all services present in the registered file descriptor sets
-    /// will be advertised.
-    pub fn with_service_name(mut self, name: impl Into<String>) -> Self {
-        self.use_all_service_names = false;
-        self.service_names.push(name.into());
-        self
-    }
-
-    /// Build a gRPC Reflection Service to be served via Tonic.
-    pub fn build(mut self) -> Result<ServerReflectionServer<impl ServerReflection>, Error> {
-        if self.include_reflection_service {
-            self = self.register_encoded_file_descriptor_set(crate::pb::v1::FILE_DESCRIPTOR_SET);
-        }
-
-        Ok(ServerReflectionServer::new(ReflectionService {
-            state: Arc::new(ReflectionServiceState::new(
-                self.service_names,
-                self.encoded_file_descriptor_sets,
-                self.file_descriptor_sets,
-                self.use_all_service_names,
-            )?),
-        }))
-    }
-}
 
 #[derive(Debug)]
-struct ReflectionServiceState {
-    service_names: Vec<String>,
-    files: HashMap<String, Arc<FileDescriptorProto>>,
-    symbols: HashMap<String, Arc<FileDescriptorProto>>,
-}
-
-impl ReflectionServiceState {
-    fn new(
-        service_names: Vec<String>,
-        encoded_file_descriptor_sets: Vec<&[u8]>,
-        mut file_descriptor_sets: Vec<FileDescriptorSet>,
-        use_all_service_names: bool,
-    ) -> Result<Self, Error> {
-        for encoded in encoded_file_descriptor_sets {
-            file_descriptor_sets.push(FileDescriptorSet::decode(encoded)?);
-        }
-
-        let mut state = ReflectionServiceState {
-            service_names,
-            files: HashMap::new(),
-            symbols: HashMap::new(),
-        };
-
-        for fds in file_descriptor_sets {
-            for fd in fds.file {
-                let name = match fd.name.clone() {
-                    None => {
-                        return Err(Error::InvalidFileDescriptorSet("missing name".to_string()));
-                    }
-                    Some(n) => n,
-                };
-
-                if state.files.contains_key(&name) {
-                    continue;
-                }
-
-                let fd = Arc::new(fd);
-                state.files.insert(name, fd.clone());
-                state.process_file(fd, use_all_service_names)?;
-            }
-        }
-
-        Ok(state)
-    }
-
-    fn process_file(
-        &mut self,
-        fd: Arc<FileDescriptorProto>,
-        use_all_service_names: bool,
-    ) -> Result<(), Error> {
-        let prefix = &fd.package.clone().unwrap_or_default();
-
-        for msg in &fd.message_type {
-            self.process_message(fd.clone(), prefix, msg)?;
-        }
-
-        for en in &fd.enum_type {
-            self.process_enum(fd.clone(), prefix, en)?;
-        }
-
-        for service in &fd.service {
-            let service_name = extract_name(prefix, "service", service.name.as_ref())?;
-            if use_all_service_names {
-                self.service_names.push(service_name.clone());
-            }
-            self.symbols.insert(service_name.clone(), fd.clone());
-
-            for method in &service.method {
-                let method_name = extract_name(&service_name, "method", method.name.as_ref())?;
-                self.symbols.insert(method_name, fd.clone());
-            }
-        }
-
-        Ok(())
-    }
-
-    fn process_message(
-        &mut self,
-        fd: Arc<FileDescriptorProto>,
-        prefix: &str,
-        msg: &DescriptorProto,
-    ) -> Result<(), Error> {
-        let message_name = extract_name(prefix, "message", msg.name.as_ref())?;
-        self.symbols.insert(message_name.clone(), fd.clone());
-
-        for nested in &msg.nested_type {
-            self.process_message(fd.clone(), &message_name, nested)?;
-        }
-
-        for en in &msg.enum_type {
-            self.process_enum(fd.clone(), &message_name, en)?;
-        }
-
-        for field in &msg.field {
-            self.process_field(fd.clone(), &message_name, field)?;
-        }
-
-        for oneof in &msg.oneof_decl {
-            let oneof_name = extract_name(&message_name, "oneof", oneof.name.as_ref())?;
-            self.symbols.insert(oneof_name, fd.clone());
-        }
-
-        Ok(())
-    }
-
-    fn process_enum(
-        &mut self,
-        fd: Arc<FileDescriptorProto>,
-        prefix: &str,
-        en: &EnumDescriptorProto,
-    ) -> Result<(), Error> {
-        let enum_name = extract_name(prefix, "enum", en.name.as_ref())?;
-        self.symbols.insert(enum_name.clone(), fd.clone());
-
-        for value in &en.value {
-            let value_name = extract_name(&enum_name, "enum value", value.name.as_ref())?;
-            self.symbols.insert(value_name, fd.clone());
-        }
-
-        Ok(())
-    }
-
-    fn process_field(
-        &mut self,
-        fd: Arc<FileDescriptorProto>,
-        prefix: &str,
-        field: &FieldDescriptorProto,
-    ) -> Result<(), Error> {
-        let field_name = extract_name(prefix, "field", field.name.as_ref())?;
-        self.symbols.insert(field_name, fd);
-        Ok(())
-    }
-
-    fn list_services(&self) -> &[String] {
-        &self.service_names
-    }
-
-    fn symbol_by_name(&self, symbol: &str) -> Result<Vec<u8>, Status> {
-        match self.symbols.get(symbol) {
-            None => Err(Status::not_found(format!("symbol '{}' not found", symbol))),
-            Some(fd) => {
-                let mut encoded_fd = Vec::new();
-                if fd.clone().encode(&mut encoded_fd).is_err() {
-                    return Err(Status::internal("encoding error"));
-                };
-
-                Ok(encoded_fd)
-            }
-        }
-    }
-
-    fn file_by_filename(&self, filename: &str) -> Result<Vec<u8>, Status> {
-        match self.files.get(filename) {
-            None => Err(Status::not_found(format!("file '{}' not found", filename))),
-            Some(fd) => {
-                let mut encoded_fd = Vec::new();
-                if fd.clone().encode(&mut encoded_fd).is_err() {
-                    return Err(Status::internal("encoding error"));
-                }
-
-                Ok(encoded_fd)
-            }
-        }
-    }
-}
-
-fn extract_name(
-    prefix: &str,
-    name_type: &str,
-    maybe_name: Option<&String>,
-) -> Result<String, Error> {
-    match maybe_name {
-        None => Err(Error::InvalidFileDescriptorSet(format!(
-            "missing {} name",
-            name_type
-        ))),
-        Some(name) => {
-            if prefix.is_empty() {
-                Ok(name.to_string())
-            } else {
-                Ok(format!("{}.{}", prefix, name))
-            }
-        }
-    }
-}
-
-#[derive(Debug)]
-struct ReflectionService {
+pub(super) struct ReflectionService {
     state: Arc<ReflectionServiceState>,
 }
 
@@ -361,5 +92,13 @@ impl ServerReflection for ReflectionService {
         });
 
         Ok(Response::new(ReceiverStream::new(resp_rx)))
+    }
+}
+
+impl From<ReflectionServiceState> for ReflectionService {
+    fn from(state: ReflectionServiceState) -> Self {
+        Self {
+            state: Arc::new(state),
+        }
     }
 }

--- a/tonic-reflection/src/server/v1alpha.rs
+++ b/tonic-reflection/src/server/v1alpha.rs
@@ -1,0 +1,104 @@
+use std::sync::Arc;
+
+use tokio::sync::mpsc;
+use tokio_stream::{wrappers::ReceiverStream, StreamExt};
+use tonic::{Request, Response, Status, Streaming};
+
+use super::ReflectionServiceState;
+use crate::pb::v1alpha::server_reflection_request::MessageRequest;
+use crate::pb::v1alpha::server_reflection_response::MessageResponse;
+pub use crate::pb::v1alpha::server_reflection_server::{ServerReflection, ServerReflectionServer};
+use crate::pb::v1alpha::{
+    ExtensionNumberResponse, FileDescriptorResponse, ListServiceResponse, ServerReflectionRequest,
+    ServerReflectionResponse, ServiceResponse,
+};
+
+#[derive(Debug)]
+pub(super) struct ReflectionService {
+    state: Arc<ReflectionServiceState>,
+}
+
+#[tonic::async_trait]
+impl ServerReflection for ReflectionService {
+    type ServerReflectionInfoStream = ReceiverStream<Result<ServerReflectionResponse, Status>>;
+
+    async fn server_reflection_info(
+        &self,
+        req: Request<Streaming<ServerReflectionRequest>>,
+    ) -> Result<Response<Self::ServerReflectionInfoStream>, Status> {
+        let mut req_rx = req.into_inner();
+        let (resp_tx, resp_rx) = mpsc::channel::<Result<ServerReflectionResponse, Status>>(1);
+
+        let state = self.state.clone();
+
+        tokio::spawn(async move {
+            while let Some(req) = req_rx.next().await {
+                let Ok(req) = req else {
+                    return;
+                };
+
+                let resp_msg = match req.message_request.clone() {
+                    None => Err(Status::invalid_argument("invalid MessageRequest")),
+                    Some(msg) => match msg {
+                        MessageRequest::FileByFilename(s) => state.file_by_filename(&s).map(|fd| {
+                            MessageResponse::FileDescriptorResponse(FileDescriptorResponse {
+                                file_descriptor_proto: vec![fd],
+                            })
+                        }),
+                        MessageRequest::FileContainingSymbol(s) => {
+                            state.symbol_by_name(&s).map(|fd| {
+                                MessageResponse::FileDescriptorResponse(FileDescriptorResponse {
+                                    file_descriptor_proto: vec![fd],
+                                })
+                            })
+                        }
+                        MessageRequest::FileContainingExtension(_) => {
+                            Err(Status::not_found("extensions are not supported"))
+                        }
+                        MessageRequest::AllExtensionNumbersOfType(_) => {
+                            // NOTE: Workaround. Some grpc clients (e.g. grpcurl) expect this method not to fail.
+                            // https://github.com/hyperium/tonic/issues/1077
+                            Ok(MessageResponse::AllExtensionNumbersResponse(
+                                ExtensionNumberResponse::default(),
+                            ))
+                        }
+                        MessageRequest::ListServices(_) => {
+                            Ok(MessageResponse::ListServicesResponse(ListServiceResponse {
+                                service: state
+                                    .list_services()
+                                    .iter()
+                                    .map(|s| ServiceResponse { name: s.clone() })
+                                    .collect(),
+                            }))
+                        }
+                    },
+                };
+
+                match resp_msg {
+                    Ok(resp_msg) => {
+                        let resp = ServerReflectionResponse {
+                            valid_host: req.host.clone(),
+                            original_request: Some(req.clone()),
+                            message_response: Some(resp_msg),
+                        };
+                        resp_tx.send(Ok(resp)).await.expect("send");
+                    }
+                    Err(status) => {
+                        resp_tx.send(Err(status)).await.expect("send");
+                        return;
+                    }
+                }
+            }
+        });
+
+        Ok(Response::new(ReceiverStream::new(resp_rx)))
+    }
+}
+
+impl From<ReflectionServiceState> for ReflectionService {
+    fn from(state: ReflectionServiceState) -> Self {
+        Self {
+            state: Arc::new(state),
+        }
+    }
+}

--- a/tonic-reflection/tests/server.rs
+++ b/tonic-reflection/tests/server.rs
@@ -100,7 +100,7 @@ async fn make_test_reflection_request(request: ServerReflectionRequest) -> Messa
     let jh = tokio::spawn(async move {
         let service = Builder::configure()
             .register_encoded_file_descriptor_set(FILE_DESCRIPTOR_SET)
-            .build()
+            .build_v1()
             .unwrap();
 
         Server::builder()

--- a/tonic-reflection/tests/versions.rs
+++ b/tonic-reflection/tests/versions.rs
@@ -1,0 +1,170 @@
+use std::net::SocketAddr;
+
+use tokio::sync::oneshot;
+use tokio_stream::{wrappers::TcpListenerStream, StreamExt};
+use tonic::{transport::Server, Request};
+
+use tonic_reflection::pb::{v1, v1alpha};
+use tonic_reflection::server::Builder;
+
+#[tokio::test]
+async fn test_v1() {
+    let response = make_v1_request(v1::ServerReflectionRequest {
+        host: "".to_string(),
+        message_request: Some(v1::server_reflection_request::MessageRequest::ListServices(
+            String::new(),
+        )),
+    })
+    .await;
+
+    if let v1::server_reflection_response::MessageResponse::ListServicesResponse(services) =
+        response
+    {
+        assert_eq!(
+            services.service,
+            vec![v1::ServiceResponse {
+                name: String::from("grpc.reflection.v1.ServerReflection")
+            }]
+        );
+    } else {
+        panic!("Expected a ListServicesResponse variant");
+    }
+}
+
+#[tokio::test]
+async fn test_v1alpha() {
+    let response = make_v1alpha_request(v1alpha::ServerReflectionRequest {
+        host: "".to_string(),
+        message_request: Some(
+            v1alpha::server_reflection_request::MessageRequest::ListServices(String::new()),
+        ),
+    })
+    .await;
+
+    if let v1alpha::server_reflection_response::MessageResponse::ListServicesResponse(services) =
+        response
+    {
+        assert_eq!(
+            services.service,
+            vec![v1alpha::ServiceResponse {
+                name: String::from("grpc.reflection.v1alpha.ServerReflection")
+            }]
+        );
+    } else {
+        panic!("Expected a ListServicesResponse variant");
+    }
+}
+
+async fn make_v1_request(
+    request: v1::ServerReflectionRequest,
+) -> v1::server_reflection_response::MessageResponse {
+    // Run a test server
+    let (shutdown_tx, shutdown_rx) = oneshot::channel();
+
+    let addr: SocketAddr = "127.0.0.1:0".parse().expect("SocketAddr parse");
+    let listener = tokio::net::TcpListener::bind(addr).await.expect("bind");
+    let local_addr = format!("http://{}", listener.local_addr().expect("local address"));
+    let jh = tokio::spawn(async move {
+        let service = Builder::configure().build().unwrap();
+
+        Server::builder()
+            .add_service(service)
+            .serve_with_incoming_shutdown(TcpListenerStream::new(listener), async {
+                drop(shutdown_rx.await)
+            })
+            .await
+            .unwrap();
+    });
+
+    // Give the test server a few ms to become available
+    tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+
+    // Construct client and send request, extract response
+    let conn = tonic::transport::Endpoint::new(local_addr)
+        .unwrap()
+        .connect()
+        .await
+        .unwrap();
+    let mut client = v1::server_reflection_client::ServerReflectionClient::new(conn);
+
+    let request = Request::new(tokio_stream::once(request));
+    let mut inbound = client
+        .server_reflection_info(request)
+        .await
+        .expect("request")
+        .into_inner();
+
+    let response = inbound
+        .next()
+        .await
+        .expect("steamed response")
+        .expect("successful response")
+        .message_response
+        .expect("some MessageResponse");
+
+    // We only expect one response per request
+    assert!(inbound.next().await.is_none());
+
+    // Shut down test server
+    shutdown_tx.send(()).expect("send shutdown");
+    jh.await.expect("server shutdown");
+
+    response
+}
+
+async fn make_v1alpha_request(
+    request: v1alpha::ServerReflectionRequest,
+) -> v1alpha::server_reflection_response::MessageResponse {
+    // Run a test server
+    let (shutdown_tx, shutdown_rx) = oneshot::channel();
+
+    let addr: SocketAddr = "127.0.0.1:0".parse().expect("SocketAddr parse");
+    let listener = tokio::net::TcpListener::bind(addr).await.expect("bind");
+    let local_addr = format!("http://{}", listener.local_addr().expect("local address"));
+    let jh = tokio::spawn(async move {
+        let service = Builder::configure().build_v1alpha().unwrap();
+
+        Server::builder()
+            .add_service(service)
+            .serve_with_incoming_shutdown(TcpListenerStream::new(listener), async {
+                drop(shutdown_rx.await)
+            })
+            .await
+            .unwrap();
+    });
+
+    // Give the test server a few ms to become available
+    tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+
+    // Construct client and send request, extract response
+    let conn = tonic::transport::Endpoint::new(local_addr)
+        .unwrap()
+        .connect()
+        .await
+        .unwrap();
+    let mut client = v1alpha::server_reflection_client::ServerReflectionClient::new(conn);
+
+    let request = Request::new(tokio_stream::once(request));
+    let mut inbound = client
+        .server_reflection_info(request)
+        .await
+        .expect("request")
+        .into_inner();
+
+    let response = inbound
+        .next()
+        .await
+        .expect("steamed response")
+        .expect("successful response")
+        .message_response
+        .expect("some MessageResponse");
+
+    // We only expect one response per request
+    assert!(inbound.next().await.is_none());
+
+    // Shut down test server
+    shutdown_tx.send(()).expect("send shutdown");
+    jh.await.expect("server shutdown");
+
+    response
+}

--- a/tonic-reflection/tests/versions.rs
+++ b/tonic-reflection/tests/versions.rs
@@ -65,7 +65,7 @@ async fn make_v1_request(
     let listener = tokio::net::TcpListener::bind(addr).await.expect("bind");
     let local_addr = format!("http://{}", listener.local_addr().expect("local address"));
     let jh = tokio::spawn(async move {
-        let service = Builder::configure().build().unwrap();
+        let service = Builder::configure().build_v1().unwrap();
 
         Server::builder()
             .add_service(service)


### PR DESCRIPTION
## Motivation

In tonic 0.12, we [upgraded to v1 reflection](https://github.com/hyperium/tonic/pull/1701). However, some tools (like Postman and Kreya) still use the v1alpha1 version of the reflection schema. This PR tries to add back the v1alpha reflection schema with minimal code duplication, by moving code around so that the `Builder` builds a schema-independent `ReflectionServiceState` which can be wrapped in a server following the requested schema version.

This should supersede #1787 and #1822 (thanks @ttkjesper for the input -- I've stolen your tests) while reducing code duplication.

Would be happy to get feedback on whether this works for people affected by this issue, as I'd like to get this merged into the [pending 0.12.2](https://github.com/hyperium/tonic/pull/1881) release.