### PR TITLE
tonic-build/tonic-prost-build: Fix features docs

### DIFF
--- a/tonic-build/README.md
+++ b/tonic-build/README.md
@@ -1,13 +1,9 @@
 # tonic-build
 
-Provides code generation for service stubs to use with tonic. For protobuf compilation via prost, use the `tonic-prost-build` crate.
+Provides code generation for service stubs to use with tonic. For protobuf compilation via prost, use the `tonic-prost-build` crate instead.
 
 # Feature flags
 
-- `cleanup-markdown`: Enables cleaning up documentation from the generated code.
-  Useful when documentation of the generated code fails `cargo test --doc` for example.
-  The `prost` feature must be enabled to use this feature.
-- `prost`: Enables usage of prost generator (enabled by default).
 - `transport`: Enables generation of `connect` method using `tonic::transport::Channel`
   (enabled by default).
 

--- a/tonic-prost-build/README.md
+++ b/tonic-prost-build/README.md
@@ -20,7 +20,6 @@ fn main() {
 
 ## Features
 
-- `prost`: Enables prost-based protobuf code generation (enabled by default)
 - `transport`: Enables transport layer code generation
 - `cleanup-markdown`: Enables markdown cleanup in generated documentation
 


### PR DESCRIPTION
tonic-build: Only has the tranport feature now. It does not have prost or cleanup-markdown.

tonic-prost-build: It does not have the prost feature.