### PR TITLE
chore(ci): Add clippy job to check error

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -28,6 +28,19 @@ jobs:
     - uses: actions/checkout@v4
     - uses: EmbarkStudios/cargo-deny-action@v2
 
+  clippy:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - uses: hecrj/setup-rust-action@v2
+      with:
+        components: clippy
+    - uses: taiki-e/install-action@protoc
+    - uses: Swatinem/rust-cache@v2
+    - run: cargo clippy --workspace --all-features --all-targets
+      env:
+        RUSTFLAGS: "-A warnings"
+
   codegen:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Adds `clippy` job to check only error to detect some kind of error like #1908 which is difficult to find.