### PR TITLE
chore(ci): Remove unnecessary protoc version lock

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -8,7 +8,6 @@ on:
     branches: [ "master" ]
 
 env:
-  PROTOC_VERSION: 3.25.1
   RUSTFLAGS: "-D warnings"
 
 jobs:
@@ -37,7 +36,7 @@ jobs:
     - name: Install protoc
       uses: taiki-e/install-action@v2
       with:
-        tool: protoc@${{ env.PROTOC_VERSION }}
+        tool: protoc@3.25.1
     - uses: Swatinem/rust-cache@v2
     - run: cargo run --package codegen
     - run: git diff --exit-code
@@ -52,10 +51,7 @@ jobs:
         toolchain: nightly-2024-08-04
     - uses: taiki-e/install-action@cargo-hack
     - uses: taiki-e/install-action@cargo-udeps
-    - name: Install protoc
-      uses: taiki-e/install-action@v2
-      with:
-        tool: protoc@${{ env.PROTOC_VERSION }}
+    - uses: taiki-e/install-action@protoc
     - uses: Swatinem/rust-cache@v2
     - run: cargo hack udeps --workspace --exclude-features tls --each-feature
     - run: cargo udeps --package tonic --features tls,transport
@@ -71,10 +67,7 @@ jobs:
     - uses: actions/checkout@v4
     - uses: hecrj/setup-rust-action@v2
     - uses: taiki-e/install-action@cargo-hack
-    - name: Install protoc
-      uses: taiki-e/install-action@v2
-      with:
-        tool: protoc@${{ env.PROTOC_VERSION }}
+    - uses: taiki-e/install-action@protoc
     - uses: Swatinem/rust-cache@v2
     - name: Check features
       run: cargo hack check --workspace --no-private --each-feature --no-dev-deps
@@ -106,10 +99,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - uses: hecrj/setup-rust-action@v2
-    - name: Install protoc
-      uses: taiki-e/install-action@v2
-      with:
-        tool: protoc@${{ env.PROTOC_VERSION }}
+    - uses: taiki-e/install-action@protoc
     - uses: Swatinem/rust-cache@v2
     - run: cargo test --workspace --all-features
       env:
@@ -124,10 +114,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - uses: hecrj/setup-rust-action@v2
-    - name: Install protoc
-      uses: taiki-e/install-action@v2
-      with:
-        tool: protoc@${{ env.PROTOC_VERSION }}
+    - uses: taiki-e/install-action@protoc
     - uses: Swatinem/rust-cache@v2
     - name: Run interop tests
       run: ./interop/test.sh

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -212,8 +212,7 @@ When making changes to `tonic-build` that affects the generated code you will
 need to ensure that each of the sub crates gets updated as well. Each of the sub
 crates like, for example `tonic-health`, generate their gRPC code via `codegen`
 crate. This requires `Protocol Buffers Compiler` of which version is same as the
-one used in the GitHub Action (see the
-[environment variable `PROTOC_VERSION`](./.github/workflows/CI.yml)).
+one used in the GitHub Action (see [`codegen` job](./.github/workflows/CI.yml)).
 
 ```
 cargo run --package codegen


### PR DESCRIPTION
Removes unnecessary `protoc` version lock. This allows to check with the latest version of `protoc`.