### PR TITLE
chore: Remove Zlib from cargo-deny config

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -36,7 +36,6 @@ allow = [
     "ISC",
     "MIT",
     "OpenSSL",
-    "Zlib",
     "Unicode-3.0",
     "MPL-2.0",
     "BSD-3-Clause",


### PR DESCRIPTION
Removes Zlib from cargo-deny config.