### PR TITLE
chore: Remove unnecessary docs.rs config

### DIFF
--- a/tonic-reflection/Cargo.toml
+++ b/tonic-reflection/Cargo.toml
@@ -20,7 +20,6 @@ rust-version = { workspace = true }
 
 [package.metadata.docs.rs]
 all-features = true
-rustdoc-args = ["--cfg", "docsrs"]
 
 [features]
 server = ["dep:prost-types", "dep:tokio", "dep:tokio-stream"]

--- a/tonic/Cargo.toml
+++ b/tonic/Cargo.toml
@@ -112,7 +112,6 @@ workspace = true
 
 [package.metadata.docs.rs]
 all-features = true
-rustdoc-args = ["--cfg", "docsrs"]
 
 [package.metadata.cargo_check_external_types]
 allowed_external_types = [


### PR DESCRIPTION
This config is set as default.

https://docs.rs/about/builds#detecting-docsrs