### PR TITLE
feat: make pub `Channel` fns that allow creating it from a custom connector

### DIFF
--- a/tonic/src/transport/channel/mod.rs
+++ b/tonic/src/transport/channel/mod.rs
@@ -16,7 +16,6 @@ use http::{
     uri::{InvalidUri, Uri},
     Request, Response,
 };
-use hyper_util::client::legacy::connect::Connection as HyperConnection;
 use std::{
     fmt,
     future::Future,
@@ -153,7 +152,7 @@ impl Channel {
         C: Service<Uri> + Send + 'static,
         C::Error: Into<crate::Error> + Send,
         C::Future: Send,
-        C::Response: rt::Read + rt::Write + HyperConnection + Unpin + Send + 'static,
+        C::Response: rt::Read + rt::Write + Unpin + Send + 'static,
     {
         let buffer_size = endpoint.buffer_size.unwrap_or(DEFAULT_BUFFER_SIZE);
         let executor = endpoint.executor.clone();
@@ -173,7 +172,7 @@ impl Channel {
         C: Service<Uri> + Send + 'static,
         C::Error: Into<crate::Error> + Send,
         C::Future: Unpin + Send,
-        C::Response: rt::Read + rt::Write + HyperConnection + Unpin + Send + 'static,
+        C::Response: rt::Read + rt::Write + Unpin + Send + 'static,
     {
         let buffer_size = endpoint.buffer_size.unwrap_or(DEFAULT_BUFFER_SIZE);
         let executor = endpoint.executor.clone();

--- a/tonic/src/transport/channel/mod.rs
+++ b/tonic/src/transport/channel/mod.rs
@@ -145,7 +145,10 @@ impl Channel {
         (Self::balance(list, DEFAULT_BUFFER_SIZE, executor), tx)
     }
 
-    pub(crate) fn new<C>(connector: C, endpoint: Endpoint) -> Self
+    /// Create a new [`Channel`] using a custom connector to the provided [Endpoint].
+    ///
+    /// This is a lower level API, prefer to use [`Endpoint::connect_lazy`] if you are not using a custom connector.
+    pub fn new<C>(connector: C, endpoint: Endpoint) -> Self
     where
         C: Service<Uri> + Send + 'static,
         C::Error: Into<crate::Error> + Send,
@@ -162,7 +165,10 @@ impl Channel {
         Channel { svc }
     }
 
-    pub(crate) async fn connect<C>(connector: C, endpoint: Endpoint) -> Result<Self, super::Error>
+    /// Connect to the provided [`Endpoint`] using the provided connector, and return a new [`Channel`].
+    ///
+    /// This is a lower level API, prefer to use [`Endpoint::connect`] if you are not using a custom connector.
+    pub async fn connect<C>(connector: C, endpoint: Endpoint) -> Result<Self, super::Error>
     where
         C: Service<Uri> + Send + 'static,
         C::Error: Into<crate::Error> + Send,


### PR DESCRIPTION
The connector is required to be a `Service` that accepts a `http::Uri` and returns a connection implementing hyper's IO traits, which is a very reasonable requirement that can be fulfilled by advanced users that need to customize any mechanics that don't fit into the paved path for HTTP and HTTPS with tonic.

One such requirement is customizing `rustls::ClientConfig`, which has come up for a number of users. They have been pointed in the direction of a custom connector, but the APIs on `Endpoint` are not always suitable:

`Endpoint::connect_(lazy_)with_connector` always wraps the provided connector with `transport::channel::service::Connector`. This wrapper raises an error `HttpsUriWithoutTlsSupport` if (the scheme is `https://` + the `tls` feature is enabled + and `Endpoint::tls_config()` was not used) [ref](https://github.com/hyperium/tonic/blob/758d4f9a95d9752465baa7db10ab6cc069fef00b/tonic/src/transport/channel/service/connector.rs#L62-L70). This is a good safety feature in general, but not if the wrapped connector is taking care of TLS.

As a side bonus, `transport::channel::service::io::BoxedIo` can be avoided.
