### PR TITLE
chore: Remove outdated clippy config

### DIFF
--- a/tests/root-crate-path/src/main.rs
+++ b/tests/root-crate-path/src/main.rs
@@ -1,4 +1,3 @@
-#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Animal {
     #[prost(string, optional, tag = "1")]

--- a/tonic/src/transport/server/mod.rs
+++ b/tonic/src/transport/server/mod.rs
@@ -748,7 +748,6 @@ impl<L> Router<L> {
     /// # Note
     /// Even when the argument given is `None` this will capture *all* requests to this service name.
     /// As a result, one cannot use this to toggle between two identically named implementations.
-    #[allow(clippy::type_complexity)]
     pub fn add_optional_service<S>(mut self, svc: Option<S>) -> Self
     where
         S: Service<Request<Body>, Response = Response<Body>, Error = Infallible>


### PR DESCRIPTION
Removes outdated clippy configs.