### PR TITLE
Improve `Status` formatting

### DIFF
--- a/tonic/src/status.rs
+++ b/tonic/src/status.rs
@@ -748,14 +748,19 @@ impl From<std::io::Error> for Status {
 
 impl fmt::Display for Status {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(
-            f,
-            "status: {:?}, message: {:?}, details: {:?}, metadata: {:?}",
-            self.code(),
-            self.message(),
-            self.details(),
-            self.metadata(),
-        )
+        write!(f, "status: '{}'", self.code())?;
+
+        if !self.message().is_empty() {
+            write!(f, ", self: {:?}", self.message())?;
+        }
+        // Binary data - not useful to human eyes.
+        // if !self.details().is_empty() {
+        //     write!(f, ", details: {:?}", self.details())?;
+        // }
+        if !self.metadata().is_empty() {
+            write!(f, ", metadata: {:?}", self.metadata().as_ref())?;
+        }
+        Ok(())
     }
 }
 


### PR DESCRIPTION
## Motivation
The `Status` struct is the canonical error message in `tonic`. Printing it currently prints out a very verbose and difficult-to-read message.

## Solution
Improve `impl, Display for status` by:

* Only printing the `message` if it is non-empty
* Only printing the `metadata` if it is non-empty`
* Always omitting the binary `details` (printing out `details: [22, 51, 50, 48, 51, 53, 98, 57, 50, 55, 50, 55, 100, 54, 101, …]` is not helping anyone)