### PR TITLE
use ring if no default crypto provider is found

### DIFF
--- a/tonic/src/transport/channel/service/tls.rs
+++ b/tonic/src/transport/channel/service/tls.rs
@@ -7,7 +7,7 @@ use tokio_rustls::{
     rustls::{
         crypto,
         pki_types::{ServerName, TrustAnchor},
-        ClientConfig, RootCertStore,
+        ClientConfig, ConfigBuilder, RootCertStore, WantsVerifier,
     },
     TlsConnector as RustlsConnector,
 };
@@ -35,14 +35,25 @@ impl TlsConnector {
         #[cfg(feature = "tls-native-roots")] with_native_roots: bool,
         #[cfg(feature = "tls-webpki-roots")] with_webpki_roots: bool,
     ) -> Result<Self, crate::BoxError> {
-        let crypto_provider = match crypto::CryptoProvider::get_default() {
-            Some(provider) => provider.clone(),
-            None => Arc::new(crypto::ring::default_provider()),
+        fn with_provider(
+            provider: Arc<crypto::CryptoProvider>,
+        ) -> ConfigBuilder<ClientConfig, WantsVerifier> {
+            ClientConfig::builder_with_provider(provider)
+                .with_safe_default_protocol_versions()
+                .unwrap()
+        }
+
+        #[allow(unreachable_patterns)]
+        let builder = match crypto::CryptoProvider::get_default() {
+            Some(provider) => with_provider(provider.clone()),
+            #[cfg(feature = "tls-ring")]
+            None => with_provider(Arc::new(crypto::ring::default_provider())),
+            #[cfg(feature = "tls-aws-lc")]
+            None => with_provider(Arc::new(crypto::aws_lc_rs::default_provider())),
+            // somehow tls is enabled, but neither of the crypto features are enabled.
+            _ => ClientConfig::builder(),
         };
 
-        let builder = ClientConfig::builder_with_provider(crypto_provider)
-            .with_safe_default_protocol_versions()
-            .unwrap();
         let mut roots = RootCertStore::from_iter(trust_anchors);
 
         #[cfg(feature = "tls-native-roots")]

--- a/tonic/src/transport/channel/service/tls.rs
+++ b/tonic/src/transport/channel/service/tls.rs
@@ -42,11 +42,7 @@ impl TlsConnector {
 
         let builder = ClientConfig::builder_with_provider(crypto_provider)
             .with_safe_default_protocol_versions()
-            .inspect_err(|e| {
-                tracing::debug!(
-                    "rustls crypto provider does not support default tls protocol versions: {e:?}"
-                );
-            })?;
+            .unwrap();
         let mut roots = RootCertStore::from_iter(trust_anchors);
 
         #[cfg(feature = "tls-native-roots")]

--- a/tonic/src/transport/channel/service/tls.rs
+++ b/tonic/src/transport/channel/service/tls.rs
@@ -36,7 +36,7 @@ impl TlsConnector {
         #[cfg(feature = "tls-webpki-roots")] with_webpki_roots: bool,
     ) -> Result<Self, crate::BoxError> {
         let crypto_provider = match crypto::CryptoProvider::get_default() {
-            Some(default) => default.clone(),
+            Some(provider) => provider.clone(),
             None => Arc::new(crypto::ring::default_provider()),
         };
 


### PR DESCRIPTION
## Motivation

Tonic hard codes the `ring` feature in rustls. When another crate depends on default rustls features they will additionally have the `aws-lc-rs` feature enabled in rustls. Having both
of these features enabled makes rustls not work "out of the box" as there will no longer
be a default crypto provider.

## Solution

Make tonic use the ring provider as a fallback if no default provider is found.
