### PR TITLE
feat(Router): permit overriding the registered route path for custom service implementation

### DIFF
--- a/tonic/src/server/mod.rs
+++ b/tonic/src/server/mod.rs
@@ -23,4 +23,11 @@ pub trait NamedService {
     ///
     /// [here]: https://github.com/grpc/grpc/blob/master/doc/PROTOCOL-HTTP2.md#requests
     const NAME: &'static str;
+
+    /// The route path that gets registered with the underlying Axum router. This trait method
+    /// can be overridden by implementors of NamedService in order to customise the http path
+    /// routing to the service.
+    fn route_path() -> String {
+        format!("/{}/*rest", Self::NAME)
+    }
 }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/hyperium/tonic/blob/master/CONTRIBUTING.md
-->

## Motivation

I am writing a generic service handler that can operate over a number of known routes (not using prost compile grpc services, but forwarding to service handlers elsewhere in the stack). 

The route builder methods all require NamedService to be implemented, and this trait is used to derive the route. This approach doesn't work for a generic service that needs to be routed many different routes. 

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? If a new feature is being added, describe the intended
use case that feature fulfills.
-->

## Solution

Move the derivation of route path from router into the a trait method of NamedService, to change no behaviour for normal services, but allow custom services to override the method and implement it's own routing scheme.

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
