### PR TITLE
chore: Use inline format argument

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,5 +41,8 @@ missing_docs = "warn"
 rust_2018_idioms = "warn"
 unreachable_pub = "warn"
 
+[workspace.lints.clippy]
+uninlined_format_args = "deny"
+
 [workspace.lints.rustdoc]
 broken_intra_doc_links = "deny"

--- a/examples/src/authentication/client.rs
+++ b/examples/src/authentication/client.rs
@@ -22,7 +22,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let response = client.unary_echo(request).await?;
 
-    println!("RESPONSE={:?}", response);
+    println!("RESPONSE={response:?}");
 
     Ok(())
 }

--- a/examples/src/autoreload/server.rs
+++ b/examples/src/autoreload/server.rs
@@ -30,7 +30,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let addr = "[::1]:50051".parse().unwrap();
     let greeter = MyGreeter::default();
 
-    println!("GreeterServer listening on {}", addr);
+    println!("GreeterServer listening on {addr}");
 
     let server = Server::builder().add_service(GreeterServer::new(greeter));
 

--- a/examples/src/blocking/client.rs
+++ b/examples/src/blocking/client.rs
@@ -47,7 +47,7 @@ fn main() -> Result<()> {
 
     let response = client.say_hello(request)?;
 
-    println!("RESPONSE={:?}", response);
+    println!("RESPONSE={response:?}");
 
     Ok(())
 }

--- a/examples/src/cancellation/client.rs
+++ b/examples/src/cancellation/client.rs
@@ -24,7 +24,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         }
     };
 
-    println!("RESPONSE={:?}", response);
+    println!("RESPONSE={response:?}");
 
     Ok(())
 }

--- a/examples/src/cancellation/server.rs
+++ b/examples/src/cancellation/server.rs
@@ -37,7 +37,7 @@ impl Greeter for MyGreeter {
             Ok(Response::new(reply))
         };
         let cancellation_future = async move {
-            println!("Request from {:?} cancelled by client", remote_addr);
+            println!("Request from {remote_addr:?} cancelled by client");
             // If this future is executed it means the request future was dropped,
             // so it doesn't actually matter what is returned here
             Err(Status::cancelled("Request cancelled by client"))
@@ -74,7 +74,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let addr = "[::1]:50051".parse().unwrap();
     let greeter = MyGreeter::default();
 
-    println!("GreeterServer listening on {}", addr);
+    println!("GreeterServer listening on {addr}");
 
     Server::builder()
         .add_service(GreeterServer::new(greeter))

--- a/examples/src/codec_buffers/client.rs
+++ b/examples/src/codec_buffers/client.rs
@@ -24,7 +24,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let response = client.say_hello(request).await?;
 
-    println!("RESPONSE={:?}", response);
+    println!("RESPONSE={response:?}");
 
     Ok(())
 }

--- a/examples/src/codec_buffers/server.rs
+++ b/examples/src/codec_buffers/server.rs
@@ -40,7 +40,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let addr = "[::1]:50051".parse().unwrap();
     let greeter = MyGreeter::default();
 
-    println!("GreeterServer listening on {}", addr);
+    println!("GreeterServer listening on {addr}");
 
     Server::builder()
         .add_service(GreeterServer::new(greeter))

--- a/examples/src/compression/server.rs
+++ b/examples/src/compression/server.rs
@@ -31,7 +31,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let addr = "[::1]:50051".parse().unwrap();
     let greeter = MyGreeter::default();
 
-    println!("GreeterServer listening on {}", addr);
+    println!("GreeterServer listening on {addr}");
 
     let service = GreeterServer::new(greeter)
         .send_compressed(CompressionEncoding::Gzip)

--- a/examples/src/dynamic/server.rs
+++ b/examples/src/dynamic/server.rs
@@ -77,7 +77,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let addr = "[::1]:50051".parse().unwrap();
 
-    println!("Grpc server listening on {}", addr);
+    println!("Grpc server listening on {addr}");
 
     Server::builder()
         .add_routes(routes_builder.routes())

--- a/examples/src/dynamic_load_balance/client.rs
+++ b/examples/src/dynamic_load_balance/client.rs
@@ -27,36 +27,36 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         println!("Added first endpoint");
         let change = Change::Insert("1", e1);
         let res = rx.send(change).await;
-        println!("{:?}", res);
+        println!("{res:?}");
         tokio::time::sleep(tokio::time::Duration::from_secs(5)).await;
         println!("Added second endpoint");
         let change = Change::Insert("2", e2);
         let res = rx.send(change).await;
-        println!("{:?}", res);
+        println!("{res:?}");
         tokio::time::sleep(tokio::time::Duration::from_secs(5)).await;
         println!("Removed first endpoint");
         let change = Change::Remove("1");
         let res = rx.send(change).await;
-        println!("{:?}", res);
+        println!("{res:?}");
 
         tokio::time::sleep(tokio::time::Duration::from_secs(5)).await;
         println!("Removed second endpoint");
         let change = Change::Remove("2");
         let res = rx.send(change).await;
-        println!("{:?}", res);
+        println!("{res:?}");
 
         tokio::time::sleep(tokio::time::Duration::from_secs(5)).await;
         println!("Added third endpoint");
         let e3 = Endpoint::from_static("http://[::1]:50051");
         let change = Change::Insert("3", e3);
         let res = rx.send(change).await;
-        println!("{:?}", res);
+        println!("{res:?}");
 
         tokio::time::sleep(tokio::time::Duration::from_secs(5)).await;
         println!("Removed third endpoint");
         let change = Change::Remove("3");
         let res = rx.send(change).await;
-        println!("{:?}", res);
+        println!("{res:?}");
         demo_done.swap(true, SeqCst);
     });
 
@@ -68,7 +68,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
         let rx = client.unary_echo(request);
         if let Ok(resp) = timeout(tokio::time::Duration::from_secs(10), rx).await {
-            println!("RESPONSE={:?}", resp);
+            println!("RESPONSE={resp:?}");
         } else {
             println!("did not receive value within 10 secs");
         }

--- a/examples/src/dynamic_load_balance/server.rs
+++ b/examples/src/dynamic_load_balance/server.rs
@@ -41,7 +41,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
         tokio::spawn(async move {
             if let Err(e) = serve.await {
-                eprintln!("Error = {:?}", e);
+                eprintln!("Error = {e:?}");
             }
 
             tx.send(()).unwrap();

--- a/examples/src/gcp/client.rs
+++ b/examples/src/gcp/client.rs
@@ -21,7 +21,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .nth(1)
         .ok_or_else(|| "Expected a project name as the first argument.".to_string())?;
 
-    let bearer_token = format!("Bearer {}", token);
+    let bearer_token = format!("Bearer {token}");
     let header_value: MetadataValue<_> = bearer_token.parse()?;
 
     let data_dir = std::path::PathBuf::from_iter([std::env!("CARGO_MANIFEST_DIR"), "data"]);
@@ -44,13 +44,13 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let response = service
         .list_topics(Request::new(ListTopicsRequest {
-            project: format!("projects/{0}", project),
+            project: format!("projects/{project}"),
             page_size: 10,
             ..Default::default()
         }))
         .await?;
 
-    println!("RESPONSE={:?}", response);
+    println!("RESPONSE={response:?}");
 
     Ok(())
 }

--- a/examples/src/grpc-web/client.rs
+++ b/examples/src/grpc-web/client.rs
@@ -23,7 +23,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let response = client.say_hello(request).await?;
 
-    println!("RESPONSE={:?}", response);
+    println!("RESPONSE={response:?}");
 
     Ok(())
 }

--- a/examples/src/grpc-web/server.rs
+++ b/examples/src/grpc-web/server.rs
@@ -38,7 +38,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .into_inner()
         .named_layer(GreeterServer::new(greeter));
 
-    println!("GreeterServer listening on {}", addr);
+    println!("GreeterServer listening on {addr}");
 
     Server::builder()
         // GrpcWeb is over http1 so we must enable it.

--- a/examples/src/h2c/client.rs
+++ b/examples/src/h2c/client.rs
@@ -23,7 +23,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let response = client.say_hello(request).await?;
 
-    println!("RESPONSE={:?}", response);
+    println!("RESPONSE={response:?}");
 
     Ok(())
 }

--- a/examples/src/h2c/server.rs
+++ b/examples/src/h2c/server.rs
@@ -36,7 +36,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let addr: SocketAddr = "[::1]:50051".parse().unwrap();
     let greeter = MyGreeter::default();
 
-    println!("GreeterServer listening on {}", addr);
+    println!("GreeterServer listening on {addr}");
 
     let incoming = TcpListener::bind(addr).await?;
     let svc = Routes::new(GreeterServer::new(greeter)).prepare();
@@ -57,7 +57,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 });
             }
             Err(e) => {
-                eprintln!("Error accepting connection: {}", e);
+                eprintln!("Error accepting connection: {e}");
             }
         }
     }

--- a/examples/src/health/server.rs
+++ b/examples/src/health/server.rs
@@ -55,7 +55,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let addr = "[::1]:50051".parse().unwrap();
     let greeter = MyGreeter::default();
 
-    println!("HealthServer + GreeterServer listening on {}", addr);
+    println!("HealthServer + GreeterServer listening on {addr}");
 
     Server::builder()
         .add_service(health_service)

--- a/examples/src/helloworld/client.rs
+++ b/examples/src/helloworld/client.rs
@@ -15,7 +15,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let response = client.say_hello(request).await?;
 
-    println!("RESPONSE={:?}", response);
+    println!("RESPONSE={response:?}");
 
     Ok(())
 }

--- a/examples/src/helloworld/server.rs
+++ b/examples/src/helloworld/server.rs
@@ -30,7 +30,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let addr = "[::1]:50051".parse().unwrap();
     let greeter = MyGreeter::default();
 
-    println!("GreeterServer listening on {}", addr);
+    println!("GreeterServer listening on {addr}");
 
     Server::builder()
         .add_service(GreeterServer::new(greeter))

--- a/examples/src/interceptor/client.rs
+++ b/examples/src/interceptor/client.rs
@@ -25,7 +25,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let response = client.say_hello(request).await?;
 
-    println!("RESPONSE={:?}", response);
+    println!("RESPONSE={response:?}");
 
     Ok(())
 }
@@ -34,7 +34,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 /// `Status` here will cancel the request and have that status returned to
 /// the caller.
 fn intercept(req: Request<()>) -> Result<Request<()>, Status> {
-    println!("Intercepting request: {:?}", req);
+    println!("Intercepting request: {req:?}");
     Ok(req)
 }
 

--- a/examples/src/interceptor/server.rs
+++ b/examples/src/interceptor/server.rs
@@ -36,7 +36,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // structs.
     let svc = GreeterServer::with_interceptor(greeter, intercept);
 
-    println!("GreeterServer listening on {}", addr);
+    println!("GreeterServer listening on {addr}");
 
     Server::builder().add_service(svc).serve(addr).await?;
 
@@ -47,7 +47,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 /// is returned, it will cancel the request and return that status to the
 /// client.
 fn intercept(mut req: Request<()>) -> Result<Request<()>, Status> {
-    println!("Intercepting request: {:?}", req);
+    println!("Intercepting request: {req:?}");
 
     // Set an extension that can be retrieved by `say_hello`
     req.extensions_mut().insert(MyExtension {

--- a/examples/src/json-codec/client.rs
+++ b/examples/src/json-codec/client.rs
@@ -22,7 +22,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let response = client.say_hello(request).await?;
 
-    println!("RESPONSE={:?}", response);
+    println!("RESPONSE={response:?}");
 
     Ok(())
 }

--- a/examples/src/json-codec/server.rs
+++ b/examples/src/json-codec/server.rs
@@ -37,7 +37,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let addr = "[::1]:50051".parse().unwrap();
     let greeter = MyGreeter::default();
 
-    println!("GreeterServer listening on {}", addr);
+    println!("GreeterServer listening on {addr}");
 
     Server::builder()
         .add_service(GreeterServer::new(greeter))

--- a/examples/src/load_balance/client.rs
+++ b/examples/src/load_balance/client.rs
@@ -22,7 +22,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
         let response = client.unary_echo(request).await?;
 
-        println!("RESPONSE={:?}", response);
+        println!("RESPONSE={response:?}");
     }
 
     Ok(())

--- a/examples/src/load_balance/server.rs
+++ b/examples/src/load_balance/server.rs
@@ -41,7 +41,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
         tokio::spawn(async move {
             if let Err(e) = serve.await {
-                eprintln!("Error = {:?}", e);
+                eprintln!("Error = {e:?}");
             }
 
             tx.send(()).unwrap();

--- a/examples/src/mock/mock.rs
+++ b/examples/src/mock/mock.rs
@@ -53,7 +53,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let response = client.say_hello(request).await?;
 
-    println!("RESPONSE={:?}", response);
+    println!("RESPONSE={response:?}");
 
     Ok(())
 }

--- a/examples/src/multiplex/client.rs
+++ b/examples/src/multiplex/client.rs
@@ -25,7 +25,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let response = greeter_client.say_hello(request).await?;
 
-    println!("GREETER RESPONSE={:?}", response);
+    println!("GREETER RESPONSE={response:?}");
 
     let request = tonic::Request::new(EchoRequest {
         message: "hello".into(),
@@ -33,7 +33,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let response = echo_client.unary_echo(request).await?;
 
-    println!("ECHO RESPONSE={:?}", response);
+    println!("ECHO RESPONSE={response:?}");
 
     Ok(())
 }

--- a/examples/src/richer-error/client.rs
+++ b/examples/src/richer-error/client.rs
@@ -29,15 +29,15 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
             if let Some(bad_request) = err_details.bad_request() {
                 // Handle bad_request details
-                println!(" {:?}", bad_request);
+                println!(" {bad_request:?}");
             }
             if let Some(help) = err_details.help() {
                 // Handle help details
-                println!(" {:?}", help);
+                println!(" {help:?}");
             }
             if let Some(localized_message) = err_details.localized_message() {
                 // Handle localized_message details
-                println!(" {:?}", localized_message);
+                println!(" {localized_message:?}");
             }
 
             println!();
@@ -46,7 +46,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         }
     };
 
-    println!(" Successful response received.\n\n {:?}\n", response);
+    println!(" Successful response received.\n\n {response:?}\n");
 
     Ok(())
 }

--- a/examples/src/richer-error/client_vec.rs
+++ b/examples/src/richer-error/client_vec.rs
@@ -32,15 +32,15 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 match err_detail {
                     ErrorDetail::BadRequest(bad_request) => {
                         // Handle bad_request details
-                        println!(" {:?}", bad_request);
+                        println!(" {bad_request:?}");
                     }
                     ErrorDetail::Help(help) => {
                         // Handle help details
-                        println!(" {:?}", help);
+                        println!(" {help:?}");
                     }
                     ErrorDetail::LocalizedMessage(localized_message) => {
                         // Handle localized_message details
-                        println!(" {:?}", localized_message);
+                        println!(" {localized_message:?}");
                     }
                     _ => {}
                 }
@@ -52,7 +52,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         }
     };
 
-    println!(" Successful response received.\n\n {:?}\n", response);
+    println!(" Successful response received.\n\n {response:?}\n");
 
     Ok(())
 }

--- a/examples/src/richer-error/server.rs
+++ b/examples/src/richer-error/server.rs
@@ -49,7 +49,7 @@ impl Greeter for MyGreeter {
         }
 
         let reply = hello_world::HelloReply {
-            message: format!("Hello {}!", name),
+            message: format!("Hello {name}!"),
         };
         Ok(Response::new(reply))
     }
@@ -60,7 +60,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let addr = "[::1]:50051".parse().unwrap();
     let greeter = MyGreeter::default();
 
-    println!("GreeterServer listening on {}", addr);
+    println!("GreeterServer listening on {addr}");
 
     Server::builder()
         .add_service(GreeterServer::new(greeter))

--- a/examples/src/richer-error/server_vec.rs
+++ b/examples/src/richer-error/server_vec.rs
@@ -49,7 +49,7 @@ impl Greeter for MyGreeter {
         }
 
         let reply = hello_world::HelloReply {
-            message: format!("Hello {}!", name),
+            message: format!("Hello {name}!"),
         };
         Ok(Response::new(reply))
     }
@@ -60,7 +60,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let addr = "[::1]:50051".parse().unwrap();
     let greeter = MyGreeter::default();
 
-    println!("GreeterServer listening on {}", addr);
+    println!("GreeterServer listening on {addr}");
 
     Server::builder()
         .add_service(GreeterServer::new(greeter))

--- a/examples/src/routeguide/client.rs
+++ b/examples/src/routeguide/client.rs
@@ -32,7 +32,7 @@ async fn print_features(client: &mut RouteGuideClient<Channel>) -> Result<(), Bo
         .into_inner();
 
     while let Some(feature) = stream.message().await? {
-        println!("FEATURE = {:?}", feature);
+        println!("FEATURE = {feature:?}");
     }
 
     Ok(())
@@ -52,7 +52,7 @@ async fn run_record_route(client: &mut RouteGuideClient<Channel>) -> Result<(), 
 
     match client.record_route(request).await {
         Ok(response) => println!("SUMMARY: {:?}", response.into_inner()),
-        Err(e) => println!("something went wrong: {:?}", e),
+        Err(e) => println!("something went wrong: {e:?}"),
     }
 
     Ok(())
@@ -72,7 +72,7 @@ async fn run_route_chat(client: &mut RouteGuideClient<Channel>) -> Result<(), Bo
                     latitude: 409146138 + elapsed.as_secs() as i32,
                     longitude: -746188906,
                 }),
-                message: format!("at {:?}", elapsed),
+                message: format!("at {elapsed:?}"),
             };
 
             yield note;
@@ -83,7 +83,7 @@ async fn run_route_chat(client: &mut RouteGuideClient<Channel>) -> Result<(), Bo
     let mut inbound = response.into_inner();
 
     while let Some(note) = inbound.message().await? {
-        println!("NOTE = {:?}", note);
+        println!("NOTE = {note:?}");
     }
 
     Ok(())
@@ -100,7 +100,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             longitude: -746_188_906,
         }))
         .await?;
-    println!("RESPONSE = {:?}", response);
+    println!("RESPONSE = {response:?}");
 
     println!("\n*** SERVER STREAMING ***");
     print_features(&mut client).await?;

--- a/examples/src/routeguide/server.rs
+++ b/examples/src/routeguide/server.rs
@@ -50,7 +50,7 @@ impl RouteGuide for RouteGuideService {
         tokio::spawn(async move {
             for feature in &features[..] {
                 if in_range(feature.location.as_ref().unwrap(), request.get_ref()) {
-                    println!("  => send {:?}", feature);
+                    println!("  => send {feature:?}");
                     tx.send(Ok(feature.clone())).await.unwrap();
                 }
             }
@@ -76,7 +76,7 @@ impl RouteGuide for RouteGuideService {
         while let Some(point) = stream.next().await {
             let point = point?;
 
-            println!("  ==> Point = {:?}", point);
+            println!("  ==> Point = {point:?}");
 
             // Increment the point count
             summary.point_count += 1;
@@ -135,7 +135,7 @@ impl RouteGuide for RouteGuideService {
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let addr = "[::1]:10000".parse().unwrap();
 
-    println!("RouteGuideServer listening on: {}", addr);
+    println!("RouteGuideServer listening on: {addr}");
 
     let route_guide = RouteGuideService {
         features: Arc::new(data::load()),

--- a/examples/src/streaming/client.rs
+++ b/examples/src/streaming/client.rs
@@ -10,7 +10,7 @@ use pb::{echo_client::EchoClient, EchoRequest};
 
 fn echo_requests_iter() -> impl Stream<Item = EchoRequest> {
     tokio_stream::iter(1..usize::MAX).map(|i| EchoRequest {
-        message: format!("msg {:02}", i),
+        message: format!("msg {i:02}"),
     })
 }
 

--- a/examples/src/tls/client.rs
+++ b/examples/src/tls/client.rs
@@ -27,7 +27,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let response = client.unary_echo(request).await?;
 
-    println!("RESPONSE={:?}", response);
+    println!("RESPONSE={response:?}");
 
     Ok(())
 }

--- a/examples/src/tls_client_auth/client.rs
+++ b/examples/src/tls_client_auth/client.rs
@@ -32,7 +32,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let response = client.unary_echo(request).await?;
 
-    println!("RESPONSE={:?}", response);
+    println!("RESPONSE={response:?}");
 
     Ok(())
 }

--- a/examples/src/tls_rustls/client.rs
+++ b/examples/src/tls_rustls/client.rs
@@ -63,7 +63,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let response = client.unary_echo(request).await?;
 
-    println!("RESPONSE={:?}", response);
+    println!("RESPONSE={response:?}");
 
     Ok(())
 }

--- a/examples/src/tls_rustls/server.rs
+++ b/examples/src/tls_rustls/server.rs
@@ -53,7 +53,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         let (conn, addr) = match listener.accept().await {
             Ok(incoming) => incoming,
             Err(e) => {
-                eprintln!("Error accepting connection: {}", e);
+                eprintln!("Error accepting connection: {e}");
                 continue;
             }
         };

--- a/examples/src/tower/client.rs
+++ b/examples/src/tower/client.rs
@@ -27,14 +27,14 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let response = client.say_hello(request).await?;
 
-    println!("RESPONSE={:?}", response);
+    println!("RESPONSE={response:?}");
 
     Ok(())
 }
 
 // An interceptor function.
 fn intercept(req: Request<()>) -> Result<Request<()>, Status> {
-    println!("received {:?}", req);
+    println!("received {req:?}");
     Ok(req)
 }
 

--- a/examples/src/tower/server.rs
+++ b/examples/src/tower/server.rs
@@ -35,7 +35,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let addr = "[::1]:50051".parse().unwrap();
     let greeter = MyGreeter::default();
 
-    println!("GreeterServer listening on {}", addr);
+    println!("GreeterServer listening on {addr}");
 
     let svc = GreeterServer::new(greeter);
 

--- a/examples/src/uds/client_standard.rs
+++ b/examples/src/uds/client_standard.rs
@@ -23,7 +23,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let response = client.say_hello(request).await?;
 
-    println!("RESPONSE={:?}", response);
+    println!("RESPONSE={response:?}");
 
     Ok(())
 }

--- a/examples/src/uds/client_with_connector.rs
+++ b/examples/src/uds/client_with_connector.rs
@@ -35,7 +35,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let response = client.say_hello(request).await?;
 
-    println!("RESPONSE={:?}", response);
+    println!("RESPONSE={response:?}");
 
     Ok(())
 }

--- a/examples/src/uds/server.rs
+++ b/examples/src/uds/server.rs
@@ -30,7 +30,7 @@ impl Greeter for MyGreeter {
         #[cfg(unix)]
         {
             let conn_info = request.extensions().get::<UdsConnectInfo>().unwrap();
-            println!("Got a request {:?} with info {:?}", request, conn_info);
+            println!("Got a request {request:?} with info {conn_info:?}");
         }
 
         let reply = hello_world::HelloReply {

--- a/interop/build.rs
+++ b/interop/build.rs
@@ -4,5 +4,5 @@ fn main() {
     tonic_build::compile_protos(proto).unwrap();
 
     // prevent needing to rebuild if files (or deps) haven't changed
-    println!("cargo:rerun-if-changed={}", proto);
+    println!("cargo:rerun-if-changed={proto}");
 }

--- a/interop/src/bin/client.rs
+++ b/interop/src/bin/client.rs
@@ -32,7 +32,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let scheme = if matches.use_tls { "https" } else { "http" };
 
     #[allow(unused_mut)]
-    let mut endpoint = Endpoint::try_from(format!("{}://localhost:10000", scheme))?
+    let mut endpoint = Endpoint::try_from(format!("{scheme}://localhost:10000"))?
         .timeout(Duration::from_secs(5))
         .concurrency_limit(30);
 
@@ -54,7 +54,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let mut failures = Vec::new();
 
     for test_case in test_cases {
-        println!("{:?}:", test_case);
+        println!("{test_case:?}:");
         let mut test_results = Vec::new();
 
         match test_case {
@@ -87,7 +87,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         }
 
         for result in test_results {
-            println!("  {}", result);
+            println!("  {result}");
 
             if result.is_failed() {
                 failures.push(result);

--- a/tests/compression/src/bidirectional_stream.rs
+++ b/tests/compression/src/bidirectional_stream.rs
@@ -89,7 +89,7 @@ async fn client_enabled_server_enabled(encoding: CompressionEncoding) {
         CompressionEncoding::Gzip => "gzip",
         CompressionEncoding::Zstd => "zstd",
         CompressionEncoding::Deflate => "deflate",
-        _ => panic!("unexpected encoding {:?}", encoding),
+        _ => panic!("unexpected encoding {encoding:?}"),
     };
     assert_eq!(res.metadata().get("grpc-encoding").unwrap(), expected);
 

--- a/tests/compression/src/client_stream.rs
+++ b/tests/compression/src/client_stream.rs
@@ -161,14 +161,11 @@ async fn client_enabled_server_disabled(encoding: CompressionEncoding) {
         CompressionEncoding::Gzip => "gzip",
         CompressionEncoding::Zstd => "zstd",
         CompressionEncoding::Deflate => "deflate",
-        _ => panic!("unexpected encoding {:?}", encoding),
+        _ => panic!("unexpected encoding {encoding:?}"),
     };
     assert_eq!(
         status.message(),
-        format!(
-            "Content is compressed with `{}` which isn't supported",
-            expected
-        )
+        format!("Content is compressed with `{expected}` which isn't supported")
     );
 }
 
@@ -218,7 +215,7 @@ async fn compressing_response_from_client_stream(encoding: CompressionEncoding) 
         CompressionEncoding::Gzip => "gzip",
         CompressionEncoding::Zstd => "zstd",
         CompressionEncoding::Deflate => "deflate",
-        _ => panic!("unexpected encoding {:?}", encoding),
+        _ => panic!("unexpected encoding {encoding:?}"),
     };
     assert_eq!(res.metadata().get("grpc-encoding").unwrap(), expected);
     let bytes_sent = response_bytes_counter.load(SeqCst);

--- a/tests/compression/src/compressing_request.rs
+++ b/tests/compression/src/compressing_request.rs
@@ -177,14 +177,11 @@ async fn client_enabled_server_disabled(encoding: CompressionEncoding) {
         CompressionEncoding::Gzip => "gzip",
         CompressionEncoding::Zstd => "zstd",
         CompressionEncoding::Deflate => "deflate",
-        _ => panic!("unexpected encoding {:?}", encoding),
+        _ => panic!("unexpected encoding {encoding:?}"),
     };
     assert_eq!(
         status.message(),
-        format!(
-            "Content is compressed with `{}` which isn't supported",
-            expected
-        )
+        format!("Content is compressed with `{expected}` which isn't supported")
     );
 
     assert_eq!(

--- a/tests/compression/src/compressing_response.rs
+++ b/tests/compression/src/compressing_response.rs
@@ -46,7 +46,7 @@ async fn client_enabled_server_enabled(encoding: CompressionEncoding) {
                     .unwrap()
                     .to_str()
                     .unwrap(),
-                format!("{},identity", expected)
+                format!("{expected},identity")
             );
             self.service.call(req)
         }
@@ -88,7 +88,7 @@ async fn client_enabled_server_enabled(encoding: CompressionEncoding) {
         CompressionEncoding::Gzip => "gzip",
         CompressionEncoding::Zstd => "zstd",
         CompressionEncoding::Deflate => "deflate",
-        _ => panic!("unexpected encoding {:?}", encoding),
+        _ => panic!("unexpected encoding {encoding:?}"),
     };
 
     for _ in 0..3 {
@@ -353,7 +353,7 @@ async fn disabling_compression_on_single_response(encoding: CompressionEncoding)
         CompressionEncoding::Gzip => "gzip",
         CompressionEncoding::Zstd => "zstd",
         CompressionEncoding::Deflate => "deflate",
-        _ => panic!("unexpected encoding {:?}", encoding),
+        _ => panic!("unexpected encoding {encoding:?}"),
     };
     assert_eq!(res.metadata().get("grpc-encoding").unwrap(), expected);
 
@@ -411,7 +411,7 @@ async fn disabling_compression_on_response_but_keeping_compression_on_stream(
         CompressionEncoding::Gzip => "gzip",
         CompressionEncoding::Zstd => "zstd",
         CompressionEncoding::Deflate => "deflate",
-        _ => panic!("unexpected encoding {:?}", encoding),
+        _ => panic!("unexpected encoding {encoding:?}"),
     };
     assert_eq!(res.metadata().get("grpc-encoding").unwrap(), expected);
 
@@ -482,7 +482,7 @@ async fn disabling_compression_on_response_from_client_stream(encoding: Compress
         CompressionEncoding::Gzip => "gzip",
         CompressionEncoding::Zstd => "zstd",
         CompressionEncoding::Deflate => "deflate",
-        _ => panic!("unexpected encoding {:?}", encoding),
+        _ => panic!("unexpected encoding {encoding:?}"),
     };
     assert_eq!(res.metadata().get("grpc-encoding").unwrap(), expected);
     let bytes_sent = response_bytes_counter.load(SeqCst);

--- a/tests/compression/src/server_stream.rs
+++ b/tests/compression/src/server_stream.rs
@@ -47,7 +47,7 @@ async fn client_enabled_server_enabled(encoding: CompressionEncoding) {
         CompressionEncoding::Gzip => "gzip",
         CompressionEncoding::Zstd => "zstd",
         CompressionEncoding::Deflate => "deflate",
-        _ => panic!("unexpected encoding {:?}", encoding),
+        _ => panic!("unexpected encoding {encoding:?}"),
     };
     assert_eq!(res.metadata().get("grpc-encoding").unwrap(), expected);
 

--- a/tests/default_stubs/src/test_defaults.rs
+++ b/tests/default_stubs/src/test_defaults.rs
@@ -145,16 +145,16 @@ async fn run_services_in_background_uds() -> (String, String) {
         .collect();
     let tmpdir = fs::canonicalize(env::temp_dir())
         .unwrap()
-        .join(format!("tonic_test_{}", suffix));
+        .join(format!("tonic_test_{suffix}"));
     fs::create_dir(&tmpdir).unwrap();
 
     let uds_filepath = tmpdir.join("impl.sock").to_str().unwrap().to_string();
     let listener = UnixListener::bind(uds_filepath.as_str()).unwrap();
-    let uds_addr = format!("unix://{}", uds_filepath);
+    let uds_addr = format!("unix://{uds_filepath}");
 
     let uds_default_stubs_filepath = tmpdir.join("stub.sock").to_str().unwrap().to_string();
     let listener_default_stubs = UnixListener::bind(uds_default_stubs_filepath.as_str()).unwrap();
-    let uds_default_stubs_addr = format!("unix://{}", uds_default_stubs_filepath);
+    let uds_default_stubs_addr = format!("unix://{uds_default_stubs_filepath}");
 
     tokio::spawn(async move {
         Server::builder()

--- a/tests/integration_tests/tests/interceptor.rs
+++ b/tests/integration_tests/tests/interceptor.rs
@@ -41,7 +41,7 @@ async fn interceptor_retrieves_grpc_method() {
         .connect_lazy();
 
     fn client_intercept(req: Request<()>) -> Result<Request<()>, Status> {
-        println!("Intercepting client request: {:?}", req);
+        println!("Intercepting client request: {req:?}");
 
         let gm = req.extensions().get::<GrpcMethod>().unwrap();
         assert_eq!(gm.service(), "test.Test");

--- a/tests/integration_tests/tests/max_message_size.rs
+++ b/tests/integration_tests/tests/max_message_size.rs
@@ -245,14 +245,11 @@ fn assert_test_case(case: TestCase) {
         (Some(_), Ok(())) => panic!("Expected failure, but got success"),
         (Some(code), Err(status)) => {
             if status.code() != code {
-                panic!(
-                    "Expected failure, got failure but wrong code, got: {:?}",
-                    status
-                )
+                panic!("Expected failure, got failure but wrong code, got: {status:?}")
             }
         }
 
-        (None, Err(status)) => panic!("Expected success, but got failure, got: {:?}", status),
+        (None, Err(status)) => panic!("Expected success, but got failure, got: {status:?}"),
 
         _ => (),
     }

--- a/tests/integration_tests/tests/timeout.rs
+++ b/tests/integration_tests/tests/timeout.rs
@@ -7,7 +7,7 @@ use tonic::{transport::Server, Code, Request, Response, Status};
 async fn cancelation_on_timeout() {
     let addr = run_service_in_background(Duration::from_secs(1), Duration::from_secs(100)).await;
 
-    let mut client = test_client::TestClient::connect(format!("http://{}", addr))
+    let mut client = test_client::TestClient::connect(format!("http://{addr}"))
         .await
         .unwrap();
 
@@ -27,7 +27,7 @@ async fn cancelation_on_timeout() {
 async fn picks_server_timeout_if_thats_sorter() {
     let addr = run_service_in_background(Duration::from_secs(1), Duration::from_millis(100)).await;
 
-    let mut client = test_client::TestClient::connect(format!("http://{}", addr))
+    let mut client = test_client::TestClient::connect(format!("http://{addr}"))
         .await
         .unwrap();
 
@@ -46,7 +46,7 @@ async fn picks_server_timeout_if_thats_sorter() {
 async fn picks_client_timeout_if_thats_sorter() {
     let addr = run_service_in_background(Duration::from_secs(1), Duration::from_secs(100)).await;
 
-    let mut client = test_client::TestClient::connect(format!("http://{}", addr))
+    let mut client = test_client::TestClient::connect(format!("http://{addr}"))
         .await
         .unwrap();
 

--- a/tests/web/build.rs
+++ b/tests/web/build.rs
@@ -7,5 +7,5 @@ fn main() {
 
     protos
         .iter()
-        .for_each(|file| println!("cargo:rerun-if-changed={}", file));
+        .for_each(|file| println!("cargo:rerun-if-changed={file}"));
 }

--- a/tests/web/tests/grpc_web.rs
+++ b/tests/web/tests/grpc_web.rs
@@ -120,14 +120,14 @@ fn build_request(base_uri: String, content_type: &str, accept: &str) -> Request<
         "grpc-web-text" => test_web::util::base64::STANDARD
             .encode(encode_body())
             .into(),
-        _ => panic!("invalid content type {}", content_type),
+        _ => panic!("invalid content type {content_type}"),
     };
 
     Request::builder()
         .method(Method::POST)
-        .header(CONTENT_TYPE, format!("application/{}", content_type))
+        .header(CONTENT_TYPE, format!("application/{content_type}"))
         .header(ORIGIN, "http://example.com")
-        .header(ACCEPT, format!("application/{}", accept))
+        .header(ACCEPT, format!("application/{accept}"))
         .uri(request_uri)
         .body(Body::new(
             Full::new(bytes).map_err(|err| Status::internal(err.to_string())),

--- a/tonic-build/src/lib.rs
+++ b/tonic-build/src/lib.rs
@@ -234,7 +234,7 @@ fn generate_attributes<'a>(
         .filter(|(matcher, _)| match_name(matcher, name))
         .flat_map(|(_, attr)| {
             // attributes cannot be parsed directly, so we pretend they're on a struct
-            syn::parse_str::<syn::DeriveInput>(&format!("{}\nstruct fake;", attr))
+            syn::parse_str::<syn::DeriveInput>(&format!("{attr}\nstruct fake;"))
                 .unwrap()
                 .attrs
         })
@@ -259,7 +259,7 @@ fn generate_doc_comment<S: AsRef<str>>(comment: S) -> TokenStream {
     let comment = comment.as_ref();
 
     let comment = if !comment.starts_with(' ') {
-        format!(" {}", comment)
+        format!(" {comment}")
     } else {
         comment.to_string()
     };

--- a/tonic-build/src/prost.rs
+++ b/tonic-build/src/prost.rs
@@ -180,7 +180,7 @@ impl crate::Method for TonicBuildMethod {
                     .unwrap()
                     .to_token_stream()
             } else {
-                syn::parse_str::<syn::Path>(&format!("{}::{}", proto_path, rust_type))
+                syn::parse_str::<syn::Path>(&format!("{proto_path}::{rust_type}"))
                     .unwrap()
                     .to_token_stream()
             }

--- a/tonic-reflection/src/server/mod.rs
+++ b/tonic-reflection/src/server/mod.rs
@@ -251,7 +251,7 @@ impl ReflectionServiceState {
 
     fn symbol_by_name(&self, symbol: &str) -> Result<Vec<u8>, Status> {
         match self.symbols.get(symbol) {
-            None => Err(Status::not_found(format!("symbol '{}' not found", symbol))),
+            None => Err(Status::not_found(format!("symbol '{symbol}' not found"))),
             Some(fd) => {
                 let mut encoded_fd = Vec::new();
                 if fd.clone().encode(&mut encoded_fd).is_err() {
@@ -265,7 +265,7 @@ impl ReflectionServiceState {
 
     fn file_by_filename(&self, filename: &str) -> Result<Vec<u8>, Status> {
         match self.files.get(filename) {
-            None => Err(Status::not_found(format!("file '{}' not found", filename))),
+            None => Err(Status::not_found(format!("file '{filename}' not found"))),
             Some(fd) => {
                 let mut encoded_fd = Vec::new();
                 if fd.clone().encode(&mut encoded_fd).is_err() {
@@ -285,14 +285,13 @@ fn extract_name(
 ) -> Result<String, Error> {
     match maybe_name {
         None => Err(Error::InvalidFileDescriptorSet(format!(
-            "missing {} name",
-            name_type
+            "missing {name_type} name"
         ))),
         Some(name) => {
             if prefix.is_empty() {
                 Ok(name.to_string())
             } else {
-                Ok(format!("{}.{}", prefix, name))
+                Ok(format!("{prefix}.{name}"))
             }
         }
     }
@@ -320,7 +319,7 @@ impl Display for Error {
         match self {
             Error::DecodeError(_) => f.write_str("error decoding FileDescriptorSet from buffer"),
             Error::InvalidFileDescriptorSet(s) => {
-                write!(f, "invalid FileDescriptorSet - {}", s)
+                write!(f, "invalid FileDescriptorSet - {s}")
             }
         }
     }

--- a/tonic-types/src/richer_error/mod.rs
+++ b/tonic-types/src/richer_error/mod.rs
@@ -1002,7 +1002,7 @@ mod tests {
             .add_help_link("link to resource", "resource.example.local")
             .set_localized_message("en-US", "message for the user");
 
-        let fmt_details = format!("{:?}", err_details);
+        let fmt_details = format!("{err_details:?}");
 
         let err_details_vec = vec![
             RetryInfo::new(Some(Duration::from_secs(5))).into(),
@@ -1021,7 +1021,7 @@ mod tests {
             LocalizedMessage::new("en-US", "message for the user").into(),
         ];
 
-        let fmt_details_vec = format!("{:?}", err_details_vec);
+        let fmt_details_vec = format!("{err_details_vec:?}");
 
         let status_from_struct = Status::with_error_details(
             Code::InvalidArgument,
@@ -1037,13 +1037,10 @@ mod tests {
 
         let ext_details = match status_from_vec.check_error_details() {
             Ok(ext_details) => ext_details,
-            Err(err) => panic!(
-                "Error extracting details struct from status_from_vec: {:?}",
-                err
-            ),
+            Err(err) => panic!("Error extracting details struct from status_from_vec: {err:?}"),
         };
 
-        let fmt_ext_details = format!("{:?}", ext_details);
+        let fmt_ext_details = format!("{ext_details:?}");
 
         assert!(
             fmt_ext_details.eq(&fmt_details),
@@ -1052,13 +1049,10 @@ mod tests {
 
         let ext_details_vec = match status_from_struct.check_error_details_vec() {
             Ok(ext_details) => ext_details,
-            Err(err) => panic!(
-                "Error extracting details_vec from status_from_struct: {:?}",
-                err
-            ),
+            Err(err) => panic!("Error extracting details_vec from status_from_struct: {err:?}"),
         };
 
-        let fmt_ext_details_vec = format!("{:?}", ext_details_vec);
+        let fmt_ext_details_vec = format!("{ext_details_vec:?}");
 
         assert!(
             fmt_ext_details_vec.eq(&fmt_details_vec),

--- a/tonic-types/src/richer_error/std_messages/bad_request.rs
+++ b/tonic-types/src/richer_error/std_messages/bad_request.rs
@@ -150,7 +150,7 @@ mod tests {
     #[test]
     fn gen_bad_request() {
         let mut br_details = BadRequest::new(Vec::new());
-        let formatted = format!("{:?}", br_details);
+        let formatted = format!("{br_details:?}");
 
         let expected = "BadRequest { field_violations: [] }";
 
@@ -168,7 +168,7 @@ mod tests {
             .add_violation("field_a", "description_a")
             .add_violation("field_b", "description_b");
 
-        let formatted = format!("{:?}", br_details);
+        let formatted = format!("{br_details:?}");
 
         let expected_filled = "BadRequest { field_violations: [FieldViolation { field: \"field_a\", description: \"description_a\" }, FieldViolation { field: \"field_b\", description: \"description_b\" }] }";
 
@@ -183,7 +183,7 @@ mod tests {
         );
 
         let gen_any = br_details.into_any();
-        let formatted = format!("{:?}", gen_any);
+        let formatted = format!("{gen_any:?}");
 
         let expected = "Any { type_url: \"type.googleapis.com/google.rpc.BadRequest\", value: [10, 24, 10, 7, 102, 105, 101, 108, 100, 95, 97, 18, 13, 100, 101, 115, 99, 114, 105, 112, 116, 105, 111, 110, 95, 97, 10, 24, 10, 7, 102, 105, 101, 108, 100, 95, 98, 18, 13, 100, 101, 115, 99, 114, 105, 112, 116, 105, 111, 110, 95, 98] }";
 
@@ -193,11 +193,11 @@ mod tests {
         );
 
         let br_details = match BadRequest::from_any(gen_any) {
-            Err(error) => panic!("Error generating BadRequest from Any: {:?}", error),
+            Err(error) => panic!("Error generating BadRequest from Any: {error:?}"),
             Ok(from_any) => from_any,
         };
 
-        let formatted = format!("{:?}", br_details);
+        let formatted = format!("{br_details:?}");
 
         assert!(
             formatted.eq(expected_filled),

--- a/tonic-types/src/richer_error/std_messages/debug_info.rs
+++ b/tonic-types/src/richer_error/std_messages/debug_info.rs
@@ -94,7 +94,7 @@ mod tests {
             "details about the error",
         );
 
-        let formatted = format!("{:?}", debug_info);
+        let formatted = format!("{debug_info:?}");
 
         let expected_filled = "DebugInfo { stack_entries: [\"trace 3\", \"trace 2\", \"trace 1\"], detail: \"details about the error\" }";
 
@@ -104,7 +104,7 @@ mod tests {
         );
 
         let gen_any = debug_info.into_any();
-        let formatted = format!("{:?}", gen_any);
+        let formatted = format!("{gen_any:?}");
 
         let expected =
             "Any { type_url: \"type.googleapis.com/google.rpc.DebugInfo\", value: [10, 7, 116, 114, 97, 99, 101, 32, 51, 10, 7, 116, 114, 97, 99, 101, 32, 50, 10, 7, 116, 114, 97, 99, 101, 32, 49, 18, 23, 100, 101, 116, 97, 105, 108, 115, 32, 97, 98, 111, 117, 116, 32, 116, 104, 101, 32, 101, 114, 114, 111, 114] }";
@@ -115,11 +115,11 @@ mod tests {
         );
 
         let br_details = match DebugInfo::from_any(gen_any) {
-            Err(error) => panic!("Error generating DebugInfo from Any: {:?}", error),
+            Err(error) => panic!("Error generating DebugInfo from Any: {error:?}"),
             Ok(from_any) => from_any,
         };
 
-        let formatted = format!("{:?}", br_details);
+        let formatted = format!("{br_details:?}");
 
         assert!(
             formatted.eq(expected_filled),

--- a/tonic-types/src/richer_error/std_messages/error_info.rs
+++ b/tonic-types/src/richer_error/std_messages/error_info.rs
@@ -114,7 +114,7 @@ mod tests {
 
         let error_info = ErrorInfo::new("SOME_INFO", "mydomain.com", metadata);
 
-        let formatted = format!("{:?}", error_info);
+        let formatted = format!("{error_info:?}");
 
         let expected_filled = "ErrorInfo { reason: \"SOME_INFO\", domain: \"mydomain.com\", metadata: {\"instanceLimitPerRequest\": \"100\"} }";
 
@@ -125,7 +125,7 @@ mod tests {
 
         let gen_any = error_info.into_any();
 
-        let formatted = format!("{:?}", gen_any);
+        let formatted = format!("{gen_any:?}");
 
         let expected =
             "Any { type_url: \"type.googleapis.com/google.rpc.ErrorInfo\", value: [10, 9, 83, 79, 77, 69, 95, 73, 78, 70, 79, 18, 12, 109, 121, 100, 111, 109, 97, 105, 110, 46, 99, 111, 109, 26, 30, 10, 23, 105, 110, 115, 116, 97, 110, 99, 101, 76, 105, 109, 105, 116, 80, 101, 114, 82, 101, 113, 117, 101, 115, 116, 18, 3, 49, 48, 48] }";
@@ -136,11 +136,11 @@ mod tests {
         );
 
         let br_details = match ErrorInfo::from_any(gen_any) {
-            Err(error) => panic!("Error generating ErrorInfo from Any: {:?}", error),
+            Err(error) => panic!("Error generating ErrorInfo from Any: {error:?}"),
             Ok(from_any) => from_any,
         };
 
-        let formatted = format!("{:?}", br_details);
+        let formatted = format!("{br_details:?}");
 
         assert!(
             formatted.eq(expected_filled),

--- a/tonic-types/src/richer_error/std_messages/help.rs
+++ b/tonic-types/src/richer_error/std_messages/help.rs
@@ -146,7 +146,7 @@ mod tests {
     #[test]
     fn gen_help() {
         let mut help = Help::new(Vec::new());
-        let formatted = format!("{:?}", help);
+        let formatted = format!("{help:?}");
 
         let expected = "Help { links: [] }";
 
@@ -163,7 +163,7 @@ mod tests {
         help.add_link("link to resource a", "resource-a.example.local")
             .add_link("link to resource b", "resource-b.example.local");
 
-        let formatted = format!("{:?}", help);
+        let formatted = format!("{help:?}");
 
         let expected_filled = "Help { links: [HelpLink { description: \"link to resource a\", url: \"resource-a.example.local\" }, HelpLink { description: \"link to resource b\", url: \"resource-b.example.local\" }] }";
 
@@ -179,7 +179,7 @@ mod tests {
 
         let gen_any = help.into_any();
 
-        let formatted = format!("{:?}", gen_any);
+        let formatted = format!("{gen_any:?}");
 
         let expected = "Any { type_url: \"type.googleapis.com/google.rpc.Help\", value: [10, 46, 10, 18, 108, 105, 110, 107, 32, 116, 111, 32, 114, 101, 115, 111, 117, 114, 99, 101, 32, 97, 18, 24, 114, 101, 115, 111, 117, 114, 99, 101, 45, 97, 46, 101, 120, 97, 109, 112, 108, 101, 46, 108, 111, 99, 97, 108, 10, 46, 10, 18, 108, 105, 110, 107, 32, 116, 111, 32, 114, 101, 115, 111, 117, 114, 99, 101, 32, 98, 18, 24, 114, 101, 115, 111, 117, 114, 99, 101, 45, 98, 46, 101, 120, 97, 109, 112, 108, 101, 46, 108, 111, 99, 97, 108] }";
 
@@ -189,11 +189,11 @@ mod tests {
         );
 
         let br_details = match Help::from_any(gen_any) {
-            Err(error) => panic!("Error generating Help from Any: {:?}", error),
+            Err(error) => panic!("Error generating Help from Any: {error:?}"),
             Ok(from_any) => from_any,
         };
 
-        let formatted = format!("{:?}", br_details);
+        let formatted = format!("{br_details:?}");
 
         assert!(
             formatted.eq(expected_filled),

--- a/tonic-types/src/richer_error/std_messages/loc_message.rs
+++ b/tonic-types/src/richer_error/std_messages/loc_message.rs
@@ -95,7 +95,7 @@ mod tests {
     fn gen_localized_message() {
         let loc_message = LocalizedMessage::new("en-US", "message for the user");
 
-        let formatted = format!("{:?}", loc_message);
+        let formatted = format!("{loc_message:?}");
 
         let expected_filled =
             "LocalizedMessage { locale: \"en-US\", message: \"message for the user\" }";
@@ -107,7 +107,7 @@ mod tests {
 
         let gen_any = loc_message.into_any();
 
-        let formatted = format!("{:?}", gen_any);
+        let formatted = format!("{gen_any:?}");
 
         let expected =
             "Any { type_url: \"type.googleapis.com/google.rpc.LocalizedMessage\", value: [10, 5, 101, 110, 45, 85, 83, 18, 20, 109, 101, 115, 115, 97, 103, 101, 32, 102, 111, 114, 32, 116, 104, 101, 32, 117, 115, 101, 114] }";
@@ -118,11 +118,11 @@ mod tests {
         );
 
         let br_details = match LocalizedMessage::from_any(gen_any) {
-            Err(error) => panic!("Error generating LocalizedMessage from Any: {:?}", error),
+            Err(error) => panic!("Error generating LocalizedMessage from Any: {error:?}"),
             Ok(from_any) => from_any,
         };
 
-        let formatted = format!("{:?}", br_details);
+        let formatted = format!("{br_details:?}");
 
         assert!(
             formatted.eq(expected_filled),

--- a/tonic-types/src/richer_error/std_messages/prec_failure.rs
+++ b/tonic-types/src/richer_error/std_messages/prec_failure.rs
@@ -170,7 +170,7 @@ mod tests {
     #[test]
     fn gen_prec_failure() {
         let mut prec_failure = PreconditionFailure::new(Vec::new());
-        let formatted = format!("{:?}", prec_failure);
+        let formatted = format!("{prec_failure:?}");
 
         let expected = "PreconditionFailure { violations: [] }";
 
@@ -188,7 +188,7 @@ mod tests {
             .add_violation("TOS", "example.local", "Terms of service not accepted")
             .add_violation("FNF", "example.local", "File not found");
 
-        let formatted = format!("{:?}", prec_failure);
+        let formatted = format!("{prec_failure:?}");
 
         let expected_filled = "PreconditionFailure { violations: [PreconditionViolation { type: \"TOS\", subject: \"example.local\", description: \"Terms of service not accepted\" }, PreconditionViolation { type: \"FNF\", subject: \"example.local\", description: \"File not found\" }] }";
 
@@ -204,7 +204,7 @@ mod tests {
 
         let gen_any = prec_failure.into_any();
 
-        let formatted = format!("{:?}", gen_any);
+        let formatted = format!("{gen_any:?}");
 
         let expected = "Any { type_url: \"type.googleapis.com/google.rpc.PreconditionFailure\", value: [10, 51, 10, 3, 84, 79, 83, 18, 13, 101, 120, 97, 109, 112, 108, 101, 46, 108, 111, 99, 97, 108, 26, 29, 84, 101, 114, 109, 115, 32, 111, 102, 32, 115, 101, 114, 118, 105, 99, 101, 32, 110, 111, 116, 32, 97, 99, 99, 101, 112, 116, 101, 100, 10, 36, 10, 3, 70, 78, 70, 18, 13, 101, 120, 97, 109, 112, 108, 101, 46, 108, 111, 99, 97, 108, 26, 14, 70, 105, 108, 101, 32, 110, 111, 116, 32, 102, 111, 117, 110, 100] }";
 
@@ -214,11 +214,11 @@ mod tests {
         );
 
         let br_details = match PreconditionFailure::from_any(gen_any) {
-            Err(error) => panic!("Error generating PreconditionFailure from Any: {:?}", error),
+            Err(error) => panic!("Error generating PreconditionFailure from Any: {error:?}"),
             Ok(from_any) => from_any,
         };
 
-        let formatted = format!("{:?}", br_details);
+        let formatted = format!("{br_details:?}");
 
         assert!(
             formatted.eq(expected_filled),

--- a/tonic-types/src/richer_error/std_messages/quota_failure.rs
+++ b/tonic-types/src/richer_error/std_messages/quota_failure.rs
@@ -147,7 +147,7 @@ mod tests {
     #[test]
     fn gen_quota_failure() {
         let mut quota_failure = QuotaFailure::new(Vec::new());
-        let formatted = format!("{:?}", quota_failure);
+        let formatted = format!("{quota_failure:?}");
 
         let expected = "QuotaFailure { violations: [] }";
 
@@ -165,7 +165,7 @@ mod tests {
             .add_violation("clientip:<ip address>", "description a")
             .add_violation("project:<project id>", "description b");
 
-        let formatted = format!("{:?}", quota_failure);
+        let formatted = format!("{quota_failure:?}");
 
         let expected_filled = "QuotaFailure { violations: [QuotaViolation { subject: \"clientip:<ip address>\", description: \"description a\" }, QuotaViolation { subject: \"project:<project id>\", description: \"description b\" }] }";
 
@@ -181,7 +181,7 @@ mod tests {
 
         let gen_any = quota_failure.into_any();
 
-        let formatted = format!("{:?}", gen_any);
+        let formatted = format!("{gen_any:?}");
 
         let expected = "Any { type_url: \"type.googleapis.com/google.rpc.QuotaFailure\", value: [10, 38, 10, 21, 99, 108, 105, 101, 110, 116, 105, 112, 58, 60, 105, 112, 32, 97, 100, 100, 114, 101, 115, 115, 62, 18, 13, 100, 101, 115, 99, 114, 105, 112, 116, 105, 111, 110, 32, 97, 10, 37, 10, 20, 112, 114, 111, 106, 101, 99, 116, 58, 60, 112, 114, 111, 106, 101, 99, 116, 32, 105, 100, 62, 18, 13, 100, 101, 115, 99, 114, 105, 112, 116, 105, 111, 110, 32, 98] }";
 
@@ -191,11 +191,11 @@ mod tests {
         );
 
         let br_details = match QuotaFailure::from_any(gen_any) {
-            Err(error) => panic!("Error generating QuotaFailure from Any: {:?}", error),
+            Err(error) => panic!("Error generating QuotaFailure from Any: {error:?}"),
             Ok(from_any) => from_any,
         };
 
-        let formatted = format!("{:?}", br_details);
+        let formatted = format!("{br_details:?}");
 
         assert!(
             formatted.eq(expected_filled),

--- a/tonic-types/src/richer_error/std_messages/request_info.rs
+++ b/tonic-types/src/richer_error/std_messages/request_info.rs
@@ -94,7 +94,7 @@ mod tests {
     fn gen_request_info() {
         let req_info = RequestInfo::new("some-id", "some-data");
 
-        let formatted = format!("{:?}", req_info);
+        let formatted = format!("{req_info:?}");
 
         let expected_filled =
             "RequestInfo { request_id: \"some-id\", serving_data: \"some-data\" }";
@@ -106,7 +106,7 @@ mod tests {
 
         let gen_any = req_info.into_any();
 
-        let formatted = format!("{:?}", gen_any);
+        let formatted = format!("{gen_any:?}");
 
         let expected =
             "Any { type_url: \"type.googleapis.com/google.rpc.RequestInfo\", value: [10, 7, 115, 111, 109, 101, 45, 105, 100, 18, 9, 115, 111, 109, 101, 45, 100, 97, 116, 97] }";
@@ -117,11 +117,11 @@ mod tests {
         );
 
         let br_details = match RequestInfo::from_any(gen_any) {
-            Err(error) => panic!("Error generating RequestInfo from Any: {:?}", error),
+            Err(error) => panic!("Error generating RequestInfo from Any: {error:?}"),
             Ok(from_any) => from_any,
         };
 
-        let formatted = format!("{:?}", br_details);
+        let formatted = format!("{br_details:?}");
 
         assert!(
             formatted.eq(expected_filled),

--- a/tonic-types/src/richer_error/std_messages/resource_info.rs
+++ b/tonic-types/src/richer_error/std_messages/resource_info.rs
@@ -111,7 +111,7 @@ mod tests {
     fn gen_resource_info() {
         let res_info = ResourceInfo::new("resource-type", "resource-name", "owner", "description");
 
-        let formatted = format!("{:?}", res_info);
+        let formatted = format!("{res_info:?}");
 
         let expected_filled = "ResourceInfo { resource_type: \"resource-type\", resource_name: \"resource-name\", owner: \"owner\", description: \"description\" }";
 
@@ -122,7 +122,7 @@ mod tests {
 
         let gen_any = res_info.into_any();
 
-        let formatted = format!("{:?}", gen_any);
+        let formatted = format!("{gen_any:?}");
 
         let expected =
             "Any { type_url: \"type.googleapis.com/google.rpc.ResourceInfo\", value: [10, 13, 114, 101, 115, 111, 117, 114, 99, 101, 45, 116, 121, 112, 101, 18, 13, 114, 101, 115, 111, 117, 114, 99, 101, 45, 110, 97, 109, 101, 26, 5, 111, 119, 110, 101, 114, 34, 11, 100, 101, 115, 99, 114, 105, 112, 116, 105, 111, 110] }";
@@ -133,11 +133,11 @@ mod tests {
         );
 
         let br_details = match ResourceInfo::from_any(gen_any) {
-            Err(error) => panic!("Error generating ResourceInfo from Any: {:?}", error),
+            Err(error) => panic!("Error generating ResourceInfo from Any: {error:?}"),
             Ok(from_any) => from_any,
         };
 
-        let formatted = format!("{:?}", br_details);
+        let formatted = format!("{br_details:?}");
 
         assert!(
             formatted.eq(expected_filled),

--- a/tonic-types/src/richer_error/std_messages/retry_info.rs
+++ b/tonic-types/src/richer_error/std_messages/retry_info.rs
@@ -126,7 +126,7 @@ mod tests {
     fn gen_retry_info() {
         let retry_info = RetryInfo::new(Some(Duration::from_secs(u64::MAX)));
 
-        let formatted = format!("{:?}", retry_info);
+        let formatted = format!("{retry_info:?}");
 
         let expected_filled = "RetryInfo { retry_delay: Some(315576000000.999999999s) }";
 
@@ -142,7 +142,7 @@ mod tests {
 
         let gen_any = retry_info.into_any();
 
-        let formatted = format!("{:?}", gen_any);
+        let formatted = format!("{gen_any:?}");
 
         let expected =
             "Any { type_url: \"type.googleapis.com/google.rpc.RetryInfo\", value: [10, 13, 8, 128, 188, 174, 206, 151, 9, 16, 255, 147, 235, 220, 3] }";
@@ -153,11 +153,11 @@ mod tests {
         );
 
         let br_details = match RetryInfo::from_any(gen_any) {
-            Err(error) => panic!("Error generating RetryInfo from Any: {:?}", error),
+            Err(error) => panic!("Error generating RetryInfo from Any: {error:?}"),
             Ok(from_any) => from_any,
         };
 
-        let formatted = format!("{:?}", br_details);
+        let formatted = format!("{br_details:?}");
 
         assert!(
             formatted.eq(expected_filled),

--- a/tonic-web/src/call.rs
+++ b/tonic-web/src/call.rs
@@ -373,7 +373,7 @@ impl Encoding {
 }
 
 fn internal_error(e: impl std::fmt::Display) -> Status {
-    Status::internal(format!("tonic-web: {}", e))
+    Status::internal(format!("tonic-web: {e}"))
 }
 
 // Key-value pairs encoded as a HTTP/1 headers block (without the terminating newline)
@@ -434,9 +434,9 @@ fn decode_trailers_frame(mut buf: Bytes) -> Result<Option<HeaderMap>, Status> {
             .unwrap_or(value);
 
         let header_key = HeaderName::try_from(key)
-            .map_err(|e| Status::internal(format!("Unable to parse HeaderName: {}", e)))?;
+            .map_err(|e| Status::internal(format!("Unable to parse HeaderName: {e}")))?;
         let header_value = HeaderValue::try_from(value)
-            .map_err(|e| Status::internal(format!("Unable to parse HeaderValue: {}", e)))?;
+            .map_err(|e| Status::internal(format!("Unable to parse HeaderValue: {e}")))?;
         map.insert(header_key, header_value);
     }
 
@@ -479,8 +479,7 @@ fn find_trailers(buf: &[u8]) -> Result<FindTrailers, Status> {
 
         if !(header == 0 || header == 1) {
             return Err(Status::internal(format!(
-                "Invalid header bit {} expected 0 or 1",
-                header
+                "Invalid header bit {header} expected 0 or 1"
             )));
         }
 

--- a/tonic-web/src/service.rs
+++ b/tonic-web/src/service.rs
@@ -359,8 +359,7 @@ mod tests {
                 assert_eq!(
                     res.status(),
                     StatusCode::METHOD_NOT_ALLOWED,
-                    "{} should not be allowed",
-                    method
+                    "{method} should not be allowed"
                 );
             }
         }
@@ -445,7 +444,7 @@ mod tests {
                 let mut req = request();
                 req.headers_mut().insert(
                     CONTENT_TYPE,
-                    HeaderValue::from_maybe_shared(format!("application/{}", variant)).unwrap(),
+                    HeaderValue::from_maybe_shared(format!("application/{variant}")).unwrap(),
                 );
 
                 let res = svc.call(req).await.unwrap();

--- a/tonic/src/codec/decode.rs
+++ b/tonic/src/codec/decode.rs
@@ -172,11 +172,10 @@ impl StreamingInner {
                     trace!("unexpected compression flag");
                     let message = if let Direction::Response(status) = self.direction {
                         format!(
-                            "protocol error: received message with invalid compression flag: {} (valid flags are 0 and 1) while receiving response with status: {}",
-                            f, status
+                            "protocol error: received message with invalid compression flag: {f} (valid flags are 0 and 1) while receiving response with status: {status}"
                         )
                     } else {
-                        format!("protocol error: received message with invalid compression flag: {} (valid flags are 0 and 1), while sending request", f)
+                        format!("protocol error: received message with invalid compression flag: {f} (valid flags are 0 and 1), while sending request")
                     };
                     return Err(Status::internal(message));
                 }
@@ -189,8 +188,7 @@ impl StreamingInner {
             if len > limit {
                 return Err(Status::out_of_range(
                     format!(
-                        "Error, decoded message length too large: found {} bytes, the limit is: {} bytes",
-                        len, limit
+                        "Error, decoded message length too large: found {len} bytes, the limit is: {limit} bytes"
                     ),
                 ));
             }
@@ -224,11 +222,10 @@ impl StreamingInner {
                 ) {
                     let message = if let Direction::Response(status) = self.direction {
                         format!(
-                            "Error decompressing: {}, while receiving response with status: {}",
-                            err, status
+                            "Error decompressing: {err}, while receiving response with status: {status}"
                         )
                     } else {
-                        format!("Error decompressing: {}, while sending request", err)
+                        format!("Error decompressing: {err}, while sending request")
                     };
                     return Err(Status::internal(message));
                 }
@@ -280,7 +277,7 @@ impl StreamingInner {
 
             Ok(None)
         } else {
-            panic!("unexpected frame: {:?}", frame);
+            panic!("unexpected frame: {frame:?}");
         })
     }
 

--- a/tonic/src/codec/encode.rs
+++ b/tonic/src/codec/encode.rs
@@ -154,7 +154,7 @@ where
 
         encoder
             .encode(item, &mut EncodeBuf::new(uncompression_buf))
-            .map_err(|err| Status::internal(format!("Error encoding: {}", err)))?;
+            .map_err(|err| Status::internal(format!("Error encoding: {err}")))?;
 
         let uncompressed_len = uncompression_buf.len();
 
@@ -167,11 +167,11 @@ where
             buf,
             uncompressed_len,
         )
-        .map_err(|err| Status::internal(format!("Error compressing: {}", err)))?;
+        .map_err(|err| Status::internal(format!("Error compressing: {err}")))?;
     } else {
         encoder
             .encode(item, &mut EncodeBuf::new(buf))
-            .map_err(|err| Status::internal(format!("Error encoding: {}", err)))?;
+            .map_err(|err| Status::internal(format!("Error encoding: {err}")))?;
     }
 
     // now that we know length, we can write the header
@@ -187,8 +187,7 @@ fn finish_encoding(
     let limit = max_message_size.unwrap_or(DEFAULT_MAX_SEND_MESSAGE_SIZE);
     if len > limit {
         return Err(Status::out_of_range(format!(
-            "Error, encoded message length too large: found {} bytes, the limit is: {} bytes",
-            len, limit
+            "Error, encoded message length too large: found {len} bytes, the limit is: {limit} bytes"
         )));
     }
 

--- a/tonic/src/metadata/encoding.rs
+++ b/tonic/src/metadata/encoding.rs
@@ -139,7 +139,7 @@ impl self::value_encoding::Sealed for Binary {
 
     fn from_static(value: &'static str) -> HeaderValue {
         if crate::util::base64::STANDARD.decode(value).is_err() {
-            panic!("Invalid base64 passed to from_static: {}", value);
+            panic!("Invalid base64 passed to from_static: {value}");
         }
         unsafe {
             // Because this is valid base64 this must be a valid HTTP header value,
@@ -173,9 +173,9 @@ impl self::value_encoding::Sealed for Binary {
 
     fn fmt(value: &HeaderValue, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         if let Ok(decoded) = Self::decode(value.as_bytes()) {
-            write!(f, "{:?}", decoded)
+            write!(f, "{decoded:?}")
         } else {
-            write!(f, "b[invalid]{:?}", value)
+            write!(f, "b[invalid]{value:?}")
         }
     }
 }

--- a/tonic/src/metadata/value.rs
+++ b/tonic/src/metadata/value.rs
@@ -795,13 +795,13 @@ fn test_debug() {
 
     for &(value, expected) in cases {
         let val = AsciiMetadataValue::try_from(value.as_bytes()).unwrap();
-        let actual = format!("{:?}", val);
+        let actual = format!("{val:?}");
         assert_eq!(expected, actual);
     }
 
     let mut sensitive = AsciiMetadataValue::from_static("password");
     sensitive.set_sensitive(true);
-    assert_eq!("Sensitive", format!("{:?}", sensitive));
+    assert_eq!("Sensitive", format!("{sensitive:?}"));
 }
 
 #[test]

--- a/tonic/src/request.rs
+++ b/tonic/src/request.rs
@@ -408,7 +408,7 @@ fn duration_to_grpc_timeout(duration: Duration) -> String {
         if value > max_size {
             None
         } else {
-            Some(format!("{}{}", value, unit))
+            Some(format!("{value}{unit}"))
         }
     }
 

--- a/tonic/src/status.rs
+++ b/tonic/src/status.rs
@@ -361,7 +361,7 @@ impl Status {
     fn from_h2_error(err: Box<h2::Error>) -> Status {
         let code = Self::code_from_h2(&err);
 
-        let mut status = Self::new(code, format!("h2 protocol error: {}", err));
+        let mut status = Self::new(code, format!("h2 protocol error: {err}"));
         status.source = Some(Arc::new(*err));
         status
     }
@@ -421,7 +421,7 @@ impl Status {
         #[cfg(feature = "server")]
         if let Some(h2_err) = err.source().and_then(|e| e.downcast_ref::<h2::Error>()) {
             let code = Status::code_from_h2(h2_err);
-            let status = Self::new(code, format!("h2 protocol error: {}", err));
+            let status = Self::new(code, format!("h2 protocol error: {err}"));
 
             return Some(status);
         }

--- a/tonic/src/transport/channel/service/user_agent.rs
+++ b/tonic/src/transport/channel/service/user_agent.rs
@@ -77,7 +77,7 @@ mod tests {
     fn prepends_custom_user_agent_to_default() {
         assert_eq!(
             UserAgent::new(Svc, Some(HeaderValue::from_static("Greeter 1.1"))).user_agent,
-            HeaderValue::from_str(&format!("Greeter 1.1 {}", TONIC_USER_AGENT)).unwrap()
+            HeaderValue::from_str(&format!("Greeter 1.1 {TONIC_USER_AGENT}")).unwrap()
         )
     }
 
@@ -115,7 +115,7 @@ mod tests {
 
     #[tokio::test]
     async fn sets_custom_user_agent_if_none_present() {
-        let expected_user_agent = format!("Greeter 1.1 {}", TONIC_USER_AGENT);
+        let expected_user_agent = format!("Greeter 1.1 {TONIC_USER_AGENT}");
         let mut ua = UserAgent::new(
             TestSvc {
                 expected_user_agent,
@@ -131,7 +131,7 @@ mod tests {
         req.headers_mut()
             .insert(USER_AGENT, HeaderValue::from_static("request-ua/x.y"));
 
-        let expected_user_agent = format!("request-ua/x.y {}", TONIC_USER_AGENT);
+        let expected_user_agent = format!("request-ua/x.y {TONIC_USER_AGENT}");
         let mut ua = UserAgent::new(
             TestSvc {
                 expected_user_agent,
@@ -147,7 +147,7 @@ mod tests {
         req.headers_mut()
             .insert(USER_AGENT, HeaderValue::from_static("request-ua/x.y"));
 
-        let expected_user_agent = format!("request-ua/x.y Greeter 1.1 {}", TONIC_USER_AGENT);
+        let expected_user_agent = format!("request-ua/x.y Greeter 1.1 {TONIC_USER_AGENT}");
         let mut ua = UserAgent::new(
             TestSvc {
                 expected_user_agent,


### PR DESCRIPTION
## Motivation

Makes the format arguments easier to read.

## Solution

Introduces `clippy::uninlined_format_args`.
