### PR TITLE
Update docs in tonic::macros

### DIFF
--- a/tonic/src/macros.rs
+++ b/tonic/src/macros.rs
@@ -44,7 +44,6 @@ macro_rules! include_proto {
 /// let descriptor_path = PathBuf::from(env::var("OUT_DIR").unwrap()).join("my_descriptor.bin")
 /// tonic_build::configure()
 ///     .file_descriptor_set_path(&descriptor_path)
-///     .format(true)
 ///     .compile_protos(&["proto/reflection.proto"], &["proto/"])?;
 /// ```
 ///


### PR DESCRIPTION
Method `format` was removed in #904, but this doc was not updated because it has an attribute `ignore`.