### PR TITLE
feat: allow get Grpc inner

### DIFF
--- a/grpc/src/generated/grpc_examples_echo.rs
+++ b/grpc/src/generated/grpc_examples_echo.rs
@@ -92,6 +92,14 @@ pub mod echo_client {
             self.inner = self.inner.max_encoding_message_size(limit);
             self
         }
+        /// Get the inner reference
+        pub fn get_inner(&self) -> &tonic::client::Grpc<T> {
+            &self.inner
+        }
+        /// Get the inner mutable reference
+        pub fn get_inner_mut(&mut self) -> &mut tonic::client::Grpc<T> {
+            &mut self.inner
+        }
         /// UnaryEcho is unary echo.
         pub async fn unary_echo(
             &mut self,

--- a/tonic-build/src/client.rs
+++ b/tonic-build/src/client.rs
@@ -130,6 +130,16 @@ pub(crate) fn generate_internal<T: Service>(
                     self
                 }
 
+                /// Get the inner reference
+                pub fn get_inner(&self) -> &tonic::client::Grpc<T> {
+                    &self.inner
+                }
+
+                /// Get the inner mutable reference
+                pub fn get_inner_mut(&mut self) -> &mut tonic::client::Grpc<T> {
+                    &mut self.inner
+                }
+
                 #methods
             }
         }

--- a/tonic-health/src/generated/grpc_health_v1.rs
+++ b/tonic-health/src/generated/grpc_health_v1.rs
@@ -135,6 +135,14 @@ pub mod health_client {
             self.inner = self.inner.max_encoding_message_size(limit);
             self
         }
+        /// Get the inner reference
+        pub fn get_inner(&self) -> &tonic::client::Grpc<T> {
+            &self.inner
+        }
+        /// Get the inner mutable reference
+        pub fn get_inner_mut(&mut self) -> &mut tonic::client::Grpc<T> {
+            &mut self.inner
+        }
         /// If the requested service is unknown, the call will fail with status
         /// NOT_FOUND.
         pub async fn check(

--- a/tonic-reflection/src/generated/grpc_reflection_v1.rs
+++ b/tonic-reflection/src/generated/grpc_reflection_v1.rs
@@ -224,6 +224,14 @@ pub mod server_reflection_client {
             self.inner = self.inner.max_encoding_message_size(limit);
             self
         }
+        /// Get the inner reference
+        pub fn get_inner(&self) -> &tonic::client::Grpc<T> {
+            &self.inner
+        }
+        /// Get the inner mutable reference
+        pub fn get_inner_mut(&mut self) -> &mut tonic::client::Grpc<T> {
+            &mut self.inner
+        }
         /// The reflection service is structured as a bidirectional stream, ensuring
         /// all related requests go to a single server.
         pub async fn server_reflection_info(

--- a/tonic-reflection/src/generated/grpc_reflection_v1alpha.rs
+++ b/tonic-reflection/src/generated/grpc_reflection_v1alpha.rs
@@ -224,6 +224,14 @@ pub mod server_reflection_client {
             self.inner = self.inner.max_encoding_message_size(limit);
             self
         }
+        /// Get the inner reference
+        pub fn get_inner(&self) -> &tonic::client::Grpc<T> {
+            &self.inner
+        }
+        /// Get the inner mutable reference
+        pub fn get_inner_mut(&mut self) -> &mut tonic::client::Grpc<T> {
+            &mut self.inner
+        }
         /// The reflection service is structured as a bidirectional stream, ensuring
         /// all related requests go to a single server.
         pub async fn server_reflection_info(

--- a/tonic/src/client/grpc.rs
+++ b/tonic/src/client/grpc.rs
@@ -318,6 +318,16 @@ impl<T> Grpc<T> {
         self.create_response(decoder, response)
     }
 
+    /// Get the inner reference
+    pub fn get_inner(&self) -> &T {
+        &self.inner
+    }
+
+    /// Get the inner mutable reference
+    pub fn get_inner_mut(&mut self) -> &mut T {
+        &mut self.inner
+    }
+
     // Keeping this code in a separate function from Self::streaming lets functions that return the
     // same output share the generated binary code
     fn create_response<M2>(


### PR DESCRIPTION
## Motivation

when user use custom channel implement, for example a dynamic channel, which can connect multi endpoints, and call `ban` method to ban the bad endpoints when rpc call is failed, with this PR user now can access the inner field

## Solution

add the getter methods to allow user access the inner field
