### PR TITLE
feat(server): Implement Clone for Router

### DIFF
--- a/tonic/src/transport/server/mod.rs
+++ b/tonic/src/transport/server/mod.rs
@@ -141,7 +141,7 @@ impl Default for Server<Identity> {
 
 /// A stack based [`Service`] router.
 #[cfg(feature = "router")]
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct Router<L = Identity> {
     server: Server<L>,
     routes: Routes,


### PR DESCRIPTION
## Motivation

Users of Tonic may want to serve the same collection of routes and services multiple times, either because the transport failed, or because they want to serve it across different transports. They may thus want to clone the `Router` itself and reuse it.

## Solution

Because both fields of `Router` are trivially cloneable (both `Server` and `Routes` derive `Clone`), we can derive `Clone` for `Router` as well.

## Alternatives
Consumers of Tonic can circumvent the lack of `Clone` on `Router` by maintaining separate `server` and `routes` fields themselves, but this is the entire purpose of the `Router` struct, and seems suboptimal. A minimal illustrative example:
```rust
struct MyCoolServer {
    addr: SocketAddr,
    server: Server,
    routes: Routes,
}

impl MyCoolServer {
    pub async fn start(self) {
        loop {
            let server = self.server.clone();
            let routes = self.routes.clone().prepare();

            if let Err(e) = self.server.clone().serve(self.addr.clone(), self.routes.clone()) {
                // Optionally log error and perform some recovery logic
            } else {
                // Optionally exit the loop or restart
            }
        }
    }
}
```