### PR TITLE
feat(client) Change client streaming 

### DIFF
--- a/examples/src/routeguide/client.rs
+++ b/examples/src/routeguide/client.rs
@@ -4,6 +4,7 @@ use std::time::Duration;
 use rand::rngs::ThreadRng;
 use rand::Rng;
 use tokio::time;
+use tokio_stream::StreamExt;
 use tonic::transport::Channel;
 use tonic::Request;
 
@@ -48,7 +49,7 @@ async fn run_record_route(client: &mut RouteGuideClient<Channel>) -> Result<(), 
     }
 
     println!("Traversing {} points", points.len());
-    let request = Request::new(tokio_stream::iter(points));
+    let request = Request::new(tokio_stream::iter(points).map(Ok));
 
     match client.record_route(request).await {
         Ok(response) => println!("SUMMARY: {:?}", response.into_inner()),
@@ -75,7 +76,7 @@ async fn run_route_chat(client: &mut RouteGuideClient<Channel>) -> Result<(), Bo
                 message: format!("at {elapsed:?}"),
             };
 
-            yield note;
+            yield Ok(note);
         }
     };
 

--- a/examples/src/streaming/client.rs
+++ b/examples/src/streaming/client.rs
@@ -35,7 +35,7 @@ async fn bidirectional_streaming_echo(client: &mut EchoClient<Channel>, num: usi
     let in_stream = echo_requests_iter().take(num);
 
     let response = client
-        .bidirectional_streaming_echo(in_stream)
+        .bidirectional_streaming_echo(in_stream.map(Ok))
         .await
         .unwrap();
 
@@ -51,7 +51,7 @@ async fn bidirectional_streaming_echo_throttle(client: &mut EchoClient<Channel>,
     let in_stream = echo_requests_iter().throttle(dur);
 
     let response = client
-        .bidirectional_streaming_echo(in_stream)
+        .bidirectional_streaming_echo(in_stream.map(Ok))
         .await
         .unwrap();
 

--- a/tests/compression/src/bidirectional_stream.rs
+++ b/tests/compression/src/bidirectional_stream.rs
@@ -77,7 +77,10 @@ async fn client_enabled_server_enabled(encoding: CompressionEncoding) {
         .accept_compressed(encoding);
 
     let data = [0_u8; UNCOMPRESSED_MIN_BODY_SIZE].to_vec();
-    let stream = tokio_stream::iter(vec![SomeData { data: data.clone() }, SomeData { data }]);
+    let stream = tokio_stream::iter(vec![
+        Ok(SomeData { data: data.clone() }),
+        Ok(SomeData { data }),
+    ]);
     let req = Request::new(stream);
 
     let res = client

--- a/tests/compression/src/client_stream.rs
+++ b/tests/compression/src/client_stream.rs
@@ -66,7 +66,10 @@ async fn client_enabled_server_enabled(encoding: CompressionEncoding) {
         test_client::TestClient::new(mock_io_channel(client).await).send_compressed(encoding);
 
     let data = [0_u8; UNCOMPRESSED_MIN_BODY_SIZE].to_vec();
-    let stream = tokio_stream::iter(vec![SomeData { data: data.clone() }, SomeData { data }]);
+    let stream = tokio_stream::iter(vec![
+        Ok(SomeData { data: data.clone() }),
+        Ok(SomeData { data }),
+    ]);
     let req = Request::new(Box::pin(stream));
 
     client.compress_input_client_stream(req).await.unwrap();
@@ -117,7 +120,10 @@ async fn client_disabled_server_enabled(encoding: CompressionEncoding) {
     let mut client = test_client::TestClient::new(mock_io_channel(client).await);
 
     let data = [0_u8; UNCOMPRESSED_MIN_BODY_SIZE].to_vec();
-    let stream = tokio_stream::iter(vec![SomeData { data: data.clone() }, SomeData { data }]);
+    let stream = tokio_stream::iter(vec![
+        Ok(SomeData { data: data.clone() }),
+        Ok(SomeData { data }),
+    ]);
     let req = Request::new(Box::pin(stream));
 
     client.compress_input_client_stream(req).await.unwrap();
@@ -151,7 +157,10 @@ async fn client_enabled_server_disabled(encoding: CompressionEncoding) {
         test_client::TestClient::new(mock_io_channel(client).await).send_compressed(encoding);
 
     let data = [0_u8; UNCOMPRESSED_MIN_BODY_SIZE].to_vec();
-    let stream = tokio_stream::iter(vec![SomeData { data: data.clone() }, SomeData { data }]);
+    let stream = tokio_stream::iter(vec![
+        Ok(SomeData { data: data.clone() }),
+        Ok(SomeData { data }),
+    ]);
     let req = Request::new(Box::pin(stream));
 
     let status = client.compress_input_client_stream(req).await.unwrap_err();

--- a/tests/web/tests/grpc.rs
+++ b/tests/web/tests/grpc.rs
@@ -33,7 +33,7 @@ async fn smoke_unary() {
 async fn smoke_client_stream() {
     let (mut c1, mut c2, mut c3, mut c4) = spawn().await.expect("clients");
 
-    let input_stream = || stream::iter(vec![input(), input()]);
+    let input_stream = || stream::iter(vec![Ok(input()), Ok(input())]);
 
     let (r1, r2, r3, r4) = try_join!(
         c1.client_stream(input_stream()),

--- a/tonic-build/src/client.rs
+++ b/tonic-build/src/client.rs
@@ -6,7 +6,7 @@ use crate::{
     generate_doc_comments, naive_snake_case,
 };
 use proc_macro2::TokenStream;
-use quote::{format_ident, quote};
+use quote::quote;
 
 pub(crate) fn generate_internal<T: Service>(
     service: &T,
@@ -226,7 +226,7 @@ fn generate_unary<T: Service>(
     compile_well_known_types: bool,
 ) -> TokenStream {
     let codec_name = syn::parse_str::<syn::Path>(method.codec_path()).unwrap();
-    let ident = format_ident!("{}", method.name());
+    let ident = quote::format_ident!("{}", method.name());
     let (request, response) = method.request_response_name(proto_path, compile_well_known_types);
     let service_name = format_service_name(service, emit_package);
     let path = format_method_path(service, method, emit_package);
@@ -257,7 +257,7 @@ fn generate_server_streaming<T: Service>(
     compile_well_known_types: bool,
 ) -> TokenStream {
     let codec_name = syn::parse_str::<syn::Path>(method.codec_path()).unwrap();
-    let ident = format_ident!("{}", method.name());
+    let ident = quote::format_ident!("{}", method.name());
     let (request, response) = method.request_response_name(proto_path, compile_well_known_types);
     let service_name = format_service_name(service, emit_package);
     let path = format_method_path(service, method, emit_package);
@@ -288,7 +288,7 @@ fn generate_client_streaming<T: Service>(
     compile_well_known_types: bool,
 ) -> TokenStream {
     let codec_name = syn::parse_str::<syn::Path>(method.codec_path()).unwrap();
-    let ident = format_ident!("{}", method.name());
+    let ident = quote::format_ident!("{}", method.name());
     let (request, response) = method.request_response_name(proto_path, compile_well_known_types);
     let service_name = format_service_name(service, emit_package);
     let path = format_method_path(service, method, emit_package);
@@ -297,7 +297,7 @@ fn generate_client_streaming<T: Service>(
     quote! {
         pub async fn #ident(
             &mut self,
-            request: impl tonic::IntoStreamingRequest<Message = #request>
+            request: impl tonic::IntoStreamingRequest<Message = std::result::Result<#request, tonic::Status>>
         ) -> std::result::Result<tonic::Response<#response>, tonic::Status> {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
@@ -319,7 +319,7 @@ fn generate_streaming<T: Service>(
     compile_well_known_types: bool,
 ) -> TokenStream {
     let codec_name = syn::parse_str::<syn::Path>(method.codec_path()).unwrap();
-    let ident = format_ident!("{}", method.name());
+    let ident = quote::format_ident!("{}", method.name());
     let (request, response) = method.request_response_name(proto_path, compile_well_known_types);
     let service_name = format_service_name(service, emit_package);
     let path = format_method_path(service, method, emit_package);
@@ -328,7 +328,7 @@ fn generate_streaming<T: Service>(
     quote! {
         pub async fn #ident(
             &mut self,
-            request: impl tonic::IntoStreamingRequest<Message = #request>
+            request: impl tonic::IntoStreamingRequest<Message = std::result::Result<#request, tonic::Status>>
         ) -> std::result::Result<tonic::Response<tonic::codec::Streaming<#response>>, tonic::Status> {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::unknown(format!("Service was not ready: {}", e.into()))

--- a/tonic-reflection/src/generated/grpc_reflection_v1.rs
+++ b/tonic-reflection/src/generated/grpc_reflection_v1.rs
@@ -229,7 +229,10 @@ pub mod server_reflection_client {
         pub async fn server_reflection_info(
             &mut self,
             request: impl tonic::IntoStreamingRequest<
-                Message = super::ServerReflectionRequest,
+                Message = std::result::Result<
+                    super::ServerReflectionRequest,
+                    tonic::Status,
+                >,
             >,
         ) -> std::result::Result<
             tonic::Response<tonic::codec::Streaming<super::ServerReflectionResponse>>,

--- a/tonic-reflection/src/generated/grpc_reflection_v1alpha.rs
+++ b/tonic-reflection/src/generated/grpc_reflection_v1alpha.rs
@@ -229,7 +229,10 @@ pub mod server_reflection_client {
         pub async fn server_reflection_info(
             &mut self,
             request: impl tonic::IntoStreamingRequest<
-                Message = super::ServerReflectionRequest,
+                Message = std::result::Result<
+                    super::ServerReflectionRequest,
+                    tonic::Status,
+                >,
             >,
         ) -> std::result::Result<
             tonic::Response<tonic::codec::Streaming<super::ServerReflectionResponse>>,

--- a/tonic/src/client/grpc.rs
+++ b/tonic/src/client/grpc.rs
@@ -218,7 +218,7 @@ impl<T> Grpc<T> {
         M1: Send + Sync + 'static,
         M2: Send + Sync + 'static,
     {
-        let request = request.map(|m| tokio_stream::once(m));
+        let request = request.map(|m| tokio_stream::once(Ok(m)));
         self.client_streaming(request, path, codec).await
     }
 
@@ -233,7 +233,7 @@ impl<T> Grpc<T> {
         T: GrpcService<Body>,
         T::ResponseBody: HttpBody + Send + 'static,
         <T::ResponseBody as HttpBody>::Error: Into<crate::BoxError>,
-        S: Stream<Item = M1> + Send + 'static,
+        S: Stream<Item = Result<M1, Status>> + Send + 'static,
         C: Codec<Encode = M1, Decode = M2>,
         M1: Send + Sync + 'static,
         M2: Send + Sync + 'static,
@@ -274,7 +274,7 @@ impl<T> Grpc<T> {
         M1: Send + Sync + 'static,
         M2: Send + Sync + 'static,
     {
-        let request = request.map(|m| tokio_stream::once(m));
+        let request = request.map(|m| tokio_stream::once(Ok(m)));
         self.streaming(request, path, codec).await
     }
 
@@ -289,7 +289,7 @@ impl<T> Grpc<T> {
         T: GrpcService<Body>,
         T::ResponseBody: HttpBody + Send + 'static,
         <T::ResponseBody as HttpBody>::Error: Into<crate::BoxError>,
-        S: Stream<Item = M1> + Send + 'static,
+        S: Stream<Item = Result<M1, Status>> + Send + 'static,
         C: Codec<Encode = M1, Decode = M2>,
         M1: Send + Sync + 'static,
         M2: Send + Sync + 'static,
@@ -298,7 +298,7 @@ impl<T> Grpc<T> {
             .map(|s| {
                 EncodeBody::new_client(
                     codec.encoder(),
-                    s.map(Ok),
+                    s,
                     self.config.send_compression_encodings,
                     self.config.max_encoding_message_size,
                 )


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/hyperium/tonic/blob/master/CONTRIBUTING.md
-->

Close issue: https://github.com/hyperium/tonic/issues/1758

## Solution

1.  `GRPC::client_streaming` accepts `Result<M1, Status>` instead `M1`
2. Change `tonic-build` 
3. Fix `examples`, `interop`, `tests`, `tonic-reflection`, etc...

