### PR TITLE
fix(tls): do not shutdown server on broken connections

### DIFF
--- a/tonic/src/transport/server/incoming.rs
+++ b/tonic/src/transport/server/incoming.rs
@@ -94,6 +94,8 @@ fn handle_accept_error(e: impl Into<crate::Error>) -> ControlFlow<crate::Error> 
         if matches!(
             e.kind(),
             io::ErrorKind::ConnectionAborted
+                | io::ErrorKind::ConnectionReset
+                | io::ErrorKind::BrokenPipe
                 | io::ErrorKind::Interrupted
                 | io::ErrorKind::InvalidData // Raised if TLS handshake failed
                 | io::ErrorKind::UnexpectedEof // Raised if TLS handshake failed


### PR DESCRIPTION
## Motivation

This is a continuation of #1938. Other errors are not fatal to the server as a whole.

I observed this today in production (we are already running #1938). While connections breaking are much less rare than "unexpected eof", they still happened once:

```
Sep 19 14:56:13 api01 watchdog.sh[19879]: {"timestamp":"2024-09-19T14:56:13.360774Z","level":"DEBUG","message":"accept loop error","error":"Connection reset by peer (os error 104)","target":"tonic::transport::server::incoming"}
```

## Solution

The solution is to add "connection reset" and "broken pipe" errors to the list of non-fatal errors that make the accept loop continue.