### PR TITLE
WIP: Add support for Certificate verification with CRL

### DIFF
--- a/examples/src/tls/server.rs
+++ b/examples/src/tls/server.rs
@@ -40,7 +40,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let cert = std::fs::read_to_string(data_dir.join("tls/server.pem"))?;
     let key = std::fs::read_to_string(data_dir.join("tls/server.key"))?;
 
-    let identity = Identity::from_pem(cert, key);
+    let identity = Identity::from_pem(cert, key, None);
 
     let addr = "[::1]:50051".parse().unwrap();
     let server = EchoServer::default();

--- a/examples/src/tls_client_auth/client.rs
+++ b/examples/src/tls_client_auth/client.rs
@@ -12,7 +12,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let server_root_ca_cert = Certificate::from_pem(server_root_ca_cert);
     let client_cert = std::fs::read_to_string(data_dir.join("tls/client1.pem"))?;
     let client_key = std::fs::read_to_string(data_dir.join("tls/client1.key"))?;
-    let client_identity = Identity::from_pem(client_cert, client_key);
+    let client_identity = Identity::from_pem(client_cert, client_key, None);
 
     let tls = ClientTlsConfig::new()
         .domain_name("localhost")

--- a/examples/src/tls_client_auth/server.rs
+++ b/examples/src/tls_client_auth/server.rs
@@ -30,7 +30,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let data_dir = std::path::PathBuf::from_iter([std::env!("CARGO_MANIFEST_DIR"), "data"]);
     let cert = std::fs::read_to_string(data_dir.join("tls/server.pem"))?;
     let key = std::fs::read_to_string(data_dir.join("tls/server.key"))?;
-    let server_identity = Identity::from_pem(cert, key);
+    let server_identity = Identity::from_pem(cert, key, None);
 
     let client_ca_cert = std::fs::read_to_string(data_dir.join("tls/client_ca.pem"))?;
     let client_ca_cert = Certificate::from_pem(client_ca_cert);

--- a/interop/src/bin/server.rs
+++ b/interop/src/bin/server.rs
@@ -29,7 +29,7 @@ async fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
     if matches.use_tls {
         let cert = std::fs::read_to_string("interop/data/server1.pem")?;
         let key = std::fs::read_to_string("interop/data/server1.key")?;
-        let identity = Identity::from_pem(cert, key);
+        let identity = Identity::from_pem(cert, key, None);
 
         builder = builder.tls_config(ServerTlsConfig::new().identity(identity))?;
     }

--- a/tonic/Cargo.toml
+++ b/tonic/Cargo.toml
@@ -30,7 +30,7 @@ deflate = ["dep:flate2"]
 zstd = ["dep:zstd"]
 default = ["router", "transport", "codegen", "prost"]
 prost = ["dep:prost"]
-_tls-any = ["dep:tokio-rustls", "dep:tokio", "tokio?/rt", "tokio?/macros"] # Internal. Please choose one of `tls-ring` or `tls-aws-lc`
+_tls-any = ["dep:rustls-pki-types", "dep:tokio-rustls", "dep:tokio", "tokio?/rt", "tokio?/macros"] # Internal. Please choose one of `tls-ring` or `tls-aws-lc`
 tls-ring = ["_tls-any", "tokio-rustls/ring"]
 tls-aws-lc = ["_tls-any", "tokio-rustls/aws-lc-rs"]
 tls-native-roots = ["_tls-any", "channel", "dep:rustls-native-certs"]
@@ -89,6 +89,7 @@ axum = {version = "0.8", default-features = false, optional = true}
 
 # rustls
 rustls-native-certs = { version = "0.8", optional = true }
+rustls-pki-types = { version = "1.11", optional = true }
 tokio-rustls = { version = "0.26.1", default-features = false, features = ["logging", "tls12"], optional = true }
 webpki-roots = { version = "0.26", optional = true }
 

--- a/tonic/src/transport/server/service/tls.rs
+++ b/tonic/src/transport/server/service/tls.rs
@@ -31,10 +31,14 @@ impl TlsAcceptor {
             Some(cert) => {
                 let mut roots = RootCertStore::empty();
                 roots.add_parsable_certificates(convert_certificate_to_pki_types(cert)?);
+                let mut _builder = WebPkiClientVerifier::builder(roots.into());
+                if let Some(crls) = &identity.crls {
+                    _builder = _builder.with_crls(crls.clone());
+                }
                 let verifier = if client_auth_optional {
-                    WebPkiClientVerifier::builder(roots.into()).allow_unauthenticated()
+                    _builder.allow_unauthenticated()
                 } else {
-                    WebPkiClientVerifier::builder(roots.into())
+                    _builder
                 }
                 .build()?;
                 builder.with_client_cert_verifier(verifier)

--- a/tonic/src/transport/tls.rs
+++ b/tonic/src/transport/tls.rs
@@ -1,3 +1,4 @@
+use rustls_pki_types::CertificateRevocationListDer;
 /// Represents a X509 certificate.
 #[derive(Debug, Clone)]
 pub struct Certificate {
@@ -9,6 +10,7 @@ pub struct Certificate {
 pub struct Identity {
     pub(crate) cert: Certificate,
     pub(crate) key: Vec<u8>,
+    pub(crate) crls: Option<Vec<CertificateRevocationListDer<'static>>>,
 }
 
 impl Certificate {
@@ -52,9 +54,9 @@ impl Identity {
     /// Parse a PEM encoded certificate and private key.
     ///
     /// The provided cert must contain at least one PEM encoded certificate.
-    pub fn from_pem(cert: impl AsRef<[u8]>, key: impl AsRef<[u8]>) -> Self {
+    pub fn from_pem(cert: impl AsRef<[u8]>, key: impl AsRef<[u8]>, crls: Option<Vec<CertificateRevocationListDer<'static>>>) -> Self {
         let cert = Certificate::from_pem(cert);
         let key = key.as_ref().into();
-        Self { cert, key }
+        Self { cert, crls, key }
     }
 }


### PR DESCRIPTION
Tonic lucks TLS with CRL support. 
rustls' [ClientCertVerifierBuilder](https://docs.rs/rustls/latest/rustls/server/struct.ClientCertVerifierBuilder.html) and [ServerCertVerifierBuilder](https://docs.rs/rustls/latest/rustls/client/struct.ServerCertVerifierBuilder.html) support _CRL_.

## Motivation

Enhance tonic implementation to support TLS setup with CRL.
Relates to #1385

## Solution

The PR is still a *Draft*. With respect to feedback, it will be elaborated further in order to achieve readiness.