### PR TITLE
chore(ci): Update to cargo-check-external-types 0.4.0

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -427,11 +427,11 @@ jobs:
     - uses: actions/checkout@v6
     - uses: dtolnay/rust-toolchain@master
       with:
-        toolchain: nightly-2025-08-06
+        toolchain: nightly-2025-10-18
     - name: Install cargo-check-external-types
       uses: taiki-e/cache-cargo-install-action@v2
       with:
-        tool: cargo-check-external-types@0.3.0
+        tool: cargo-check-external-types@0.4.0
     - uses: taiki-e/install-action@cargo-hack
     - uses: Swatinem/rust-cache@v2
     - run: cargo hack --no-private check-external-types --all-features


### PR DESCRIPTION
Updates to `cargo-check-external-types` 0.4.0.

https://github.com/awslabs/cargo-check-external-types/releases/tag/v0.4.0