### PR TITLE
chore: Update cargo-deny config

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -23,6 +23,8 @@ skip = [
     { crate = "wasi@0.11.0+wasi-snapshot-preview1", reason = "quickcheck depends on rand which depends on it" },
     { crate = "itertools@0.12.1", reason = "aws-lc-sys depends on bindgen which depends on it" },
     { crate = "unicode-width@0.1.14", reason = "protox depends on miette wich depends on it" },
+    { crate = "rustix@0.38.44", reason = "aws-lc-sys depends on bindgen which depends on it" },
+    { crate = "linux-raw-sys@0.4.15", reason = "rustix 0.38.44 depends on it" },
 ]
 skip-tree = [
     { crate = "windows-sys" },

--- a/tests/compression/Cargo.toml
+++ b/tests/compression/Cargo.toml
@@ -11,7 +11,7 @@ http-body = "1"
 http-body-util = "0.1"
 hyper = "1"
 hyper-util = "0.1"
-paste = "1.0.12"
+paste = { package = "pastey", version = "*" }
 pin-project = "1.0"
 prost = "0.13"
 tokio = {version = "1.0", features = ["macros", "rt-multi-thread", "net"]}


### PR DESCRIPTION
The paste dependency in aws-lc-rs is removed after v1.12.6 so the only paste dependency is in tonic's tests.
The change migrates the current usage of paste to pastey package.

I also cherry-picked your change in #2210 so the `cargo deny check` will pass.

Reference: https://github.com/aws/aws-lc-rs/releases/tag/v1.12.6
