### PR TITLE
chore(web): Remove unnecessary BoxError type alias and Into BoxError trait bound

### DIFF
--- a/tonic-web/src/layer.rs
+++ b/tonic-web/src/layer.rs
@@ -1,4 +1,4 @@
-use super::{BoxBody, BoxError, GrpcWebService};
+use super::{BoxBody, GrpcWebService};
 
 use tower_layer::Layer;
 use tower_service::Service;
@@ -21,7 +21,6 @@ where
     S: Service<http::Request<BoxBody>, Response = http::Response<BoxBody>>,
     S: Send + 'static,
     S::Future: Send + 'static,
-    S::Error: Into<BoxError> + Send,
 {
     type Service = GrpcWebService<S>;
 

--- a/tonic-web/src/lib.rs
+++ b/tonic-web/src/lib.rs
@@ -127,8 +127,6 @@ const DEFAULT_ALLOW_HEADERS: [HeaderName; 4] = [
     HeaderName::from_static("grpc-timeout"),
 ];
 
-type BoxError = Box<dyn std::error::Error + Send + Sync>;
-
 /// Enable a tonic service to handle grpc-web requests with the default configuration.
 ///
 /// You can customize the CORS configuration composing the [`GrpcWebLayer`] with the cors layer of your choice.
@@ -137,7 +135,6 @@ where
     S: Service<http::Request<BoxBody>, Response = http::Response<BoxBody>>,
     S: Clone + Send + 'static,
     S::Future: Send + 'static,
-    S::Error: Into<BoxError> + Send,
 {
     let cors = CorsLayer::new()
         .allow_origin(AllowOrigin::mirror_request())
@@ -159,7 +156,6 @@ where
     S: Service<http::Request<BoxBody>, Response = http::Response<BoxBody>>,
     S: Clone + Send + 'static,
     S::Future: Send + 'static,
-    S::Error: Into<BoxError> + Send,
 {
     type Response = S::Response;
     type Error = S::Error;

--- a/tonic-web/src/service.rs
+++ b/tonic-web/src/service.rs
@@ -15,7 +15,6 @@ use tracing::{debug, trace};
 
 use crate::call::content_types::is_grpc_web;
 use crate::call::{Encoding, GrpcWebCall};
-use crate::BoxError;
 
 /// Service implementing the grpc-web protocol.
 #[derive(Debug, Clone)]
@@ -68,7 +67,6 @@ where
 impl<S> Service<Request<BoxBody>> for GrpcWebService<S>
 where
     S: Service<Request<BoxBody>, Response = Response<BoxBody>>,
-    S::Error: Into<BoxError>,
 {
     type Response = S::Response;
     type Error = S::Error;
@@ -160,7 +158,6 @@ enum Case<F> {
 impl<F, E> Future for ResponseFuture<F>
 where
     F: Future<Output = Result<Response<BoxBody>, E>>,
-    E: Into<BoxError>,
 {
     type Output = Result<Response<BoxBody>, E>;
 


### PR DESCRIPTION
Removes unnecessary `BoxError` type alias and `Into<BoxError>` trait bound.