### PR TITLE
chore(interceptor)!: Rename Interceptor call method to intercept

### DIFF
--- a/examples/src/interceptor/client.rs
+++ b/examples/src/interceptor/client.rs
@@ -43,7 +43,7 @@ fn intercept(req: Request<()>) -> Result<Request<()>, Status> {
 struct MyInterceptor;
 
 impl Interceptor for MyInterceptor {
-    fn call(&mut self, request: tonic::Request<()>) -> Result<tonic::Request<()>, Status> {
+    fn intercept(&mut self, request: tonic::Request<()>) -> Result<tonic::Request<()>, Status> {
         Ok(request)
     }
 }

--- a/tonic/src/service/interceptor.rs
+++ b/tonic/src/service/interceptor.rs
@@ -40,14 +40,14 @@ use tower_service::Service;
 /// [tower-example]: https://github.com/hyperium/tonic/tree/master/examples/src/tower
 pub trait Interceptor {
     /// Intercept a request before it is sent, optionally cancelling it.
-    fn call(&mut self, request: crate::Request<()>) -> Result<crate::Request<()>, Status>;
+    fn intercept(&mut self, request: crate::Request<()>) -> Result<crate::Request<()>, Status>;
 }
 
 impl<F> Interceptor for F
 where
     F: FnMut(crate::Request<()>) -> Result<crate::Request<()>, Status>,
 {
-    fn call(&mut self, request: crate::Request<()>) -> Result<crate::Request<()>, Status> {
+    fn intercept(&mut self, request: crate::Request<()>) -> Result<crate::Request<()>, Status> {
         self(request)
     }
 }
@@ -140,7 +140,7 @@ where
 
         match self
             .interceptor
-            .call(crate::Request::from_parts(metadata, extensions, ()))
+            .intercept(crate::Request::from_parts(metadata, extensions, ()))
         {
             Ok(req) => {
                 let (metadata, extensions, _) = req.into_parts();


### PR DESCRIPTION
Renames `Interceptor`'s `call` method to `intercept` to explain the method's purpose.