### PR TITLE
feat(server): Remove into_service api

### DIFF
--- a/tonic/src/transport/server/mod.rs
+++ b/tonic/src/transport/server/mod.rs
@@ -895,6 +895,7 @@ impl<L> Router<L> {
     }
 
     /// Create a tower service out of a router.
+    #[deprecated(since = "0.12.4", note = "compose the layers and the `Routes`")]
     pub fn into_service<ResBody>(self) -> L::Service
     where
         L: Layer<Routes>,


### PR DESCRIPTION
Removes `into_service()` api. This is the same as the one composed of the layers and the `Routes`.