### PR TITLE
chore(server): Remove unnecessary bound from MaybeEmptyBody

### DIFF
--- a/tonic/src/transport/server/service/recover_error.rs
+++ b/tonic/src/transport/server/service/recover_error.rs
@@ -94,7 +94,7 @@ impl<B> MaybeEmptyBody<B> {
 
 impl<B> http_body::Body for MaybeEmptyBody<B>
 where
-    B: http_body::Body + Send,
+    B: http_body::Body,
 {
     type Data = B::Data;
     type Error = B::Error;


### PR DESCRIPTION
Removes unnecessary bound from `MaybeEmptyBody`.