### PR TITLE
chore(Dev): ignore .idea directory that Intellij IDEs add automatically

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ target/
 **/*.rs.bk
 Cargo.lock
 tags
+.idea


### PR DESCRIPTION
Very minor quality-of-life thing; I keep accidentally committing the dir that IDEA creates and having to remove it. 