### PR TITLE
Make `Status::into_http()` generic over any kind of `Default`-able Body

### DIFF
--- a/tonic/src/service/interceptor.rs
+++ b/tonic/src/service/interceptor.rs
@@ -216,12 +216,7 @@ where
                 .poll(cx)
                 .map(|result| result.map(|res| res.map(boxed))),
             KindProj::Status(status) => {
-                let response = status
-                    .take()
-                    .unwrap()
-                    .into_http()
-                    .map(|_| B::default())
-                    .map(boxed);
+                let response = status.take().unwrap().into_http();
                 Poll::Ready(Ok(response))
             }
         }
@@ -287,7 +282,7 @@ mod tests {
     #[tokio::test]
     async fn handles_intercepted_status_as_response() {
         let message = "Blocked by the interceptor";
-        let expected = Status::permission_denied(message).into_http();
+        let expected = Status::permission_denied(message).into_http::<BoxBody>();
 
         let svc = tower::service_fn(|_: http::Request<TestBody>| async {
             Ok::<_, Status>(http::Response::new(TestBody))

--- a/tonic/src/status.rs
+++ b/tonic/src/status.rs
@@ -1,5 +1,5 @@
 use crate::metadata::MetadataMap;
-use crate::{body::BoxBody, metadata::GRPC_CONTENT_TYPE};
+use crate::metadata::GRPC_CONTENT_TYPE;
 use base64::Engine as _;
 use bytes::Bytes;
 use http::{
@@ -579,8 +579,8 @@ impl Status {
     }
 
     /// Build an `http::Response` from the given `Status`.
-    pub fn into_http(self) -> http::Response<BoxBody> {
-        let mut response = http::Response::new(BoxBody::default());
+    pub fn into_http<B: Default>(self) -> http::Response<B> {
+        let mut response = http::Response::new(B::default());
         response
             .headers_mut()
             .insert(http::header::CONTENT_TYPE, GRPC_CONTENT_TYPE);


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/hyperium/tonic/blob/master/CONTRIBUTING.md
-->

## Motivation

We have middleware that works for both gRPC and non-gRPC requests where it would be useful to leverage `Status::into_http()` in case the request content-type indicates it was a gRPC request, but don't want to couple to tonic's `BoxBody`.

For creating an empty body, relying on `Default` seems pretty reasonable and is an existing pattern in the ecosystem e.g. https://github.com/tower-rs/tower-http/blob/66dd321a73f87ab204011f07853e156f81cfeb7b/tower-http/src/timeout/service.rs#L109

## Solution

Make `into_http` generic over the body so long as it implements `Default`.