### PR TITLE
feat: Add tcp setting getters to endpoint

### DIFF
--- a/tonic/src/transport/channel/endpoint.rs
+++ b/tonic/src/transport/channel/endpoint.rs
@@ -415,6 +415,25 @@ impl Endpoint {
     pub fn uri(&self) -> &Uri {
         &self.uri
     }
+
+    /// Get the value of `TCP_NODELAY` option for accepted connections.
+    pub fn get_tcp_nodelay(&self) -> bool {
+        self.tcp_nodelay
+    }
+
+    /// Get the connect timeout.
+    pub fn get_connect_timeout(&self) -> Option<Duration> {
+        self.connect_timeout
+    }
+
+    /// Get whether TCP keepalive messages are enabled on accepted connections.
+    ///
+    /// If `None` is specified, keepalive is disabled, otherwise the duration
+    /// specified will be the time to remain idle before sending TCP keepalive
+    /// probes.
+    pub fn get_tcp_keepalive(&self) -> Option<Duration> {
+        self.tcp_keepalive
+    }
 }
 
 impl From<Uri> for Endpoint {


### PR DESCRIPTION
Add getters for tcp settings to Endpoints. The purpose for this is that `connect_with_connector` doesn't set TCP settings on the socket, because it's using a provided connector. In the cases where a library is creating a custom TCP connection, we want to be able to respect user tcp settings, in particular connection timeout. Adding these getters allows this.

## Motivation

The purpose for this is that `connect_with_connector` doesn't set TCP settings on the socket, because it's using a provided connector. In the cases where a library is creating a custom TCP connection, we want to be able to respect user tcp settings, in particular connection timeout. Adding these getters allows this.

## Solution

Adds simple getters for existing tcp settings on an endpoint.
