### PR TITLE
chore: Rename Error to BoxError

### DIFF
--- a/tonic/src/body.rs
+++ b/tonic/src/body.rs
@@ -9,7 +9,7 @@ pub type BoxBody = http_body_util::combinators::UnsyncBoxBody<bytes::Bytes, crat
 pub fn boxed<B>(body: B) -> BoxBody
 where
     B: http_body::Body<Data = bytes::Bytes> + Send + 'static,
-    B::Error: Into<crate::Error>,
+    B::Error: Into<crate::BoxError>,
 {
     body.map_err(crate::Status::map_error).boxed_unsync()
 }

--- a/tonic/src/client/grpc.rs
+++ b/tonic/src/client/grpc.rs
@@ -213,7 +213,7 @@ impl<T> Grpc<T> {
     where
         T: GrpcService<BoxBody>,
         T::ResponseBody: Body + Send + 'static,
-        <T::ResponseBody as Body>::Error: Into<crate::Error>,
+        <T::ResponseBody as Body>::Error: Into<crate::BoxError>,
         C: Codec<Encode = M1, Decode = M2>,
         M1: Send + Sync + 'static,
         M2: Send + Sync + 'static,
@@ -232,7 +232,7 @@ impl<T> Grpc<T> {
     where
         T: GrpcService<BoxBody>,
         T::ResponseBody: Body + Send + 'static,
-        <T::ResponseBody as Body>::Error: Into<crate::Error>,
+        <T::ResponseBody as Body>::Error: Into<crate::BoxError>,
         S: Stream<Item = M1> + Send + 'static,
         C: Codec<Encode = M1, Decode = M2>,
         M1: Send + Sync + 'static,
@@ -269,7 +269,7 @@ impl<T> Grpc<T> {
     where
         T: GrpcService<BoxBody>,
         T::ResponseBody: Body + Send + 'static,
-        <T::ResponseBody as Body>::Error: Into<crate::Error>,
+        <T::ResponseBody as Body>::Error: Into<crate::BoxError>,
         C: Codec<Encode = M1, Decode = M2>,
         M1: Send + Sync + 'static,
         M2: Send + Sync + 'static,
@@ -288,7 +288,7 @@ impl<T> Grpc<T> {
     where
         T: GrpcService<BoxBody>,
         T::ResponseBody: Body + Send + 'static,
-        <T::ResponseBody as Body>::Error: Into<crate::Error>,
+        <T::ResponseBody as Body>::Error: Into<crate::BoxError>,
         S: Stream<Item = M1> + Send + 'static,
         C: Codec<Encode = M1, Decode = M2>,
         M1: Send + Sync + 'static,
@@ -328,7 +328,7 @@ impl<T> Grpc<T> {
     where
         T: GrpcService<BoxBody>,
         T::ResponseBody: Body + Send + 'static,
-        <T::ResponseBody as Body>::Error: Into<crate::Error>,
+        <T::ResponseBody as Body>::Error: Into<crate::BoxError>,
     {
         let encoding = CompressionEncoding::from_encoding_header(
             response.headers(),

--- a/tonic/src/client/service.rs
+++ b/tonic/src/client/service.rs
@@ -14,7 +14,7 @@ pub trait GrpcService<ReqBody> {
     /// Responses body given by the service.
     type ResponseBody: Body;
     /// Errors produced by the service.
-    type Error: Into<crate::Error>;
+    type Error: Into<crate::BoxError>;
     /// The future response value.
     type Future: Future<Output = Result<http::Response<Self::ResponseBody>, Self::Error>>;
 
@@ -32,9 +32,9 @@ pub trait GrpcService<ReqBody> {
 impl<T, ReqBody, ResBody> GrpcService<ReqBody> for T
 where
     T: Service<http::Request<ReqBody>, Response = http::Response<ResBody>>,
-    T::Error: Into<crate::Error>,
+    T::Error: Into<crate::BoxError>,
     ResBody: Body,
-    <ResBody as Body>::Error: Into<crate::Error>,
+    <ResBody as Body>::Error: Into<crate::BoxError>,
 {
     type ResponseBody = ResBody;
     type Error = T::Error;

--- a/tonic/src/codec/decode.rs
+++ b/tonic/src/codec/decode.rs
@@ -65,7 +65,7 @@ impl<T> Streaming<T> {
     ) -> Self
     where
         B: Body + Send + 'static,
-        B::Error: Into<crate::Error>,
+        B::Error: Into<crate::BoxError>,
         D: Decoder<Item = T, Error = Status> + Send + 'static,
     {
         Self::new(
@@ -81,7 +81,7 @@ impl<T> Streaming<T> {
     pub fn new_empty<B, D>(decoder: D, body: B) -> Self
     where
         B: Body + Send + 'static,
-        B::Error: Into<crate::Error>,
+        B::Error: Into<crate::BoxError>,
         D: Decoder<Item = T, Error = Status> + Send + 'static,
     {
         Self::new(decoder, body, Direction::EmptyResponse, None, None)
@@ -97,7 +97,7 @@ impl<T> Streaming<T> {
     ) -> Self
     where
         B: Body + Send + 'static,
-        B::Error: Into<crate::Error>,
+        B::Error: Into<crate::BoxError>,
         D: Decoder<Item = T, Error = Status> + Send + 'static,
     {
         Self::new(
@@ -118,7 +118,7 @@ impl<T> Streaming<T> {
     ) -> Self
     where
         B: Body + Send + 'static,
-        B::Error: Into<crate::Error>,
+        B::Error: Into<crate::BoxError>,
         D: Decoder<Item = T, Error = Status> + Send + 'static,
     {
         let buffer_size = decoder.buffer_settings().buffer_size;

--- a/tonic/src/lib.rs
+++ b/tonic/src/lib.rs
@@ -128,7 +128,7 @@ pub use request::{IntoRequest, IntoStreamingRequest, Request};
 pub use response::Response;
 pub use status::{Code, ConnectError, Status, TimeoutExpired};
 
-pub(crate) type Error = Box<dyn std::error::Error + Send + Sync>;
+pub(crate) type BoxError = Box<dyn std::error::Error + Send + Sync>;
 
 #[doc(hidden)]
 #[cfg(feature = "codegen")]

--- a/tonic/src/server/grpc.rs
+++ b/tonic/src/server/grpc.rs
@@ -228,7 +228,7 @@ where
     where
         S: UnaryService<T::Decode, Response = T::Encode>,
         B: Body + Send + 'static,
-        B::Error: Into<crate::Error> + Send,
+        B::Error: Into<crate::BoxError> + Send,
     {
         let accept_encoding = CompressionEncoding::from_accept_encoding_header(
             req.headers(),
@@ -272,7 +272,7 @@ where
         S: ServerStreamingService<T::Decode, Response = T::Encode>,
         S::ResponseStream: Send + 'static,
         B: Body + Send + 'static,
-        B::Error: Into<crate::Error> + Send,
+        B::Error: Into<crate::BoxError> + Send,
     {
         let accept_encoding = CompressionEncoding::from_accept_encoding_header(
             req.headers(),
@@ -312,7 +312,7 @@ where
     where
         S: ClientStreamingService<T::Decode, Response = T::Encode>,
         B: Body + Send + 'static,
-        B::Error: Into<crate::Error> + Send + 'static,
+        B::Error: Into<crate::BoxError> + Send + 'static,
     {
         let accept_encoding = CompressionEncoding::from_accept_encoding_header(
             req.headers(),
@@ -346,7 +346,7 @@ where
         S: StreamingService<T::Decode, Response = T::Encode> + Send,
         S::ResponseStream: Send + 'static,
         B: Body + Send + 'static,
-        B::Error: Into<crate::Error> + Send,
+        B::Error: Into<crate::BoxError> + Send,
     {
         let accept_encoding = CompressionEncoding::from_accept_encoding_header(
             req.headers(),
@@ -371,7 +371,7 @@ where
     ) -> Result<Request<T::Decode>, Status>
     where
         B: Body + Send + 'static,
-        B::Error: Into<crate::Error> + Send,
+        B::Error: Into<crate::BoxError> + Send,
     {
         let request_compression_encoding = self.request_encoding_if_supported(&request)?;
 
@@ -404,7 +404,7 @@ where
     ) -> Result<Request<Streaming<T::Decode>>, Status>
     where
         B: Body + Send + 'static,
-        B::Error: Into<crate::Error> + Send,
+        B::Error: Into<crate::BoxError> + Send,
     {
         let encoding = self.request_encoding_if_supported(&request)?;
 

--- a/tonic/src/service/router.rs
+++ b/tonic/src/service/router.rs
@@ -143,10 +143,10 @@ async fn unimplemented() -> impl axum::response::IntoResponse {
 impl<B> Service<Request<B>> for Routes
 where
     B: http_body::Body<Data = bytes::Bytes> + Send + 'static,
-    B::Error: Into<crate::Error>,
+    B::Error: Into<crate::BoxError>,
 {
     type Response = Response<BoxBody>;
-    type Error = crate::Error;
+    type Error = crate::BoxError;
     type Future = RoutesFuture;
 
     #[inline]
@@ -168,7 +168,7 @@ impl fmt::Debug for RoutesFuture {
 }
 
 impl Future for RoutesFuture {
-    type Output = Result<Response<BoxBody>, crate::Error>;
+    type Output = Result<Response<BoxBody>, crate::BoxError>;
 
     fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         match ready!(Pin::new(&mut self.as_mut().0).poll(cx)) {

--- a/tonic/src/status.rs
+++ b/tonic/src/status.rs
@@ -883,10 +883,10 @@ impl From<Code> for i32 {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::Error;
+    use crate::BoxError;
 
     #[derive(Debug)]
-    struct Nested(Error);
+    struct Nested(BoxError);
 
     impl fmt::Display for Nested {
         fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -911,7 +911,7 @@ mod tests {
 
     #[test]
     fn from_error_unknown() {
-        let orig: Error = "peek-a-boo".into();
+        let orig: BoxError = "peek-a-boo".into();
         let found = Status::from_error(orig);
 
         assert_eq!(found.code(), Code::Unknown);

--- a/tonic/src/transport/channel/endpoint.rs
+++ b/tonic/src/transport/channel/endpoint.rs
@@ -46,7 +46,7 @@ impl Endpoint {
     pub fn new<D>(dst: D) -> Result<Self, Error>
     where
         D: TryInto<Self>,
-        D::Error: Into<crate::Error>,
+        D::Error: Into<crate::BoxError>,
     {
         let me = dst.try_into().map_err(|e| Error::from_source(e.into()))?;
         #[cfg(feature = "tls")]
@@ -366,7 +366,7 @@ impl Endpoint {
         C: Service<Uri> + Send + 'static,
         C::Response: rt::Read + rt::Write + Send + Unpin,
         C::Future: Send,
-        crate::Error: From<C::Error> + Send,
+        crate::BoxError: From<C::Error> + Send,
     {
         let connector = self.connector(connector);
 
@@ -391,7 +391,7 @@ impl Endpoint {
         C: Service<Uri> + Send + 'static,
         C::Response: rt::Read + rt::Write + Send + Unpin,
         C::Future: Send,
-        crate::Error: From<C::Error> + Send,
+        crate::BoxError: From<C::Error> + Send,
     {
         let connector = self.connector(connector);
         if let Some(connect_timeout) = self.connect_timeout {

--- a/tonic/src/transport/channel/mod.rs
+++ b/tonic/src/transport/channel/mod.rs
@@ -64,14 +64,14 @@ const DEFAULT_BUFFER_SIZE: usize = 1024;
 /// cloning the `Channel` type is cheap and encouraged.
 #[derive(Clone)]
 pub struct Channel {
-    svc: Buffer<Request<BoxBody>, BoxFuture<'static, Result<Response<BoxBody>, crate::Error>>>,
+    svc: Buffer<Request<BoxBody>, BoxFuture<'static, Result<Response<BoxBody>, crate::BoxError>>>,
 }
 
 /// A future that resolves to an HTTP response.
 ///
 /// This is returned by the `Service::call` on [`Channel`].
 pub struct ResponseFuture {
-    inner: BufferResponseFuture<BoxFuture<'static, Result<Response<BoxBody>, crate::Error>>>,
+    inner: BufferResponseFuture<BoxFuture<'static, Result<Response<BoxBody>, crate::BoxError>>>,
 }
 
 impl Channel {
@@ -147,7 +147,7 @@ impl Channel {
     pub(crate) fn new<C>(connector: C, endpoint: Endpoint) -> Self
     where
         C: Service<Uri> + Send + 'static,
-        C::Error: Into<crate::Error> + Send,
+        C::Error: Into<crate::BoxError> + Send,
         C::Future: Send,
         C::Response: rt::Read + rt::Write + HyperConnection + Unpin + Send + 'static,
     {
@@ -165,7 +165,7 @@ impl Channel {
     pub(crate) async fn connect<C>(connector: C, endpoint: Endpoint) -> Result<Self, super::Error>
     where
         C: Service<Uri> + Send + 'static,
-        C::Error: Into<crate::Error> + Send,
+        C::Error: Into<crate::BoxError> + Send,
         C::Future: Unpin + Send,
         C::Response: rt::Read + rt::Write + HyperConnection + Unpin + Send + 'static,
     {
@@ -184,7 +184,7 @@ impl Channel {
     pub(crate) fn balance<D, E>(discover: D, buffer_size: usize, executor: E) -> Self
     where
         D: Discover<Service = Connection> + Unpin + Send + 'static,
-        D::Error: Into<crate::Error>,
+        D::Error: Into<crate::BoxError>,
         D::Key: Hash + Send + Clone,
         E: Executor<BoxFuture<'static, ()>> + Send + Sync + 'static,
     {

--- a/tonic/src/transport/channel/service/add_origin.rs
+++ b/tonic/src/transport/channel/service/add_origin.rs
@@ -30,10 +30,10 @@ impl<T, ReqBody> Service<Request<ReqBody>> for AddOrigin<T>
 where
     T: Service<Request<ReqBody>>,
     T::Future: Send + 'static,
-    T::Error: Into<crate::Error>,
+    T::Error: Into<crate::BoxError>,
 {
     type Response = T::Response;
-    type Error = crate::Error;
+    type Error = crate::BoxError;
     type Future = BoxFuture<'static, Result<Self::Response, Self::Error>>;
 
     fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {

--- a/tonic/src/transport/channel/service/connection.rs
+++ b/tonic/src/transport/channel/service/connection.rs
@@ -21,14 +21,14 @@ use tower::{
 use tower_service::Service;
 
 pub(crate) struct Connection {
-    inner: BoxService<Request<BoxBody>, Response<BoxBody>, crate::Error>,
+    inner: BoxService<Request<BoxBody>, Response<BoxBody>, crate::BoxError>,
 }
 
 impl Connection {
     fn new<C>(connector: C, endpoint: Endpoint, is_lazy: bool) -> Self
     where
         C: Service<Uri> + Send + 'static,
-        C::Error: Into<crate::Error> + Send,
+        C::Error: Into<crate::BoxError> + Send,
         C::Future: Send,
         C::Response: rt::Read + rt::Write + Unpin + Send + 'static,
     {
@@ -77,10 +77,13 @@ impl Connection {
         }
     }
 
-    pub(crate) async fn connect<C>(connector: C, endpoint: Endpoint) -> Result<Self, crate::Error>
+    pub(crate) async fn connect<C>(
+        connector: C,
+        endpoint: Endpoint,
+    ) -> Result<Self, crate::BoxError>
     where
         C: Service<Uri> + Send + 'static,
-        C::Error: Into<crate::Error> + Send,
+        C::Error: Into<crate::BoxError> + Send,
         C::Future: Unpin + Send,
         C::Response: rt::Read + rt::Write + Unpin + Send + 'static,
     {
@@ -90,7 +93,7 @@ impl Connection {
     pub(crate) fn lazy<C>(connector: C, endpoint: Endpoint) -> Self
     where
         C: Service<Uri> + Send + 'static,
-        C::Error: Into<crate::Error> + Send,
+        C::Error: Into<crate::BoxError> + Send,
         C::Future: Send,
         C::Response: rt::Read + rt::Write + Unpin + Send + 'static,
     {
@@ -100,7 +103,7 @@ impl Connection {
 
 impl Service<Request<BoxBody>> for Connection {
     type Response = Response<BoxBody>;
-    type Error = crate::Error;
+    type Error = crate::BoxError;
     type Future = BoxFuture<'static, Result<Self::Response, Self::Error>>;
 
     fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
@@ -138,7 +141,7 @@ impl From<hyper::client::conn::http2::SendRequest<BoxBody>> for SendRequest {
 
 impl tower::Service<Request<BoxBody>> for SendRequest {
     type Response = Response<BoxBody>;
-    type Error = crate::Error;
+    type Error = crate::BoxError;
     type Future = BoxFuture<'static, Result<Self::Response, Self::Error>>;
 
     fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
@@ -171,12 +174,12 @@ impl<C> MakeSendRequestService<C> {
 impl<C> tower::Service<Uri> for MakeSendRequestService<C>
 where
     C: Service<Uri> + Send + 'static,
-    C::Error: Into<crate::Error> + Send,
+    C::Error: Into<crate::BoxError> + Send,
     C::Future: Send,
     C::Response: rt::Read + rt::Write + Unpin + Send,
 {
     type Response = SendRequest;
-    type Error = crate::Error;
+    type Error = crate::BoxError;
     type Future = BoxFuture<'static, Result<Self::Response, Self::Error>>;
 
     fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {

--- a/tonic/src/transport/channel/service/connector.rs
+++ b/tonic/src/transport/channel/service/connector.rs
@@ -35,7 +35,7 @@ where
     C: Service<Uri>,
     C::Response: rt::Read + rt::Write + Unpin + Send + 'static,
     C::Future: Send + 'static,
-    crate::Error: From<C::Error> + Send + 'static,
+    crate::BoxError: From<C::Error> + Send + 'static,
 {
     type Response = BoxedIo;
     type Error = ConnectError;
@@ -69,7 +69,7 @@ where
                     };
                 }
 
-                Ok::<_, crate::Error>(BoxedIo::new(io))
+                Ok::<_, crate::BoxError>(BoxedIo::new(io))
             }
             .await
             .map_err(ConnectError)

--- a/tonic/src/transport/channel/service/discover.rs
+++ b/tonic/src/transport/channel/service/discover.rs
@@ -24,7 +24,7 @@ impl<K: Hash + Eq + Clone> DynamicServiceStream<K> {
 }
 
 impl<K: Hash + Eq + Clone> Stream for DynamicServiceStream<K> {
-    type Item = DiscoverResult<K, Connection, crate::Error>;
+    type Item = DiscoverResult<K, Connection, crate::BoxError>;
 
     fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
         let c = &mut self.changes;

--- a/tonic/src/transport/channel/service/tls.rs
+++ b/tonic/src/transport/channel/service/tls.rs
@@ -32,7 +32,7 @@ impl TlsConnector {
         assume_http2: bool,
         #[cfg(feature = "tls-native-roots")] with_native_roots: bool,
         #[cfg(feature = "tls-webpki-roots")] with_webpki_roots: bool,
-    ) -> Result<Self, crate::Error> {
+    ) -> Result<Self, crate::BoxError> {
         let builder = ClientConfig::builder();
         let mut roots = RootCertStore::from_iter(trust_anchors);
 
@@ -75,7 +75,7 @@ impl TlsConnector {
         })
     }
 
-    pub(crate) async fn connect<I>(&self, io: I) -> Result<BoxedIo, crate::Error>
+    pub(crate) async fn connect<I>(&self, io: I) -> Result<BoxedIo, crate::BoxError>
     where
         I: AsyncRead + AsyncWrite + Send + Unpin + 'static,
     {

--- a/tonic/src/transport/channel/tls.rs
+++ b/tonic/src/transport/channel/tls.rs
@@ -112,7 +112,7 @@ impl ClientTlsConfig {
         config
     }
 
-    pub(crate) fn into_tls_connector(self, uri: &Uri) -> Result<TlsConnector, crate::Error> {
+    pub(crate) fn into_tls_connector(self, uri: &Uri) -> Result<TlsConnector, crate::BoxError> {
         let domain = match &self.domain {
             Some(domain) => domain,
             None => uri.host().ok_or_else(Error::new_invalid_uri)?,

--- a/tonic/src/transport/error.rs
+++ b/tonic/src/transport/error.rs
@@ -33,7 +33,7 @@ impl Error {
         self
     }
 
-    pub(crate) fn from_source(source: impl Into<crate::Error>) -> Self {
+    pub(crate) fn from_source(source: impl Into<crate::BoxError>) -> Self {
         Error::new(Kind::Transport).with(source)
     }
 

--- a/tonic/src/transport/server/incoming.rs
+++ b/tonic/src/transport/server/incoming.rs
@@ -22,10 +22,10 @@ use super::service::TlsAcceptor;
 #[cfg(not(feature = "tls"))]
 pub(crate) fn tcp_incoming<IO, IE>(
     incoming: impl Stream<Item = Result<IO, IE>>,
-) -> impl Stream<Item = Result<ServerIo<IO>, crate::Error>>
+) -> impl Stream<Item = Result<ServerIo<IO>, crate::BoxError>>
 where
     IO: AsyncRead + AsyncWrite + Unpin + Send + 'static,
-    IE: Into<crate::Error>,
+    IE: Into<crate::BoxError>,
 {
     async_stream::try_stream! {
         let mut incoming = pin!(incoming);
@@ -46,10 +46,10 @@ where
 pub(crate) fn tcp_incoming<IO, IE>(
     incoming: impl Stream<Item = Result<IO, IE>>,
     tls: Option<TlsAcceptor>,
-) -> impl Stream<Item = Result<ServerIo<IO>, crate::Error>>
+) -> impl Stream<Item = Result<ServerIo<IO>, crate::BoxError>>
 where
     IO: AsyncRead + AsyncWrite + Unpin + Send + 'static,
-    IE: Into<crate::Error>,
+    IE: Into<crate::BoxError>,
 {
     async_stream::try_stream! {
         let mut incoming = pin!(incoming);
@@ -92,7 +92,7 @@ where
     }
 }
 
-fn handle_tcp_accept_error(e: impl Into<crate::Error>) -> ControlFlow<crate::Error> {
+fn handle_tcp_accept_error(e: impl Into<crate::BoxError>) -> ControlFlow<crate::BoxError> {
     let e = e.into();
     tracing::debug!(error = %e, "accept loop error");
     if let Some(e) = e.downcast_ref::<io::Error>() {
@@ -115,10 +115,10 @@ fn handle_tcp_accept_error(e: impl Into<crate::Error>) -> ControlFlow<crate::Err
 #[cfg(feature = "tls")]
 async fn select<IO: 'static, IE>(
     incoming: &mut (impl Stream<Item = Result<IO, IE>> + Unpin),
-    tasks: &mut tokio::task::JoinSet<Result<ServerIo<IO>, crate::Error>>,
+    tasks: &mut tokio::task::JoinSet<Result<ServerIo<IO>, crate::BoxError>>,
 ) -> SelectOutput<IO>
 where
-    IE: Into<crate::Error>,
+    IE: Into<crate::BoxError>,
 {
     if tasks.is_empty() {
         return match incoming.try_next().await {
@@ -151,8 +151,8 @@ where
 enum SelectOutput<A> {
     Incoming(A),
     Io(ServerIo<A>),
-    TcpErr(crate::Error),
-    TlsErr(crate::Error),
+    TcpErr(crate::BoxError),
+    TlsErr(crate::BoxError),
     Done,
 }
 
@@ -203,7 +203,7 @@ impl TcpIncoming {
         addr: SocketAddr,
         nodelay: bool,
         keepalive: Option<Duration>,
-    ) -> Result<Self, crate::Error> {
+    ) -> Result<Self, crate::BoxError> {
         let std_listener = StdTcpListener::bind(addr)?;
         std_listener.set_nonblocking(true)?;
 
@@ -220,7 +220,7 @@ impl TcpIncoming {
         listener: TcpListener,
         nodelay: bool,
         keepalive: Option<Duration>,
-    ) -> Result<Self, crate::Error> {
+    ) -> Result<Self, crate::BoxError> {
         Ok(Self {
             inner: TcpListenerStream::new(listener),
             nodelay,

--- a/tonic/src/transport/server/mod.rs
+++ b/tonic/src/transport/server/mod.rs
@@ -68,7 +68,8 @@ use tower::{
     Service, ServiceBuilder, ServiceExt,
 };
 
-type BoxService = tower::util::BoxCloneService<Request<BoxBody>, Response<BoxBody>, crate::Error>;
+type BoxService =
+    tower::util::BoxCloneService<Request<BoxBody>, Response<BoxBody>, crate::BoxError>;
 type TraceInterceptor = Arc<dyn Fn(&http::Request<()>) -> tracing::Span + Send + Sync + 'static>;
 
 const DEFAULT_HTTP2_KEEPALIVE_TIMEOUT_SECS: u64 = 20;
@@ -539,14 +540,14 @@ impl<L> Server<L> {
             Service<Request<BoxBody>, Response = Response<ResBody>> + Clone + Send + 'static,
         <<L as Layer<S>>::Service as Service<Request<BoxBody>>>::Future: Send + 'static,
         <<L as Layer<S>>::Service as Service<Request<BoxBody>>>::Error:
-            Into<crate::Error> + Send + 'static,
+            Into<crate::BoxError> + Send + 'static,
         I: Stream<Item = Result<IO, IE>>,
         IO: AsyncRead + AsyncWrite + Connected + Unpin + Send + 'static,
         IO::ConnectInfo: Clone + Send + Sync + 'static,
-        IE: Into<crate::Error>,
+        IE: Into<crate::BoxError>,
         F: Future<Output = ()>,
         ResBody: http_body::Body<Data = Bytes> + Send + 'static,
-        ResBody::Error: Into<crate::Error>,
+        ResBody::Error: Into<crate::BoxError>,
     {
         let trace_interceptor = self.trace_interceptor.clone();
         let concurrency_limit = self.concurrency_limit;
@@ -787,9 +788,9 @@ impl<L> Router<L> {
             Service<Request<BoxBody>, Response = Response<ResBody>> + Clone + Send + 'static,
         <<L as Layer<Routes>>::Service as Service<Request<BoxBody>>>::Future: Send + 'static,
         <<L as Layer<Routes>>::Service as Service<Request<BoxBody>>>::Error:
-            Into<crate::Error> + Send,
+            Into<crate::BoxError> + Send,
         ResBody: http_body::Body<Data = Bytes> + Send + 'static,
-        ResBody::Error: Into<crate::Error>,
+        ResBody::Error: Into<crate::BoxError>,
     {
         let incoming = TcpIncoming::new(addr, self.server.tcp_nodelay, self.server.tcp_keepalive)
             .map_err(super::Error::from_source)?;
@@ -819,9 +820,9 @@ impl<L> Router<L> {
             Service<Request<BoxBody>, Response = Response<ResBody>> + Clone + Send + 'static,
         <<L as Layer<Routes>>::Service as Service<Request<BoxBody>>>::Future: Send + 'static,
         <<L as Layer<Routes>>::Service as Service<Request<BoxBody>>>::Error:
-            Into<crate::Error> + Send,
+            Into<crate::BoxError> + Send,
         ResBody: http_body::Body<Data = Bytes> + Send + 'static,
-        ResBody::Error: Into<crate::Error>,
+        ResBody::Error: Into<crate::BoxError>,
     {
         let incoming = TcpIncoming::new(addr, self.server.tcp_nodelay, self.server.tcp_keepalive)
             .map_err(super::Error::from_source)?;
@@ -844,15 +845,15 @@ impl<L> Router<L> {
         I: Stream<Item = Result<IO, IE>>,
         IO: AsyncRead + AsyncWrite + Connected + Unpin + Send + 'static,
         IO::ConnectInfo: Clone + Send + Sync + 'static,
-        IE: Into<crate::Error>,
+        IE: Into<crate::BoxError>,
         L: Layer<Routes>,
         L::Service:
             Service<Request<BoxBody>, Response = Response<ResBody>> + Clone + Send + 'static,
         <<L as Layer<Routes>>::Service as Service<Request<BoxBody>>>::Future: Send + 'static,
         <<L as Layer<Routes>>::Service as Service<Request<BoxBody>>>::Error:
-            Into<crate::Error> + Send,
+            Into<crate::BoxError> + Send,
         ResBody: http_body::Body<Data = Bytes> + Send + 'static,
-        ResBody::Error: Into<crate::Error>,
+        ResBody::Error: Into<crate::BoxError>,
     {
         self.server
             .serve_with_shutdown::<_, _, future::Ready<()>, _, _, ResBody>(
@@ -880,16 +881,16 @@ impl<L> Router<L> {
         I: Stream<Item = Result<IO, IE>>,
         IO: AsyncRead + AsyncWrite + Connected + Unpin + Send + 'static,
         IO::ConnectInfo: Clone + Send + Sync + 'static,
-        IE: Into<crate::Error>,
+        IE: Into<crate::BoxError>,
         F: Future<Output = ()>,
         L: Layer<Routes>,
         L::Service:
             Service<Request<BoxBody>, Response = Response<ResBody>> + Clone + Send + 'static,
         <<L as Layer<Routes>>::Service as Service<Request<BoxBody>>>::Future: Send + 'static,
         <<L as Layer<Routes>>::Service as Service<Request<BoxBody>>>::Error:
-            Into<crate::Error> + Send,
+            Into<crate::BoxError> + Send,
         ResBody: http_body::Body<Data = Bytes> + Send + 'static,
-        ResBody::Error: Into<crate::Error>,
+        ResBody::Error: Into<crate::BoxError>,
     {
         self.server
             .serve_with_shutdown(self.routes.prepare(), incoming, Some(signal))
@@ -920,12 +921,12 @@ struct Svc<S> {
 impl<S, ResBody> Service<Request<BoxBody>> for Svc<S>
 where
     S: Service<Request<BoxBody>, Response = Response<ResBody>>,
-    S::Error: Into<crate::Error>,
+    S::Error: Into<crate::BoxError>,
     ResBody: http_body::Body<Data = Bytes> + Send + 'static,
-    ResBody::Error: Into<crate::Error>,
+    ResBody::Error: Into<crate::BoxError>,
 {
     type Response = Response<BoxBody>;
-    type Error = crate::Error;
+    type Error = crate::BoxError;
     type Future = SvcFuture<S::Future>;
 
     fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
@@ -964,11 +965,11 @@ struct SvcFuture<F> {
 impl<F, E, ResBody> Future for SvcFuture<F>
 where
     F: Future<Output = Result<Response<ResBody>, E>>,
-    E: Into<crate::Error>,
+    E: Into<crate::BoxError>,
     ResBody: http_body::Body<Data = Bytes> + Send + 'static,
-    ResBody::Error: Into<crate::Error>,
+    ResBody::Error: Into<crate::BoxError>,
 {
-    type Output = Result<Response<BoxBody>, crate::Error>;
+    type Output = Result<Response<BoxBody>, crate::BoxError>;
 
     fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         let this = self.project();
@@ -1000,12 +1001,12 @@ where
     IO: Connected,
     S: Service<Request<BoxBody>, Response = Response<ResBody>> + Clone + Send + 'static,
     S::Future: Send + 'static,
-    S::Error: Into<crate::Error> + Send,
+    S::Error: Into<crate::BoxError> + Send,
     ResBody: http_body::Body<Data = Bytes> + Send + 'static,
-    ResBody::Error: Into<crate::Error>,
+    ResBody::Error: Into<crate::BoxError>,
 {
     type Response = BoxService;
-    type Error = crate::Error;
+    type Error = crate::BoxError;
     type Future = future::Ready<Result<Self::Response, Self::Error>>;
 
     fn poll_ready(&mut self, _cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {

--- a/tonic/src/transport/server/service/recover_error.rs
+++ b/tonic/src/transport/server/service/recover_error.rs
@@ -25,10 +25,10 @@ impl<S> RecoverError<S> {
 impl<S, R, ResBody> Service<R> for RecoverError<S>
 where
     S: Service<R, Response = Response<ResBody>>,
-    S::Error: Into<crate::Error>,
+    S::Error: Into<crate::BoxError>,
 {
     type Response = Response<MaybeEmptyBody<ResBody>>;
-    type Error = crate::Error;
+    type Error = crate::BoxError;
     type Future = ResponseFuture<S::Future>;
 
     fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
@@ -51,12 +51,12 @@ pub(crate) struct ResponseFuture<F> {
 impl<F, E, ResBody> Future for ResponseFuture<F>
 where
     F: Future<Output = Result<Response<ResBody>, E>>,
-    E: Into<crate::Error>,
+    E: Into<crate::BoxError>,
 {
-    type Output = Result<Response<MaybeEmptyBody<ResBody>>, crate::Error>;
+    type Output = Result<Response<MaybeEmptyBody<ResBody>>, crate::BoxError>;
 
     fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
-        let result: Result<Response<_>, crate::Error> =
+        let result: Result<Response<_>, crate::BoxError> =
             ready!(self.project().inner.poll(cx)).map_err(Into::into);
 
         match result {

--- a/tonic/src/transport/server/service/tls.rs
+++ b/tonic/src/transport/server/service/tls.rs
@@ -22,7 +22,7 @@ impl TlsAcceptor {
         identity: Identity,
         client_ca_root: Option<Certificate>,
         client_auth_optional: bool,
-    ) -> Result<Self, crate::Error> {
+    ) -> Result<Self, crate::BoxError> {
         let builder = ServerConfig::builder();
 
         let builder = match client_ca_root {
@@ -49,7 +49,7 @@ impl TlsAcceptor {
         })
     }
 
-    pub(crate) async fn accept<IO>(&self, io: IO) -> Result<TlsStream<IO>, crate::Error>
+    pub(crate) async fn accept<IO>(&self, io: IO) -> Result<TlsStream<IO>, crate::BoxError>
     where
         IO: AsyncRead + AsyncWrite + Unpin,
     {

--- a/tonic/src/transport/server/tls.rs
+++ b/tonic/src/transport/server/tls.rs
@@ -56,7 +56,7 @@ impl ServerTlsConfig {
         }
     }
 
-    pub(crate) fn tls_acceptor(&self) -> Result<TlsAcceptor, crate::Error> {
+    pub(crate) fn tls_acceptor(&self) -> Result<TlsAcceptor, crate::BoxError> {
         TlsAcceptor::new(
             self.identity.clone().unwrap(),
             self.client_ca_root.clone(),

--- a/tonic/src/transport/service/grpc_timeout.rs
+++ b/tonic/src/transport/service/grpc_timeout.rs
@@ -28,10 +28,10 @@ impl<S> GrpcTimeout<S> {
 impl<S, ReqBody> Service<Request<ReqBody>> for GrpcTimeout<S>
 where
     S: Service<Request<ReqBody>>,
-    S::Error: Into<crate::Error>,
+    S::Error: Into<crate::BoxError>,
 {
     type Response = S::Response;
-    type Error = crate::Error;
+    type Error = crate::BoxError;
     type Future = ResponseFuture<S::Future>;
 
     fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
@@ -73,9 +73,9 @@ pub(crate) struct ResponseFuture<F> {
 impl<F, Res, E> Future for ResponseFuture<F>
 where
     F: Future<Output = Result<Res, E>>,
-    E: Into<crate::Error>,
+    E: Into<crate::BoxError>,
 {
-    type Output = Result<Res, crate::Error>;
+    type Output = Result<Res, crate::BoxError>;
 
     fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         let this = self.project();

--- a/tonic/src/transport/service/tls.rs
+++ b/tonic/src/transport/service/tls.rs
@@ -55,7 +55,7 @@ pub(crate) fn load_identity(
 pub(crate) fn add_certs_from_pem(
     mut certs: &mut dyn std::io::BufRead,
     roots: &mut RootCertStore,
-) -> Result<(), crate::Error> {
+) -> Result<(), crate::BoxError> {
     for cert in rustls_pemfile::certs(&mut certs).collect::<Result<Vec<_>, _>>()? {
         roots
             .add(cert)


### PR DESCRIPTION
Renames `Error` to `BoxError` to describe what it is more descriptive. Given that there is other `Error` type, I feel it is clearer.