### PR TITLE
chore: Add itertools 0.12.1 to cargo-deny skip config

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -19,6 +19,7 @@ deny = [
     { crate = "term" },
 ]
 skip = [
+    { crate = "itertools@0.12.1", reason = "aws-lc-sys depends on bindgen which depends on it" },
     { crate = "sync_wrapper@0.1.2", reason = "tower depends on it" }
 ]
 skip-tree = [


### PR DESCRIPTION
Adds `itertools` 0.12.1 to cargo-deny skip config.