### PR TITLE
feat(build): Rename compile method with compile_protos

### DIFF
--- a/codegen/src/main.rs
+++ b/codegen/src/main.rs
@@ -87,7 +87,7 @@ fn codegen(
         .build_server(build_server)
         .out_dir(&tempdir)
         .file_descriptor_set_path(file_descriptor_set_path)
-        .compile(&iface_files, &include_dirs)
+        .compile_protos(&iface_files, &include_dirs)
         .unwrap();
 
     for path in std::fs::read_dir(tempdir.path()).unwrap() {

--- a/examples/build.rs
+++ b/examples/build.rs
@@ -3,13 +3,13 @@ use std::{env, path::PathBuf};
 fn main() {
     tonic_build::configure()
         .type_attribute("routeguide.Point", "#[derive(Hash)]")
-        .compile(&["proto/routeguide/route_guide.proto"], &["proto"])
+        .compile_protos(&["proto/routeguide/route_guide.proto"], &["proto"])
         .unwrap();
 
     let out_dir = PathBuf::from(env::var("OUT_DIR").unwrap());
     tonic_build::configure()
         .file_descriptor_set_path(out_dir.join("helloworld_descriptor.bin"))
-        .compile(&["proto/helloworld/helloworld.proto"], &["proto"])
+        .compile_protos(&["proto/helloworld/helloworld.proto"], &["proto"])
         .unwrap();
 
     tonic_build::compile_protos("proto/echo/echo.proto").unwrap();
@@ -21,12 +21,12 @@ fn main() {
         .server_attribute("Echo", "#[derive(PartialEq)]")
         .client_mod_attribute("attrs", "#[cfg(feature = \"client\")]")
         .client_attribute("Echo", "#[derive(PartialEq)]")
-        .compile(&["proto/attrs/attrs.proto"], &["proto"])
+        .compile_protos(&["proto/attrs/attrs.proto"], &["proto"])
         .unwrap();
 
     tonic_build::configure()
         .build_server(false)
-        .compile(
+        .compile_protos(
             &["proto/googleapis/google/pubsub/v1/pubsub.proto"],
             &["proto/googleapis"],
         )
@@ -39,7 +39,7 @@ fn main() {
     tonic_build::configure()
         .out_dir(smallbuff_copy)
         .codec_path("crate::common::SmallBufferCodec")
-        .compile(&["proto/helloworld/helloworld.proto"], &["proto"])
+        .compile_protos(&["proto/helloworld/helloworld.proto"], &["proto"])
         .unwrap();
 }
 

--- a/tests/default_stubs/build.rs
+++ b/tests/default_stubs/build.rs
@@ -1,9 +1,9 @@
 fn main() {
     tonic_build::configure()
-        .compile(&["proto/test.proto"], &["proto"])
+        .compile_protos(&["proto/test.proto"], &["proto"])
         .unwrap();
     tonic_build::configure()
         .generate_default_stubs(true)
-        .compile(&["proto/test_default.proto"], &["proto"])
+        .compile_protos(&["proto/test_default.proto"], &["proto"])
         .unwrap();
 }

--- a/tests/disable_comments/build.rs
+++ b/tests/disable_comments/build.rs
@@ -6,6 +6,6 @@ fn main() {
         .disable_comments("test.Service1.Rpc1")
         .build_client(true)
         .build_server(true)
-        .compile_with_config(config, &["proto/test.proto"], &["proto"])
+        .compile_protos_with_config(config, &["proto/test.proto"], &["proto"])
         .unwrap();
 }

--- a/tests/extern_path/my_application/build.rs
+++ b/tests/extern_path/my_application/build.rs
@@ -3,7 +3,7 @@ fn main() -> Result<(), std::io::Error> {
         .build_server(false)
         .build_client(true)
         .extern_path(".uuid", "::uuid")
-        .compile(
+        .compile_protos(
             &["service.proto", "uuid.proto"],
             &["../proto/my_application", "../proto/uuid"],
         )?;

--- a/tests/root-crate-path/build.rs
+++ b/tests/root-crate-path/build.rs
@@ -1,7 +1,7 @@
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     tonic_build::configure()
         .extern_path(".foo.bar.baz.Animal", "crate::Animal")
-        .compile(&["foo.proto"], &["."])?;
+        .compile_protos(&["foo.proto"], &["."])?;
 
     Ok(())
 }

--- a/tests/skip_debug/build.rs
+++ b/tests/skip_debug/build.rs
@@ -5,7 +5,7 @@ fn main() {
         .skip_debug("test.Output")
         .build_client(true)
         .build_server(true)
-        .compile_with_config(config, &["proto/test.proto"], &["proto"])
+        .compile_protos_with_config(config, &["proto/test.proto"], &["proto"])
         .unwrap();
 
     // Add a dummy impl Debug to the skipped debug implementations to avoid missing impl Debug errors

--- a/tests/use_arc_self/build.rs
+++ b/tests/use_arc_self/build.rs
@@ -1,6 +1,6 @@
 fn main() {
     tonic_build::configure()
         .use_arc_self(true)
-        .compile(&["proto/test.proto"], &["proto"])
+        .compile_protos(&["proto/test.proto"], &["proto"])
         .unwrap();
 }

--- a/tests/wellknown-compiled/build.rs
+++ b/tests/wellknown-compiled/build.rs
@@ -4,7 +4,7 @@ fn main() {
 
     tonic_build::configure()
         .compile_well_known_types(true)
-        .compile_with_config(
+        .compile_protos_with_config(
             config,
             &["proto/google.proto", "proto/test.proto"],
             &["proto"],

--- a/tonic-build/src/prost.rs
+++ b/tonic-build/src/prost.rs
@@ -58,7 +58,7 @@ pub fn compile_protos(proto: impl AsRef<Path>) -> io::Result<()> {
         .parent()
         .expect("proto file should reside in a directory");
 
-    self::configure().compile(&[proto_path], &[proto_dir])
+    self::configure().compile_protos(&[proto_path], &[proto_dir])
 }
 
 /// Non-path Rust types allowed for request/response types.
@@ -596,17 +596,39 @@ impl Builder {
     }
 
     /// Compile the .proto files and execute code generation.
+    #[deprecated(since = "0.12.3", note = "renamed to `compile_protos()`")]
     pub fn compile(
         self,
         protos: &[impl AsRef<Path>],
         includes: &[impl AsRef<Path>],
     ) -> io::Result<()> {
-        self.compile_with_config(Config::new(), protos, includes)
+        self.compile_protos(protos, includes)
     }
 
     /// Compile the .proto files and execute code generation using a
     /// custom `prost_build::Config`.
+    #[deprecated(since = "0.12.3", note = "renamed to `compile_protos_with_config()`")]
     pub fn compile_with_config(
+        self,
+        config: Config,
+        protos: &[impl AsRef<Path>],
+        includes: &[impl AsRef<Path>],
+    ) -> io::Result<()> {
+        self.compile_protos_with_config(config, protos, includes)
+    }
+
+    /// Compile the .proto files and execute code generation.
+    pub fn compile_protos(
+        self,
+        protos: &[impl AsRef<Path>],
+        includes: &[impl AsRef<Path>],
+    ) -> io::Result<()> {
+        self.compile_protos_with_config(Config::new(), protos, includes)
+    }
+
+    /// Compile the .proto files and execute code generation using a
+    /// custom `prost_build::Config`.
+    pub fn compile_protos_with_config(
         self,
         mut config: Config,
         protos: &[impl AsRef<Path>],

--- a/tonic-web/tests/integration/build.rs
+++ b/tonic-web/tests/integration/build.rs
@@ -2,7 +2,7 @@ fn main() {
     let protos = &["proto/test.proto"];
 
     tonic_build::configure()
-        .compile(protos, &["proto"])
+        .compile_protos(protos, &["proto"])
         .unwrap();
 
     protos


### PR DESCRIPTION
Renames `compile()` method with `compile_protos()` and `compile_with_config` with `compile_protos_with_config`. This makes the same naming rule with the API compiling from file descriptor set, and also makes it easier to understand as it has the same naming style as `prost-build`.
