### PR TITLE
chore: Remove resolved cargo-deny config

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -49,17 +49,3 @@ allow = [
     "MPL-2.0",
     "BSD-3-Clause",
 ]
-
-[[licenses.clarify]]
-crate = "ring"
-# SPDX considers OpenSSL to encompass both the OpenSSL and SSLeay licenses
-# https://spdx.org/licenses/OpenSSL.html
-# ISC - Both BoringSSL and ring use this for their new files
-# MIT - "Files in third_party/ have their own licenses, as described therein. The MIT
-# license, for third_party/fiat, which, unlike other third_party directories, is
-# compiled into non-test libraries, is included below."
-# OpenSSL - Obviously
-expression = "ISC AND MIT AND OpenSSL"
-license-files = [
-    { path = "LICENSE", hash = 0xbd0eed23 },
-]


### PR DESCRIPTION
Removes the resolved cargo-deny config.