### PR TITLE
Return a Result type from the PersistentChannel instead of unwrapping.

### DIFF
--- a/grpc/examples/inmemory.rs
+++ b/grpc/examples/inmemory.rs
@@ -46,7 +46,8 @@ async fn main() {
 
     println!("Creating channel for {}", lis.target());
     let chan_opts = ChannelOptions::default();
-    let chan = grpc::client::Channel::new(lis.target().as_str(), None, chan_opts);
+    let chan = grpc::client::Channel::new(lis.target().as_str(), None, chan_opts)
+        .expect("Could not create channel");
 
     let outbound = async_stream::stream! {
         yield Box::new(MyReqMessage("My Request 1".to_string())) as Box<dyn Message>;

--- a/grpc/examples/multiaddr.rs
+++ b/grpc/examples/multiaddr.rs
@@ -70,7 +70,8 @@ async fn main() {
     let target = String::from("inmemory:///dummy");
     println!("Creating channel for {target}");
     let chan_opts = ChannelOptions::default();
-    let chan = grpc::client::Channel::new(target.as_str(), None, chan_opts);
+    let chan = grpc::client::Channel::new(target.as_str(), None, chan_opts)
+        .expect("Could not create channel.");
 
     let outbound = async_stream::stream! {
         yield Box::new(MyReqMessage("My Request 1".to_string())) as Box<dyn Message>;

--- a/grpc/src/client/channel.rs
+++ b/grpc/src/client/channel.rs
@@ -136,7 +136,6 @@ impl Channel {
     /// connection to a service.  Channel creation cannot fail, but if the
     /// target string is invalid, the returned channel will never connect, and
     /// will fail all RPCs.
-    // TODO: should this return a Result instead?
     pub fn new(
         target: &str,
         credentials: Option<Box<dyn Credentials>>,


### PR DESCRIPTION
Currently the PersistentChannel constructor panics if the URL cannot be parsed. This adds a check for a parse error and returns a corresponding Status::INVALID_ARGUMENT if the parse failed.  Using the Status struct should be conformant with the C++ implementation and the current tonic implementation.


## Motivation

Standardize error handling, handle a TODO.

## Solution

Using a Result object to return. The Status code is to conform with the [gRPC spec ](https://github.com/ejona86/grpc/blob/call-semantics/doc/PROTOCOL-SEMANTICS.md)