### PR TITLE
chore: fix documentation typos and grammar issues in status.rs and codec/mod.rs

### DIFF
--- a/tonic/src/codec/mod.rs
+++ b/tonic/src/codec/mod.rs
@@ -88,7 +88,7 @@ impl Default for BufferSettings {
     }
 }
 
-// Doc hidden because its used in tests in another crate but not part of the
+// Doc hidden because it's used in tests in another crate but not part of the
 // public api.
 #[doc(hidden)]
 pub const HEADER_SIZE: usize =
@@ -110,7 +110,7 @@ pub trait Codec {
 
     /// The encoder that can encode a message.
     type Encoder: Encoder<Item = Self::Encode, Error = Status> + Send + 'static;
-    /// The encoder that can decode a message.
+    /// The decoder that can decode a message.
     type Decoder: Decoder<Item = Self::Decode, Error = Status> + Send + 'static;
 
     /// Fetch the encoder.

--- a/tonic/src/status.rs
+++ b/tonic/src/status.rs
@@ -273,7 +273,7 @@ impl Status {
     ///
     /// Unlike `InvalidArgument`, this error indicates a problem that may be
     /// fixed if the system state changes. For example, a 32-bit file system will
-    /// generate `InvalidArgument if asked to read at an offset that is not in the
+    /// generate `InvalidArgument` if asked to read at an offset that is not in the
     /// range [0,2^32-1], but it will generate `OutOfRange` if asked to read from
     /// an offset past the current file size.
     ///


### PR DESCRIPTION


<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

If this change is intended for tonic `v0.14.x` please make this PR against that branch
otherwise, it may not get included in a relase for a long time.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/hyperium/tonic/blob/master/CONTRIBUTING.md
-->

## Motivation

This commit fixes several documentation issues:

1. Corrected missing backtick in InvalidArgument code formatting in status.rs

2. Fixed "its" to "it's" typo in codec/mod.rs

3. Corrected misleading comment that referred to "encoder" when it should be "decoder" in codec/mod.rs


<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? If a new feature is being added, describe the intended
use case that feature fulfills.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
