### PR TITLE
build: suppress `clippy::wildcard_imports` in generated code

### DIFF
--- a/tonic-build/src/client.rs
+++ b/tonic-build/src/client.rs
@@ -49,6 +49,7 @@ pub(crate) fn generate_internal<T: Service>(
                 unused_variables,
                 dead_code,
                 missing_docs,
+                clippy::wildcard_imports,
                 // will trigger if compression is disabled
                 clippy::let_unit_value,
             )]

--- a/tonic-build/src/server.rs
+++ b/tonic-build/src/server.rs
@@ -100,6 +100,7 @@ pub(crate) fn generate_internal<T: Service>(
                 unused_variables,
                 dead_code,
                 missing_docs,
+                clippy::wildcard_imports,
                 // will trigger if compression is disabled
                 clippy::let_unit_value,
             )]

--- a/tonic-health/src/generated/grpc_health_v1.rs
+++ b/tonic-health/src/generated/grpc_health_v1.rs
@@ -57,7 +57,13 @@ pub mod health_check_response {
 }
 /// Generated client implementations.
 pub mod health_client {
-    #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
+    #![allow(
+        unused_variables,
+        dead_code,
+        missing_docs,
+        clippy::wildcard_imports,
+        clippy::let_unit_value,
+    )]
     use tonic::codegen::*;
     use tonic::codegen::http::Uri;
     #[derive(Debug, Clone)]
@@ -198,7 +204,13 @@ pub mod health_client {
 }
 /// Generated server implementations.
 pub mod health_server {
-    #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
+    #![allow(
+        unused_variables,
+        dead_code,
+        missing_docs,
+        clippy::wildcard_imports,
+        clippy::let_unit_value,
+    )]
     use tonic::codegen::*;
     /// Generated trait containing gRPC methods that should be implemented for use with HealthServer.
     #[async_trait]

--- a/tonic-reflection/src/generated/grpc_reflection_v1.rs
+++ b/tonic-reflection/src/generated/grpc_reflection_v1.rs
@@ -146,7 +146,13 @@ pub struct ErrorResponse {
 }
 /// Generated client implementations.
 pub mod server_reflection_client {
-    #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
+    #![allow(
+        unused_variables,
+        dead_code,
+        missing_docs,
+        clippy::wildcard_imports,
+        clippy::let_unit_value,
+    )]
     use tonic::codegen::*;
     use tonic::codegen::http::Uri;
     #[derive(Debug, Clone)]
@@ -255,7 +261,13 @@ pub mod server_reflection_client {
 }
 /// Generated server implementations.
 pub mod server_reflection_server {
-    #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
+    #![allow(
+        unused_variables,
+        dead_code,
+        missing_docs,
+        clippy::wildcard_imports,
+        clippy::let_unit_value,
+    )]
     use tonic::codegen::*;
     /// Generated trait containing gRPC methods that should be implemented for use with ServerReflectionServer.
     #[async_trait]

--- a/tonic-reflection/src/generated/grpc_reflection_v1alpha.rs
+++ b/tonic-reflection/src/generated/grpc_reflection_v1alpha.rs
@@ -146,7 +146,13 @@ pub struct ErrorResponse {
 }
 /// Generated client implementations.
 pub mod server_reflection_client {
-    #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
+    #![allow(
+        unused_variables,
+        dead_code,
+        missing_docs,
+        clippy::wildcard_imports,
+        clippy::let_unit_value,
+    )]
     use tonic::codegen::*;
     use tonic::codegen::http::Uri;
     #[derive(Debug, Clone)]
@@ -255,7 +261,13 @@ pub mod server_reflection_client {
 }
 /// Generated server implementations.
 pub mod server_reflection_server {
-    #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
+    #![allow(
+        unused_variables,
+        dead_code,
+        missing_docs,
+        clippy::wildcard_imports,
+        clippy::let_unit_value,
+    )]
     use tonic::codegen::*;
     /// Generated trait containing gRPC methods that should be implemented for use with ServerReflectionServer.
     #[async_trait]


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/hyperium/tonic/blob/master/CONTRIBUTING.md
-->

## Motivation

The `clippy::wildcard_imports` is not enabled by default, but some projects might enable it, causing tonic-build to generate code failing to lint.

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? If a new feature is being added, describe the intended
use case that feature fulfills.
-->

## Solution

`#[allow(clippy::wildcard_imports)]` in generated code

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
