### PR TITLE
grpc: change the LB policy config parsing API to accept JSON values instead of String

### DIFF
--- a/grpc/Cargo.toml
+++ b/grpc/Cargo.toml
@@ -10,3 +10,5 @@ url = "2.5.0"
 tokio = { version = "1.37.0", features = ["sync"] }
 tonic = { version = "0.13.0", path = "../tonic", default-features = false, features = ["codegen"] }
 futures-core = "0.3.31"
+serde_json = "1.0.140"
+serde = "1.0.219"

--- a/grpc/src/client/load_balancing/mod.rs
+++ b/grpc/src/client/load_balancing/mod.rs
@@ -48,6 +48,31 @@ pub trait WorkScheduler: Send + Sync {
     fn schedule_work(&self);
 }
 
+/// Abstract representation of the configuration for any LB policy, stored as
+/// JSON.  Hides internal storage details and includes a method to deserialize
+/// the JSON into a concrete policy struct.
+#[derive(Debug)]
+pub struct ParsedJsonLbConfig(pub serde_json::Value);
+
+impl ParsedJsonLbConfig {
+    /// Converts the JSON configuration into a concrete type that represents the
+    /// configuration of an LB policy.
+    ///
+    /// This will typically be used by the LB policy builder to parse the
+    /// configuration into a type that can be used by the LB policy.
+    pub fn convert_to<T: serde::de::DeserializeOwned>(
+        &self,
+    ) -> Result<T, Box<dyn Error + Send + Sync>> {
+        let res: T = match serde_json::from_value(self.0.clone()) {
+            Ok(v) => v,
+            Err(e) => {
+                return Err(format!("{}", e).into());
+            }
+        };
+        Ok(res)
+    }
+}
+
 /// An LB policy factory that produces LbPolicy instances used by the channel
 /// to manage connections and pick connections for RPCs.
 pub trait LbPolicyBuilder: Send + Sync {
@@ -69,7 +94,7 @@ pub trait LbPolicyBuilder: Send + Sync {
     /// default implementation returns Ok(None).
     fn parse_config(
         &self,
-        _config: &str,
+        _config: &ParsedJsonLbConfig,
     ) -> Result<Option<LbConfig>, Box<dyn Error + Send + Sync>> {
         Ok(None)
     }
@@ -235,9 +260,9 @@ pub struct Pick {
 ///
 /// - READY transitions to IDLE when the connection is lost.
 ///
-/// - TRANSIENT_FAILURE transitions to CONNECTING when the reconnect backoff
-///   timer has expired.  This timer scales exponentially and is reset when the
-///   subchannel becomes READY.
+/// - TRANSIENT_FAILURE transitions to IDLE when the reconnect backoff timer has
+///   expired.  This timer scales exponentially and is reset when the subchannel
+///   becomes READY.
 ///
 /// When a Subchannel is dropped, it is disconnected, and no subsequent state
 /// updates will be provided for it to the LB policy.


### PR DESCRIPTION
The existing `parse_config` method on the `LbPolicyBuilder` trait accepts configuration as a `&str`.  Passing parsed JSON to this API is better for the following reasons:
- the LB policy configuration is part of the ServiceConfig which is also represented as JSON. The channel would parse the service config before even attempting to send the LB policy configuration portion of the ServiceConfig to the LB policy builder. Therefore, the LB policy configuration is already available as parsed JSON.
- Aligns better with other gRPC languages (except Go).
