### PR TITLE
chore: Update to cargo-check-external-types 0.1.13

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -146,11 +146,11 @@ jobs:
     - uses: actions/checkout@v4
     - uses: dtolnay/rust-toolchain@master
       with:
-        toolchain: nightly-2024-05-01
+        toolchain: nightly-2024-06-30
     - name: Install cargo-check-external-types
       uses: taiki-e/cache-cargo-install-action@v2
       with:
-        tool: cargo-check-external-types@0.1.12
+        tool: cargo-check-external-types@0.1.13
     - uses: taiki-e/install-action@cargo-hack
     - uses: Swatinem/rust-cache@v2
     - run: cargo hack --no-private check-external-types


### PR DESCRIPTION
This seems to be introduced at the recent changes in `pin-project`.

https://github.com/taiki-e/pin-project/pull/357