### PR TITLE
chore(grpc): Remove once_cell dependency

### DIFF
--- a/grpc/Cargo.toml
+++ b/grpc/Cargo.toml
@@ -14,7 +14,6 @@ http = "1.1.0"
 http-body = "1.0.1"
 hyper = { version = "1.6.0", features = ["client", "http2"] }
 hyper-util = "0.1.14"
-once_cell = "1.19.0"
 parking_lot = "0.12.4"
 pin-project-lite = "0.2.16"
 rand = "0.9"
@@ -43,5 +42,4 @@ allowed_external_types = [
     "tonic::*",
     "futures_core::stream::Stream",
     "tokio::sync::oneshot::Sender",
-    "once_cell::sync::Lazy",
 ]

--- a/grpc/src/client/load_balancing/registry.rs
+++ b/grpc/src/client/load_balancing/registry.rs
@@ -1,9 +1,7 @@
 use std::{
     collections::HashMap,
-    sync::{Arc, Mutex},
+    sync::{Arc, LazyLock, Mutex},
 };
-
-use once_cell::sync::Lazy;
 
 use super::LbPolicyBuilder;
 
@@ -39,4 +37,4 @@ impl Default for LbPolicyRegistry {
 
 /// The registry used if a local registry is not provided to a channel or if it
 /// does not exist in the local registry.
-pub static GLOBAL_LB_REGISTRY: Lazy<LbPolicyRegistry> = Lazy::new(LbPolicyRegistry::new);
+pub static GLOBAL_LB_REGISTRY: LazyLock<LbPolicyRegistry> = LazyLock::new(LbPolicyRegistry::new);

--- a/grpc/src/client/transport/registry.rs
+++ b/grpc/src/client/transport/registry.rs
@@ -1,9 +1,7 @@
 use std::{
     collections::HashMap,
-    sync::{Arc, Mutex},
+    sync::{Arc, LazyLock, Mutex},
 };
-
-use once_cell::sync::Lazy;
 
 use super::Transport;
 
@@ -59,4 +57,5 @@ impl Default for TransportRegistry {
 
 /// The registry used if a local registry is not provided to a channel or if it
 /// does not exist in the local registry.
-pub static GLOBAL_TRANSPORT_REGISTRY: Lazy<TransportRegistry> = Lazy::new(TransportRegistry::new);
+pub static GLOBAL_TRANSPORT_REGISTRY: LazyLock<TransportRegistry> =
+    LazyLock::new(TransportRegistry::new);

--- a/grpc/src/inmemory/mod.rs
+++ b/grpc/src/inmemory/mod.rs
@@ -3,7 +3,7 @@ use std::{
     ops::Add,
     sync::{
         atomic::{AtomicU32, Ordering},
-        Arc,
+        Arc, LazyLock,
     },
 };
 
@@ -18,7 +18,6 @@ use crate::{
     server,
     service::{Request, Response, Service},
 };
-use once_cell::sync::Lazy;
 use tokio::sync::{mpsc, oneshot, Mutex, Notify};
 use tonic::async_trait;
 
@@ -93,8 +92,8 @@ impl crate::server::Listener for Arc<Listener> {
     }
 }
 
-static LISTENERS: Lazy<std::sync::Mutex<HashMap<String, Arc<Listener>>>> =
-    Lazy::new(std::sync::Mutex::default);
+static LISTENERS: LazyLock<std::sync::Mutex<HashMap<String, Arc<Listener>>>> =
+    LazyLock::new(std::sync::Mutex::default);
 
 struct ClientTransport {}
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/hyperium/tonic/blob/master/CONTRIBUTING.md
-->

## Motivation

The standard library provides `LazyLock`.

## Solution

Replaces `once_cell::sync::Lazy` with `LazyLock`.