### PR TITLE
fix(ci): remove comment from manifest to unblock version parsing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,13 +9,13 @@ members = [
   "tonic-reflection",
   "tonic-prost",
   "tonic-prost-build",
-  "tonic-web", # Non-published crates
+  "tonic-web",
   "examples",
   "codegen",
   "grpc",
   "xds-client",
   "tonic-xds",
-  "interop", # Tests
+  "interop",
   "tests/disable_comments",
   "tests/wellknown",
   "tests/wellknown-compiled",


### PR DESCRIPTION
## Motivation

Ref: #2500 CI blocked because of `yq` failed to parse manifest with comments in array.

## Solution

Removing the comments from manifest.