### PR TITLE
fix(tls): do not shutdown server on unexpected Eof

### DIFF
--- a/tonic/src/transport/server/incoming.rs
+++ b/tonic/src/transport/server/incoming.rs
@@ -96,6 +96,7 @@ fn handle_accept_error(e: impl Into<crate::Error>) -> ControlFlow<crate::Error> 
             io::ErrorKind::ConnectionAborted
                 | io::ErrorKind::Interrupted
                 | io::ErrorKind::InvalidData // Raised if TLS handshake failed
+                | io::ErrorKind::UnexpectedEof // Raised if TLS handshake failed
                 | io::ErrorKind::WouldBlock
         ) {
             return ControlFlow::Continue(());


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/hyperium/tonic/blob/master/CONTRIBUTING.md
-->

## Motivation

When receiving non TLS packets (like TCP healtchecks), the server shuts down due to the UnexpectedEof returned by rustls.

## Solution

Ignore this error
