### PR TITLE
chore: Remove version and publish field from internal crate

### DIFF
--- a/codegen/Cargo.toml
+++ b/codegen/Cargo.toml
@@ -3,8 +3,6 @@ name = "codegen"
 authors = ["Lucio Franco <luciofranco14@gmail.com>"]
 license = "MIT"
 edition = "2021"
-publish = false
-version = "0.1.0"
 
 [dependencies]
 protox = "0.7"

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -3,8 +3,6 @@ authors = ["Lucio Franco <luciofranco14@gmail.com>"]
 edition = "2021"
 license = "MIT"
 name = "examples"
-publish = false
-version = "0.1.0"
 
 [[bin]]
 name = "helloworld-server"

--- a/interop/Cargo.toml
+++ b/interop/Cargo.toml
@@ -3,8 +3,6 @@ authors = ["Lucio Franco <luciofranco14@gmail.com>"]
 edition = "2021"
 license = "MIT"
 name = "interop"
-publish = false
-version = "0.1.0"
 
 [[bin]]
 name = "client"

--- a/tests/ambiguous_methods/Cargo.toml
+++ b/tests/ambiguous_methods/Cargo.toml
@@ -3,8 +3,6 @@ authors = ["Yonathan Randolph <yonathan@gmail.com>"]
 edition = "2021"
 license = "MIT"
 name = "ambiguous_methods"
-publish = false
-version = "0.1.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/tests/compression/Cargo.toml
+++ b/tests/compression/Cargo.toml
@@ -3,8 +3,6 @@ authors = ["Lucio Franco <luciofranco14@gmail.com>"]
 edition = "2021"
 license = "MIT"
 name = "compression"
-publish = false
-version = "0.1.0"
 
 [dependencies]
 bytes = "1"

--- a/tests/default_stubs/Cargo.toml
+++ b/tests/default_stubs/Cargo.toml
@@ -3,8 +3,6 @@ authors = ["Jordan Singh <me@jordansingh.com>"]
 edition = "2021"
 license = "MIT"
 name = "default_stubs"
-publish = false
-version = "0.1.0"
 
 [dependencies]
 tokio = {version = "1.0", features = ["macros", "rt-multi-thread", "net"]}

--- a/tests/deprecated_methods/Cargo.toml
+++ b/tests/deprecated_methods/Cargo.toml
@@ -2,8 +2,6 @@
 name = "deprecated_methods"
 edition = "2021"
 license = "MIT"
-publish = false
-version = "0.1.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/tests/disable_comments/Cargo.toml
+++ b/tests/disable_comments/Cargo.toml
@@ -3,8 +3,6 @@ authors = ["bouzuya <m@bouzuya.net>"]
 edition = "2021"
 license = "MIT"
 name = "disable-comments"
-publish = false
-version = "0.1.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/tests/extern_path/my_application/Cargo.toml
+++ b/tests/extern_path/my_application/Cargo.toml
@@ -3,8 +3,6 @@ authors = ["Danny Hua <danny@42layers.io>"]
 edition = "2021"
 license = "MIT"
 name = "my_application"
-publish = false
-version = "0.1.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/tests/extern_path/uuid/Cargo.toml
+++ b/tests/extern_path/uuid/Cargo.toml
@@ -3,8 +3,6 @@ authors = ["Danny Hua <danny@42layers.io>"]
 edition = "2021"
 license = "MIT"
 name = "uuid1"
-publish = false
-version = "0.1.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/tests/included_service/Cargo.toml
+++ b/tests/included_service/Cargo.toml
@@ -3,8 +3,6 @@ authors = ["Lucio Franco <luciofranco14@gmail.com>"]
 edition = "2021"
 license = "MIT"
 name = "included_service"
-publish = false
-version = "0.1.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/tests/integration_tests/Cargo.toml
+++ b/tests/integration_tests/Cargo.toml
@@ -3,8 +3,6 @@ authors = ["Lucio Franco <luciofranco14@gmail.com>"]
 edition = "2021"
 license = "MIT"
 name = "integration-tests"
-publish = false
-version = "0.1.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/tests/root-crate-path/Cargo.toml
+++ b/tests/root-crate-path/Cargo.toml
@@ -3,8 +3,6 @@ authors = ["Lucio Franco <luciofranco14@gmail.com>"]
 edition = "2021"
 license = "MIT"
 name = "root-crate-path"
-publish = false
-version = "0.1.0"
 
 [dependencies]
 prost = "0.13"

--- a/tests/same_name/Cargo.toml
+++ b/tests/same_name/Cargo.toml
@@ -3,8 +3,6 @@ authors = ["Lucio Franco <luciofranco14@gmail.com>"]
 edition = "2021"
 license = "MIT"
 name = "same_name"
-publish = false
-version = "0.1.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/tests/service_named_result/Cargo.toml
+++ b/tests/service_named_result/Cargo.toml
@@ -1,8 +1,6 @@
 [package]
 name = "service_named_result"
-version = "0.1.0"
 edition = "2021"
-publish = false
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/tests/service_named_service/Cargo.toml
+++ b/tests/service_named_service/Cargo.toml
@@ -3,8 +3,6 @@ authors = ["Lucio Franco <luciofranco14@gmail.com>"]
 edition = "2021"
 license = "MIT"
 name = "service_named_service"
-publish = false
-version = "0.1.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/tests/skip_debug/Cargo.toml
+++ b/tests/skip_debug/Cargo.toml
@@ -3,8 +3,6 @@ authors = ["Andrew Yuan <Andrew.Yuan@temporal.io>"]
 edition = "2021"
 license = "MIT"
 name = "skip_debug"
-publish = false
-version = "0.1.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/tests/stream_conflict/Cargo.toml
+++ b/tests/stream_conflict/Cargo.toml
@@ -2,8 +2,6 @@
 authors = ["Ben Sully <ben@bsull.io>"]
 edition = "2021"
 name = "stream_conflict"
-publish = false
-version = "0.1.0"
 license = "MIT"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/tests/use_arc_self/Cargo.toml
+++ b/tests/use_arc_self/Cargo.toml
@@ -3,8 +3,6 @@ authors = ["Aurimas Blažulionis <aurimas@chorus.one>"]
 edition = "2021"
 license = "MIT"
 name = "use_arc_self"
-publish = false
-version = "0.1.0"
 
 [dependencies]
 tokio-stream = "0.1"

--- a/tests/web/Cargo.toml
+++ b/tests/web/Cargo.toml
@@ -2,8 +2,6 @@
 authors = ["Juan Alvarez <j@yabit.io>"]
 edition = "2021"
 name = "test_web"
-publish = false
-version = "0.1.0"
 license = "MIT"
 
 [dependencies]

--- a/tests/wellknown-compiled/Cargo.toml
+++ b/tests/wellknown-compiled/Cargo.toml
@@ -3,8 +3,6 @@ authors = ["Lucio Franco <luciofranco14@gmail.com>"]
 edition = "2021"
 license = "MIT"
 name = "wellknown-compiled"
-publish = false
-version = "0.1.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/tests/wellknown/Cargo.toml
+++ b/tests/wellknown/Cargo.toml
@@ -3,8 +3,6 @@ authors = ["Lucio Franco <luciofranco14@gmail.com>"]
 edition = "2021"
 license = "MIT"
 name = "wellknown"
-publish = false
-version = "0.1.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 


### PR DESCRIPTION
Rust 1.75 supports the manifest without the version field. This regards it as publish false.

https://github.com/rust-lang/cargo/pull/12786/