### PR TITLE
feat: plumb skip_debug through prost builder

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,5 +27,6 @@ members = [
   "tests/use_arc_self",
   "tests/default_stubs",
   "tests/deprecated_methods",
+  "tests/skip_debug",
 ]
 resolver = "2"

--- a/tests/skip_debug/Cargo.toml
+++ b/tests/skip_debug/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+authors = ["Andrew Yuan <Andrew.Yuan@temporal.io>"]
+edition = "2021"
+license = "MIT"
+name = "skip_debug"
+publish = false
+version = "0.1.0"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+prost = "0.13"
+tonic = { path = "../../tonic" }
+
+[build-dependencies]
+prost-build = "0.13"
+tonic-build = { path = "../../tonic-build" }

--- a/tests/skip_debug/build.rs
+++ b/tests/skip_debug/build.rs
@@ -1,0 +1,26 @@
+fn main() {
+    let config = prost_build::Config::default();
+    tonic_build::configure()
+        .skip_debug("test.Test")
+        .skip_debug("test.Output")
+        .build_client(true)
+        .build_server(true)
+        .compile_with_config(config, &["proto/test.proto"], &["proto"])
+        .unwrap();
+
+    // Add a dummy impl Debug to the skipped debug implementations to avoid missing impl Debug errors
+    let out = std::path::PathBuf::from(std::env::var("OUT_DIR").unwrap());
+    let file_path = out.join("test.rs");
+    let mut file_contents = std::fs::read_to_string(&file_path).unwrap();
+    let debug_impl = r#"
+impl std::fmt::Debug for Output {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{:?}", self)
+    }
+}
+"#;
+    file_contents.push_str(debug_impl);
+
+    // Replace the original file with the modified content
+    std::fs::write(&file_path, file_contents).unwrap();
+}

--- a/tests/skip_debug/proto/test.proto
+++ b/tests/skip_debug/proto/test.proto
@@ -1,0 +1,11 @@
+syntax = "proto3";
+
+package test;
+
+service Test {
+  rpc Rpc(Input) returns (Output);
+}
+
+message Input {}
+
+message Output {}

--- a/tests/skip_debug/src/lib.rs
+++ b/tests/skip_debug/src/lib.rs
@@ -1,0 +1,3 @@
+pub mod pb {
+    tonic::include_proto!("test");
+}

--- a/tests/skip_debug/tests/skip_debug.rs
+++ b/tests/skip_debug/tests/skip_debug.rs
@@ -1,0 +1,8 @@
+use std::{fs, path::PathBuf};
+
+#[test]
+fn skip_debug() {
+    let path = PathBuf::from(std::env::var("OUT_DIR").unwrap()).join("test.rs");
+    let s = fs::read_to_string(path).unwrap();
+    assert!(s.contains("#[prost(skip_debug)]\npub struct Output {}"));
+}

--- a/tonic-build/src/prost.rs
+++ b/tonic-build/src/prost.rs
@@ -42,6 +42,7 @@ pub fn configure() -> Builder {
         use_arc_self: false,
         generate_default_stubs: false,
         compile_settings: CompileSettings::default(),
+        skip_debug: HashSet::default(),
     }
 }
 
@@ -307,6 +308,7 @@ pub struct Builder {
     pub(crate) use_arc_self: bool,
     pub(crate) generate_default_stubs: bool,
     pub(crate) compile_settings: CompileSettings,
+    pub(crate) skip_debug: HashSet<String>,
 
     out_dir: Option<PathBuf>,
 }
@@ -589,6 +591,12 @@ impl Builder {
         self
     }
 
+    /// Skips generating `impl Debug` for types
+    pub fn skip_debug(mut self, path: impl AsRef<str>) -> Self {
+        self.skip_debug.insert(path.as_ref().to_string());
+        self
+    }
+
     /// Compile the .proto files and execute code generation.
     pub fn compile(
         self,
@@ -644,6 +652,9 @@ impl Builder {
         }
         if let Some(path) = self.include_file.as_ref() {
             config.include_file(path);
+        }
+        if !self.skip_debug.is_empty() {
+            config.skip_debug(&self.skip_debug);
         }
 
         for arg in self.protoc_args.iter() {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/hyperium/tonic/blob/master/CONTRIBUTING.md
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? If a new feature is being added, describe the intended
use case that feature fulfills.
-->

[skip_debug](https://docs.rs/prost-build/0.13.1/prost_build/struct.Config.html#method.skip_debug) is a method supported for prost `Config`. tonic doesn't support this method today.

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
Added a new `skip_debug()` method to prost `Builder` and added a corresponding test.
