### PR TITLE
fix(server): Use Status::into_http api in recover error service

### DIFF
--- a/tonic/src/transport/server/service/recover_error.rs
+++ b/tonic/src/transport/server/service/recover_error.rs
@@ -66,8 +66,8 @@ where
             }
             Err(err) => match Status::try_from_error(err) {
                 Ok(status) => {
-                    let mut res = Response::new(MaybeEmptyBody::empty());
-                    status.add_header(res.headers_mut()).unwrap();
+                    let (parts, ()) = status.into_http::<()>().into_parts();
+                    let res = Response::from_parts(parts, MaybeEmptyBody::empty());
                     Poll::Ready(Ok(res))
                 }
                 Err(err) => Poll::Ready(Err(err)),


### PR DESCRIPTION
Converting from the `Status` to http response should be done with `Status::into_http` which is implemented for that purpose.

Resolves #2092.