### PR TITLE
Revert "fix(tonic-build): cargo build script outputs are not functional"

### DIFF
--- a/interop/build.rs
+++ b/interop/build.rs
@@ -4,5 +4,5 @@ fn main() {
     tonic_build::compile_protos(proto).unwrap();
 
     // prevent needing to rebuild if files (or deps) haven't changed
-    println!("cargo::rerun-if-changed={}", proto);
+    println!("cargo:rerun-if-changed={}", proto);
 }

--- a/tonic-build/src/prost.rs
+++ b/tonic-build/src/prost.rs
@@ -551,7 +551,7 @@ impl Builder {
     }
 
     /// Enable or disable emitting
-    /// [`cargo::rerun-if-changed=PATH`](https://doc.rust-lang.org/cargo/reference/build-scripts.html#rerun-if-changed)
+    /// [`cargo:rerun-if-changed=PATH`](https://doc.rust-lang.org/cargo/reference/build-scripts.html#rerun-if-changed)
     /// instructions for Cargo.
     ///
     /// If set, writes instructions to `stdout` for Cargo so that it understands
@@ -652,14 +652,14 @@ impl Builder {
 
         if self.emit_rerun_if_changed {
             for path in protos.iter() {
-                println!("cargo::rerun-if-changed={}", path.as_ref().display())
+                println!("cargo:rerun-if-changed={}", path.as_ref().display())
             }
 
             for path in includes.iter() {
                 // Cargo will watch the **entire** directory recursively. If we
                 // could figure out which files are imported by our protos we
                 // could specify only those files instead.
-                println!("cargo::rerun-if-changed={}", path.as_ref().display())
+                println!("cargo:rerun-if-changed={}", path.as_ref().display())
             }
         }
 

--- a/tonic-web/tests/integration/build.rs
+++ b/tonic-web/tests/integration/build.rs
@@ -7,5 +7,5 @@ fn main() {
 
     protos
         .iter()
-        .for_each(|file| println!("cargo::rerun-if-changed={}", file));
+        .for_each(|file| println!("cargo:rerun-if-changed={}", file));
 }


### PR DESCRIPTION
Reverts #1821.

Resolves #1894.