### PR TITLE
chore: Introduce rust-version in manifest

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -91,8 +91,16 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - uses: hecrj/setup-rust-action@v2
+    - name: Resolve MSRV aware dependencies
+      run: cargo update
+      env:
+        CARGO_RESOLVER_INCOMPATIBLE_RUST_VERSIONS: fallback
+    - name: Get MSRV from manifest file
+      id: msrv
+      run: echo "version=$(yq '.workspace.package.rust-version' Cargo.toml)" >> $GITHUB_OUTPUT
+    - uses: hecrj/setup-rust-action@v2
       with:
-        rust-version: "1.75"    # msrv
+        rust-version: ${{ steps.msrv.outputs.version }}
     - uses: taiki-e/install-action@cargo-no-dev-deps
     - uses: Swatinem/rust-cache@v2
     - run: cargo no-dev-deps --no-private check --all-features

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,9 @@ members = [
 ]
 resolver = "2"
 
+[workspace.package]
+rust-version = "1.75"
+
 [workspace.lints.rust]
 missing_debug_implementations = "warn"
 missing_docs = "warn"

--- a/tonic-build/Cargo.toml
+++ b/tonic-build/Cargo.toml
@@ -13,6 +13,7 @@ name = "tonic-build"
 readme = "README.md"
 repository = "https://github.com/hyperium/tonic"
 version = "0.13.0"
+rust-version = { workspace = true }
 
 [dependencies]
 prettyplease = { version = "0.2" }

--- a/tonic-health/Cargo.toml
+++ b/tonic-health/Cargo.toml
@@ -13,6 +13,7 @@ name = "tonic-health"
 readme = "README.md"
 repository = "https://github.com/hyperium/tonic"
 version = "0.13.0"
+rust-version = { workspace = true }
 
 [dependencies]
 prost = "0.13"

--- a/tonic-reflection/Cargo.toml
+++ b/tonic-reflection/Cargo.toml
@@ -16,6 +16,7 @@ name = "tonic-reflection"
 readme = "README.md"
 repository = "https://github.com/hyperium/tonic"
 version = "0.13.0"
+rust-version = { workspace = true }
 
 [package.metadata.docs.rs]
 all-features = true

--- a/tonic-types/Cargo.toml
+++ b/tonic-types/Cargo.toml
@@ -16,6 +16,7 @@ name = "tonic-types"
 readme = "README.md"
 repository = "https://github.com/hyperium/tonic"
 version = "0.13.0"
+rust-version = { workspace = true }
 
 [dependencies]
 prost = "0.13"

--- a/tonic-web/Cargo.toml
+++ b/tonic-web/Cargo.toml
@@ -13,6 +13,7 @@ name = "tonic-web"
 readme = "README.md"
 repository = "https://github.com/hyperium/tonic"
 version = "0.13.0"
+rust-version = { workspace = true }
 
 [dependencies]
 base64 = "0.22"

--- a/tonic/Cargo.toml
+++ b/tonic/Cargo.toml
@@ -21,6 +21,7 @@ license = "MIT"
 readme = "../README.md"
 repository = "https://github.com/hyperium/tonic"
 version = "0.13.0"
+rust-version = {workspace = true}
 
 [features]
 codegen = ["dep:async-trait"]


### PR DESCRIPTION
Introduces rust-version in the manifest. This allows to use MSRV aware dependency resolver.