### PR TITLE
chore: Update cargo-deny config to allow Unicode-3.0 license

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -37,7 +37,7 @@ allow = [
     "MIT",
     "OpenSSL",
     "Zlib",
-    "Unicode-DFS-2016",
+    "Unicode-3.0",
     "MPL-2.0",
     "BSD-3-Clause",
 ]


### PR DESCRIPTION
Updates to Unicode-3.0 license.

https://github.com/dtolnay/unicode-ident/releases/tag/1.0.14