### PR TITLE
chore(interop): Replace repeat and take with repeat_n

### DIFF
--- a/interop/src/lib.rs
+++ b/interop/src/lib.rs
@@ -18,14 +18,14 @@ pub fn trace_init() {
 pub fn client_payload(size: usize) -> pb::Payload {
     pb::Payload {
         r#type: default::Default::default(),
-        body: iter::repeat(0u8).take(size).collect(),
+        body: iter::repeat_n(0u8, size).collect(),
     }
 }
 
 pub fn server_payload(size: usize) -> pb::Payload {
     pb::Payload {
         r#type: default::Default::default(),
-        body: iter::repeat(0u8).take(size).collect(),
+        body: iter::repeat_n(0u8, size).collect(),
     }
 }
 


### PR DESCRIPTION
`repeat_n` can be used instead of `repeat` and `take`.