### PR TITLE
chore(tonic): Fix to remove documentation for prost feature flag

### DIFF
--- a/tonic/src/lib.rs
+++ b/tonic/src/lib.rs
@@ -32,7 +32,6 @@
 //!   [`rustls-native-certs`] crate. Not enabled by default.
 //! - `tls-webpki-roots`: Add the standard trust roots from the [`webpki-roots`] crate to
 //!   `rustls`-based gRPC clients. Not enabled by default.
-//! - `prost`: Enables the [`prost`] based gRPC [`Codec`] implementation. Enabled by default.
 //! - `gzip`: Enables compressing requests, responses, and streams. Depends on [`flate2`].
 //!   Not enabled by default.
 //! - `deflate`: Enables compressing requests, responses, and streams. Depends on [`flate2`].


### PR DESCRIPTION
The `prost` feature toggle was removed in `tonic` v0.14, but it remains in the crate documentation. This Pull Request will remove it.

## Motivation

I want to fix the discrepancy between the documentation and the code.

## Solution

Removed non-existent prost feature flag from documentation.