### PR TITLE
chore(ci): Update to nightly-2025-03-27 on udeps ci

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -59,7 +59,7 @@ jobs:
     - uses: actions/checkout@v4
     - uses: dtolnay/rust-toolchain@master
       with:
-        toolchain: nightly-2024-12-01
+        toolchain: nightly-2025-03-27
     - uses: taiki-e/install-action@cargo-hack
     - uses: taiki-e/install-action@cargo-udeps
     - uses: taiki-e/install-action@protoc


### PR DESCRIPTION
Updates to nightly-2025-03-27 on udeps ci.