### PR TITLE
feat(prost-build): Add `service_generator` method to `Builder`

### DIFF
--- a/tonic-prost-build/src/lib.rs
+++ b/tonic-prost-build/src/lib.rs
@@ -312,8 +312,6 @@ struct ServiceGenerator {
     compile_well_known_types: bool,
     codec_path: String,
     disable_comments: HashSet<String>,
-    #[allow(dead_code)]
-    out_dir: PathBuf,
 }
 
 impl ServiceGenerator {
@@ -331,7 +329,6 @@ impl ServiceGenerator {
         compile_well_known_types: bool,
         codec_path: String,
         disable_comments: HashSet<String>,
-        out_dir: PathBuf,
     ) -> Self {
         ServiceGenerator {
             build_client,
@@ -345,7 +342,6 @@ impl ServiceGenerator {
             compile_well_known_types,
             codec_path,
             disable_comments,
-            out_dir,
         }
     }
 }
@@ -794,7 +790,6 @@ impl Builder {
                 self.compile_well_known_types,
                 self.codec_path.clone(),
                 self.disable_comments,
-                out_dir,
             );
 
             config.service_generator(Box::new(service_generator));
@@ -897,7 +892,6 @@ impl Builder {
                 self.compile_well_known_types,
                 self.codec_path.clone(),
                 self.disable_comments,
-                out_dir,
             );
 
             config.service_generator(Box::new(service_generator));
@@ -906,5 +900,23 @@ impl Builder {
         config.compile_fds(fds)?;
 
         Ok(())
+    }
+
+    /// Turn the builder into a `ServiceGenerator` ready to be passed to `prost-build`s
+    /// `Config::service_generator`.
+    pub fn service_generator(self) -> Box<dyn prost_build::ServiceGenerator> {
+        Box::new(ServiceGenerator::new(
+            self.build_client,
+            self.build_server,
+            self.build_transport,
+            self.client_attributes,
+            self.server_attributes,
+            self.use_arc_self,
+            self.generate_default_stubs,
+            self.proto_path,
+            self.compile_well_known_types,
+            self.codec_path.clone(),
+            self.disable_comments,
+        ))
     }
 }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/hyperium/tonic/blob/master/CONTRIBUTING.md
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? If a new feature is being added, describe the intended
use case that feature fulfills.
-->

Tonic v0.13 had [a `service_generator` method on `tonic_build::Builder`](https://docs.rs/tonic-build/0.13.1/tonic_build/struct.Builder.html#method.service_generator), which allowed retrieving the `prost_build::ServiceGenerator` implementation for more advanced customization. This method was removed in v0.14, but would still be useful to have in `tonic_prost_build`.

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

This adds back the `service_generator` method to `tonic_prost_build::Builder`. The previous implementation of `service_generator` is [here](https://github.com/hyperium/tonic/blob/v0.13.1/tonic-build/src/prost.rs#L703-L707).

I've also removed the `out_dir` field from the `Builder` struct since this was not used and would require the `service_generator` method definition to differ from v0.13.

I've duplicated the `ServiceGenerator::new` call since this was already duplicated between `compile_with_config` and `compile_fds_with_config`. Instead of duplicating the `ServiceGenerator::new` call, should I change the other calls from `ServiceGenerator::new` to `self.service_generator()`?
