### PR TITLE
feat(tonic): add From<BoxError> implementation for tonic::transport::Error

### DIFF
--- a/tonic/src/transport/error.rs
+++ b/tonic/src/transport/error.rs
@@ -90,3 +90,9 @@ impl StdError for Error {
             .map(|source| &**source as &(dyn StdError + 'static))
     }
 }
+
+impl From<crate::BoxError> for Error {
+    fn from(value: crate::BoxError) -> Self {
+        Self::from_source(value)
+    }
+}


### PR DESCRIPTION
Addresses https://github.com/hyperium/tonic/issues/978

This PR keeps the `tonic::transport::Error` constructor methods private while allowing external users to map `BoxError`s into `tonic::transpoert::Error`, which makes it possible to do something like:

```rust
fn test() -> Result<(), crate::transport::Error> {
    let err = Err(crate::BoxError::from("test"));
    err?;
    Ok(())
}
```

More details about why users would want to build `tonic::transport::Error` in the issue.

Also, completely open to alternatives.