### PR TITLE
feat: Add `apply_interceptor` method for additional service configura…

### DIFF
--- a/tonic-build/src/server.rs
+++ b/tonic-build/src/server.rs
@@ -141,6 +141,13 @@ pub(crate) fn generate_internal<T: Service>(
                     InterceptedService::new(Self::new(inner), interceptor)
                 }
 
+                pub fn apply_interceptor<F>(service: Self, interceptor: F) -> InterceptedService<Self, F>
+                where
+                    F: tonic::service::Interceptor,
+                {
+                    InterceptedService::new(service, interceptor)
+                }
+                
                 #configure_compression_methods
 
                 #configure_max_message_size_methods


### PR DESCRIPTION
…tion

This commit introduces the `apply_interceptor` method, which allows for additional configuration options like `accept_compressed`, `send_compressed`, `max_decoding_message_size`, and `max_encoding_message_size` when applying an interceptor.

## Motivation

- The new method provides flexibility for users needing more control over service configuration.

## Solution

- The existing `with_interceptor` method remains unchanged to maintain backward compatibility.

