### PR TITLE
chore(doc): Add link definition to aws-lc-rs crate

### DIFF
--- a/tonic/src/lib.rs
+++ b/tonic/src/lib.rs
@@ -74,6 +74,7 @@
 //! [`tower`]: https://docs.rs/tower
 //! [`tonic-build`]: https://docs.rs/tonic-build
 //! [`ring`]: https://docs.rs/ring
+//! [`aws-lc-rs`]: https://docs.rs/aws-lc-rs
 //! [`tonic-examples`]: https://github.com/hyperium/tonic/tree/master/examples
 //! [`Codec`]: codec/trait.Codec.html
 //! [`Channel`]: transport/struct.Channel.html


### PR DESCRIPTION
## Motivation

Fixes that the `aws-lc-rs` link in the `tls-aws-lc` feature document does not work.

## Solution

Add a link definition to the `aws-lc-rs` crate.