### PR TITLE
chore: Use lint config in manifest

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,3 +30,12 @@ members = [
   "tests/skip_debug",
 ]
 resolver = "2"
+
+[workspace.lints.rust]
+missing_debug_implementations = "warn"
+missing_docs = "warn"
+rust_2018_idioms = "warn"
+unreachable_pub = "warn"
+
+[workspace.lints.rustdoc]
+broken_intra_doc_links = "deny"

--- a/tonic-build/Cargo.toml
+++ b/tonic-build/Cargo.toml
@@ -28,6 +28,9 @@ prost = ["prost-build", "dep:prost-types"]
 cleanup-markdown = ["prost-build?/cleanup-markdown"]
 transport = []
 
+[lints]
+workspace = true
+
 [package.metadata.docs.rs]
 all-features = true
 

--- a/tonic-build/src/lib.rs
+++ b/tonic-build/src/lib.rs
@@ -61,16 +61,9 @@
 //! fails with `No such file or directory` error.
 
 #![recursion_limit = "256"]
-#![warn(
-    missing_debug_implementations,
-    missing_docs,
-    rust_2018_idioms,
-    unreachable_pub
-)]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/tokio-rs/website/master/public/img/icons/tonic.svg"
 )]
-#![deny(rustdoc::broken_intra_doc_links)]
 #![doc(html_root_url = "https://docs.rs/tonic-build/0.13.0")]
 #![doc(issue_tracker_base_url = "https://github.com/hyperium/tonic/issues/")]
 #![doc(test(no_crate_inject, attr(deny(rust_2018_idioms))))]

--- a/tonic-health/Cargo.toml
+++ b/tonic-health/Cargo.toml
@@ -30,6 +30,9 @@ tokio = {version = "1.0", features = ["rt-multi-thread", "macros"]}
 tokio-stream = "0.1"
 prost-types = "0.13.0"
 
+[lints]
+workspace = true
+
 [package.metadata.cargo_check_external_types]
 allowed_external_types = [
   "tonic::*",

--- a/tonic-health/src/lib.rs
+++ b/tonic-health/src/lib.rs
@@ -6,16 +6,9 @@
 //!
 //! [here]: https://github.com/hyperium/tonic/blob/master/examples/src/health/server.rs
 
-#![warn(
-    missing_debug_implementations,
-    missing_docs,
-    rust_2018_idioms,
-    unreachable_pub
-)]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/tokio-rs/website/master/public/img/icons/tonic.svg"
 )]
-#![deny(rustdoc::broken_intra_doc_links)]
 #![doc(html_root_url = "https://docs.rs/tonic-health/0.13.0")]
 #![doc(issue_tracker_base_url = "https://github.com/hyperium/tonic/issues/")]
 #![doc(test(no_crate_inject, attr(deny(rust_2018_idioms))))]

--- a/tonic-reflection/Cargo.toml
+++ b/tonic-reflection/Cargo.toml
@@ -36,6 +36,9 @@ tonic = { version = "0.13.0", path = "../tonic", default-features = false, featu
 [dev-dependencies]
 tonic = { version = "0.13.0", path = "../tonic", default-features = false, features = ["transport"] }
 
+[lints]
+workspace = true
+
 [package.metadata.cargo_check_external_types]
 allowed_external_types = [
   "tonic::*",

--- a/tonic-reflection/src/lib.rs
+++ b/tonic-reflection/src/lib.rs
@@ -1,15 +1,8 @@
 //! A `tonic` based gRPC Server Reflection implementation.
 
-#![warn(
-    missing_debug_implementations,
-    missing_docs,
-    rust_2018_idioms,
-    unreachable_pub
-)]
 #![doc(
     html_logo_url = "https://github.com/hyperium/tonic/raw/master/.github/assets/tonic-docs.png"
 )]
-#![deny(rustdoc::broken_intra_doc_links)]
 #![doc(html_root_url = "https://docs.rs/tonic-reflection/0.13.0")]
 #![doc(issue_tracker_base_url = "https://github.com/hyperium/tonic/issues/")]
 #![doc(test(no_crate_inject, attr(deny(rust_2018_idioms))))]

--- a/tonic-reflection/tests/server.rs
+++ b/tonic-reflection/tests/server.rs
@@ -1,3 +1,5 @@
+#![allow(missing_docs)]
+
 use prost::Message;
 use std::net::SocketAddr;
 use tokio::sync::oneshot;

--- a/tonic-reflection/tests/versions.rs
+++ b/tonic-reflection/tests/versions.rs
@@ -1,3 +1,5 @@
+#![allow(missing_docs)]
+
 use std::net::SocketAddr;
 
 use tokio::sync::oneshot;

--- a/tonic-types/Cargo.toml
+++ b/tonic-types/Cargo.toml
@@ -22,6 +22,9 @@ prost = "0.13"
 prost-types = "0.13"
 tonic = { version = "0.13.0", path = "../tonic", default-features = false }
 
+[lints]
+workspace = true
+
 [package.metadata.cargo_check_external_types]
 allowed_external_types = [
   "tonic::*",

--- a/tonic-types/src/lib.rs
+++ b/tonic-types/src/lib.rs
@@ -140,16 +140,9 @@
 //! [error_details.proto]: https://github.com/googleapis/googleapis/blob/master/google/rpc/error_details.proto
 //! [Richer Error example]: https://github.com/hyperium/tonic/tree/master/examples/src/richer-error
 
-#![warn(
-    missing_debug_implementations,
-    missing_docs,
-    rust_2018_idioms,
-    unreachable_pub
-)]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/tokio-rs/website/master/public/img/icons/tonic.svg"
 )]
-#![deny(rustdoc::broken_intra_doc_links)]
 #![doc(html_root_url = "https://docs.rs/tonic-types/0.13.0")]
 #![doc(issue_tracker_base_url = "https://github.com/hyperium/tonic/issues/")]
 

--- a/tonic-web/Cargo.toml
+++ b/tonic-web/Cargo.toml
@@ -30,6 +30,9 @@ tracing = "0.1"
 tokio = { version = "1", features = ["macros", "rt"] }
 tower-http = { version = "0.6", features = ["cors"] }
 
+[lints]
+workspace = true
+
 [package.metadata.cargo_check_external_types]
 allowed_external_types = [
   "tonic::*",

--- a/tonic-web/src/client.rs
+++ b/tonic-web/src/client.rs
@@ -78,7 +78,7 @@ where
     }
 }
 
-/// Response future for the [`GrpcWebService`].
+/// Response future for the [`GrpcWebService`](crate::GrpcWebService).
 #[pin_project]
 #[must_use = "futures do nothing unless polled"]
 pub struct ResponseFuture<F> {

--- a/tonic-web/src/lib.rs
+++ b/tonic-web/src/lib.rs
@@ -68,12 +68,6 @@
 //! [`tonic_web`]: https://github.com/hyperium/tonic
 //! [grpc-web]: https://github.com/grpc/grpc-web
 //! [tower]: https://github.com/tower-rs/tower
-#![warn(
-    missing_debug_implementations,
-    missing_docs,
-    rust_2018_idioms,
-    unreachable_pub
-)]
 #![doc(html_root_url = "https://docs.rs/tonic-web/0.13.0")]
 #![doc(issue_tracker_base_url = "https://github.com/hyperium/tonic/issues/")]
 

--- a/tonic/Cargo.toml
+++ b/tonic/Cargo.toml
@@ -107,6 +107,9 @@ static_assertions = "1.0"
 tokio = {version = "1.0", features = ["rt", "macros"]}
 tower = {version = "0.5", features = ["full"]}
 
+[lints]
+workspace = true
+
 [package.metadata.docs.rs]
 all-features = true
 rustdoc-args = ["--cfg", "docsrs"]

--- a/tonic/benches/decode.rs
+++ b/tonic/benches/decode.rs
@@ -1,3 +1,5 @@
+#![allow(missing_docs)]
+
 use bencher::{benchmark_group, benchmark_main, Bencher};
 use bytes::{Buf, BufMut, Bytes, BytesMut};
 use http_body::{Body, Frame, SizeHint};
@@ -45,11 +47,11 @@ struct MockBody {
 }
 
 impl MockBody {
-    pub fn new(data: Bytes, chunk_size: usize) -> Self {
+    fn new(data: Bytes, chunk_size: usize) -> Self {
         MockBody { data, chunk_size }
     }
 
-    pub fn len(&self) -> usize {
+    fn len(&self) -> usize {
         self.data.len()
     }
 }

--- a/tonic/src/lib.rs
+++ b/tonic/src/lib.rs
@@ -86,13 +86,6 @@
 //! [`zstd`]: https://docs.rs/zstd
 
 #![recursion_limit = "256"]
-#![warn(
-    missing_debug_implementations,
-    missing_docs,
-    rust_2018_idioms,
-    unreachable_pub
-)]
-#![deny(rustdoc::broken_intra_doc_links)]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/tokio-rs/website/master/public/img/icons/tonic.svg"
 )]


### PR DESCRIPTION
Rust 1.74 supports lint config in the manifest.

https://github.com/rust-lang/cargo/pull/12648/