### PR TITLE
Fix percent-encoding of percent sign in `grpc-message` header

### DIFF
--- a/tonic/src/metadata/map.rs
+++ b/tonic/src/metadata/map.rs
@@ -2500,7 +2500,7 @@ mod tests {
     #[test]
     fn test_to_headers_encoding() {
         use crate::Status;
-        let special_char_message = "Beyond ascii \t\n\r🌶️💉💧🐮🍺";
+        let special_char_message = "Beyond 100% ascii \t\n\r🌶️💉💧🐮🍺";
         let s1 = Status::unknown(special_char_message);
 
         assert_eq!(s1.message(), special_char_message);
@@ -2509,6 +2509,17 @@ mod tests {
         let s2 = Status::from_header_map(&s1_map).unwrap();
 
         assert_eq!(s1.message(), s2.message());
+
+        assert!(
+            s1_map
+                .get("grpc-message")
+                .unwrap()
+                .to_str()
+                .unwrap()
+                .starts_with("Beyond%20100%25%20ascii"),
+            "Percent sign or other character isn't encoded as desired: {:?}",
+            s1_map.get("grpc-message")
+        );
     }
 
     #[test]

--- a/tonic/src/status.rs
+++ b/tonic/src/status.rs
@@ -14,6 +14,7 @@ const ENCODING_SET: &AsciiSet = &CONTROLS
     .add(b' ')
     .add(b'"')
     .add(b'#')
+    .add(b'%')
     .add(b'<')
     .add(b'>')
     .add(b'`')


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/hyperium/tonic/blob/master/CONTRIBUTING.md
-->

## Motivation

I got an unexpected JavaScript client-side gRPC-Web error `Uncaught URIError: malformed URI sequence` and traced it down to the `%` character not being encoded by the tonic-based server. My error message included a percent sign 😏.

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? If a new feature is being added, describe the intended
use case that feature fulfills.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

Correct usage of the dependent crate's `AsciiSet` structure. Otherwise, the `%` character doesn't get changed at all.