### PR TITLE
Clean up EncodeBody API

### DIFF
--- a/tonic/Cargo.toml
+++ b/tonic/Cargo.toml
@@ -69,7 +69,7 @@ percent-encoding = "2.1"
 pin-project = "1.0.11"
 tower-layer = "0.3"
 tower-service = "0.3"
-tokio-stream = {version = "0.1", default-features = false}
+tokio-stream = {version = "0.1.16", default-features = false}
 
 # prost
 prost = {version = "0.13", default-features = false, features = ["std"], optional = true}

--- a/tonic/src/client/grpc.rs
+++ b/tonic/src/client/grpc.rs
@@ -1,9 +1,10 @@
 use crate::codec::compression::{CompressionEncoding, EnabledCompressionEncodings};
+use crate::codec::EncodeBody;
 use crate::metadata::GRPC_CONTENT_TYPE;
 use crate::{
     body::BoxBody,
     client::GrpcService,
-    codec::{encode_client, Codec, Decoder, Streaming},
+    codec::{Codec, Decoder, Streaming},
     request::SanitizeHeaders,
     Code, Request, Response, Status,
 };
@@ -295,7 +296,7 @@ impl<T> Grpc<T> {
     {
         let request = request
             .map(|s| {
-                encode_client(
+                EncodeBody::new_client(
                     codec.encoder(),
                     s.map(Ok),
                     self.config.send_compression_encodings,

--- a/tonic/src/client/grpc.rs
+++ b/tonic/src/client/grpc.rs
@@ -297,7 +297,7 @@ impl<T> Grpc<T> {
             .map(|s| {
                 encode_client(
                     codec.encoder(),
-                    s,
+                    s.map(Ok),
                     self.config.send_compression_encodings,
                     self.config.max_encoding_message_size,
                 )

--- a/tonic/src/codec/encode.rs
+++ b/tonic/src/codec/encode.rs
@@ -66,7 +66,7 @@ where
 ///  * The encoded buffer surpasses YIELD_THRESHOLD.
 #[pin_project(project = EncodedBytesProj)]
 #[derive(Debug)]
-pub(crate) struct EncodedBytes<T, U> {
+struct EncodedBytes<T, U> {
     #[pin]
     source: U,
     encoder: T,

--- a/tonic/src/codec/encode.rs
+++ b/tonic/src/codec/encode.rs
@@ -66,11 +66,7 @@ where
 ///  * The encoded buffer surpasses YIELD_THRESHOLD.
 #[pin_project(project = EncodedBytesProj)]
 #[derive(Debug)]
-pub(crate) struct EncodedBytes<T, U>
-where
-    T: Encoder<Error = Status>,
-    U: Stream<Item = Result<T::Item, Status>>,
-{
+pub(crate) struct EncodedBytes<T, U> {
     #[pin]
     source: U,
     encoder: T,
@@ -81,11 +77,7 @@ where
     error: Option<Status>,
 }
 
-impl<T, U> EncodedBytes<T, U>
-where
-    T: Encoder<Error = Status>,
-    U: Stream<Item = Result<T::Item, Status>>,
-{
+impl<T: Encoder, U> EncodedBytes<T, U> {
     // `source` should be fused stream.
     fn new(
         encoder: T,

--- a/tonic/src/codec/encode.rs
+++ b/tonic/src/codec/encode.rs
@@ -20,14 +20,14 @@ pub fn encode_client<T, U>(
     source: U,
     compression_encoding: Option<CompressionEncoding>,
     max_message_size: Option<usize>,
-) -> EncodeBody<T, impl Stream<Item = Result<T::Item, Status>>>
+) -> EncodeBody<T, U>
 where
     T: Encoder<Error = Status>,
-    U: Stream<Item = T::Item>,
+    U: Stream,
 {
     let stream = EncodedBytes::new(
         encoder,
-        source.map(Ok),
+        source,
         compression_encoding,
         SingleMessageCompressionOverride::default(),
         max_message_size,

--- a/tonic/src/codec/mod.rs
+++ b/tonic/src/codec/mod.rs
@@ -16,7 +16,7 @@ use std::io;
 pub use self::buffer::{DecodeBuf, EncodeBuf};
 pub use self::compression::{CompressionEncoding, EnabledCompressionEncodings};
 pub use self::decode::Streaming;
-pub use self::encode::{encode_client, encode_server, EncodeBody};
+pub use self::encode::{encode_client, EncodeBody};
 #[cfg(feature = "prost")]
 pub use self::prost::ProstCodec;
 

--- a/tonic/src/codec/mod.rs
+++ b/tonic/src/codec/mod.rs
@@ -16,7 +16,7 @@ use std::io;
 pub use self::buffer::{DecodeBuf, EncodeBuf};
 pub use self::compression::{CompressionEncoding, EnabledCompressionEncodings};
 pub use self::decode::Streaming;
-pub use self::encode::{encode_client, EncodeBody};
+pub use self::encode::EncodeBody;
 #[cfg(feature = "prost")]
 pub use self::prost::ProstCodec;
 

--- a/tonic/src/codec/prost.rs
+++ b/tonic/src/codec/prost.rs
@@ -150,9 +150,7 @@ fn from_decode_error(error: prost::DecodeError) -> crate::Status {
 #[cfg(test)]
 mod tests {
     use crate::codec::compression::SingleMessageCompressionOverride;
-    use crate::codec::{
-        encode_server, DecodeBuf, Decoder, EncodeBuf, Encoder, Streaming, HEADER_SIZE,
-    };
+    use crate::codec::{DecodeBuf, Decoder, EncodeBody, EncodeBuf, Encoder, Streaming, HEADER_SIZE};
     use crate::Status;
     use bytes::{Buf, BufMut, BytesMut};
     use http_body::Body;
@@ -228,7 +226,7 @@ mod tests {
         let messages = std::iter::repeat_with(move || Ok::<_, Status>(msg.clone())).take(10000);
         let source = tokio_stream::iter(messages);
 
-        let mut body = pin!(encode_server(
+        let mut body = pin!(EncodeBody::new_server(
             encoder,
             source,
             None,
@@ -250,7 +248,7 @@ mod tests {
         let messages = std::iter::once(Ok::<_, Status>(msg));
         let source = tokio_stream::iter(messages);
 
-        let mut body = pin!(encode_server(
+        let mut body = pin!(EncodeBody::new_server(
             encoder,
             source,
             None,
@@ -278,6 +276,8 @@ mod tests {
     #[cfg(not(target_family = "windows"))]
     #[tokio::test]
     async fn encode_too_big() {
+        use crate::codec::EncodeBody;
+
         let encoder = MockEncoder::default();
 
         let msg = vec![0u8; u32::MAX as usize + 1];
@@ -285,7 +285,7 @@ mod tests {
         let messages = std::iter::once(Ok::<_, Status>(msg));
         let source = tokio_stream::iter(messages);
 
-        let mut body = pin!(encode_server(
+        let mut body = pin!(EncodeBody::new_server(
             encoder,
             source,
             None,

--- a/tonic/src/codec/prost.rs
+++ b/tonic/src/codec/prost.rs
@@ -150,7 +150,9 @@ fn from_decode_error(error: prost::DecodeError) -> crate::Status {
 #[cfg(test)]
 mod tests {
     use crate::codec::compression::SingleMessageCompressionOverride;
-    use crate::codec::{DecodeBuf, Decoder, EncodeBody, EncodeBuf, Encoder, Streaming, HEADER_SIZE};
+    use crate::codec::{
+        DecodeBuf, Decoder, EncodeBody, EncodeBuf, Encoder, Streaming, HEADER_SIZE,
+    };
     use crate::Status;
     use bytes::{Buf, BufMut, BytesMut};
     use http_body::Body;

--- a/tonic/src/server/grpc.rs
+++ b/tonic/src/server/grpc.rs
@@ -1,10 +1,11 @@
 use crate::codec::compression::{
     CompressionEncoding, EnabledCompressionEncodings, SingleMessageCompressionOverride,
 };
+use crate::codec::EncodeBody;
 use crate::metadata::GRPC_CONTENT_TYPE;
 use crate::{
     body::BoxBody,
-    codec::{encode_server, Codec, Streaming},
+    codec::{Codec, Streaming},
     server::{ClientStreamingService, ServerStreamingService, StreamingService, UnaryService},
     Request, Status,
 };
@@ -447,7 +448,7 @@ where
             );
         }
 
-        let body = encode_server(
+        let body = EncodeBody::new_server(
             self.codec.encoder(),
             body,
             accept_encoding,


### PR DESCRIPTION
Follow-up to #1884 to simplify the newly public low-level `EncodeBody` API.

cc @zakhenry 