### PR TITLE
chore: Bump msrv to 1.75

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -92,7 +92,7 @@ jobs:
     - uses: actions/checkout@v4
     - uses: hecrj/setup-rust-action@v2
       with:
-        rust-version: "1.71.1"    # msrv
+        rust-version: "1.75"    # msrv
     - uses: taiki-e/install-action@cargo-no-dev-deps
     - uses: Swatinem/rust-cache@v2
     - run: cargo no-dev-deps --no-private check --all-features

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ may be a good resource as it shows examples of many of the gRPC features.
 
 ### Rust Version
 
-`tonic`'s MSRV is `1.71.1`.
+`tonic`'s MSRV is `1.75`.
 
 ### Dependencies
 


### PR DESCRIPTION
`axum` 0.8 requires Rust 1.75.

https://github.com/tokio-rs/axum/releases/tag/axum-v0.8.0