### PR TITLE
Allow direct access to modify the TLS config

### DIFF
--- a/tonic/src/transport/channel/service/tls.rs
+++ b/tonic/src/transport/channel/service/tls.rs
@@ -13,10 +13,13 @@ use tokio_rustls::{
 };
 
 use super::io::BoxedIo;
-use crate::transport::{channel::tls::ModdifyConfigFn, service::tls::{
-    convert_certificate_to_pki_types, convert_identity_to_pki_types, TlsError, ALPN_H2,
-}};
 use crate::transport::tls::{Certificate, Identity};
+use crate::transport::{
+    channel::tls::ModdifyConfigFn,
+    service::tls::{
+        convert_certificate_to_pki_types, convert_identity_to_pki_types, TlsError, ALPN_H2,
+    },
+};
 
 #[derive(Clone)]
 pub(crate) struct TlsConnector {

--- a/tonic/src/transport/channel/service/tls.rs
+++ b/tonic/src/transport/channel/service/tls.rs
@@ -13,9 +13,9 @@ use tokio_rustls::{
 };
 
 use super::io::BoxedIo;
-use crate::transport::service::tls::{
+use crate::transport::{channel::tls::ModdifyConfigFn, service::tls::{
     convert_certificate_to_pki_types, convert_identity_to_pki_types, TlsError, ALPN_H2,
-};
+}};
 use crate::transport::tls::{Certificate, Identity};
 
 #[derive(Clone)]
@@ -34,7 +34,7 @@ impl TlsConnector {
         domain: &str,
         assume_http2: bool,
         use_key_log: bool,
-        modify_config: Option<Arc<dyn Fn(&mut ClientConfig) + Send + Sync>>,
+        modify_config: Option<ModdifyConfigFn>,
         #[cfg(feature = "tls-native-roots")] with_native_roots: bool,
         #[cfg(feature = "tls-webpki-roots")] with_webpki_roots: bool,
     ) -> Result<Self, crate::BoxError> {
@@ -97,7 +97,7 @@ impl TlsConnector {
         config.alpn_protocols.push(ALPN_H2.into());
 
         if let Some(modify_config) = modify_config {
-            modify_config(&mut config);
+            modify_config.0(&mut config);
         }
 
         Ok(Self {

--- a/tonic/src/transport/channel/service/tls.rs
+++ b/tonic/src/transport/channel/service/tls.rs
@@ -34,6 +34,7 @@ impl TlsConnector {
         domain: &str,
         assume_http2: bool,
         use_key_log: bool,
+        modify_config: Option<Arc<dyn Fn(&mut ClientConfig) + Send + Sync>>,
         #[cfg(feature = "tls-native-roots")] with_native_roots: bool,
         #[cfg(feature = "tls-webpki-roots")] with_webpki_roots: bool,
     ) -> Result<Self, crate::BoxError> {
@@ -94,6 +95,11 @@ impl TlsConnector {
         }
 
         config.alpn_protocols.push(ALPN_H2.into());
+
+        if let Some(modify_config) = modify_config {
+            modify_config(&mut config);
+        }
+
         Ok(Self {
             config: Arc::new(config),
             domain: Arc::new(ServerName::try_from(domain)?.to_owned()),

--- a/tonic/src/transport/channel/tls.rs
+++ b/tonic/src/transport/channel/tls.rs
@@ -23,7 +23,9 @@ pub struct ClientTlsConfig {
 }
 
 #[derive(Clone)]
-struct ModdifyConfigFn(std::sync::Arc<dyn Fn(&mut tokio_rustls::rustls::ClientConfig) + Send + Sync>);
+struct ModdifyConfigFn(
+    std::sync::Arc<dyn Fn(&mut tokio_rustls::rustls::ClientConfig) + Send + Sync>,
+);
 
 impl std::fmt::Debug for ModdifyConfigFn {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {

--- a/tonic/src/transport/channel/tls.rs
+++ b/tonic/src/transport/channel/tls.rs
@@ -155,11 +155,11 @@ impl ClientTlsConfig {
             domain,
             self.assume_http2,
             self.use_key_log,
+            self.modify_config.map(|f| f.0),
             #[cfg(feature = "tls-native-roots")]
             self.with_native_roots,
             #[cfg(feature = "tls-webpki-roots")]
             self.with_webpki_roots,
-            self.modify_config.map(|f| f.0),
         )
     }
 }

--- a/tonic/src/transport/channel/tls.rs
+++ b/tonic/src/transport/channel/tls.rs
@@ -24,7 +24,7 @@ pub struct ClientTlsConfig {
 
 #[derive(Clone)]
 pub(crate) struct ModdifyConfigFn(
-    pub std::sync::Arc<dyn Fn(&mut tokio_rustls::rustls::ClientConfig) + Send + Sync>,
+    pub(crate) std::sync::Arc<dyn Fn(&mut tokio_rustls::rustls::ClientConfig) + Send + Sync>,
 );
 
 impl std::fmt::Debug for ModdifyConfigFn {

--- a/tonic/src/transport/channel/tls.rs
+++ b/tonic/src/transport/channel/tls.rs
@@ -24,7 +24,7 @@ pub struct ClientTlsConfig {
 
 #[derive(Clone)]
 pub(crate) struct ModdifyConfigFn(
-   pub std::sync::Arc<dyn Fn(&mut tokio_rustls::rustls::ClientConfig) + Send + Sync>,
+    pub std::sync::Arc<dyn Fn(&mut tokio_rustls::rustls::ClientConfig) + Send + Sync>,
 );
 
 impl std::fmt::Debug for ModdifyConfigFn {

--- a/tonic/src/transport/channel/tls.rs
+++ b/tonic/src/transport/channel/tls.rs
@@ -23,8 +23,8 @@ pub struct ClientTlsConfig {
 }
 
 #[derive(Clone)]
-struct ModdifyConfigFn(
-    std::sync::Arc<dyn Fn(&mut tokio_rustls::rustls::ClientConfig) + Send + Sync>,
+pub(crate) struct ModdifyConfigFn(
+   pub std::sync::Arc<dyn Fn(&mut tokio_rustls::rustls::ClientConfig) + Send + Sync>,
 );
 
 impl std::fmt::Debug for ModdifyConfigFn {
@@ -157,7 +157,7 @@ impl ClientTlsConfig {
             domain,
             self.assume_http2,
             self.use_key_log,
-            self.modify_config.map(|f| f.0),
+            self.modify_config,
             #[cfg(feature = "tls-native-roots")]
             self.with_native_roots,
             #[cfg(feature = "tls-webpki-roots")]


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/hyperium/tonic/blob/master/CONTRIBUTING.md
-->

## Motivation
For work we need direct access to the tls config to customise the `ServerCertVerifier`.
Also direct access allow any further  config changes to made without  any changes to tonic

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? If a new feature is being added, describe the intended
use case that feature fulfills.
-->

## Solution
To solve access to the tls i have added a method to `ClientTlsConfig` called `modify_config`(could be named somthing else maybe).
```rs
 pub fn modify_config<F>(self, f: F) -> Self
    where
        F: Fn(&mut tokio_rustls::rustls::ClientConfig) + Send + Sync + 'static,
    {
        let modify_config = ModdifyConfigFn(std::sync::Arc::new(f));
        ClientTlsConfig {
            modify_config: Some(modify_config),
            ..self
        }
    }
```
this allows users to directly modify `tokio_rustls::rustls::ClientConfig` to fit their needs.
this function is called in `TlsConnector::new` after all tonic config changes are set

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
