### PR TITLE
Separate channel creation and state probe, and error handling thereof.

### DIFF
--- a/grpc/src/client/channel.rs
+++ b/grpc/src/client/channel.rs
@@ -188,8 +188,8 @@ struct PersistentChannel {
 }
 
 impl PersistentChannel {
-    // Channels begin idle so new does not automatically connect.
-    // ChannelOptions are only non-required parameters.
+    // Channels begin idle so `new()` does not automatically connect.
+    // ChannelOption contain only optional parameters.
     fn new(
         target: &str,
         _credentials: Option<Box<dyn Credentials>>,


### PR DESCRIPTION
## Motivation

Currently the `Channel` object is calling into the `PersistentChannel` internals to do things like provision an active channel and check state. The division of where work and error handling is managed becomes muddied in this situation, which complicates handling errors in ways that aren't `unwrap`. 

This was also motivated by work to implement the always-failing PersistentChannel PR, but it seemed like it could be broken off into it's own PR.

## Solution

Moving the actual mechanics into the `PersistentChannel` object, which owns channel config, and allows `Channel` to be a lightweight handles for users to interact with. Specifically state probing and channel creation are now in `PersistentChannel`.

`PersistentChannel` calls are wrapped in `Result` objects that are translated at the `Channel` level to the appropriate public-facing API objects.  `get_or_create_active_channel()` just becomes `get_active_channel()` and passes the 'create' flag, which controls whether a new channel is created if it does not already exist.

The external semantics should stay the same as they have been.

This does not yet address the error that can surface in `call()`, because it's not yet clear what the error reporting story is. 