### PR TITLE
feat(build): Add simple api to compile file descriptor set

### DIFF
--- a/tonic-build/src/lib.rs
+++ b/tonic-build/src/lib.rs
@@ -83,7 +83,7 @@ use quote::TokenStreamExt;
 mod prost;
 
 #[cfg(feature = "prost")]
-pub use prost::{compile_protos, configure, Builder};
+pub use prost::{compile_fds, compile_protos, configure, Builder};
 
 pub mod manual;
 

--- a/tonic-build/src/prost.rs
+++ b/tonic-build/src/prost.rs
@@ -61,6 +61,11 @@ pub fn compile_protos(proto: impl AsRef<Path>) -> io::Result<()> {
     self::configure().compile(&[proto_path], &[proto_dir])
 }
 
+/// Simple file descriptor set compiling. Use [`configure`] instead if you need more options.
+pub fn compile_fds(fds: prost_types::FileDescriptorSet) -> io::Result<()> {
+    self::configure().compile_fds(fds)
+}
+
 /// Non-path Rust types allowed for request/response types.
 const NON_PATH_TYPE_ALLOWLIST: &[&str] = &["()"];
 


### PR DESCRIPTION
Adds a simple API to compile file descriptor set, corresponding to `tonic_build::compile_protos()`.