### PR TITLE
chore(tls): Update to rustls-native-certs 0.8

### DIFF
--- a/tonic/Cargo.toml
+++ b/tonic/Cargo.toml
@@ -89,7 +89,7 @@ axum = {version = "0.7", default-features = false, optional = true}
 
 # rustls
 rustls-pemfile = { version = "2.0", optional = true }
-rustls-native-certs = { version = "0.7", optional = true }
+rustls-native-certs = { version = "0.8", optional = true }
 tokio-rustls = { version = "0.26", default-features = false, features = ["logging", "tls12", "ring"], optional = true }
 webpki-roots = { version = "0.26", optional = true }
 

--- a/tonic/src/transport/service/tls.rs
+++ b/tonic/src/transport/service/tls.rs
@@ -14,6 +14,8 @@ pub(crate) const ALPN_H2: &[u8] = b"h2";
 pub(crate) enum TlsError {
     #[cfg(feature = "channel")]
     H2NotNegotiated,
+    #[cfg(feature = "tls-native-roots")]
+    NativeCertsNotFound,
     CertificateParseError,
     PrivateKeyParseError,
 }
@@ -23,6 +25,8 @@ impl fmt::Display for TlsError {
         match self {
             #[cfg(feature = "channel")]
             TlsError::H2NotNegotiated => write!(f, "HTTP/2 was not negotiated."),
+            #[cfg(feature = "tls-native-roots")]
+            TlsError::NativeCertsNotFound => write!(f, "no native certs found"),
             TlsError::CertificateParseError => write!(f, "Error parsing TLS certificate."),
             TlsError::PrivateKeyParseError => write!(
                 f,


### PR DESCRIPTION
Updates to `rustls-native-certs` 0.8.