### PR TITLE
chore: Update to tokio-rustls 0.16.1 and remove rustls-pki-types from direct dependency

### DIFF
--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -264,7 +264,7 @@ tower = ["dep:tower", "dep:http"]
 json-codec = ["dep:serde", "dep:serde_json", "dep:bytes"]
 compression = ["tonic/gzip"]
 tls = ["tonic/tls-ring"]
-tls-rustls = ["dep:http", "dep:hyper", "dep:hyper-util", "dep:hyper-rustls", "dep:tower", "tower-http/util", "tower-http/add-extension", "dep:rustls-pki-types", "dep:tokio-rustls"]
+tls-rustls = ["dep:http", "dep:hyper", "dep:hyper-util", "dep:hyper-rustls", "dep:tower", "tower-http/util", "tower-http/add-extension", "dep:tokio-rustls"]
 tls-client-auth = ["tonic/tls-ring"]
 types = ["dep:tonic-types"]
 h2c = ["dep:hyper", "dep:tower", "dep:http", "dep:hyper-util"]
@@ -300,9 +300,8 @@ hyper-util = { version = "0.1.4", optional = true }
 listenfd = { version = "1.0", optional = true }
 bytes = { version = "1", optional = true }
 h2 = { version = "0.4", optional = true }
-tokio-rustls = { version = "0.26", optional = true, features = ["ring", "tls12"], default-features = false }
+tokio-rustls = { version = "0.26.1", optional = true, features = ["ring", "tls12"], default-features = false }
 hyper-rustls = { version = "0.27.0", features = ["http2", "ring", "tls12"], optional = true, default-features = false }
-rustls-pki-types = { version = "1.10", optional = true }
 tower-http = { version = "0.6", optional = true }
 
 [build-dependencies]

--- a/tonic/Cargo.toml
+++ b/tonic/Cargo.toml
@@ -28,7 +28,7 @@ gzip = ["dep:flate2"]
 zstd = ["dep:zstd"]
 default = ["transport", "codegen", "prost"]
 prost = ["dep:prost"]
-_tls-any = ["dep:rustls-pki-types", "dep:tokio-rustls", "dep:tokio", "tokio?/rt", "tokio?/macros"] # Internal. Please choose one of `tls-ring` or `tls-aws-lc`
+_tls-any = ["dep:tokio-rustls", "dep:tokio", "tokio?/rt", "tokio?/macros"] # Internal. Please choose one of `tls-ring` or `tls-aws-lc`
 tls-ring = ["_tls-any", "tokio-rustls/ring"]
 tls-aws-lc = ["_tls-any", "tokio-rustls/aws-lc-rs"]
 tls-native-roots = ["_tls-any", "channel", "dep:rustls-native-certs"]
@@ -87,9 +87,8 @@ tower = {version = "0.5", default-features = false, optional = true}
 axum = {version = "0.7", default-features = false, optional = true}
 
 # rustls
-rustls-pki-types = { version = "1.9", features = ["std"], optional = true }
 rustls-native-certs = { version = "0.8", optional = true }
-tokio-rustls = { version = "0.26", default-features = false, features = ["logging", "tls12"], optional = true }
+tokio-rustls = { version = "0.26.1", default-features = false, features = ["logging", "tls12"], optional = true }
 webpki-roots = { version = "0.26", optional = true }
 
 # compression


### PR DESCRIPTION
`tokio-rustls` 0.16.1 has been released, which ensures that the `rustls` version is 0.23.15, which uses `rustls-pki-types` 0.10, which introduced PEM APIs and the Error trait is implemented on the error type.

https://crates.io/crates/tokio-rustls/0.26.1