### PR TITLE
Remove metadata from `tonic::Status` `Display` impl.

### DIFF
--- a/tonic/src/status.rs
+++ b/tonic/src/status.rs
@@ -754,9 +754,8 @@ impl fmt::Display for Status {
             write!(f, ", message: {:?}", self.message())?;
         }
         // We intentionally omit `self.details` since it's binary data, not fit for human eyes.
-        if !self.metadata().is_empty() {
-            write!(f, ", metadata: {:?}", self.metadata().as_ref())?;
-        }
+        // Additionally, `self.metadata` contains low-level details that only belong in the `Debug`
+        // impl.
         if let Some(source) = self.source() {
             write!(f, ", source: {source:?}")?;
         }


### PR DESCRIPTION
Fixes #2480.