### PR TITLE
feat: Expose GrpcTimeout middleware

### DIFF
--- a/tonic/Cargo.toml
+++ b/tonic/Cargo.toml
@@ -35,20 +35,22 @@ tls-aws-lc = ["_tls-any", "tokio-rustls/aws-lc-rs"]
 tls-native-roots = ["_tls-any", "channel", "dep:rustls-native-certs"]
 tls-webpki-roots = ["_tls-any","channel", "dep:webpki-roots"]
 router = ["dep:axum", "dep:tower", "tower?/util"]
+timeout = ["dep:tokio", "tokio?/time"]
 server = [
+  "timeout",
   "dep:h2",
   "dep:hyper", "hyper?/server",
   "dep:hyper-util", "hyper-util?/service", "hyper-util?/server-auto",
   "dep:socket2",
-  "dep:tokio", "tokio?/macros", "tokio?/net", "tokio?/time",
+  "dep:tokio", "tokio?/macros", "tokio?/net",
   "tokio-stream/net",
   "dep:tower", "tower?/util", "tower?/limit",
 ]
 channel = [
+  "timeout",
   "dep:hyper", "hyper?/client",
   "dep:hyper-util", "hyper-util?/client-legacy",
   "dep:tower", "tower?/balance", "tower?/buffer", "tower?/discover", "tower?/limit", "tower?/util",
-  "dep:tokio", "tokio?/time",
   "dep:hyper-timeout",
 ]
 transport = ["server", "channel"]

--- a/tonic/src/lib.rs
+++ b/tonic/src/lib.rs
@@ -22,6 +22,8 @@
 //! - `server`: Enables just the full featured server portion of the `transport` feature.
 //! - `channel`: Enables just the full featured channel portion of the `transport` feature.
 //! - `router`: Enables the [`axum`] based service router. Enabled by default.
+//! - `timeout`: Enables timeout related feature including `GrpcTimeout` middleware. Enabled
+//!   by default.
 //! - `codegen`: Enables all the required exports and optional dependencies required
 //!   for [`tonic-build`]. Enabled by default.
 //! - `tls-ring`: Enables the [`rustls`] based TLS options for the `transport` feature using

--- a/tonic/src/service/mod.rs
+++ b/tonic/src/service/mod.rs
@@ -16,3 +16,8 @@ pub use axum::{body::Body as AxumBody, Router as AxumRouter};
 
 pub mod recover_error;
 pub use self::recover_error::{RecoverError, RecoverErrorLayer};
+
+#[cfg(feature = "timeout")]
+pub mod grpc_timeout;
+#[cfg(feature = "timeout")]
+pub use self::grpc_timeout::{GrpcTimeout, GrpcTimeoutLayer};

--- a/tonic/src/transport/channel/service/connection.rs
+++ b/tonic/src/transport/channel/service/connection.rs
@@ -1,7 +1,8 @@
 use super::{AddOrigin, Reconnect, SharedExec, UserAgent};
 use crate::{
     body::Body,
-    transport::{channel::BoxFuture, service::GrpcTimeout, Endpoint},
+    service::GrpcTimeoutLayer,
+    transport::{channel::BoxFuture, Endpoint},
 };
 use http::{Request, Response, Uri};
 use hyper::rt;
@@ -62,7 +63,7 @@ impl Connection {
                 AddOrigin::new(s, origin)
             })
             .layer_fn(|s| UserAgent::new(s, endpoint.user_agent.clone()))
-            .layer_fn(|s| GrpcTimeout::new(s, endpoint.timeout))
+            .layer(GrpcTimeoutLayer::new(endpoint.timeout))
             .option_layer(endpoint.concurrency_limit.map(ConcurrencyLimitLayer::new))
             .option_layer(endpoint.rate_limit.map(|(l, d)| RateLimitLayer::new(l, d)))
             .into_inner();

--- a/tonic/src/transport/server/mod.rs
+++ b/tonic/src/transport/server/mod.rs
@@ -42,9 +42,8 @@ pub use incoming::TcpIncoming;
 use crate::transport::Error;
 
 use self::service::{ConnectInfoLayer, ServerIo};
-use super::service::GrpcTimeout;
 use crate::body::Body;
-use crate::service::RecoverErrorLayer;
+use crate::service::{GrpcTimeoutLayer, RecoverErrorLayer};
 use bytes::Bytes;
 use http::{Request, Response};
 use http_body_util::BodyExt;
@@ -1090,7 +1089,7 @@ where
         let svc = ServiceBuilder::new()
             .layer(RecoverErrorLayer::new())
             .option_layer(concurrency_limit.map(ConcurrencyLimitLayer::new))
-            .layer_fn(|s| GrpcTimeout::new(s, timeout))
+            .layer(GrpcTimeoutLayer::new(timeout))
             .service(svc);
 
         let svc = ServiceBuilder::new()

--- a/tonic/src/transport/service/mod.rs
+++ b/tonic/src/transport/service/mod.rs
@@ -1,5 +1,2 @@
-pub(crate) mod grpc_timeout;
 #[cfg(feature = "_tls-any")]
 pub(crate) mod tls;
-
-pub(crate) use self::grpc_timeout::GrpcTimeout;


### PR DESCRIPTION
Exposes the GrpcTimeout middleware. This allows users to use independent of the transport server.