### PR TITLE
chore(ci): Update to nightly-2024-12-01 on udeps ci

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -57,7 +57,7 @@ jobs:
     - uses: actions/checkout@v4
     - uses: dtolnay/rust-toolchain@master
       with:
-        toolchain: nightly-2024-08-04
+        toolchain: nightly-2024-12-01
     - uses: taiki-e/install-action@cargo-hack
     - uses: taiki-e/install-action@cargo-udeps
     - uses: taiki-e/install-action@protoc


### PR DESCRIPTION
Updates to nightly-2024-12-01 on udeps ci.