### PR TITLE
chore(ci): pin protoc version

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -82,7 +82,9 @@ jobs:
     - uses: hecrj/setup-rust-action@v2
       with:
         components: clippy
-    - uses: taiki-e/install-action@protoc
+    - uses: taiki-e/install-action@v2
+      with:
+        tool: protoc@3.31.1
     - name: Restore protoc plugin from cache
       id: cache-plugin
       uses: actions/cache@v4
@@ -115,7 +117,9 @@ jobs:
         toolchain: nightly-2025-03-27
     - uses: taiki-e/install-action@cargo-hack
     - uses: taiki-e/install-action@cargo-udeps
-    - uses: taiki-e/install-action@protoc
+    - uses: taiki-e/install-action@v2
+      with:
+        tool: protoc@3.31.1
     - name: Restore protoc plugin from cache
       id: cache-plugin
       uses: actions/cache@v4
@@ -147,7 +151,9 @@ jobs:
     - uses: actions/checkout@v4
     - uses: hecrj/setup-rust-action@v2
     - uses: taiki-e/install-action@cargo-hack
-    - uses: taiki-e/install-action@protoc
+    - uses: taiki-e/install-action@v2
+      with:
+        tool: protoc@3.31.1
     - name: Restore protoc plugin from cache
       id: cache-plugin
       uses: actions/cache@v4
@@ -198,7 +204,9 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - uses: hecrj/setup-rust-action@v2
-    - uses: taiki-e/install-action@protoc
+    - uses: taiki-e/install-action@v2
+      with:
+        tool: protoc@3.31.1
     - name: Restore protoc plugin from cache
       id: cache-plugin
       uses: actions/cache@v4
@@ -235,7 +243,9 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - uses: hecrj/setup-rust-action@v2
-    - uses: taiki-e/install-action@protoc
+    - uses: taiki-e/install-action@v2
+      with:
+        tool: protoc@3.31.1
     - name: Restore protoc plugin from cache
       id: cache-plugin
       uses: actions/cache@v4


### PR DESCRIPTION
Fixes: https://github.com/hyperium/tonic/issues/2386

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

If this change is intended for tonic `v0.14.x` please make this PR against that branch
otherwise, it may not get included in a relase for a long time.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/hyperium/tonic/blob/master/CONTRIBUTING.md
-->

Interop tests are failing since the [protobuf codegen requires the same version as protoc](https://github.com/protocolbuffers/protobuf/blob/2ae8154f366a6d776bcc3ac931413bc4d99f578e/rust/release_crates/protobuf_codegen/src/lib.rs#L136-L148) to work. This PR pins the protoc version to fix the tests.