### PR TITLE
fix: relax MSRV for most packages

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-rust-version = "1.86"
+rust-version = "1.85"
 
 [workspace.lints.rust]
 missing_debug_implementations = "warn"

--- a/grpc/Cargo.toml
+++ b/grpc/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.9.0-alpha.1"
 edition = "2021"
 authors = ["gRPC Authors"]
 license = "MIT"
+rust-version = "1.86"
 
 [dependencies]
 bytes = "1.10.1"


### PR DESCRIPTION
Relax the MSRV to `1.85` for most packages, which was bumped in 
#2338. Override it in `grpc` which requires `1.86`.

Tested with:

```sh
cargo +1.85 build -p tonic -p tonic-build -p tonic-prost -p tonic-prost-build --all-features --all-targets
cargo build -p grpc --all-features --all-targets
```

