### PR TITLE
grpc: use pointers for load_balancing::WeakSubchannel hash/eq operations

### DIFF
--- a/grpc/src/client/load_balancing/mod.rs
+++ b/grpc/src/client/load_balancing/mod.rs
@@ -31,6 +31,7 @@ use std::{
     fmt::{Debug, Display},
     hash::{Hash, Hasher},
     ops::{Add, Sub},
+    ptr::addr_eq,
     sync::{
         atomic::{AtomicI64, Ordering::Relaxed},
         Arc, Mutex, Weak,
@@ -456,21 +457,13 @@ impl WeakSubchannel {
 
 impl Hash for WeakSubchannel {
     fn hash<H: Hasher>(&self, state: &mut H) {
-        if let Some(strong) = self.upgrade() {
-            return strong.dyn_hash(&mut Box::new(state as &mut dyn Hasher));
-        }
-        panic!("WeakSubchannel is not valid");
+        (self.0.as_ptr() as *const () as usize).hash(state);
     }
 }
 
 impl PartialEq for WeakSubchannel {
     fn eq(&self, other: &Self) -> bool {
-        if let Some(strong_self) = self.upgrade() {
-            if let Some(strong_other) = other.upgrade() {
-                return strong_self.dyn_eq(&Box::new(&strong_other as &dyn Any));
-            }
-        }
-        false
+        addr_eq(self.0.as_ptr(), other.0.as_ptr())
     }
 }
 


### PR DESCRIPTION
This is an old change that I found in my client that never got pushed upstream, but is worth having.

Upgrading weak to owned before performing these operations is more expensive.  Just using the pointer is simpler and quicker and equally valid.
