### PR TITLE
chore(ci): Update to cargo-check-external-types 0.3.0

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -268,11 +268,11 @@ jobs:
     - uses: actions/checkout@v4
     - uses: dtolnay/rust-toolchain@master
       with:
-        toolchain: nightly-2025-05-04
+        toolchain: nightly-2025-08-06
     - name: Install cargo-check-external-types
       uses: taiki-e/cache-cargo-install-action@v2
       with:
-        tool: cargo-check-external-types@0.2.0
+        tool: cargo-check-external-types@0.3.0
     - uses: taiki-e/install-action@cargo-hack
     - uses: Swatinem/rust-cache@v2
     - run: cargo hack --no-private check-external-types --all-features


### PR DESCRIPTION
Updates to cargo-check-external-types 0.3.0.