### PR TITLE
chore(grpc): Remove direct dependent on futures-core and futures-util

### DIFF
--- a/grpc/Cargo.toml
+++ b/grpc/Cargo.toml
@@ -7,8 +7,6 @@ license = "MIT"
 
 [dependencies]
 bytes = "1.10.1"
-futures-core = "0.3.31"
-futures-util = "0.3.31"
 hickory-resolver = { version = "0.25.1", optional = true }
 http = "1.1.0"
 http-body = "1.0.1"

--- a/grpc/examples/inmemory.rs
+++ b/grpc/examples/inmemory.rs
@@ -1,8 +1,8 @@
 use std::any::Any;
 
-use futures_util::stream::StreamExt;
 use grpc::service::{Message, Request, Response, Service};
 use grpc::{client::ChannelOptions, inmemory};
+use tokio_stream::StreamExt;
 use tonic::async_trait;
 
 struct Handler {}

--- a/grpc/examples/multiaddr.rs
+++ b/grpc/examples/multiaddr.rs
@@ -1,8 +1,8 @@
 use std::any::Any;
 
-use futures_util::StreamExt;
 use grpc::service::{Message, Request, Response, Service};
 use grpc::{client::ChannelOptions, inmemory};
+use tokio_stream::StreamExt;
 use tonic::async_trait;
 
 struct Handler {

--- a/grpc/src/service.rs
+++ b/grpc/src/service.rs
@@ -24,7 +24,7 @@
 
 use std::{any::Any, pin::Pin};
 
-use futures_core::Stream;
+use tokio_stream::Stream;
 use tonic::{async_trait, Request as TonicRequest, Response as TonicResponse, Status};
 
 pub type Request = TonicRequest<Pin<Box<dyn Stream<Item = Box<dyn Message>> + Send + Sync>>>;


### PR DESCRIPTION
Removes the direct dependent on futures-core and futures-util crates.