### PR TITLE
fix(tonic-prost-build): restore missing emit_rerun_if_changed functionality

### DIFF
--- a/tonic-prost-build/src/lib.rs
+++ b/tonic-prost-build/src/lib.rs
@@ -795,6 +795,19 @@ impl Builder {
             config.service_generator(Box::new(service_generator));
         };
 
+        if self.emit_rerun_if_changed {
+            for path in protos.iter() {
+                println!("cargo:rerun-if-changed={}", path.as_ref().display())
+            }
+
+            for path in includes.iter() {
+                // Cargo will watch the **entire** directory recursively. If we
+                // could figure out which files are imported by our protos we
+                // could specify only those files instead.
+                println!("cargo:rerun-if-changed={}", path.as_ref().display())
+            }
+        }
+
         config.compile_protos(protos, includes)?;
 
         Ok(())


### PR DESCRIPTION
## Motivation

Solves issue where emit_rerun_if_changed is ignored.

Based on a cursory analysis it seems emit_rerun_if_changed was broken since the tonic-prost-build extraction:

- June 21, 2022 (commit 1d2083a1a690edcb): emit_rerun_if_changed feature added to tonic-build with working implementation
- July 25, 2025 (commit 969408eeb110115e): tonic-prost-build extracted from tonic-build - implementation accidentally omitted

Original implementation: https://github.com/hyperium/tonic/commit/1d2083a1a690edcb3f95343edfe229339c4257b7#diff-b0934b805d6c8c11cd87db5e7e77d3e5d2d72d5c72d36e16ce7e99516a8e6b84R435-R449

Extraction commit that lost the implementation: https://github.com/hyperium/tonic/commit/969408eeb110115e1f1d370f590d132346ca5fcf


## Solution

Restores the missing implementation that emits cargo:rerun-if-changed directives for proto files.