### PR TITLE
feat(tonic-web): Create enable_with_cors method

### DIFF
--- a/tonic-web/src/lib.rs
+++ b/tonic-web/src/lib.rs
@@ -127,7 +127,7 @@ type BoxError = Box<dyn std::error::Error + Send + Sync>;
 
 /// Enable a tonic service to handle grpc-web requests with the default configuration.
 ///
-/// You can customize the CORS configuration composing the [`GrpcWebLayer`] with the cors layer of your choice.
+/// You can customize the CORS configuration using enable_with_cors
 pub fn enable<S>(service: S) -> CorsGrpcWeb<S>
 where
     S: Service<http::Request<BoxBody>, Response = http::Response<BoxBody>>,
@@ -148,6 +148,17 @@ where
                 .collect::<Vec<HeaderName>>(),
         );
 
+    enable_with_cors(service, cors)
+}
+
+/// Enable a tonic service to handle grpc-web requests with a custom CORS configuration.
+pub fn enable_with_cors<S>(service: S, cors: CorsLayer) -> CorsGrpcWeb<S>
+where
+    S: Service<http::Request<BoxBody>, Response = http::Response<BoxBody>>,
+    S: Clone + Send + 'static,
+    S::Future: Send + 'static,
+    S::Error: Into<BoxError> + Send,
+{
     tower_layer::layer_fn(|s| CorsGrpcWeb(cors.layer(s))).layer(GrpcWebService::new(service))
 }
 


### PR DESCRIPTION
## Motivation

I've not had any luck using the recommended ways to enable custom CORS for GRPC-web using the recommended mechanisms.

## Solution

 This helper method is a much easier escape hatch for custom CORS layering. Instead of calling `tonic_web::enable(service)` which uses a default CORS layer you instead call `tonic_web::enable_with_cors(service, cors_layer)` with your own cors layer. 
