### PR TITLE
fix: add `tower?/util` dep for `channel` feature only builds

### DIFF
--- a/tonic/Cargo.toml
+++ b/tonic/Cargo.toml
@@ -47,7 +47,7 @@ server = [
 channel = [
   "dep:hyper", "hyper?/client",
   "dep:hyper-util", "hyper-util?/client-legacy",
-  "dep:tower", "tower?/balance", "tower?/buffer", "tower?/discover", "tower?/limit",
+  "dep:tower", "tower?/balance", "tower?/buffer", "tower?/discover", "tower?/limit", "tower?/util",
   "dep:tokio", "tokio?/time",
   "dep:hyper-timeout",
 ]


### PR DESCRIPTION
The `channel` feature needs `tower?/util` feature to be built with `no-default-features`.