### PR TITLE
feat(tonic): Exclude benches-disabled to remove Apache-2.0 resource

### DIFF
--- a/tonic/Cargo.toml
+++ b/tonic/Cargo.toml
@@ -21,6 +21,7 @@ readme = "../README.md"
 repository = "https://github.com/hyperium/tonic"
 version = "0.13.0"
 rust-version = {workspace = true}
+exclude = ["benches-disabled"]
 
 [features]
 codegen = ["dep:async-trait"]


### PR DESCRIPTION
Separated out the change from #2163. This can be applied independently.