### PR TITLE
chore(tls): Use rustls-pki-types pem api

### DIFF
--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -276,7 +276,7 @@ tower = ["dep:tower", "tower?/timeout", "dep:http"]
 json-codec = ["dep:serde", "dep:serde_json", "dep:bytes"]
 compression = ["tonic/gzip"]
 tls = ["tonic/tls"]
-tls-rustls = ["dep:http", "dep:hyper", "dep:hyper-util", "dep:hyper-rustls", "dep:tower", "tower-http/util", "tower-http/add-extension", "dep:rustls-pemfile", "dep:tokio-rustls", "dep:pin-project", "dep:http-body-util"]
+tls-rustls = ["dep:http", "dep:hyper", "dep:hyper-util", "dep:hyper-rustls", "dep:tower", "tower-http/util", "tower-http/add-extension", "dep:rustls-pki-types", "dep:tokio-rustls", "dep:pin-project", "dep:http-body-util"]
 dynamic-load-balance = ["dep:tower"]
 timeout = ["tokio/time", "dep:tower", "tower?/timeout"]
 tls-client-auth = ["tonic/tls"]
@@ -317,7 +317,7 @@ bytes = { version = "1", optional = true }
 h2 = { version = "0.4", optional = true }
 tokio-rustls = { version = "0.26", optional = true, features = ["ring", "tls12"], default-features = false }
 hyper-rustls = { version = "0.27.0", features = ["http2", "ring", "tls12"], optional = true, default-features = false }
-rustls-pemfile = { version = "2.0.0", optional = true }
+rustls-pki-types = { version = "1.10", optional = true }
 tower-http = { version = "0.6", optional = true }
 pin-project = { version = "1.0.11", optional = true }
 

--- a/examples/src/tls_rustls/client.rs
+++ b/examples/src/tls_rustls/client.rs
@@ -8,7 +8,10 @@ pub mod pb {
 use hyper::Uri;
 use hyper_util::{client::legacy::connect::HttpConnector, rt::TokioExecutor};
 use pb::{echo_client::EchoClient, EchoRequest};
-use tokio_rustls::rustls::{ClientConfig, RootCertStore};
+use tokio_rustls::rustls::{
+    pki_types::{pem::PemObject as _, CertificateDer},
+    {ClientConfig, RootCertStore},
+};
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -18,7 +21,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let mut roots = RootCertStore::empty();
 
     let mut buf = std::io::BufReader::new(&fd);
-    let certs = rustls_pemfile::certs(&mut buf).collect::<Result<Vec<_>, _>>()?;
+    let certs = CertificateDer::pem_reader_iter(&mut buf).collect::<Result<Vec<_>, _>>()?;
     roots.add_parsable_certificates(certs.into_iter());
 
     let tls = ClientConfig::builder()

--- a/examples/src/tls_rustls/server.rs
+++ b/examples/src/tls_rustls/server.rs
@@ -11,7 +11,10 @@ use pb::{EchoRequest, EchoResponse};
 use std::sync::Arc;
 use tokio::net::TcpListener;
 use tokio_rustls::{
-    rustls::{pki_types::CertificateDer, ServerConfig},
+    rustls::{
+        pki_types::{pem::PemObject as _, CertificateDer, PrivateKeyDer},
+        ServerConfig,
+    },
     TlsAcceptor,
 };
 use tonic::{body::boxed, service::Routes, Request, Response, Status};
@@ -24,12 +27,12 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let certs = {
         let fd = std::fs::File::open(data_dir.join("tls/server.pem"))?;
         let mut buf = std::io::BufReader::new(&fd);
-        rustls_pemfile::certs(&mut buf).collect::<Result<Vec<_>, _>>()?
+        CertificateDer::pem_reader_iter(&mut buf).collect::<Result<Vec<_>, _>>()?
     };
     let key = {
         let fd = std::fs::File::open(data_dir.join("tls/server.key"))?;
         let mut buf = std::io::BufReader::new(&fd);
-        rustls_pemfile::private_key(&mut buf)?.unwrap()
+        PrivateKeyDer::from_pem_reader(&mut buf)?
     };
 
     let mut tls = ServerConfig::builder()

--- a/tonic/Cargo.toml
+++ b/tonic/Cargo.toml
@@ -28,7 +28,7 @@ gzip = ["dep:flate2"]
 zstd = ["dep:zstd"]
 default = ["transport", "codegen", "prost"]
 prost = ["dep:prost"]
-_tls-any = ["dep:rustls-pemfile", "dep:tokio-rustls", "dep:tokio", "tokio?/rt", "tokio?/macros"] # Internal. Please choose one of `tls-ring` or `tls-aws-lc`
+_tls-any = ["dep:rustls-pki-types", "dep:tokio-rustls", "dep:tokio", "tokio?/rt", "tokio?/macros"] # Internal. Please choose one of `tls-ring` or `tls-aws-lc`
 tls = ["tls-ring"] # Deprecated. Please use `tls-ring` or `tls-aws-lc` instead.
 tls-ring = ["_tls-any", "tokio-rustls/ring"]
 tls-aws-lc = ["_tls-any", "tokio-rustls/aws-lc-rs"]
@@ -91,7 +91,7 @@ tower = {version = "0.5", default-features = false, optional = true}
 axum = {version = "0.7", default-features = false, optional = true}
 
 # rustls
-rustls-pemfile = { version = "2.0", optional = true }
+rustls-pki-types = { version = "1.9", features = ["std"], optional = true }
 rustls-native-certs = { version = "0.8", optional = true }
 tokio-rustls = { version = "0.26", default-features = false, features = ["logging", "tls12"], optional = true }
 webpki-roots = { version = "0.26", optional = true }


### PR DESCRIPTION
Uses `rustls-pki-types` pem APIs directly. Depends on  #1763.