### PR TITLE
feat(grpc): make ChildManager call the parent work_scheduler

### DIFF
--- a/grpc/src/client/load_balancing/mod.rs
+++ b/grpc/src/client/load_balancing/mod.rs
@@ -59,6 +59,7 @@ pub(crate) use registry::GLOBAL_LB_REGISTRY;
 
 /// A collection of data configured on the channel that is constructing this
 /// LbPolicy.
+#[derive(Debug)]
 pub(crate) struct LbPolicyOptions {
     /// A hook into the channel's work scheduler that allows the LbPolicy to
     /// request the ability to perform operations on the ChannelController.


### PR DESCRIPTION
This is based on top of #2442; please review only the final commit in this PR.

I found this pattern for writing tests to be painful.  I will try to spend some time working on another approach.

The main problem I had with the tests was that the test_utils mod creates the `StubPolicy` and `StubPolicyData` meaning the tests have a hard time observing what the children Funcs did except by observing what was called on the child_controller or work_scheduler.