### PR TITLE
chore: Remove html_root_url

### DIFF
--- a/prepare-release.sh
+++ b/prepare-release.sh
@@ -33,10 +33,6 @@ CRATES=( \
 )
 
 for CRATE in "${CRATES[@]}"; do
-  # Update html_root_url attributes.
-  sed -i -E "s~html_root_url = \"https://docs\.rs/${TONIC_CRATE_MATCHER}/$VERSION_MATCHER\"~html_root_url = \"https://docs.rs/\1/${VERSION}\"~" \
-    "$DIR/$CRATE/src/lib.rs"
-
   # Update documentation url in Cargo.toml
   sed -i -E "s~documentation = \"https://docs\.rs/$CRATE/$VERSION_MATCHER\"~documentation = \"https://docs.rs/${CRATE}/${VERSION}\"~" \
     "$DIR/$CRATE/Cargo.toml"

--- a/tonic-build/src/lib.rs
+++ b/tonic-build/src/lib.rs
@@ -64,7 +64,6 @@
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/tokio-rs/website/master/public/img/icons/tonic.svg"
 )]
-#![doc(html_root_url = "https://docs.rs/tonic-build/0.13.0")]
 #![doc(issue_tracker_base_url = "https://github.com/hyperium/tonic/issues/")]
 #![doc(test(no_crate_inject, attr(deny(rust_2018_idioms))))]
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]

--- a/tonic-health/src/lib.rs
+++ b/tonic-health/src/lib.rs
@@ -9,7 +9,6 @@
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/tokio-rs/website/master/public/img/icons/tonic.svg"
 )]
-#![doc(html_root_url = "https://docs.rs/tonic-health/0.13.0")]
 #![doc(issue_tracker_base_url = "https://github.com/hyperium/tonic/issues/")]
 #![doc(test(no_crate_inject, attr(deny(rust_2018_idioms))))]
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]

--- a/tonic-reflection/src/lib.rs
+++ b/tonic-reflection/src/lib.rs
@@ -3,7 +3,6 @@
 #![doc(
     html_logo_url = "https://github.com/hyperium/tonic/raw/master/.github/assets/tonic-docs.png"
 )]
-#![doc(html_root_url = "https://docs.rs/tonic-reflection/0.13.0")]
 #![doc(issue_tracker_base_url = "https://github.com/hyperium/tonic/issues/")]
 #![doc(test(no_crate_inject, attr(deny(rust_2018_idioms))))]
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]

--- a/tonic-types/src/lib.rs
+++ b/tonic-types/src/lib.rs
@@ -143,7 +143,6 @@
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/tokio-rs/website/master/public/img/icons/tonic.svg"
 )]
-#![doc(html_root_url = "https://docs.rs/tonic-types/0.13.0")]
 #![doc(issue_tracker_base_url = "https://github.com/hyperium/tonic/issues/")]
 
 mod generated {

--- a/tonic-web/src/lib.rs
+++ b/tonic-web/src/lib.rs
@@ -68,7 +68,6 @@
 //! [`tonic_web`]: https://github.com/hyperium/tonic
 //! [grpc-web]: https://github.com/grpc/grpc-web
 //! [tower]: https://github.com/tower-rs/tower
-#![doc(html_root_url = "https://docs.rs/tonic-web/0.13.0")]
 #![doc(issue_tracker_base_url = "https://github.com/hyperium/tonic/issues/")]
 
 pub use call::GrpcWebCall;

--- a/tonic/Cargo.toml
+++ b/tonic/Cargo.toml
@@ -2,7 +2,6 @@
 name = "tonic"
 # When releasing to crates.io:
 # - Remove path dependencies
-# - Update html_root_url.
 # - Update doc url
 #   - Cargo.toml
 #   - README.md

--- a/tonic/src/lib.rs
+++ b/tonic/src/lib.rs
@@ -91,7 +91,6 @@
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/tokio-rs/website/master/public/img/icons/tonic.svg"
 )]
-#![doc(html_root_url = "https://docs.rs/tonic/0.13.0")]
 #![doc(issue_tracker_base_url = "https://github.com/hyperium/tonic/issues/")]
 #![doc(test(no_crate_inject, attr(deny(rust_2018_idioms))))]
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]


### PR DESCRIPTION
Removes `html_root_url`. See https://github.com/tokio-rs/tokio/pull/3489.