### PR TITLE
chore: Expose `TlsError`

### DIFF
--- a/tonic/src/transport/mod.rs
+++ b/tonic/src/transport/mod.rs
@@ -97,6 +97,8 @@ mod error;
 mod service;
 #[cfg(feature = "_tls-any")]
 mod tls;
+#[cfg(feature = "_tls-any")]
+pub use service::TlsError;
 
 #[doc(inline)]
 #[cfg(feature = "channel")]

--- a/tonic/src/transport/service/mod.rs
+++ b/tonic/src/transport/service/mod.rs
@@ -1,5 +1,7 @@
 pub(crate) mod grpc_timeout;
 #[cfg(feature = "_tls-any")]
 pub(crate) mod tls;
+#[cfg(feature = "_tls-any")]
+pub use tls::TlsError;
 
 pub(crate) use self::grpc_timeout::GrpcTimeout;

--- a/tonic/src/transport/service/tls.rs
+++ b/tonic/src/transport/service/tls.rs
@@ -7,13 +7,19 @@ use crate::transport::{Certificate, Identity};
 /// h2 alpn in plain format for rustls.
 pub(crate) const ALPN_H2: &[u8] = b"h2";
 
+/// Errors that can occur when configuring TLS.
 #[derive(Debug)]
-pub(crate) enum TlsError {
+#[non_exhaustive]
+pub enum TlsError {
+    /// HTTP/2 protocol was not negotiated during the TLS handshake.
     #[cfg(feature = "channel")]
     H2NotNegotiated,
+    /// No native root certificates were found on the system.
     #[cfg(feature = "tls-native-roots")]
     NativeCertsNotFound,
+    /// Failed to parse the provided TLS certificate.
     CertificateParseError,
+    /// Failed to parse the provided private key. Only RSA and PKCS8-encoded keys are supported.
     PrivateKeyParseError,
 }
 


### PR DESCRIPTION
## Motivation

When parsing errors from `tonic`, we currently apply conditional logic to notify users if their machine lacks native root certificates. We currently do this based off of the string returned from the error.

If `tonic` exposed the `TlsError` type, we'd be able to do this in a more type-safe way.

## Solution

Expose `TlsError` from `tonic::transport`.
