### PR TITLE
feat!: Add Body type

### DIFF
--- a/examples/src/h2c/client.rs
+++ b/examples/src/h2c/client.rs
@@ -39,14 +39,14 @@ mod h2c {
         client::legacy::{connect::HttpConnector, Client},
         rt::TokioExecutor,
     };
-    use tonic::body::BoxBody;
+    use tonic::body::Body;
     use tower::Service;
 
     pub struct H2cChannel {
-        pub client: Client<HttpConnector, BoxBody>,
+        pub client: Client<HttpConnector, Body>,
     }
 
-    impl Service<http::Request<BoxBody>> for H2cChannel {
+    impl Service<http::Request<Body>> for H2cChannel {
         type Response = http::Response<Incoming>;
         type Error = hyper::Error;
         type Future =
@@ -56,7 +56,7 @@ mod h2c {
             Poll::Ready(Ok(()))
         }
 
-        fn call(&mut self, request: http::Request<BoxBody>) -> Self::Future {
+        fn call(&mut self, request: http::Request<Body>) -> Self::Future {
             let client = self.client.clone();
 
             Box::pin(async move {
@@ -65,7 +65,7 @@ mod h2c {
                 let h2c_req = hyper::Request::builder()
                     .uri(origin)
                     .header(http::header::UPGRADE, "h2c")
-                    .body(BoxBody::default())
+                    .body(Body::default())
                     .unwrap();
 
                 let res = client.request(h2c_req).await.unwrap();

--- a/examples/src/tls_rustls/server.rs
+++ b/examples/src/tls_rustls/server.rs
@@ -17,7 +17,7 @@ use tokio_rustls::{
     },
     TlsAcceptor,
 };
-use tonic::{body::boxed, service::Routes, Request, Response, Status};
+use tonic::{body::Body, service::Routes, Request, Response, Status};
 use tower::ServiceExt;
 use tower_http::ServiceBuilderExt;
 
@@ -82,7 +82,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
             http.serve_connection(
                 TokioIo::new(conn),
-                TowerToHyperService::new(svc.map_request(|req: http::Request<_>| req.map(boxed))),
+                TowerToHyperService::new(
+                    svc.map_request(|req: http::Request<_>| req.map(Body::new)),
+                ),
             )
             .await
             .unwrap();

--- a/examples/src/tower/client.rs
+++ b/examples/src/tower/client.rs
@@ -43,7 +43,7 @@ mod service {
     use std::future::Future;
     use std::pin::Pin;
     use std::task::{Context, Poll};
-    use tonic::body::BoxBody;
+    use tonic::body::Body;
     use tonic::transport::Channel;
     use tower::Service;
 
@@ -57,8 +57,8 @@ mod service {
         }
     }
 
-    impl Service<Request<BoxBody>> for AuthSvc {
-        type Response = Response<BoxBody>;
+    impl Service<Request<Body>> for AuthSvc {
+        type Response = Response<Body>;
         type Error = Box<dyn std::error::Error + Send + Sync>;
         #[allow(clippy::type_complexity)]
         type Future = Pin<Box<dyn Future<Output = Result<Self::Response, Self::Error>> + Send>>;
@@ -67,7 +67,7 @@ mod service {
             self.inner.poll_ready(cx).map_err(Into::into)
         }
 
-        fn call(&mut self, req: Request<BoxBody>) -> Self::Future {
+        fn call(&mut self, req: Request<Body>) -> Self::Future {
             // See: https://docs.rs/tower/latest/tower/trait.Service.html#be-careful-when-cloning-inner-services
             let clone = self.inner.clone();
             let mut inner = std::mem::replace(&mut self.inner, clone);

--- a/tests/compression/src/util.rs
+++ b/tests/compression/src/util.rs
@@ -1,6 +1,6 @@
 use super::*;
 use bytes::{Buf, Bytes};
-use http_body::{Body, Frame};
+use http_body::{Body as HttpBody, Frame};
 use http_body_util::BodyExt as _;
 use hyper_util::rt::TokioIo;
 use pin_project::pin_project;
@@ -13,7 +13,7 @@ use std::{
     task::{ready, Context, Poll},
 };
 use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
-use tonic::body::BoxBody;
+use tonic::body::Body;
 use tonic::codec::CompressionEncoding;
 use tonic::transport::{server::Connected, Channel};
 use tower_http::map_request_body::MapRequestBodyLayer;
@@ -42,9 +42,9 @@ pub struct CountBytesBody<B> {
     pub counter: Arc<AtomicUsize>,
 }
 
-impl<B> Body for CountBytesBody<B>
+impl<B> HttpBody for CountBytesBody<B>
 where
-    B: Body<Data = Bytes>,
+    B: HttpBody<Data = Bytes>,
 {
     type Data = B::Data;
     type Error = B::Error;
@@ -95,7 +95,7 @@ impl<T> ChannelBody<T> {
     }
 }
 
-impl<T> Body for ChannelBody<T>
+impl<T> HttpBody for ChannelBody<T>
 where
     T: Buf,
 {
@@ -114,8 +114,8 @@ where
 #[allow(dead_code)]
 pub fn measure_request_body_size_layer(
     bytes_sent_counter: Arc<AtomicUsize>,
-) -> MapRequestBodyLayer<impl Fn(BoxBody) -> BoxBody + Clone> {
-    MapRequestBodyLayer::new(move |mut body: BoxBody| {
+) -> MapRequestBodyLayer<impl Fn(Body) -> Body + Clone> {
+    MapRequestBodyLayer::new(move |mut body: Body| {
         let (tx, new_body) = ChannelBody::new();
 
         let bytes_sent_counter = bytes_sent_counter.clone();
@@ -128,7 +128,7 @@ pub fn measure_request_body_size_layer(
             }
         });
 
-        new_body.boxed_unsync()
+        Body::new(new_body)
     })
 }
 
@@ -157,7 +157,7 @@ impl AssertRightEncoding {
         Self { encoding }
     }
 
-    pub fn call<B: Body>(self, req: http::Request<B>) -> http::Request<B> {
+    pub fn call<B: HttpBody>(self, req: http::Request<B>) -> http::Request<B> {
         let expected = match self.encoding {
             CompressionEncoding::Gzip => "gzip",
             CompressionEncoding::Zstd => "zstd",

--- a/tests/integration_tests/tests/extensions.rs
+++ b/tests/integration_tests/tests/extensions.rs
@@ -8,7 +8,7 @@ use std::{
 };
 use tokio::sync::oneshot;
 use tonic::{
-    body::BoxBody,
+    body::Body,
     server::NamedService,
     transport::{Endpoint, Server},
     Request, Response, Status,
@@ -112,9 +112,9 @@ struct InterceptedService<S> {
     inner: S,
 }
 
-impl<S> Service<http::Request<BoxBody>> for InterceptedService<S>
+impl<S> Service<http::Request<Body>> for InterceptedService<S>
 where
-    S: Service<http::Request<BoxBody>, Response = http::Response<BoxBody>>
+    S: Service<http::Request<Body>, Response = http::Response<Body>>
         + NamedService
         + Clone
         + Send
@@ -129,7 +129,7 @@ where
         self.inner.poll_ready(cx)
     }
 
-    fn call(&mut self, mut req: http::Request<BoxBody>) -> Self::Future {
+    fn call(&mut self, mut req: http::Request<Body>) -> Self::Future {
         let clone = self.inner.clone();
         let mut inner = std::mem::replace(&mut self.inner, clone);
 

--- a/tests/integration_tests/tests/origin.rs
+++ b/tests/integration_tests/tests/origin.rs
@@ -76,9 +76,9 @@ struct OriginService<S> {
     inner: S,
 }
 
-impl<T> Service<Request<tonic::body::BoxBody>> for OriginService<T>
+impl<T> Service<Request<tonic::body::Body>> for OriginService<T>
 where
-    T: Service<Request<tonic::body::BoxBody>>,
+    T: Service<Request<tonic::body::Body>>,
     T::Future: Send + 'static,
     T::Error: Into<Box<dyn std::error::Error + Send + Sync>>,
 {
@@ -90,7 +90,7 @@ where
         self.inner.poll_ready(cx).map_err(Into::into)
     }
 
-    fn call(&mut self, req: Request<tonic::body::BoxBody>) -> Self::Future {
+    fn call(&mut self, req: Request<tonic::body::Body>) -> Self::Future {
         assert_eq!(req.uri().host(), Some("docs.rs"));
         let fut = self.inner.call(req);
 

--- a/tests/web/tests/grpc_web.rs
+++ b/tests/web/tests/grpc_web.rs
@@ -11,7 +11,7 @@ use hyper_util::rt::TokioExecutor;
 use prost::Message;
 use tokio::net::TcpListener;
 use tokio_stream::wrappers::TcpListenerStream;
-use tonic::body::BoxBody;
+use tonic::body::Body;
 use tonic::transport::Server;
 
 use test_web::pb::{test_server::TestServer, Input, Output};
@@ -108,7 +108,7 @@ fn encode_body() -> Bytes {
     buf.split_to(len + 5).freeze()
 }
 
-fn build_request(base_uri: String, content_type: &str, accept: &str) -> Request<BoxBody> {
+fn build_request(base_uri: String, content_type: &str, accept: &str) -> Request<Body> {
     use header::{ACCEPT, CONTENT_TYPE, ORIGIN};
 
     let request_uri = format!("{}/{}/{}", base_uri, "test.Test", "UnaryCall")
@@ -129,7 +129,7 @@ fn build_request(base_uri: String, content_type: &str, accept: &str) -> Request<
         .header(ORIGIN, "http://example.com")
         .header(ACCEPT, format!("application/{}", accept))
         .uri(request_uri)
-        .body(BoxBody::new(
+        .body(Body::new(
             Full::new(bytes).map_err(|err| Status::internal(err.to_string())),
         ))
         .unwrap()

--- a/tonic-build/src/client.rs
+++ b/tonic-build/src/client.rs
@@ -67,7 +67,7 @@ pub(crate) fn generate_internal<T: Service>(
 
             impl<T> #service_ident<T>
             where
-                T: tonic::client::GrpcService<tonic::body::BoxBody>,
+                T: tonic::client::GrpcService<tonic::body::Body>,
                 T::Error: Into<StdError>,
                 T::ResponseBody: Body<Data = Bytes> + std::marker::Send  + 'static,
                 <T::ResponseBody as Body>::Error: Into<StdError> + std::marker::Send,
@@ -87,10 +87,10 @@ pub(crate) fn generate_internal<T: Service>(
                     F: tonic::service::Interceptor,
                     T::ResponseBody: Default,
                     T: tonic::codegen::Service<
-                        http::Request<tonic::body::BoxBody>,
-                        Response = http::Response<<T as tonic::client::GrpcService<tonic::body::BoxBody>>::ResponseBody>
+                        http::Request<tonic::body::Body>,
+                        Response = http::Response<<T as tonic::client::GrpcService<tonic::body::Body>>::ResponseBody>
                     >,
-                    <T as tonic::codegen::Service<http::Request<tonic::body::BoxBody>>>::Error: Into<StdError> + std::marker::Send + std::marker::Sync,
+                    <T as tonic::codegen::Service<http::Request<tonic::body::Body>>>::Error: Into<StdError> + std::marker::Send + std::marker::Sync,
                 {
                     #service_ident::new(InterceptedService::new(inner, interceptor))
                 }

--- a/tonic-build/src/server.rs
+++ b/tonic-build/src/server.rs
@@ -152,7 +152,7 @@ pub(crate) fn generate_internal<T: Service>(
                     B: Body + std::marker::Send + 'static,
                     B::Error: Into<StdError> + std::marker::Send + 'static,
             {
-                type Response = http::Response<tonic::body::BoxBody>;
+                type Response = http::Response<tonic::body::Body>;
                 type Error = std::convert::Infallible;
                 type Future = BoxFuture<Self::Response, Self::Error>;
 
@@ -165,7 +165,7 @@ pub(crate) fn generate_internal<T: Service>(
                         #methods
 
                         _ => Box::pin(async move {
-                            let mut response = http::Response::new(tonic::body::BoxBody::default());
+                            let mut response = http::Response::new(tonic::body::Body::default());
                             let headers = response.headers_mut();
                             headers.insert(tonic::Status::GRPC_STATUS, (tonic::Code::Unimplemented as i32).into());
                             headers.insert(http::header::CONTENT_TYPE, tonic::metadata::GRPC_CONTENT_TYPE);

--- a/tonic-health/Cargo.toml
+++ b/tonic-health/Cargo.toml
@@ -43,6 +43,5 @@ allowed_external_types = [
   "prost::*",
 
   "futures_core::stream::Stream",
-  "http_body_util::combinators::box_body::UnsyncBoxBody",
   "tower_service::Service",
 ]

--- a/tonic-health/src/generated/grpc_health_v1.rs
+++ b/tonic-health/src/generated/grpc_health_v1.rs
@@ -72,7 +72,7 @@ pub mod health_client {
     }
     impl<T> HealthClient<T>
     where
-        T: tonic::client::GrpcService<tonic::body::BoxBody>,
+        T: tonic::client::GrpcService<tonic::body::Body>,
         T::Error: Into<StdError>,
         T::ResponseBody: Body<Data = Bytes> + std::marker::Send + 'static,
         <T::ResponseBody as Body>::Error: Into<StdError> + std::marker::Send,
@@ -93,13 +93,13 @@ pub mod health_client {
             F: tonic::service::Interceptor,
             T::ResponseBody: Default,
             T: tonic::codegen::Service<
-                http::Request<tonic::body::BoxBody>,
+                http::Request<tonic::body::Body>,
                 Response = http::Response<
-                    <T as tonic::client::GrpcService<tonic::body::BoxBody>>::ResponseBody,
+                    <T as tonic::client::GrpcService<tonic::body::Body>>::ResponseBody,
                 >,
             >,
             <T as tonic::codegen::Service<
-                http::Request<tonic::body::BoxBody>,
+                http::Request<tonic::body::Body>,
             >>::Error: Into<StdError> + std::marker::Send + std::marker::Sync,
         {
             HealthClient::new(InterceptedService::new(inner, interceptor))
@@ -315,7 +315,7 @@ pub mod health_server {
         B: Body + std::marker::Send + 'static,
         B::Error: Into<StdError> + std::marker::Send + 'static,
     {
-        type Response = http::Response<tonic::body::BoxBody>;
+        type Response = http::Response<tonic::body::Body>;
         type Error = std::convert::Infallible;
         type Future = BoxFuture<Self::Response, Self::Error>;
         fn poll_ready(
@@ -420,7 +420,7 @@ pub mod health_server {
                 _ => {
                     Box::pin(async move {
                         let mut response = http::Response::new(
-                            tonic::body::BoxBody::default(),
+                            tonic::body::Body::default(),
                         );
                         let headers = response.headers_mut();
                         headers

--- a/tonic-reflection/Cargo.toml
+++ b/tonic-reflection/Cargo.toml
@@ -49,6 +49,5 @@ allowed_external_types = [
   "prost_types::*",
 
   "futures_core::stream::Stream",
-  "http_body_util::combinators::box_body::UnsyncBoxBody",
   "tower_service::Service",
 ]

--- a/tonic-reflection/src/generated/grpc_reflection_v1.rs
+++ b/tonic-reflection/src/generated/grpc_reflection_v1.rs
@@ -161,7 +161,7 @@ pub mod server_reflection_client {
     }
     impl<T> ServerReflectionClient<T>
     where
-        T: tonic::client::GrpcService<tonic::body::BoxBody>,
+        T: tonic::client::GrpcService<tonic::body::Body>,
         T::Error: Into<StdError>,
         T::ResponseBody: Body<Data = Bytes> + std::marker::Send + 'static,
         <T::ResponseBody as Body>::Error: Into<StdError> + std::marker::Send,
@@ -182,13 +182,13 @@ pub mod server_reflection_client {
             F: tonic::service::Interceptor,
             T::ResponseBody: Default,
             T: tonic::codegen::Service<
-                http::Request<tonic::body::BoxBody>,
+                http::Request<tonic::body::Body>,
                 Response = http::Response<
-                    <T as tonic::client::GrpcService<tonic::body::BoxBody>>::ResponseBody,
+                    <T as tonic::client::GrpcService<tonic::body::Body>>::ResponseBody,
                 >,
             >,
             <T as tonic::codegen::Service<
-                http::Request<tonic::body::BoxBody>,
+                http::Request<tonic::body::Body>,
             >>::Error: Into<StdError> + std::marker::Send + std::marker::Sync,
         {
             ServerReflectionClient::new(InterceptedService::new(inner, interceptor))
@@ -356,7 +356,7 @@ pub mod server_reflection_server {
         B: Body + std::marker::Send + 'static,
         B::Error: Into<StdError> + std::marker::Send + 'static,
     {
-        type Response = http::Response<tonic::body::BoxBody>;
+        type Response = http::Response<tonic::body::Body>;
         type Error = std::convert::Infallible;
         type Future = BoxFuture<Self::Response, Self::Error>;
         fn poll_ready(
@@ -422,7 +422,7 @@ pub mod server_reflection_server {
                 _ => {
                     Box::pin(async move {
                         let mut response = http::Response::new(
-                            tonic::body::BoxBody::default(),
+                            tonic::body::Body::default(),
                         );
                         let headers = response.headers_mut();
                         headers

--- a/tonic-reflection/src/generated/grpc_reflection_v1alpha.rs
+++ b/tonic-reflection/src/generated/grpc_reflection_v1alpha.rs
@@ -161,7 +161,7 @@ pub mod server_reflection_client {
     }
     impl<T> ServerReflectionClient<T>
     where
-        T: tonic::client::GrpcService<tonic::body::BoxBody>,
+        T: tonic::client::GrpcService<tonic::body::Body>,
         T::Error: Into<StdError>,
         T::ResponseBody: Body<Data = Bytes> + std::marker::Send + 'static,
         <T::ResponseBody as Body>::Error: Into<StdError> + std::marker::Send,
@@ -182,13 +182,13 @@ pub mod server_reflection_client {
             F: tonic::service::Interceptor,
             T::ResponseBody: Default,
             T: tonic::codegen::Service<
-                http::Request<tonic::body::BoxBody>,
+                http::Request<tonic::body::Body>,
                 Response = http::Response<
-                    <T as tonic::client::GrpcService<tonic::body::BoxBody>>::ResponseBody,
+                    <T as tonic::client::GrpcService<tonic::body::Body>>::ResponseBody,
                 >,
             >,
             <T as tonic::codegen::Service<
-                http::Request<tonic::body::BoxBody>,
+                http::Request<tonic::body::Body>,
             >>::Error: Into<StdError> + std::marker::Send + std::marker::Sync,
         {
             ServerReflectionClient::new(InterceptedService::new(inner, interceptor))
@@ -356,7 +356,7 @@ pub mod server_reflection_server {
         B: Body + std::marker::Send + 'static,
         B::Error: Into<StdError> + std::marker::Send + 'static,
     {
-        type Response = http::Response<tonic::body::BoxBody>;
+        type Response = http::Response<tonic::body::Body>;
         type Error = std::convert::Infallible;
         type Future = BoxFuture<Self::Response, Self::Error>;
         fn poll_ready(
@@ -422,7 +422,7 @@ pub mod server_reflection_server {
                 _ => {
                     Box::pin(async move {
                         let mut response = http::Response::new(
-                            tonic::body::BoxBody::default(),
+                            tonic::body::Body::default(),
                         );
                         let headers = response.headers_mut();
                         headers

--- a/tonic-web/Cargo.toml
+++ b/tonic-web/Cargo.toml
@@ -20,7 +20,6 @@ bytes = "1"
 tokio-stream = "0.1"
 http = "1"
 http-body = "1"
-http-body-util = "0.1"
 pin-project = "1"
 tonic = { version = "0.13.0", path = "../tonic", default-features = false }
 tower-service = "0.3"
@@ -42,7 +41,6 @@ allowed_external_types = [
 
   # not major released
   "futures_core::stream::Stream",
-  "http_body_util::combinators::box_body::UnsyncBoxBody",
   "tower_layer::Layer",
   "tower_service::Service",
 ]

--- a/tonic-web/src/lib.rs
+++ b/tonic-web/src/lib.rs
@@ -116,7 +116,7 @@ use std::{
     task::{Context, Poll},
     time::Duration,
 };
-use tonic::{body::BoxBody, server::NamedService, Status};
+use tonic::{body::Body, server::NamedService, Status};
 use tower_http::cors::{AllowOrigin, CorsLayer};
 use tower_layer::Layer;
 use tower_service::Service;
@@ -162,7 +162,7 @@ pub struct CorsGrpcWeb<S>(tower_http::cors::Cors<GrpcWebService<S>>);
 
 impl<S, B> Service<http::Request<B>> for CorsGrpcWeb<S>
 where
-    S: Service<http::Request<BoxBody>, Response = http::Response<BoxBody>>,
+    S: Service<http::Request<Body>, Response = http::Response<Body>>,
     B: http_body::Body<Data = bytes::Bytes> + Send + 'static,
     B::Error: Into<BoxError> + std::fmt::Display,
 {
@@ -190,9 +190,9 @@ pub struct CorsGrpcWebResponseFuture<F>(
 
 impl<F, E> Future for CorsGrpcWebResponseFuture<F>
 where
-    F: Future<Output = Result<http::Response<BoxBody>, E>>,
+    F: Future<Output = Result<http::Response<Body>, E>>,
 {
-    type Output = Result<http::Response<BoxBody>, E>;
+    type Output = Result<http::Response<Body>, E>;
 
     fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         self.project().0.poll(cx)

--- a/tonic-web/src/service.rs
+++ b/tonic-web/src/service.rs
@@ -4,10 +4,9 @@ use std::pin::Pin;
 use std::task::{ready, Context, Poll};
 
 use http::{header, HeaderMap, HeaderValue, Method, Request, Response, StatusCode, Version};
-use http_body_util::BodyExt;
 use pin_project::pin_project;
 use tonic::metadata::GRPC_CONTENT_TYPE;
-use tonic::{body::BoxBody, server::NamedService};
+use tonic::{body::Body, server::NamedService};
 use tower_service::Service;
 use tracing::{debug, trace};
 
@@ -46,7 +45,7 @@ impl<S> GrpcWebService<S> {
 
 impl<S> GrpcWebService<S>
 where
-    S: Service<Request<BoxBody>, Response = Response<BoxBody>>,
+    S: Service<Request<Body>, Response = Response<Body>>,
 {
     fn response(&self, status: StatusCode) -> ResponseFuture<S::Future> {
         ResponseFuture {
@@ -54,7 +53,7 @@ where
                 res: Some(
                     Response::builder()
                         .status(status)
-                        .body(BoxBody::default())
+                        .body(Body::default())
                         .unwrap(),
                 ),
             },
@@ -64,7 +63,7 @@ where
 
 impl<S, B> Service<Request<B>> for GrpcWebService<S>
 where
-    S: Service<Request<BoxBody>, Response = Response<BoxBody>>,
+    S: Service<Request<Body>, Response = Response<Body>>,
     B: http_body::Body<Data = bytes::Bytes> + Send + 'static,
     B::Error: Into<crate::BoxError> + fmt::Display,
 {
@@ -116,7 +115,7 @@ where
                 debug!(kind = "other h2", content_type = ?req.headers().get(header::CONTENT_TYPE));
                 ResponseFuture {
                     case: Case::Other {
-                        future: self.inner.call(req.map(tonic::body::boxed)),
+                        future: self.inner.call(req.map(Body::new)),
                     },
                 }
             }
@@ -151,15 +150,15 @@ enum Case<F> {
         future: F,
     },
     ImmediateResponse {
-        res: Option<Response<BoxBody>>,
+        res: Option<Response<Body>>,
     },
 }
 
 impl<F, E> Future for ResponseFuture<F>
 where
-    F: Future<Output = Result<Response<BoxBody>, E>>,
+    F: Future<Output = Result<Response<Body>, E>>,
 {
-    type Output = Result<Response<BoxBody>, E>;
+    type Output = Result<Response<Body>, E>;
 
     fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         let mut this = self.project();
@@ -197,7 +196,7 @@ impl<'a> RequestKind<'a> {
 // Mutating request headers to conform to a gRPC request is not really
 // necessary for us at this point. We could remove most of these except
 // maybe for inserting `header::TE`, which tonic should check?
-fn coerce_request<B>(mut req: Request<B>, encoding: Encoding) -> Request<BoxBody>
+fn coerce_request<B>(mut req: Request<B>, encoding: Encoding) -> Request<Body>
 where
     B: http_body::Body<Data = bytes::Bytes> + Send + 'static,
     B::Error: Into<crate::BoxError> + fmt::Display,
@@ -215,17 +214,17 @@ where
         HeaderValue::from_static("identity,deflate,gzip"),
     );
 
-    req.map(|b| GrpcWebCall::request(b, encoding).boxed_unsync())
+    req.map(|b| Body::new(GrpcWebCall::request(b, encoding)))
 }
 
-fn coerce_response<B>(res: Response<B>, encoding: Encoding) -> Response<BoxBody>
+fn coerce_response<B>(res: Response<B>, encoding: Encoding) -> Response<Body>
 where
     B: http_body::Body<Data = bytes::Bytes> + Send + 'static,
     B::Error: Into<crate::BoxError> + fmt::Display,
 {
     let mut res = res
         .map(|b| GrpcWebCall::response(b, encoding))
-        .map(BoxBody::new);
+        .map(Body::new);
 
     res.headers_mut().insert(
         header::CONTENT_TYPE,
@@ -249,8 +248,8 @@ mod tests {
     #[derive(Debug, Clone)]
     struct Svc;
 
-    impl tower_service::Service<Request<BoxBody>> for Svc {
-        type Response = Response<BoxBody>;
+    impl tower_service::Service<Request<Body>> for Svc {
+        type Response = Response<Body>;
         type Error = String;
         type Future = BoxFuture<Self::Response, Self::Error>;
 
@@ -258,8 +257,8 @@ mod tests {
             Poll::Ready(Ok(()))
         }
 
-        fn call(&mut self, _: Request<BoxBody>) -> Self::Future {
-            Box::pin(async { Ok(Response::new(BoxBody::default())) })
+        fn call(&mut self, _: Request<Body>) -> Self::Future {
+            Box::pin(async { Ok(Response::new(Body::default())) })
         }
     }
 
@@ -269,7 +268,7 @@ mod tests {
 
     fn enable<S>(service: S) -> tower_http::cors::Cors<GrpcWebService<S>>
     where
-        S: Service<http::Request<BoxBody>, Response = http::Response<BoxBody>>,
+        S: Service<http::Request<Body>, Response = http::Response<Body>>,
     {
         tower_layer::Stack::new(
             crate::GrpcWebLayer::new(),
@@ -282,12 +281,12 @@ mod tests {
         use super::*;
         use tower_layer::Layer;
 
-        fn request() -> Request<BoxBody> {
+        fn request() -> Request<Body> {
             Request::builder()
                 .method(Method::POST)
                 .header(CONTENT_TYPE, GRPC_WEB)
                 .header(ORIGIN, "http://example.com")
-                .body(BoxBody::default())
+                .body(Body::default())
                 .unwrap()
         }
 
@@ -363,13 +362,13 @@ mod tests {
     mod options {
         use super::*;
 
-        fn request() -> Request<BoxBody> {
+        fn request() -> Request<Body> {
             Request::builder()
                 .method(Method::OPTIONS)
                 .header(ORIGIN, "http://example.com")
                 .header(ACCESS_CONTROL_REQUEST_HEADERS, "x-grpc-web")
                 .header(ACCESS_CONTROL_REQUEST_METHOD, "POST")
-                .body(BoxBody::default())
+                .body(Body::default())
                 .unwrap()
         }
 
@@ -385,11 +384,11 @@ mod tests {
     mod grpc {
         use super::*;
 
-        fn request() -> Request<BoxBody> {
+        fn request() -> Request<Body> {
             Request::builder()
                 .version(Version::HTTP_2)
                 .header(CONTENT_TYPE, GRPC_CONTENT_TYPE)
-                .body(BoxBody::default())
+                .body(Body::default())
                 .unwrap()
         }
 
@@ -409,7 +408,7 @@ mod tests {
 
             let req = Request::builder()
                 .header(CONTENT_TYPE, GRPC_CONTENT_TYPE)
-                .body(BoxBody::default())
+                .body(Body::default())
                 .unwrap();
 
             let res = svc.call(req).await.unwrap();
@@ -437,10 +436,10 @@ mod tests {
     mod other {
         use super::*;
 
-        fn request() -> Request<BoxBody> {
+        fn request() -> Request<Body> {
             Request::builder()
                 .header(CONTENT_TYPE, "application/text")
-                .body(BoxBody::default())
+                .body(Body::default())
                 .unwrap()
         }
 

--- a/tonic/Cargo.toml
+++ b/tonic/Cargo.toml
@@ -136,7 +136,6 @@ allowed_external_types = [
   "axum::routing::Router",
   "futures_core::stream::Stream",
   "h2::error::Error",
-  "http_body_util::combinators::box_body::UnsyncBoxBody",
   "tower_service::Service",
   "tower_layer::Layer",
   "tower_layer::stack::Stack",

--- a/tonic/src/body.rs
+++ b/tonic/src/body.rs
@@ -1,28 +1,94 @@
 //! HTTP specific body utilities.
 
-use http_body_util::BodyExt;
+use std::{pin::Pin, task::Poll};
 
-/// A type erased HTTP body used for tonic services.
-pub type BoxBody = http_body_util::combinators::UnsyncBoxBody<bytes::Bytes, crate::Status>;
+use http_body_util::BodyExt as _;
 
-/// Convert a [`http_body::Body`] into a [`BoxBody`].
-pub fn boxed<B>(body: B) -> BoxBody
-where
-    B: http_body::Body<Data = bytes::Bytes> + Send + 'static,
-    B::Error: Into<crate::BoxError>,
-{
-    let mut body = Some(body);
-    if let Some(body) = <dyn std::any::Any>::downcast_mut::<Option<BoxBody>>(&mut body) {
-        body.take().unwrap()
-    } else {
-        body.unwrap()
+// A type erased HTTP body.
+type BoxBody = http_body_util::combinators::UnsyncBoxBody<bytes::Bytes, crate::Status>;
+
+/// A body type used in `tonic`.
+#[derive(Debug)]
+pub struct Body {
+    kind: Kind,
+}
+
+#[derive(Debug)]
+enum Kind {
+    Empty,
+    Wrap(BoxBody),
+}
+
+impl Body {
+    fn from_kind(kind: Kind) -> Self {
+        Self { kind }
+    }
+
+    /// Create a new empty `Body`.
+    pub const fn empty() -> Self {
+        Self { kind: Kind::Empty }
+    }
+
+    /// Create a new `Body` from an existing `Body`.
+    pub fn new<B>(body: B) -> Self
+    where
+        B: http_body::Body<Data = bytes::Bytes> + Send + 'static,
+        B::Error: Into<crate::BoxError>,
+    {
+        if body.is_end_stream() {
+            return Self::empty();
+        }
+
+        let mut body = Some(body);
+
+        if let Some(body) = <dyn std::any::Any>::downcast_mut::<Option<Body>>(&mut body) {
+            return body.take().unwrap();
+        }
+
+        if let Some(body) = <dyn std::any::Any>::downcast_mut::<Option<BoxBody>>(&mut body) {
+            return Self::from_kind(Kind::Wrap(body.take().unwrap()));
+        }
+
+        let body = body
+            .unwrap()
             .map_err(crate::Status::map_error)
-            .boxed_unsync()
+            .boxed_unsync();
+
+        Self::from_kind(Kind::Wrap(body))
     }
 }
 
-/// Create an empty `BoxBody`
-#[deprecated(since = "0.12.4", note = "use `BoxBody::default()` instead")]
-pub fn empty_body() -> BoxBody {
-    BoxBody::default()
+impl Default for Body {
+    fn default() -> Self {
+        Self::empty()
+    }
+}
+
+impl http_body::Body for Body {
+    type Data = bytes::Bytes;
+    type Error = crate::Status;
+
+    fn poll_frame(
+        mut self: std::pin::Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> Poll<Option<Result<http_body::Frame<Self::Data>, Self::Error>>> {
+        match &mut self.kind {
+            Kind::Empty => Poll::Ready(None),
+            Kind::Wrap(body) => Pin::new(body).poll_frame(cx),
+        }
+    }
+
+    fn size_hint(&self) -> http_body::SizeHint {
+        match &self.kind {
+            Kind::Empty => http_body::SizeHint::with_exact(0),
+            Kind::Wrap(body) => body.size_hint(),
+        }
+    }
+
+    fn is_end_stream(&self) -> bool {
+        match &self.kind {
+            Kind::Empty => true,
+            Kind::Wrap(body) => body.is_end_stream(),
+        }
+    }
 }

--- a/tonic/src/codegen.rs
+++ b/tonic/src/codegen.rs
@@ -19,6 +19,3 @@ pub use http_body::Body;
 pub type BoxFuture<T, E> = self::Pin<Box<dyn self::Future<Output = Result<T, E>> + Send + 'static>>;
 pub type BoxStream<T> =
     self::Pin<Box<dyn tokio_stream::Stream<Item = Result<T, crate::Status>> + Send + 'static>>;
-
-#[allow(deprecated)]
-pub use crate::body::empty_body;

--- a/tonic/src/server/grpc.rs
+++ b/tonic/src/server/grpc.rs
@@ -4,12 +4,12 @@ use crate::codec::compression::{
 use crate::codec::EncodeBody;
 use crate::metadata::GRPC_CONTENT_TYPE;
 use crate::{
-    body::BoxBody,
+    body::Body,
     codec::{Codec, Streaming},
     server::{ClientStreamingService, ServerStreamingService, StreamingService, UnaryService},
     Request, Status,
 };
-use http_body::Body;
+use http_body::Body as HttpBody;
 use std::{fmt, pin::pin};
 use tokio_stream::{Stream, StreamExt};
 
@@ -224,10 +224,10 @@ where
         &mut self,
         mut service: S,
         req: http::Request<B>,
-    ) -> http::Response<BoxBody>
+    ) -> http::Response<Body>
     where
         S: UnaryService<T::Decode, Response = T::Encode>,
-        B: Body + Send + 'static,
+        B: HttpBody + Send + 'static,
         B::Error: Into<crate::BoxError> + Send,
     {
         let accept_encoding = CompressionEncoding::from_accept_encoding_header(
@@ -267,11 +267,11 @@ where
         &mut self,
         mut service: S,
         req: http::Request<B>,
-    ) -> http::Response<BoxBody>
+    ) -> http::Response<Body>
     where
         S: ServerStreamingService<T::Decode, Response = T::Encode>,
         S::ResponseStream: Send + 'static,
-        B: Body + Send + 'static,
+        B: HttpBody + Send + 'static,
         B::Error: Into<crate::BoxError> + Send,
     {
         let accept_encoding = CompressionEncoding::from_accept_encoding_header(
@@ -308,10 +308,10 @@ where
         &mut self,
         mut service: S,
         req: http::Request<B>,
-    ) -> http::Response<BoxBody>
+    ) -> http::Response<Body>
     where
         S: ClientStreamingService<T::Decode, Response = T::Encode>,
-        B: Body + Send + 'static,
+        B: HttpBody + Send + 'static,
         B::Error: Into<crate::BoxError> + Send + 'static,
     {
         let accept_encoding = CompressionEncoding::from_accept_encoding_header(
@@ -341,11 +341,11 @@ where
         &mut self,
         mut service: S,
         req: http::Request<B>,
-    ) -> http::Response<BoxBody>
+    ) -> http::Response<Body>
     where
         S: StreamingService<T::Decode, Response = T::Encode> + Send,
         S::ResponseStream: Send + 'static,
-        B: Body + Send + 'static,
+        B: HttpBody + Send + 'static,
         B::Error: Into<crate::BoxError> + Send,
     {
         let accept_encoding = CompressionEncoding::from_accept_encoding_header(
@@ -370,7 +370,7 @@ where
         request: http::Request<B>,
     ) -> Result<Request<T::Decode>, Status>
     where
-        B: Body + Send + 'static,
+        B: HttpBody + Send + 'static,
         B::Error: Into<crate::BoxError> + Send,
     {
         let request_compression_encoding = self.request_encoding_if_supported(&request)?;
@@ -403,7 +403,7 @@ where
         request: http::Request<B>,
     ) -> Result<Request<Streaming<T::Decode>>, Status>
     where
-        B: Body + Send + 'static,
+        B: HttpBody + Send + 'static,
         B::Error: Into<crate::BoxError> + Send,
     {
         let encoding = self.request_encoding_if_supported(&request)?;
@@ -426,7 +426,7 @@ where
         accept_encoding: Option<CompressionEncoding>,
         compression_override: SingleMessageCompressionOverride,
         max_message_size: Option<usize>,
-    ) -> http::Response<BoxBody>
+    ) -> http::Response<Body>
     where
         B: Stream<Item = Result<T::Encode, Status>> + Send + 'static,
     {
@@ -456,7 +456,7 @@ where
             max_message_size,
         );
 
-        http::Response::from_parts(parts, BoxBody::new(body))
+        http::Response::from_parts(parts, Body::new(body))
     }
 
     fn request_encoding_if_supported<B>(

--- a/tonic/src/service/router.rs
+++ b/tonic/src/service/router.rs
@@ -1,9 +1,4 @@
-use crate::{
-    body::{boxed, BoxBody},
-    metadata::GRPC_CONTENT_TYPE,
-    server::NamedService,
-    Status,
-};
+use crate::{body::Body, metadata::GRPC_CONTENT_TYPE, server::NamedService, Status};
 use http::{HeaderValue, Request, Response};
 use std::{
     convert::Infallible,
@@ -30,7 +25,7 @@ impl RoutesBuilder {
     /// Add a new service.
     pub fn add_service<S>(&mut self, svc: S) -> &mut Self
     where
-        S: Service<Request<BoxBody>, Error = Infallible> + NamedService + Clone + Send + 'static,
+        S: Service<Request<Body>, Error = Infallible> + NamedService + Clone + Send + 'static,
         S::Response: axum::response::IntoResponse,
         S::Future: Send + 'static,
     {
@@ -57,7 +52,7 @@ impl Routes {
     /// Create a new routes with `svc` already added to it.
     pub fn new<S>(svc: S) -> Self
     where
-        S: Service<Request<BoxBody>, Error = Infallible> + NamedService + Clone + Send + 'static,
+        S: Service<Request<Body>, Error = Infallible> + NamedService + Clone + Send + 'static,
         S::Response: axum::response::IntoResponse,
         S::Future: Send + 'static,
     {
@@ -72,13 +67,13 @@ impl Routes {
     /// Add a new service.
     pub fn add_service<S>(mut self, svc: S) -> Self
     where
-        S: Service<Request<BoxBody>, Error = Infallible> + NamedService + Clone + Send + 'static,
+        S: Service<Request<Body>, Error = Infallible> + NamedService + Clone + Send + 'static,
         S::Response: axum::response::IntoResponse,
         S::Future: Send + 'static,
     {
         self.router = self.router.route_service(
             &format!("/{}/*rest", S::NAME),
-            svc.map_request(|req: Request<axum::body::Body>| req.map(boxed)),
+            svc.map_request(|req: Request<axum::body::Body>| req.map(Body::new)),
         );
         self
     }
@@ -145,7 +140,7 @@ where
     B: http_body::Body<Data = bytes::Bytes> + Send + 'static,
     B::Error: Into<crate::BoxError>,
 {
-    type Response = Response<BoxBody>;
+    type Response = Response<Body>;
     type Error = crate::BoxError;
     type Future = RoutesFuture;
 
@@ -168,11 +163,11 @@ impl fmt::Debug for RoutesFuture {
 }
 
 impl Future for RoutesFuture {
-    type Output = Result<Response<BoxBody>, crate::BoxError>;
+    type Output = Result<Response<Body>, crate::BoxError>;
 
     fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         match ready!(Pin::new(&mut self.as_mut().0).poll(cx)) {
-            Ok(res) => Ok(res.map(boxed)).into(),
+            Ok(res) => Ok(res.map(Body::new)).into(),
             // NOTE: This pattern is not needed from Rust 1.82.
             // See https://github.com/rust-lang/rust/pull/122792.
             #[allow(unreachable_patterns)]

--- a/tonic/src/transport/mod.rs
+++ b/tonic/src/transport/mod.rs
@@ -21,7 +21,6 @@
 //! # #[cfg(feature = "rustls")]
 //! # use tonic::transport::{Channel, Certificate, ClientTlsConfig};
 //! # use std::time::Duration;
-//! # use tonic::body::BoxBody;
 //! # use tonic::client::GrpcService;;
 //! # use http::Request;
 //! # #[cfg(feature = "rustls")]
@@ -49,20 +48,20 @@
 //! # use std::convert::Infallible;
 //! # #[cfg(feature = "rustls")]
 //! # use tonic::transport::{Server, Identity, ServerTlsConfig};
-//! # use tonic::body::BoxBody;
+//! # use tonic::body::Body;
 //! # use tower::Service;
 //! # #[cfg(feature = "rustls")]
 //! # async fn do_thing() -> Result<(), Box<dyn std::error::Error>> {
 //! # #[derive(Clone)]
 //! # pub struct Svc;
-//! # impl Service<hyper::Request<BoxBody>> for Svc {
-//! #   type Response = hyper::Response<BoxBody>;
+//! # impl Service<hyper::Request<Body>> for Svc {
+//! #   type Response = hyper::Response<Body>;
 //! #   type Error = Infallible;
 //! #   type Future = std::future::Ready<Result<Self::Response, Self::Error>>;
 //! #   fn poll_ready(&mut self, _cx: &mut std::task::Context<'_>) -> std::task::Poll<Result<(), Self::Error>> {
 //! #       Ok(()).into()
 //! #  }
-//! #   fn call(&mut self, _req: hyper::Request<BoxBody>) -> Self::Future {
+//! #   fn call(&mut self, _req: hyper::Request<Body>) -> Self::Future {
 //! #       unimplemented!()
 //! #   }
 //! # }

--- a/tonic/src/transport/server/incoming.rs
+++ b/tonic/src/transport/server/incoming.rs
@@ -176,13 +176,13 @@ impl TcpIncoming {
     /// ```no_run
     /// # use tower_service::Service;
     /// # use http::{request::Request, response::Response};
-    /// # use tonic::{body::BoxBody, server::NamedService, transport::{Server, server::TcpIncoming}};
+    /// # use tonic::{body::Body, server::NamedService, transport::{Server, server::TcpIncoming}};
     /// # use core::convert::Infallible;
     /// # use std::error::Error;
     /// # fn main() { }  // Cannot have type parameters, hence instead define:
     /// # fn run<S>(some_service: S) -> Result<(), Box<dyn Error + Send + Sync>>
     /// # where
-    /// #   S: Service<Request<BoxBody>, Response = Response<BoxBody>, Error = Infallible> + NamedService + Clone + Send + 'static,
+    /// #   S: Service<Request<Body>, Response = Response<Body>, Error = Infallible> + NamedService + Clone + Send + 'static,
     /// #   S::Future: Send + 'static,
     /// # {
     /// // Find a free port

--- a/tonic/src/transport/server/mod.rs
+++ b/tonic/src/transport/server/mod.rs
@@ -38,7 +38,7 @@ use crate::transport::Error;
 
 use self::service::{RecoverError, ServerIo};
 use super::service::GrpcTimeout;
-use crate::body::{boxed, BoxBody};
+use crate::body::Body;
 use crate::server::NamedService;
 use bytes::Bytes;
 use http::{Request, Response};
@@ -68,8 +68,7 @@ use tower::{
     Service, ServiceBuilder, ServiceExt,
 };
 
-type BoxService =
-    tower::util::BoxCloneService<Request<BoxBody>, Response<BoxBody>, crate::BoxError>;
+type BoxService = tower::util::BoxCloneService<Request<Body>, Response<Body>, crate::BoxError>;
 type TraceInterceptor = Arc<dyn Fn(&http::Request<()>) -> tracing::Span + Send + Sync + 'static>;
 
 const DEFAULT_HTTP2_KEEPALIVE_TIMEOUT_SECS: u64 = 20;
@@ -395,7 +394,7 @@ impl<L> Server<L> {
     /// route around different services.
     pub fn add_service<S>(&mut self, svc: S) -> Router<L>
     where
-        S: Service<Request<BoxBody>, Response = Response<BoxBody>, Error = Infallible>
+        S: Service<Request<Body>, Response = Response<Body>, Error = Infallible>
             + NamedService
             + Clone
             + Send
@@ -416,7 +415,7 @@ impl<L> Server<L> {
     /// As a result, one cannot use this to toggle between two identically named implementations.
     pub fn add_optional_service<S>(&mut self, svc: Option<S>) -> Router<L>
     where
-        S: Service<Request<BoxBody>, Response = Response<BoxBody>, Error = Infallible>
+        S: Service<Request<Body>, Response = Response<Body>, Error = Infallible>
             + NamedService
             + Clone
             + Send
@@ -532,10 +531,9 @@ impl<L> Server<L> {
     ) -> Result<(), super::Error>
     where
         L: Layer<S>,
-        L::Service:
-            Service<Request<BoxBody>, Response = Response<ResBody>> + Clone + Send + 'static,
-        <<L as Layer<S>>::Service as Service<Request<BoxBody>>>::Future: Send + 'static,
-        <<L as Layer<S>>::Service as Service<Request<BoxBody>>>::Error:
+        L::Service: Service<Request<Body>, Response = Response<ResBody>> + Clone + Send + 'static,
+        <<L as Layer<S>>::Service as Service<Request<Body>>>::Future: Send + 'static,
+        <<L as Layer<S>>::Service as Service<Request<Body>>>::Error:
             Into<crate::BoxError> + Send + 'static,
         I: Stream<Item = Result<IO, IE>>,
         IO: AsyncRead + AsyncWrite + Connected + Unpin + Send + 'static,
@@ -640,7 +638,7 @@ impl<L> Server<L> {
                         .map_err(super::Error::from_source)?;
 
                     let hyper_io = TokioIo::new(io);
-                    let hyper_svc = TowerToHyperService::new(req_svc.map_request(|req: Request<Incoming>| req.map(boxed)));
+                    let hyper_svc = TowerToHyperService::new(req_svc.map_request(|req: Request<Incoming>| req.map(Body::new)));
 
                     serve_connection(hyper_io, hyper_svc, server.clone(), graceful.then(|| signal_rx.clone()), max_connection_age);
                 }
@@ -733,7 +731,7 @@ impl<L> Router<L> {
     /// Add a new service to this router.
     pub fn add_service<S>(mut self, svc: S) -> Self
     where
-        S: Service<Request<BoxBody>, Response = Response<BoxBody>, Error = Infallible>
+        S: Service<Request<Body>, Response = Response<Body>, Error = Infallible>
             + NamedService
             + Clone
             + Send
@@ -752,7 +750,7 @@ impl<L> Router<L> {
     #[allow(clippy::type_complexity)]
     pub fn add_optional_service<S>(mut self, svc: Option<S>) -> Self
     where
-        S: Service<Request<BoxBody>, Response = Response<BoxBody>, Error = Infallible>
+        S: Service<Request<Body>, Response = Response<Body>, Error = Infallible>
             + NamedService
             + Clone
             + Send
@@ -779,10 +777,9 @@ impl<L> Router<L> {
     pub async fn serve<ResBody>(self, addr: SocketAddr) -> Result<(), super::Error>
     where
         L: Layer<Routes> + Clone,
-        L::Service:
-            Service<Request<BoxBody>, Response = Response<ResBody>> + Clone + Send + 'static,
-        <<L as Layer<Routes>>::Service as Service<Request<BoxBody>>>::Future: Send + 'static,
-        <<L as Layer<Routes>>::Service as Service<Request<BoxBody>>>::Error:
+        L::Service: Service<Request<Body>, Response = Response<ResBody>> + Clone + Send + 'static,
+        <<L as Layer<Routes>>::Service as Service<Request<Body>>>::Future: Send + 'static,
+        <<L as Layer<Routes>>::Service as Service<Request<Body>>>::Error:
             Into<crate::BoxError> + Send,
         ResBody: http_body::Body<Data = Bytes> + Send + 'static,
         ResBody::Error: Into<crate::BoxError>,
@@ -811,10 +808,9 @@ impl<L> Router<L> {
     ) -> Result<(), super::Error>
     where
         L: Layer<Routes>,
-        L::Service:
-            Service<Request<BoxBody>, Response = Response<ResBody>> + Clone + Send + 'static,
-        <<L as Layer<Routes>>::Service as Service<Request<BoxBody>>>::Future: Send + 'static,
-        <<L as Layer<Routes>>::Service as Service<Request<BoxBody>>>::Error:
+        L::Service: Service<Request<Body>, Response = Response<ResBody>> + Clone + Send + 'static,
+        <<L as Layer<Routes>>::Service as Service<Request<Body>>>::Future: Send + 'static,
+        <<L as Layer<Routes>>::Service as Service<Request<Body>>>::Error:
             Into<crate::BoxError> + Send,
         ResBody: http_body::Body<Data = Bytes> + Send + 'static,
         ResBody::Error: Into<crate::BoxError>,
@@ -841,10 +837,10 @@ impl<L> Router<L> {
         IO: AsyncRead + AsyncWrite + Connected + Unpin + Send + 'static,
         IE: Into<crate::BoxError>,
         L: Layer<Routes>,
-        L::Service:
-            Service<Request<BoxBody>, Response = Response<ResBody>> + Clone + Send + 'static,
-        <<L as Layer<Routes>>::Service as Service<Request<BoxBody>>>::Future: Send + 'static,
-        <<L as Layer<Routes>>::Service as Service<Request<BoxBody>>>::Error:
+
+        L::Service: Service<Request<Body>, Response = Response<ResBody>> + Clone + Send + 'static,
+        <<L as Layer<Routes>>::Service as Service<Request<Body>>>::Future: Send + 'static,
+        <<L as Layer<Routes>>::Service as Service<Request<Body>>>::Error:
             Into<crate::BoxError> + Send,
         ResBody: http_body::Body<Data = Bytes> + Send + 'static,
         ResBody::Error: Into<crate::BoxError>,
@@ -877,10 +873,9 @@ impl<L> Router<L> {
         IE: Into<crate::BoxError>,
         F: Future<Output = ()>,
         L: Layer<Routes>,
-        L::Service:
-            Service<Request<BoxBody>, Response = Response<ResBody>> + Clone + Send + 'static,
-        <<L as Layer<Routes>>::Service as Service<Request<BoxBody>>>::Future: Send + 'static,
-        <<L as Layer<Routes>>::Service as Service<Request<BoxBody>>>::Error:
+        L::Service: Service<Request<Body>, Response = Response<ResBody>> + Clone + Send + 'static,
+        <<L as Layer<Routes>>::Service as Service<Request<Body>>>::Future: Send + 'static,
+        <<L as Layer<Routes>>::Service as Service<Request<Body>>>::Error:
             Into<crate::BoxError> + Send,
         ResBody: http_body::Body<Data = Bytes> + Send + 'static,
         ResBody::Error: Into<crate::BoxError>,
@@ -912,14 +907,14 @@ struct Svc<S> {
     trace_interceptor: Option<TraceInterceptor>,
 }
 
-impl<S, ResBody> Service<Request<BoxBody>> for Svc<S>
+impl<S, ResBody> Service<Request<Body>> for Svc<S>
 where
-    S: Service<Request<BoxBody>, Response = Response<ResBody>>,
+    S: Service<Request<Body>, Response = Response<ResBody>>,
     S::Error: Into<crate::BoxError>,
     ResBody: http_body::Body<Data = Bytes> + Send + 'static,
     ResBody::Error: Into<crate::BoxError>,
 {
-    type Response = Response<BoxBody>;
+    type Response = Response<Body>;
     type Error = crate::BoxError;
     type Future = SvcFuture<S::Future>;
 
@@ -927,7 +922,7 @@ where
         self.inner.poll_ready(cx).map_err(Into::into)
     }
 
-    fn call(&mut self, mut req: Request<BoxBody>) -> Self::Future {
+    fn call(&mut self, mut req: Request<Body>) -> Self::Future {
         let span = if let Some(trace_interceptor) = &self.trace_interceptor {
             let (parts, body) = req.into_parts();
             let bodyless_request = Request::from_parts(parts, ());
@@ -963,14 +958,14 @@ where
     ResBody: http_body::Body<Data = Bytes> + Send + 'static,
     ResBody::Error: Into<crate::BoxError>,
 {
-    type Output = Result<Response<BoxBody>, crate::BoxError>;
+    type Output = Result<Response<Body>, crate::BoxError>;
 
     fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         let this = self.project();
         let _guard = this.span.enter();
 
         let response: Response<ResBody> = ready!(this.inner.poll(cx)).map_err(Into::into)?;
-        let response = response.map(|body| boxed(body.map_err(Into::into)));
+        let response = response.map(|body| Body::new(body.map_err(Into::into)));
         Poll::Ready(Ok(response))
     }
 }
@@ -993,7 +988,7 @@ struct MakeSvc<S, IO> {
 impl<S, ResBody, IO> Service<&ServerIo<IO>> for MakeSvc<S, IO>
 where
     IO: Connected,
-    S: Service<Request<BoxBody>, Response = Response<ResBody>> + Clone + Send + 'static,
+    S: Service<Request<Body>, Response = Response<ResBody>> + Clone + Send + 'static,
     S::Future: Send + 'static,
     S::Error: Into<crate::BoxError> + Send,
     ResBody: http_body::Body<Data = Bytes> + Send + 'static,
@@ -1023,7 +1018,7 @@ where
 
         let svc = ServiceBuilder::new()
             .layer(BoxCloneService::layer())
-            .map_request(move |mut request: Request<BoxBody>| {
+            .map_request(move |mut request: Request<Body>| {
                 match &conn_info {
                     tower::util::Either::Left(inner) => {
                         request.extensions_mut().insert(inner.clone());


### PR DESCRIPTION
Instead of exposing `http-body-util`'s `UnsyncBoxBody`, defining our own `Body` type, which makes the `http-body-util` crate an internal dependency. This also allow us to define methods to the body type.