### PR TITLE
chore(doc): Replace deprecated compile with compile_protos

### DIFF
--- a/examples/routeguide-tutorial.md
+++ b/examples/routeguide-tutorial.md
@@ -816,7 +816,7 @@ fn main() {
     tonic_build::configure()
         .build_client(false)
         .out_dir("another_crate/src/pb")
-        .compile(&["path/my_proto.proto"], &["path"])
+        .compile_protos(&["path/my_proto.proto"], &["path"])
         .expect("failed to compile protos");
 }
 ```

--- a/tonic-build/README.md
+++ b/tonic-build/README.md
@@ -33,7 +33,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 fn main() -> Result<(), Box<dyn std::error::Error>> {
    tonic_build::configure()
         .build_server(false)
-        .compile(
+        .compile_protos(
             &["proto/helloworld/helloworld.proto"],
             &["proto/helloworld"],
         )?;
@@ -74,7 +74,7 @@ fn main() {
     tonic_build::configure()
         .build_server(false)
         //.out_dir("src/google")  // you can change the generated code's location
-        .compile(
+        .compile_protos(
             &["proto/googleapis/google/pubsub/v1/pubsub.proto"],
             &["proto/googleapis"], // specify the root location to search proto dependencies
         ).unwrap();

--- a/tonic-build/src/lib.rs
+++ b/tonic-build/src/lib.rs
@@ -36,7 +36,7 @@
 //! fn main() -> Result<(), Box<dyn std::error::Error>> {
 //!    tonic_build::configure()
 //!         .build_server(false)
-//!         .compile(
+//!         .compile_protos(
 //!             &["proto/helloworld/helloworld.proto"],
 //!             &["proto/helloworld"],
 //!         )?;

--- a/tonic/src/macros.rs
+++ b/tonic/src/macros.rs
@@ -45,7 +45,7 @@ macro_rules! include_proto {
 /// tonic_build::configure()
 ///     .file_descriptor_set_path(&descriptor_path)
 ///     .format(true)
-///     .compile(&["proto/reflection.proto"], &["proto/"])?;
+///     .compile_protos(&["proto/reflection.proto"], &["proto/"])?;
 /// ```
 ///
 /// Can be included like this:


### PR DESCRIPTION
Replaces deprecated `compile` with `compile_protos`.