### PR TITLE
chore: Add unicode-width 0.1.14 to cargo-deny skip config

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -20,6 +20,7 @@ deny = [
 ]
 skip = [
     { crate = "itertools@0.12.1", reason = "aws-lc-sys depends on bindgen which depends on it" },
+    { crate = "unicode-width@0.1.14", reason = "protox depends on miette wich depends on it" },
 ]
 skip-tree = [
     { crate = "windows-sys" },


### PR DESCRIPTION
Add `unicode-width` 0.1.14 to cargo-deny skip config