### PR TITLE
chore(test): Remove unnecessary macro_use

### DIFF
--- a/tests/ambiguous_methods/src/lib.rs
+++ b/tests/ambiguous_methods/src/lib.rs
@@ -1,4 +1,1 @@
-#[macro_use]
-extern crate tonic;
-
 tonic::include_proto!("ambiguous_methods");


### PR DESCRIPTION
Removes the unnecessary macro_use.