### PR TITLE
chore: relax msrv for most crates

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -183,9 +183,9 @@ jobs:
         rust-version: ${{ steps.msrv.outputs.version }}
     - uses: taiki-e/install-action@cargo-no-dev-deps
     - uses: Swatinem/rust-cache@v2
-    # grpc has an higher MSRV so we exclude it
-    - run: cargo no-dev-deps --no-private check --all-features --workspace --exclude grpc
-    - run: cargo no-dev-deps --no-private doc --no-deps --all-features --workspace --exclude grpc
+    # we exlude crates that do not use rust-version = { workspace = true }
+    - run: cargo no-dev-deps --no-private check --all-features --workspace --exclude grpc --exclude tonic-protobuf\*
+    - run: cargo no-dev-deps --no-private doc --no-deps --all-features --workspace --exclude grpc --exclude tonic-protobuf\*
       env:
         RUSTDOCFLAGS: "-D warnings"
 

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -183,8 +183,9 @@ jobs:
         rust-version: ${{ steps.msrv.outputs.version }}
     - uses: taiki-e/install-action@cargo-no-dev-deps
     - uses: Swatinem/rust-cache@v2
-    - run: cargo no-dev-deps --no-private check --all-features
-    - run: cargo no-dev-deps --no-private doc --no-deps --all-features
+    # grpc has an higher MSRV so we exclude it
+    - run: cargo no-dev-deps --no-private check --all-features --workspace --exclude grpc
+    - run: cargo no-dev-deps --no-private doc --no-deps --all-features --workspace --exclude grpc
       env:
         RUSTDOCFLAGS: "-D warnings"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-rust-version = "1.82"
+rust-version = "1.75"
 
 [workspace.lints.rust]
 missing_debug_implementations = "warn"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-rust-version = "1.86"
+rust-version = "1.82"
 
 [workspace.lints.rust]
 missing_debug_implementations = "warn"

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ may be a good resource as it shows examples of many of the gRPC features.
 
 ### Rust Version
 
-`tonic`'s MSRV is `1.75`.
+`tonic`'s MSRV is `1.82`.
 
 ### Dependencies
 

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ may be a good resource as it shows examples of many of the gRPC features.
 
 ### Rust Version
 
-`tonic`'s MSRV is `1.82`.
+`tonic`'s MSRV is `1.75`.
 
 ### Dependencies
 

--- a/grpc/Cargo.toml
+++ b/grpc/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.9.0-alpha.1"
 edition = "2021"
 authors = ["gRPC Authors"]
 license = "MIT"
+rust-version = "1.86"
 
 [dependencies]
 bytes = "1.10.1"

--- a/tonic/src/codec/compression.rs
+++ b/tonic/src/codec/compression.rs
@@ -4,7 +4,7 @@ use bytes::{Buf, BufMut, BytesMut};
 use flate2::read::{GzDecoder, GzEncoder};
 #[cfg(feature = "deflate")]
 use flate2::read::{ZlibDecoder, ZlibEncoder};
-use std::fmt;
+use std::{borrow::Cow, fmt};
 #[cfg(feature = "zstd")]
 use zstd::stream::read::{Decoder, Encoder};
 
@@ -152,8 +152,8 @@ impl CompressionEncoding {
             b"identity" => Ok(None),
             other => {
                 let other = match std::str::from_utf8(other) {
-                    Ok(s) => s,
-                    Err(_) => &format!("{other:?}"),
+                    Ok(s) => Cow::Borrowed(s),
+                    Err(_) => Cow::Owned(format!("{other:?}")),
                 };
 
                 let mut status = Status::unimplemented(format!(


### PR DESCRIPTION
## Motivation
Closes #2361 

## Solution
Relax version of the workspace to 1.75 ~~1.82~~, specify msrv for `grpc` crate as 1.86.
Exclude `grpc` and `tonic-protobuf*` from msrv check. They require a higher msrv and they do not specify `rust-version = { workspace = true }`.

A small code change is used because we cannot rely on automatic lifetime extension of temporaries.

~~Without the `grpc` crate we would need to bump only to 1.79 because of `protobuf-codegen v4.31.1-release`.~~
~~With `grpc` we need 1.82 because of `icu_*` crates.~~

~~We could move grpc to another workspace to avoid bumping the tonic to 1.82, but I don't think is worth it.~~