### PR TITLE
chore(test): Use any port in test

### DIFF
--- a/tests/integration_tests/tests/client_layer.rs
+++ b/tests/integration_tests/tests/client_layer.rs
@@ -1,9 +1,9 @@
 use http::{header::HeaderName, HeaderValue};
 use integration_tests::pb::{test_client::TestClient, test_server, Input, Output};
 use std::time::Duration;
-use tokio::sync::oneshot;
+use tokio::{net::TcpListener, sync::oneshot};
 use tonic::{
-    transport::{Endpoint, Server},
+    transport::{server::TcpIncoming, Endpoint, Server},
     Request, Response, Status,
 };
 use tower::ServiceBuilder;
@@ -26,16 +26,22 @@ async fn connect_supports_standard_tower_layers() {
     let (tx, rx) = oneshot::channel();
     let svc = test_server::TestServer::new(Svc);
 
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let incoming = TcpIncoming::from_listener(listener, true, None).unwrap();
+
     // Start the server now, second call should succeed
     let jh = tokio::spawn(async move {
         Server::builder()
             .add_service(svc)
-            .serve_with_shutdown("127.0.0.1:1340".parse().unwrap(), async { drop(rx.await) })
+            .serve_with_incoming_shutdown(incoming, async { drop(rx.await) })
             .await
             .unwrap();
     });
 
-    let channel = Endpoint::from_static("http://127.0.0.1:1340").connect_lazy();
+    let channel = Endpoint::from_shared(format!("http://{addr}"))
+        .unwrap()
+        .connect_lazy();
 
     // prior to https://github.com/hyperium/tonic/pull/974
     // this would not compile. (specifically the `TraceLayer`)

--- a/tests/integration_tests/tests/complex_tower_middleware.rs
+++ b/tests/integration_tests/tests/complex_tower_middleware.rs
@@ -26,7 +26,7 @@ async fn complex_tower_layers_work() {
     Server::builder()
         .layer(MyServiceLayer::new())
         .add_service(svc)
-        .serve("127.0.0.1:1322".parse().unwrap())
+        .serve("127.0.0.1:0".parse().unwrap())
         .await
         .unwrap();
 }

--- a/tests/integration_tests/tests/connection.rs
+++ b/tests/integration_tests/tests/connection.rs
@@ -1,9 +1,9 @@
 use integration_tests::pb::{test_client::TestClient, test_server, Input, Output};
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
-use tokio::sync::oneshot;
+use tokio::{net::TcpListener, sync::oneshot};
 use tonic::{
-    transport::{Endpoint, Server},
+    transport::{server::TcpIncoming, Endpoint, Server},
     Code, Request, Response, Status,
 };
 
@@ -40,17 +40,21 @@ async fn connect_returns_err_via_call_after_connected() {
     let sender = Arc::new(Mutex::new(Some(tx)));
     let svc = test_server::TestServer::new(Svc(sender));
 
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let incoming = TcpIncoming::from_listener(listener, true, None).unwrap();
+
     let jh = tokio::spawn(async move {
         Server::builder()
             .add_service(svc)
-            .serve_with_shutdown("127.0.0.1:1338".parse().unwrap(), async { drop(rx.await) })
+            .serve_with_incoming_shutdown(incoming, async { drop(rx.await) })
             .await
             .unwrap();
     });
 
     tokio::time::sleep(Duration::from_millis(100)).await;
 
-    let mut client = TestClient::connect("http://127.0.0.1:1338").await.unwrap();
+    let mut client = TestClient::connect(format!("http://{addr}")).await.unwrap();
 
     // First call should pass, then shutdown the server
     client.unary_call(Request::new(Input {})).await.unwrap();
@@ -71,21 +75,32 @@ async fn connect_lazy_reconnects_after_first_failure() {
     let sender = Arc::new(Mutex::new(Some(tx)));
     let svc = test_server::TestServer::new(Svc(sender));
 
-    let channel = Endpoint::from_static("http://127.0.0.1:1339").connect_lazy();
+    {
+        let channel = Endpoint::from_static("http://127.0.0.1:0").connect_lazy();
+        let mut client = TestClient::new(channel);
 
-    let mut client = TestClient::new(channel);
+        // First call should fail, the server is not running
+        client.unary_call(Request::new(Input {})).await.unwrap_err();
+    }
 
-    // First call should fail, the server is not running
-    client.unary_call(Request::new(Input {})).await.unwrap_err();
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let incoming = TcpIncoming::from_listener(listener, true, None).unwrap();
 
     // Start the server now, second call should succeed
     let jh = tokio::spawn(async move {
         Server::builder()
             .add_service(svc)
-            .serve_with_shutdown("127.0.0.1:1339".parse().unwrap(), async { drop(rx.await) })
+            .serve_with_incoming_shutdown(incoming, async { drop(rx.await) })
             .await
             .unwrap();
     });
+
+    let channel = Endpoint::from_shared(format!("http://{addr}"))
+        .unwrap()
+        .connect_lazy();
+
+    let mut client = TestClient::new(channel);
 
     tokio::time::sleep(Duration::from_millis(100)).await;
     client.unary_call(Request::new(Input {})).await.unwrap();

--- a/tests/integration_tests/tests/streams.rs
+++ b/tests/integration_tests/tests/streams.rs
@@ -31,7 +31,7 @@ async fn status_from_server_stream_with_source() {
     let jh = tokio::spawn(async move {
         Server::builder()
             .add_service(svc)
-            .serve_with_shutdown("127.0.0.1:1339".parse().unwrap(), async { drop(rx.await) })
+            .serve_with_shutdown("127.0.0.1:0".parse().unwrap(), async { drop(rx.await) })
             .await
             .unwrap();
     });

--- a/tests/integration_tests/tests/user_agent.rs
+++ b/tests/integration_tests/tests/user_agent.rs
@@ -1,8 +1,8 @@
 use integration_tests::pb::{test_client, test_server, Input, Output};
 use std::time::Duration;
-use tokio::sync::oneshot;
+use tokio::{net::TcpListener, sync::oneshot};
 use tonic::{
-    transport::{Endpoint, Server},
+    transport::{server::TcpIncoming, Endpoint, Server},
     Request, Response, Status,
 };
 
@@ -24,17 +24,22 @@ async fn writes_user_agent_header() {
 
     let (tx, rx) = oneshot::channel::<()>();
 
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let incoming = TcpIncoming::from_listener(listener, true, None).unwrap();
+
     let jh = tokio::spawn(async move {
         Server::builder()
             .add_service(svc)
-            .serve_with_shutdown("127.0.0.1:1322".parse().unwrap(), async { drop(rx.await) })
+            .serve_with_incoming_shutdown(incoming, async { drop(rx.await) })
             .await
             .unwrap();
     });
 
     tokio::time::sleep(Duration::from_millis(100)).await;
 
-    let channel = Endpoint::from_static("http://127.0.0.1:1322")
+    let channel = Endpoint::from_shared(format!("http://{addr}"))
+        .unwrap()
         .user_agent("my-client")
         .expect("valid user agent")
         .connect()


### PR DESCRIPTION
Uses any port in the tests to allow parallel tests.