### PR TITLE
chore: Bump msrv to 1.71.1

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -90,7 +90,7 @@ jobs:
     - uses: actions/checkout@v4
     - uses: hecrj/setup-rust-action@v2
       with:
-        rust-version: "1.70"    # msrv
+        rust-version: "1.71.1"    # msrv
     - uses: taiki-e/install-action@cargo-no-dev-deps
     - uses: Swatinem/rust-cache@v2
     - run: cargo no-dev-deps --no-private check --all-features

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ For IntelliJ IDEA users, please refer to [this](https://github.com/intellij-rust
 
 ### Rust Version
 
-`tonic`'s MSRV is `1.70`.
+`tonic`'s MSRV is `1.71.1`.
 
 ```bash
 $ rustup update


### PR DESCRIPTION


<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/hyperium/tonic/blob/master/CONTRIBUTING.md
-->

## Motivation
I intend to increase the MSRV of `prost` to 1.71.1, because of their dependencies. I intend to release that in 0.13.3 (current version is 0.13.1). https://github.com/tokio-rs/prost/pull/1135

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? If a new feature is being added, describe the intended
use case that feature fulfills.
-->

## Solution
 I think `tonic` should already increase to prevent future breakage.
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
