### PR TITLE
allow configuration of max_local_error_reset_streams

### DIFF
--- a/tonic/Cargo.toml
+++ b/tonic/Cargo.toml
@@ -75,7 +75,7 @@ async-trait = {version = "0.1.13", optional = true}
 # transport
 h2 = {version = "0.4", optional = true}
 hyper = {version = "1", features = ["http1", "http2"], optional = true}
-hyper-util = { version = "0.1.4", features = ["tokio"], optional = true }
+hyper-util = { version = "0.1.11", features = ["tokio"], optional = true }
 socket2 = { version = "0.6", optional = true, features = ["all"] }
 tokio = {version = "1", default-features = false, optional = true}
 tower = {version = "0.5", default-features = false, optional = true}


### PR DESCRIPTION
Squashed version of https://github.com/hyperium/tonic/pull/2421 applied to `master`.