### PR TITLE
Expose connectors constructed from `Endpoint`

### DIFF
--- a/tonic/src/transport/channel/mod.rs
+++ b/tonic/src/transport/channel/mod.rs
@@ -7,7 +7,7 @@ mod tls;
 mod uds_connector;
 
 pub use self::service::Change;
-pub use endpoint::Endpoint;
+pub use endpoint::{Endpoint, ServiceTrait};
 #[cfg(feature = "_tls-any")]
 pub use tls::ClientTlsConfig;
 


### PR DESCRIPTION
This change exposes the `Endpoint::http_connector()` and `Endpoint::uds_connector()` constructed by the `Endpoint` type. The motivation for exposing these types is to allow users to wrap the tonic provided Connectors into a e.g. a proxy service (like that one provided by hyper-utils). I decided to explicitly use the opaque `impl Trait` variant here to prevent exposing too much internal details. The new trait is added to simplify expressing the relevant return trait, it's not strictly required for this change.