### PR TITLE
fix: Fill GRPC_CONTENT_TYPE when handing recover errors

### DIFF
--- a/tonic/src/transport/server/service/recover_error.rs
+++ b/tonic/src/transport/server/service/recover_error.rs
@@ -1,3 +1,4 @@
+use crate::metadata::GRPC_CONTENT_TYPE;
 use crate::Status;
 use http::Response;
 use http_body::Frame;
@@ -67,6 +68,8 @@ where
             Err(err) => match Status::try_from_error(err) {
                 Ok(status) => {
                     let mut res = Response::new(MaybeEmptyBody::empty());
+                    res.headers_mut()
+                        .insert(http::header::CONTENT_TYPE, GRPC_CONTENT_TYPE);
                     status.add_header(res.headers_mut()).unwrap();
                     Poll::Ready(Ok(res))
                 }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.


Contributors guide: https://github.com/hyperium/tonic/blob/master/CONTRIBUTING.md
-->


## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? If a new feature is being added, describe the intended
use case that feature fulfills.
-->

Fix https://github.com/hyperium/tonic/issues/2090.

## Solution
 Filling http content-type in responses when services are cancelled by tonic.

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
