### PR TITLE
chore(router): Remove unnecessary type converting

### DIFF
--- a/tonic/src/service/router.rs
+++ b/tonic/src/service/router.rs
@@ -151,7 +151,7 @@ where
 
     #[inline]
     fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
-        Service::<Request<B>>::poll_ready(&mut self.router, cx).map_err(|e| match e {})
+        Service::<Request<B>>::poll_ready(&mut self.router, cx)
     }
 
     fn call(&mut self, req: Request<B>) -> Self::Future {


### PR DESCRIPTION
Removes unnecessary type converting.