### PR TITLE
grpc(chore): reformat all imports: unnest and order (std, foreign, crate)

### DIFF
--- a/grpc/examples/inmemory.rs
+++ b/grpc/examples/inmemory.rs
@@ -24,11 +24,16 @@
 
 use std::any::Any;
 
-use grpc::credentials::InsecureChannelCredentials;
-use grpc::service::{Message, Request, Response, Service};
-use grpc::{client::ChannelOptions, inmemory};
 use tokio_stream::StreamExt;
 use tonic::async_trait;
+
+use grpc::client::ChannelOptions;
+use grpc::credentials::InsecureChannelCredentials;
+use grpc::inmemory;
+use grpc::service::Message;
+use grpc::service::Request;
+use grpc::service::Response;
+use grpc::service::Service;
 
 struct Handler {}
 

--- a/grpc/examples/multiaddr.rs
+++ b/grpc/examples/multiaddr.rs
@@ -24,11 +24,16 @@
 
 use std::any::Any;
 
-use grpc::credentials::InsecureChannelCredentials;
-use grpc::service::{Message, Request, Response, Service};
-use grpc::{client::ChannelOptions, inmemory};
 use tokio_stream::StreamExt;
 use tonic::async_trait;
+
+use grpc::client::ChannelOptions;
+use grpc::credentials::InsecureChannelCredentials;
+use grpc::inmemory;
+use grpc::service::Message;
+use grpc::service::Request;
+use grpc::service::Response;
+use grpc::service::Service;
 
 struct Handler {
     id: String,

--- a/grpc/src/client/channel.rs
+++ b/grpc/src/client/channel.rs
@@ -23,41 +23,59 @@
  */
 
 use core::panic;
-use std::{
-    any::Any,
-    error::Error,
-    mem,
-    str::FromStr,
-    sync::{Arc, Mutex},
-    time::{Duration, Instant},
-    vec,
-};
-
-use tokio::sync::{mpsc, watch, Notify};
+use std::any::Any;
+use std::error::Error;
+use std::mem;
+use std::str::FromStr;
+use std::sync::Arc;
+use std::sync::Mutex;
+use std::time::Duration;
+use std::time::Instant;
+use std::vec;
 
 use serde_json::json;
+use tokio::sync::mpsc;
+use tokio::sync::watch;
+use tokio::sync::Notify;
 use url::Url; // NOTE: http::Uri requires non-empty authority portion of URI
 
-use crate::rt::{default_runtime, GrpcEndpoint};
-use crate::service::{Request, Response, Service};
-use crate::{attributes::Attributes, credentials::ChannelCredentials};
-use crate::{client::ConnectivityState, rt::GrpcRuntime};
-use crate::{credentials::dyn_wrapper::DynChannelCredentials, rt};
-
-use super::name_resolution::{self, global_registry, Address, ResolverUpdate};
-use super::service_config::ServiceConfig;
-use super::transport::{TransportRegistry, GLOBAL_TRANSPORT_REGISTRY};
-use super::{
-    load_balancing::{
-        self, pick_first, ExternalSubchannel, LbPolicy, LbPolicyBuilder, LbPolicyOptions, LbState,
-        ParsedJsonLbConfig, PickResult, Picker, Subchannel, SubchannelState, WorkScheduler,
-        GLOBAL_LB_REGISTRY,
-    },
-    subchannel::{
-        InternalSubchannel, InternalSubchannelPool, NopBackoff, SubchannelKey,
-        SubchannelStateWatcher,
-    },
-};
+use crate::attributes::Attributes;
+use crate::client::load_balancing::pick_first;
+use crate::client::load_balancing::ExternalSubchannel;
+use crate::client::load_balancing::LbPolicy;
+use crate::client::load_balancing::LbPolicyBuilder;
+use crate::client::load_balancing::LbPolicyOptions;
+use crate::client::load_balancing::LbState;
+use crate::client::load_balancing::ParsedJsonLbConfig;
+use crate::client::load_balancing::PickResult;
+use crate::client::load_balancing::Picker;
+use crate::client::load_balancing::Subchannel;
+use crate::client::load_balancing::SubchannelState;
+use crate::client::load_balancing::WorkScheduler;
+use crate::client::load_balancing::GLOBAL_LB_REGISTRY;
+use crate::client::load_balancing::{self};
+use crate::client::name_resolution::global_registry;
+use crate::client::name_resolution::Address;
+use crate::client::name_resolution::ResolverUpdate;
+use crate::client::name_resolution::{self};
+use crate::client::service_config::ServiceConfig;
+use crate::client::subchannel::InternalSubchannel;
+use crate::client::subchannel::InternalSubchannelPool;
+use crate::client::subchannel::NopBackoff;
+use crate::client::subchannel::SubchannelKey;
+use crate::client::subchannel::SubchannelStateWatcher;
+use crate::client::transport::TransportRegistry;
+use crate::client::transport::GLOBAL_TRANSPORT_REGISTRY;
+use crate::client::ConnectivityState;
+use crate::credentials::dyn_wrapper::DynChannelCredentials;
+use crate::credentials::ChannelCredentials;
+use crate::rt;
+use crate::rt::default_runtime;
+use crate::rt::GrpcEndpoint;
+use crate::rt::GrpcRuntime;
+use crate::service::Request;
+use crate::service::Response;
+use crate::service::Service;
 
 #[non_exhaustive]
 pub struct ChannelOptions {

--- a/grpc/src/client/load_balancing/child_manager.rs
+++ b/grpc/src/client/load_balancing/child_manager.rs
@@ -29,21 +29,29 @@
 // policy in use.  Complete tests must be written before it can be used in
 // production.
 
+use std::collections::HashMap;
 use std::collections::HashSet;
 use std::error::Error;
 use std::fmt::Debug;
+use std::hash::Hash;
+use std::mem;
+use std::sync::Arc;
 use std::sync::Mutex;
-use std::{collections::HashMap, hash::Hash, mem, sync::Arc};
 
-use crate::client::load_balancing::{
-    ChannelController, LbConfig, LbPolicy, LbPolicyBuilder, LbPolicyOptions, LbState,
-    WeakSubchannel, WorkScheduler,
-};
-use crate::client::name_resolution::{Address, ResolverUpdate};
+use crate::client::load_balancing::ChannelController;
+use crate::client::load_balancing::LbConfig;
+use crate::client::load_balancing::LbPolicy;
+use crate::client::load_balancing::LbPolicyBuilder;
+use crate::client::load_balancing::LbPolicyOptions;
+use crate::client::load_balancing::LbState;
+use crate::client::load_balancing::Subchannel;
+use crate::client::load_balancing::SubchannelState;
+use crate::client::load_balancing::WeakSubchannel;
+use crate::client::load_balancing::WorkScheduler;
+use crate::client::name_resolution::Address;
+use crate::client::name_resolution::ResolverUpdate;
 use crate::client::ConnectivityState;
 use crate::rt::GrpcRuntime;
-
-use super::{Subchannel, SubchannelState};
 
 // An LbPolicy implementation that manages multiple children.
 #[derive(Debug)]
@@ -468,15 +476,23 @@ impl ChildWorkScheduler {
 
 #[cfg(test)]
 mod test {
-    use crate::client::load_balancing::child_manager::{ChildManager, ChildUpdate};
-    use crate::client::load_balancing::test_utils::{
-        self, StubPolicyFuncs, TestChannelController, TestEvent, TestWorkScheduler,
-    };
-    use crate::client::load_balancing::{
-        ChannelController, LbPolicyBuilder, LbState, QueuingPicker, Subchannel, SubchannelState,
-        GLOBAL_LB_REGISTRY,
-    };
-    use crate::client::name_resolution::{Address, Endpoint, ResolverUpdate};
+    use crate::client::load_balancing::child_manager::ChildManager;
+    use crate::client::load_balancing::child_manager::ChildUpdate;
+    use crate::client::load_balancing::test_utils::StubPolicyFuncs;
+    use crate::client::load_balancing::test_utils::TestChannelController;
+    use crate::client::load_balancing::test_utils::TestEvent;
+    use crate::client::load_balancing::test_utils::TestWorkScheduler;
+    use crate::client::load_balancing::test_utils::{self};
+    use crate::client::load_balancing::ChannelController;
+    use crate::client::load_balancing::LbPolicyBuilder;
+    use crate::client::load_balancing::LbState;
+    use crate::client::load_balancing::QueuingPicker;
+    use crate::client::load_balancing::Subchannel;
+    use crate::client::load_balancing::SubchannelState;
+    use crate::client::load_balancing::GLOBAL_LB_REGISTRY;
+    use crate::client::name_resolution::Address;
+    use crate::client::name_resolution::Endpoint;
+    use crate::client::name_resolution::ResolverUpdate;
     use crate::client::service_config::LbConfig;
     use crate::client::ConnectivityState;
     use crate::rt::default_runtime;

--- a/grpc/src/client/load_balancing/graceful_switch.rs
+++ b/grpc/src/client/load_balancing/graceful_switch.rs
@@ -22,18 +22,25 @@
  *
  */
 
-use crate::client::load_balancing::child_manager::{ChildManager, ChildUpdate};
-use crate::client::load_balancing::{
-    ChannelController, LbConfig, LbPolicy, LbPolicyBuilder, LbState, ParsedJsonLbConfig,
-    Subchannel, SubchannelState, WorkScheduler, GLOBAL_LB_REGISTRY,
-};
-use crate::client::name_resolution::ResolverUpdate;
-use crate::client::ConnectivityState;
-use crate::rt::GrpcRuntime;
-
 use std::collections::HashMap;
 use std::error::Error;
 use std::sync::Arc;
+
+use crate::client::load_balancing::child_manager::ChildManager;
+use crate::client::load_balancing::child_manager::ChildUpdate;
+use crate::client::load_balancing::ChannelController;
+use crate::client::load_balancing::LbConfig;
+use crate::client::load_balancing::LbPolicy;
+use crate::client::load_balancing::LbPolicyBuilder;
+use crate::client::load_balancing::LbState;
+use crate::client::load_balancing::ParsedJsonLbConfig;
+use crate::client::load_balancing::Subchannel;
+use crate::client::load_balancing::SubchannelState;
+use crate::client::load_balancing::WorkScheduler;
+use crate::client::load_balancing::GLOBAL_LB_REGISTRY;
+use crate::client::name_resolution::ResolverUpdate;
+use crate::client::ConnectivityState;
+use crate::rt::GrpcRuntime;
 
 #[derive(Debug, Clone)]
 struct GracefulSwitchLbConfig {
@@ -246,23 +253,35 @@ impl GracefulSwitchPolicy {
 #[cfg(test)]
 mod test {
     use crate::client::load_balancing::graceful_switch::GracefulSwitchPolicy;
-    use crate::client::load_balancing::test_utils::{
-        self, reg_stub_policy, StubPolicyData, StubPolicyFuncs, TestChannelController, TestEvent,
-        TestSubchannel, TestWorkScheduler,
-    };
-    use crate::client::load_balancing::{
-        ChannelController, LbPolicy, ParsedJsonLbConfig, PickResult, Picker, Subchannel,
-        SubchannelState,
-    };
-    use crate::client::load_balancing::{LbState, Pick};
-    use crate::client::name_resolution::{Address, Endpoint, ResolverUpdate};
+    use crate::client::load_balancing::test_utils::reg_stub_policy;
+    use crate::client::load_balancing::test_utils::StubPolicyData;
+    use crate::client::load_balancing::test_utils::StubPolicyFuncs;
+    use crate::client::load_balancing::test_utils::TestChannelController;
+    use crate::client::load_balancing::test_utils::TestEvent;
+    use crate::client::load_balancing::test_utils::TestSubchannel;
+    use crate::client::load_balancing::test_utils::TestWorkScheduler;
+    use crate::client::load_balancing::test_utils::{self};
+    use crate::client::load_balancing::ChannelController;
+    use crate::client::load_balancing::LbPolicy;
+    use crate::client::load_balancing::LbState;
+    use crate::client::load_balancing::ParsedJsonLbConfig;
+    use crate::client::load_balancing::Pick;
+    use crate::client::load_balancing::PickResult;
+    use crate::client::load_balancing::Picker;
+    use crate::client::load_balancing::Subchannel;
+    use crate::client::load_balancing::SubchannelState;
+    use crate::client::name_resolution::Address;
+    use crate::client::name_resolution::Endpoint;
+    use crate::client::name_resolution::ResolverUpdate;
     use crate::client::ConnectivityState;
     use crate::rt::default_runtime;
     use crate::service::Request;
+    use std::panic;
+    use std::sync::Arc;
     use std::time::Duration;
-    use std::{panic, sync::Arc};
     use tokio::select;
-    use tokio::sync::mpsc::{self, UnboundedReceiver};
+    use tokio::sync::mpsc::UnboundedReceiver;
+    use tokio::sync::mpsc::{self};
     use tonic::metadata::MetadataMap;
 
     const DEFAULT_TEST_SHORT_TIMEOUT: Duration = Duration::from_millis(10);

--- a/grpc/src/client/load_balancing/mod.rs
+++ b/grpc/src/client/load_balancing/mod.rs
@@ -23,28 +23,30 @@
  */
 
 use core::panic;
-use std::{
-    any::Any,
-    error::Error,
-    fmt::{Debug, Display},
-    hash::{Hash, Hasher},
-    ptr::addr_eq,
-    sync::{Arc, Mutex, Weak},
-};
-use tonic::{metadata::MetadataMap, Status};
+use std::any::Any;
+use std::error::Error;
+use std::fmt::Debug;
+use std::fmt::Display;
+use std::hash::Hash;
+use std::hash::Hasher;
+use std::ptr::addr_eq;
+use std::sync::Arc;
+use std::sync::Mutex;
+use std::sync::Weak;
 
-use crate::{
-    client::channel::WorkQueueTx,
-    rt::GrpcRuntime,
-    service::{Request, Response},
-};
+use tonic::metadata::MetadataMap;
+use tonic::Status;
 
-use crate::client::{
-    channel::{InternalChannelController, WorkQueueItem},
-    name_resolution::{Address, ResolverUpdate},
-    subchannel::InternalSubchannel,
-    ConnectivityState,
-};
+use crate::client::channel::InternalChannelController;
+use crate::client::channel::WorkQueueItem;
+use crate::client::channel::WorkQueueTx;
+use crate::client::name_resolution::Address;
+use crate::client::name_resolution::ResolverUpdate;
+use crate::client::subchannel::InternalSubchannel;
+use crate::client::ConnectivityState;
+use crate::rt::GrpcRuntime;
+use crate::service::Request;
+use crate::service::Response;
 
 pub(crate) mod child_manager;
 pub(crate) mod graceful_switch;
@@ -55,7 +57,8 @@ pub(crate) mod round_robin;
 pub(crate) mod test_utils;
 
 pub(crate) mod registry;
-use super::{service_config::LbConfig, subchannel::SubchannelStateWatcher};
+use super::service_config::LbConfig;
+use super::subchannel::SubchannelStateWatcher;
 pub(crate) use registry::GLOBAL_LB_REGISTRY;
 
 /// A collection of data configured on the channel that is constructing this

--- a/grpc/src/client/load_balancing/pick_first.rs
+++ b/grpc/src/client/load_balancing/pick_first.rs
@@ -22,24 +22,29 @@
  *
  */
 
-use std::{error::Error, sync::Arc, time::Duration};
+use std::error::Error;
+use std::sync::Arc;
+use std::time::Duration;
 
 use tonic::metadata::MetadataMap;
 
-use crate::{
-    client::{
-        load_balancing::{LbPolicy, LbPolicyBuilder, LbState},
-        name_resolution::{Address, ResolverUpdate},
-        ConnectivityState,
-    },
-    rt::GrpcRuntime,
-    service::Request,
-};
-
-use super::{
-    ChannelController, LbConfig, LbPolicyOptions, Pick, PickResult, Picker, Subchannel,
-    SubchannelState, WorkScheduler,
-};
+use crate::client::load_balancing::ChannelController;
+use crate::client::load_balancing::LbConfig;
+use crate::client::load_balancing::LbPolicy;
+use crate::client::load_balancing::LbPolicyBuilder;
+use crate::client::load_balancing::LbPolicyOptions;
+use crate::client::load_balancing::LbState;
+use crate::client::load_balancing::Pick;
+use crate::client::load_balancing::PickResult;
+use crate::client::load_balancing::Picker;
+use crate::client::load_balancing::Subchannel;
+use crate::client::load_balancing::SubchannelState;
+use crate::client::load_balancing::WorkScheduler;
+use crate::client::name_resolution::Address;
+use crate::client::name_resolution::ResolverUpdate;
+use crate::client::ConnectivityState;
+use crate::rt::GrpcRuntime;
+use crate::service::Request;
 
 pub(crate) static POLICY_NAME: &str = "pick_first";
 

--- a/grpc/src/client/load_balancing/registry.rs
+++ b/grpc/src/client/load_balancing/registry.rs
@@ -22,12 +22,12 @@
  *
  */
 
-use std::{
-    collections::HashMap,
-    sync::{Arc, LazyLock, Mutex},
-};
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::sync::LazyLock;
+use std::sync::Mutex;
 
-use super::LbPolicyBuilder;
+use crate::client::load_balancing::LbPolicyBuilder;
 
 /// A registry to store and retrieve LB policies.  LB policies are indexed by
 /// their names.

--- a/grpc/src/client/load_balancing/round_robin.rs
+++ b/grpc/src/client/load_balancing/round_robin.rs
@@ -22,18 +22,31 @@
  *
  */
 
-use crate::client::load_balancing::child_manager::{ChildManager, ChildUpdate};
+use std::error::Error;
+use std::sync::atomic::AtomicUsize;
+use std::sync::atomic::Ordering;
+use std::sync::Arc;
+use std::sync::Once;
+
+use crate::client::load_balancing::child_manager::ChildManager;
+use crate::client::load_balancing::child_manager::ChildUpdate;
 use crate::client::load_balancing::pick_first;
-use crate::client::load_balancing::{
-    ChannelController, FailingPicker, LbConfig, LbPolicy, LbPolicyBuilder, LbPolicyOptions,
-    LbState, PickResult, Picker, Subchannel, SubchannelState, GLOBAL_LB_REGISTRY,
-};
-use crate::client::name_resolution::{Endpoint, ResolverUpdate};
+use crate::client::load_balancing::ChannelController;
+use crate::client::load_balancing::FailingPicker;
+use crate::client::load_balancing::LbConfig;
+use crate::client::load_balancing::LbPolicy;
+use crate::client::load_balancing::LbPolicyBuilder;
+use crate::client::load_balancing::LbPolicyOptions;
+use crate::client::load_balancing::LbState;
+use crate::client::load_balancing::PickResult;
+use crate::client::load_balancing::Picker;
+use crate::client::load_balancing::Subchannel;
+use crate::client::load_balancing::SubchannelState;
+use crate::client::load_balancing::GLOBAL_LB_REGISTRY;
+use crate::client::name_resolution::Endpoint;
+use crate::client::name_resolution::ResolverUpdate;
 use crate::client::ConnectivityState;
 use crate::service::Request;
-use std::error::Error;
-use std::sync::atomic::{AtomicUsize, Ordering};
-use std::sync::{Arc, Once};
 
 pub(crate) static POLICY_NAME: &str = "round_robin";
 static START: Once = Once::new();
@@ -233,15 +246,29 @@ impl Picker for RoundRobinPicker {
 #[cfg(test)]
 mod test {
     use crate::client::load_balancing::child_manager::ChildManager;
-    use crate::client::load_balancing::round_robin::{self, RoundRobinPolicy};
-    use crate::client::load_balancing::test_utils::{
-        self, StubPolicyData, StubPolicyFuncs, TestChannelController, TestEvent, TestWorkScheduler,
-    };
-    use crate::client::load_balancing::{
-        pick_first, ChannelController, FailingPicker, LbPolicy, LbState, Pick, PickResult, Picker,
-        QueuingPicker, Subchannel, SubchannelState, GLOBAL_LB_REGISTRY,
-    };
-    use crate::client::name_resolution::{Address, Endpoint, ResolverUpdate};
+    use crate::client::load_balancing::pick_first;
+    use crate::client::load_balancing::round_robin::RoundRobinPolicy;
+    use crate::client::load_balancing::round_robin::{self};
+    use crate::client::load_balancing::test_utils::StubPolicyData;
+    use crate::client::load_balancing::test_utils::StubPolicyFuncs;
+    use crate::client::load_balancing::test_utils::TestChannelController;
+    use crate::client::load_balancing::test_utils::TestEvent;
+    use crate::client::load_balancing::test_utils::TestWorkScheduler;
+    use crate::client::load_balancing::test_utils::{self};
+    use crate::client::load_balancing::ChannelController;
+    use crate::client::load_balancing::FailingPicker;
+    use crate::client::load_balancing::LbPolicy;
+    use crate::client::load_balancing::LbState;
+    use crate::client::load_balancing::Pick;
+    use crate::client::load_balancing::PickResult;
+    use crate::client::load_balancing::Picker;
+    use crate::client::load_balancing::QueuingPicker;
+    use crate::client::load_balancing::Subchannel;
+    use crate::client::load_balancing::SubchannelState;
+    use crate::client::load_balancing::GLOBAL_LB_REGISTRY;
+    use crate::client::name_resolution::Address;
+    use crate::client::name_resolution::Endpoint;
+    use crate::client::name_resolution::ResolverUpdate;
     use crate::client::ConnectivityState;
     use crate::rt::default_runtime;
     use crate::service::Request;

--- a/grpc/src/client/load_balancing/test_utils.rs
+++ b/grpc/src/client/load_balancing/test_utils.rs
@@ -22,19 +22,32 @@
  *
  */
 
-use crate::client::load_balancing::{
-    ChannelController, ForwardingSubchannel, LbPolicy, LbPolicyBuilder, LbPolicyOptions, LbState,
-    ParsedJsonLbConfig, Subchannel, SubchannelState, WorkScheduler,
-};
-use crate::client::name_resolution::{Address, ResolverUpdate};
-use crate::client::service_config::LbConfig;
-use crate::service::{Message, Request};
-use serde::{Deserialize, Serialize};
 use std::any::Any;
 use std::error::Error;
+use std::fmt::Debug;
 use std::hash::Hash;
-use std::{fmt::Debug, sync::Arc};
-use tokio::sync::{mpsc, Notify};
+use std::sync::Arc;
+
+use serde::Deserialize;
+use serde::Serialize;
+use tokio::sync::mpsc;
+use tokio::sync::Notify;
+
+use crate::client::load_balancing::ChannelController;
+use crate::client::load_balancing::ForwardingSubchannel;
+use crate::client::load_balancing::LbPolicy;
+use crate::client::load_balancing::LbPolicyBuilder;
+use crate::client::load_balancing::LbPolicyOptions;
+use crate::client::load_balancing::LbState;
+use crate::client::load_balancing::ParsedJsonLbConfig;
+use crate::client::load_balancing::Subchannel;
+use crate::client::load_balancing::SubchannelState;
+use crate::client::load_balancing::WorkScheduler;
+use crate::client::name_resolution::Address;
+use crate::client::name_resolution::ResolverUpdate;
+use crate::client::service_config::LbConfig;
+use crate::service::Message;
+use crate::service::Request;
 
 #[derive(Debug)]
 pub(crate) struct EmptyMessage {}

--- a/grpc/src/client/mod.rs
+++ b/grpc/src/client/mod.rs
@@ -25,10 +25,11 @@
 use std::fmt::Display;
 
 pub mod channel;
-pub mod service_config;
-mod subchannel;
 pub use channel::Channel;
 pub use channel::ChannelOptions;
+
+pub mod service_config;
+mod subchannel;
 
 pub(crate) mod load_balancing;
 pub(crate) mod name_resolution;

--- a/grpc/src/client/name_resolution/backoff.rs
+++ b/grpc/src/client/name_resolution/backoff.rs
@@ -22,8 +22,9 @@
  *
  */
 
-use rand::Rng;
 use std::time::Duration;
+
+use rand::Rng;
 
 #[derive(Clone)]
 pub(crate) struct BackoffConfig {
@@ -114,9 +115,9 @@ impl ExponentialBackoff {
 mod tests {
     use std::time::Duration;
 
-    use crate::client::name_resolution::backoff::{
-        BackoffConfig, ExponentialBackoff, DEFAULT_EXPONENTIAL_CONFIG,
-    };
+    use crate::client::name_resolution::backoff::BackoffConfig;
+    use crate::client::name_resolution::backoff::ExponentialBackoff;
+    use crate::client::name_resolution::backoff::DEFAULT_EXPONENTIAL_CONFIG;
 
     // Epsilon for floating point comparisons if needed, though Duration
     // comparisons are often better.

--- a/grpc/src/client/name_resolution/dns/mod.rs
+++ b/grpc/src/client/name_resolution/dns/mod.rs
@@ -25,29 +25,35 @@
 //! This module implements a DNS resolver to be installed as the default resolver
 //! in grpc.
 
-use std::{
-    net::{IpAddr, SocketAddr},
-    sync::{
-        atomic::{AtomicU64, Ordering},
-        Arc,
-    },
-    time::{Duration, SystemTime},
-};
+use std::net::IpAddr;
+use std::net::SocketAddr;
+use std::sync::atomic::AtomicU64;
+use std::sync::atomic::Ordering;
+use std::sync::Arc;
+use std::time::Duration;
+use std::time::SystemTime;
 
 use parking_lot::Mutex;
 use tokio::sync::Notify;
 use url::Host;
 
-use crate::{
-    byte_str::ByteStr,
-    client::name_resolution::{global_registry, ChannelController, ResolverBuilder, Target},
-    rt::{self, BoxedTaskHandle},
-};
-
-use super::{
-    backoff::{BackoffConfig, ExponentialBackoff, DEFAULT_EXPONENTIAL_CONFIG},
-    Address, Endpoint, NopResolver, Resolver, ResolverOptions, ResolverUpdate, TCP_IP_NETWORK_TYPE,
-};
+use crate::byte_str::ByteStr;
+use crate::client::name_resolution::backoff::BackoffConfig;
+use crate::client::name_resolution::backoff::ExponentialBackoff;
+use crate::client::name_resolution::backoff::DEFAULT_EXPONENTIAL_CONFIG;
+use crate::client::name_resolution::global_registry;
+use crate::client::name_resolution::Address;
+use crate::client::name_resolution::ChannelController;
+use crate::client::name_resolution::Endpoint;
+use crate::client::name_resolution::NopResolver;
+use crate::client::name_resolution::Resolver;
+use crate::client::name_resolution::ResolverBuilder;
+use crate::client::name_resolution::ResolverOptions;
+use crate::client::name_resolution::ResolverUpdate;
+use crate::client::name_resolution::Target;
+use crate::client::name_resolution::TCP_IP_NETWORK_TYPE;
+use crate::rt::BoxedTaskHandle;
+use crate::rt::{self};
 
 #[cfg(test)]
 mod test;

--- a/grpc/src/client/name_resolution/dns/test.rs
+++ b/grpc/src/client/name_resolution/dns/test.rs
@@ -22,28 +22,38 @@
  *
  */
 
-use std::{future::Future, pin::Pin, sync::Arc, time::Duration};
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::Arc;
+use std::time::Duration;
 
-use tokio::sync::mpsc::{self, UnboundedSender};
+use tokio::sync::mpsc::UnboundedSender;
+use tokio::sync::mpsc::{self};
 use url::Host;
 
-use crate::{
-    client::{
-        name_resolution::{
-            backoff::{BackoffConfig, DEFAULT_EXPONENTIAL_CONFIG},
-            dns::{
-                get_min_resolution_interval, get_resolving_timeout, parse_endpoint_and_authority,
-                reg, DnsResolver, HostPort,
-            },
-            global_registry, ChannelController, Resolver, ResolverOptions, ResolverUpdate, Target,
-            WorkScheduler,
-        },
-        service_config::ServiceConfig,
-    },
-    rt::{self, tokio::TokioRuntime, BoxFuture, GrpcRuntime, TcpOptions},
-};
-
-use super::{DnsOptions, ParseResult};
+use crate::client::name_resolution::backoff::BackoffConfig;
+use crate::client::name_resolution::backoff::DEFAULT_EXPONENTIAL_CONFIG;
+use crate::client::name_resolution::dns::get_min_resolution_interval;
+use crate::client::name_resolution::dns::get_resolving_timeout;
+use crate::client::name_resolution::dns::parse_endpoint_and_authority;
+use crate::client::name_resolution::dns::reg;
+use crate::client::name_resolution::dns::DnsOptions;
+use crate::client::name_resolution::dns::DnsResolver;
+use crate::client::name_resolution::dns::HostPort;
+use crate::client::name_resolution::dns::ParseResult;
+use crate::client::name_resolution::global_registry;
+use crate::client::name_resolution::ChannelController;
+use crate::client::name_resolution::Resolver;
+use crate::client::name_resolution::ResolverOptions;
+use crate::client::name_resolution::ResolverUpdate;
+use crate::client::name_resolution::Target;
+use crate::client::name_resolution::WorkScheduler;
+use crate::client::service_config::ServiceConfig;
+use crate::rt::tokio::TokioRuntime;
+use crate::rt::BoxFuture;
+use crate::rt::GrpcRuntime;
+use crate::rt::TcpOptions;
+use crate::rt::{self};
 
 const DEFAULT_TEST_SHORT_TIMEOUT: Duration = Duration::from_millis(10);
 

--- a/grpc/src/client/name_resolution/mod.rs
+++ b/grpc/src/client/name_resolution/mod.rs
@@ -28,21 +28,23 @@
 //! network addresses (typically IP addresses) used by the channel to connect to
 //! a service.
 use core::fmt;
+use std::fmt::Display;
+use std::fmt::Formatter;
+use std::hash::Hash;
+use std::str::FromStr;
+use std::sync::Arc;
 
-use super::service_config::ServiceConfig;
-use crate::{attributes::Attributes, byte_str::ByteStr, rt::GrpcRuntime};
-use std::{
-    fmt::{Display, Formatter},
-    hash::Hash,
-    str::FromStr,
-    sync::Arc,
-};
+use url::Url;
+
+use crate::attributes::Attributes;
+use crate::byte_str::ByteStr;
+use crate::client::service_config::ServiceConfig;
+use crate::rt::GrpcRuntime;
 
 mod backoff;
 mod dns;
 mod registry;
 pub(crate) use registry::global_registry;
-use url::Url;
 
 /// Target represents a target for gRPC, as specified in:
 /// https://github.com/grpc/grpc/blob/master/doc/naming.md.

--- a/grpc/src/client/name_resolution/registry.rs
+++ b/grpc/src/client/name_resolution/registry.rs
@@ -22,12 +22,12 @@
  *
  */
 
-use std::{
-    collections::HashMap,
-    sync::{Arc, Mutex, OnceLock},
-};
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::sync::Mutex;
+use std::sync::OnceLock;
 
-use super::ResolverBuilder;
+use crate::client::name_resolution::ResolverBuilder;
 
 static GLOBAL_RESOLVER_REGISTRY: OnceLock<ResolverRegistry> = OnceLock::new();
 

--- a/grpc/src/client/service_config.rs
+++ b/grpc/src/client/service_config.rs
@@ -21,7 +21,9 @@
  * IN THE SOFTWARE.
  *
  */
-use std::{any::Any, sync::Arc};
+
+use std::any::Any;
+use std::sync::Arc;
 
 /// An in-memory representation of a service config, usually provided to gRPC as
 /// a JSON object.

--- a/grpc/src/client/subchannel.rs
+++ b/grpc/src/client/subchannel.rs
@@ -22,28 +22,36 @@
  *
  */
 
-use super::{
-    channel::{InternalChannelController, WorkQueueTx},
-    load_balancing::{ExternalSubchannel, SubchannelState},
-    name_resolution::Address,
-    transport::Transport,
-    ConnectivityState,
-};
-use crate::{
-    client::{channel::WorkQueueItem, transport::TransportOptions},
-    rt::{BoxedTaskHandle, GrpcRuntime},
-    service::{Request, Response, Service},
-};
 use core::panic;
-use std::time::{Duration, Instant};
-use std::{
-    collections::BTreeMap,
-    error::Error,
-    fmt::{Debug, Display},
-    sync::{Arc, Mutex, RwLock, Weak},
-};
-use tokio::sync::{mpsc, oneshot};
+use std::collections::BTreeMap;
+use std::error::Error;
+use std::fmt::Debug;
+use std::fmt::Display;
+use std::sync::Arc;
+use std::sync::Mutex;
+use std::sync::RwLock;
+use std::sync::Weak;
+use std::time::Duration;
+use std::time::Instant;
+
+use tokio::sync::mpsc;
+use tokio::sync::oneshot;
 use tonic::async_trait;
+
+use crate::client::channel::InternalChannelController;
+use crate::client::channel::WorkQueueItem;
+use crate::client::channel::WorkQueueTx;
+use crate::client::load_balancing::ExternalSubchannel;
+use crate::client::load_balancing::SubchannelState;
+use crate::client::name_resolution::Address;
+use crate::client::transport::Transport;
+use crate::client::transport::TransportOptions;
+use crate::client::ConnectivityState;
+use crate::rt::BoxedTaskHandle;
+use crate::rt::GrpcRuntime;
+use crate::service::Request;
+use crate::service::Response;
+use crate::service::Service;
 
 type SharedService = Arc<dyn Service>;
 

--- a/grpc/src/client/transport/mod.rs
+++ b/grpc/src/client/transport/mod.rs
@@ -22,9 +22,11 @@
  *
  */
 
-use crate::{rt::GrpcRuntime, service::Service};
 use std::time::Duration;
 use std::time::Instant;
+
+use crate::rt::GrpcRuntime;
+use crate::service::Service;
 
 mod registry;
 

--- a/grpc/src/client/transport/registry.rs
+++ b/grpc/src/client/transport/registry.rs
@@ -22,9 +22,13 @@
  *
  */
 
-use super::Transport;
-use std::sync::{Arc, LazyLock, Mutex};
-use std::{collections::HashMap, fmt::Debug};
+use std::collections::HashMap;
+use std::fmt::Debug;
+use std::sync::Arc;
+use std::sync::LazyLock;
+use std::sync::Mutex;
+
+use crate::client::transport::Transport;
 
 /// A registry to store and retrieve transports.  Transports are indexed by
 /// the address type they are intended to handle.

--- a/grpc/src/client/transport/tonic/test.rs
+++ b/grpc/src/client/transport/tonic/test.rs
@@ -22,23 +22,36 @@
  *
  */
 
+use std::any::Any;
+use std::pin::Pin;
+use std::sync::Arc;
+use std::time::Duration;
+
+use bytes::Bytes;
+use tokio::net::TcpListener;
+use tokio::sync::mpsc;
+use tokio::sync::oneshot;
+use tokio::sync::Notify;
+use tokio::time::timeout;
+use tokio_stream::wrappers::ReceiverStream;
+use tokio_stream::Stream;
+use tokio_stream::StreamExt;
+use tonic::async_trait;
+use tonic::transport::Server;
+use tonic::Request;
+use tonic::Response;
+use tonic::Status;
+use tonic_prost::prost::Message as ProstMessage;
+
 use crate::client::name_resolution::TCP_IP_NETWORK_TYPE;
 use crate::client::transport::registry::GLOBAL_TRANSPORT_REGISTRY;
 use crate::client::transport::TransportOptions;
-use crate::echo_pb::echo_server::{Echo, EchoServer};
-use crate::echo_pb::{EchoRequest, EchoResponse};
+use crate::echo_pb::echo_server::Echo;
+use crate::echo_pb::echo_server::EchoServer;
+use crate::echo_pb::EchoRequest;
+use crate::echo_pb::EchoResponse;
 use crate::service::Message;
 use crate::service::Request as GrpcRequest;
-use bytes::Bytes;
-use std::any::Any;
-use std::{pin::Pin, sync::Arc, time::Duration};
-use tokio::net::TcpListener;
-use tokio::sync::{mpsc, oneshot, Notify};
-use tokio::time::timeout;
-use tokio_stream::{wrappers::ReceiverStream, Stream, StreamExt};
-use tonic::async_trait;
-use tonic::{transport::Server, Request, Response, Status};
-use tonic_prost::prost::Message as ProstMessage;
 
 const DEFAULT_TEST_DURATION: Duration = Duration::from_secs(10);
 const DEFAULT_TEST_SHORT_DURATION: Duration = Duration::from_millis(10);

--- a/grpc/src/codec.rs
+++ b/grpc/src/codec.rs
@@ -22,11 +22,14 @@
  *
  */
 
-use bytes::{Buf, BufMut, Bytes};
-use tonic::{
-    codec::{Codec, Decoder, EncodeBuf, Encoder},
-    Status,
-};
+use bytes::Buf;
+use bytes::BufMut;
+use bytes::Bytes;
+use tonic::codec::Codec;
+use tonic::codec::Decoder;
+use tonic::codec::EncodeBuf;
+use tonic::codec::Encoder;
+use tonic::Status;
 
 /// An adapter for sending and receiving messages as bytes using tonic.
 /// Coding/decoding is handled within gRPC.

--- a/grpc/src/credentials/client.rs
+++ b/grpc/src/credentials/client.rs
@@ -23,8 +23,10 @@
  */
 
 use crate::attributes::Attributes;
-use crate::credentials::common::{Authority, SecurityLevel};
-use crate::rt::{GrpcEndpoint, GrpcRuntime};
+use crate::credentials::common::Authority;
+use crate::credentials::common::SecurityLevel;
+use crate::rt::GrpcEndpoint;
+use crate::rt::GrpcRuntime;
 
 #[trait_variant::make(Send)]
 pub trait ChannelCredsInternal {

--- a/grpc/src/credentials/dyn_wrapper.rs
+++ b/grpc/src/credentials/dyn_wrapper.rs
@@ -24,13 +24,16 @@
 
 use tonic::async_trait;
 
-use crate::credentials::client::{
-    ClientConnectionSecurityContext, ClientHandshakeInfo, HandshakeOutput,
-};
+use crate::credentials::client::ClientConnectionSecurityContext;
+use crate::credentials::client::ClientHandshakeInfo;
+use crate::credentials::client::HandshakeOutput;
 use crate::credentials::common::Authority;
 use crate::credentials::server::HandshakeOutput as ServerHandshakeOutput;
-use crate::credentials::{ChannelCredentials, ProtocolInfo, ServerCredentials};
-use crate::rt::{GrpcEndpoint, GrpcRuntime};
+use crate::credentials::ChannelCredentials;
+use crate::credentials::ProtocolInfo;
+use crate::credentials::ServerCredentials;
+use crate::rt::GrpcEndpoint;
+use crate::rt::GrpcRuntime;
 use crate::send_future::SendFuture;
 
 type BoxEndpoint = Box<dyn GrpcEndpoint>;
@@ -121,11 +124,14 @@ where
 mod tests {
     use super::*;
     use crate::credentials::client::ClientHandshakeInfo;
-    use crate::credentials::common::{Authority, SecurityLevel};
+    use crate::credentials::common::Authority;
+    use crate::credentials::common::SecurityLevel;
     use crate::credentials::insecure::InsecureChannelCredentials;
     use crate::credentials::InsecureServerCredentials;
-    use crate::rt::{self, TcpOptions};
-    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+    use crate::rt::TcpOptions;
+    use crate::rt::{self};
+    use tokio::io::AsyncReadExt;
+    use tokio::io::AsyncWriteExt;
     use tokio::net::TcpListener;
 
     #[tokio::test]

--- a/grpc/src/credentials/insecure.rs
+++ b/grpc/src/credentials/insecure.rs
@@ -23,14 +23,20 @@
  */
 
 use crate::attributes::Attributes;
-use crate::credentials::client::{
-    self, ClientConnectionSecurityContext, ClientConnectionSecurityInfo, ClientHandshakeInfo,
-    HandshakeOutput,
-};
-use crate::credentials::common::{Authority, SecurityLevel};
-use crate::credentials::server::{self, ServerConnectionSecurityInfo};
-use crate::credentials::{ChannelCredentials, ProtocolInfo, ServerCredentials};
-use crate::rt::{GrpcEndpoint, GrpcRuntime};
+use crate::credentials::client::ClientConnectionSecurityContext;
+use crate::credentials::client::ClientConnectionSecurityInfo;
+use crate::credentials::client::ClientHandshakeInfo;
+use crate::credentials::client::HandshakeOutput;
+use crate::credentials::client::{self};
+use crate::credentials::common::Authority;
+use crate::credentials::common::SecurityLevel;
+use crate::credentials::server::ServerConnectionSecurityInfo;
+use crate::credentials::server::{self};
+use crate::credentials::ChannelCredentials;
+use crate::credentials::ProtocolInfo;
+use crate::credentials::ServerCredentials;
+use crate::rt::GrpcEndpoint;
+use crate::rt::GrpcRuntime;
 
 /// An implementation of [`ChannelCredentials`] for insecure connections.
 ///
@@ -128,20 +134,24 @@ impl ServerCredentials for InsecureServerCredentials {
 
 #[cfg(test)]
 mod test {
-    use tokio::io::{AsyncReadExt, AsyncWriteExt};
-    use tokio::net::{TcpListener, TcpStream};
+    use tokio::io::AsyncReadExt;
+    use tokio::io::AsyncWriteExt;
+    use tokio::net::TcpListener;
+    use tokio::net::TcpStream;
 
-    use crate::credentials::client::{
-        ChannelCredsInternal as ClientSealed, ClientConnectionSecurityContext, ClientHandshakeInfo,
-    };
-    use crate::credentials::common::{Authority, SecurityLevel};
+    use crate::credentials::client::ChannelCredsInternal as ClientSealed;
+    use crate::credentials::client::ClientConnectionSecurityContext;
+    use crate::credentials::client::ClientHandshakeInfo;
+    use crate::credentials::common::Authority;
+    use crate::credentials::common::SecurityLevel;
     use crate::credentials::server::ServerCredsInternal;
-    use crate::credentials::{
-        ChannelCredentials, InsecureChannelCredentials, InsecureServerCredentials,
-        ServerCredentials,
-    };
+    use crate::credentials::ChannelCredentials;
+    use crate::credentials::InsecureChannelCredentials;
+    use crate::credentials::InsecureServerCredentials;
+    use crate::credentials::ServerCredentials;
     use crate::rt::GrpcEndpoint;
-    use crate::rt::{self, TcpOptions};
+    use crate::rt::TcpOptions;
+    use crate::rt::{self};
 
     #[tokio::test]
     async fn test_insecure_client_credentials() {

--- a/grpc/src/credentials/mod.rs
+++ b/grpc/src/credentials/mod.rs
@@ -27,7 +27,8 @@ pub(crate) mod dyn_wrapper;
 mod insecure;
 pub(crate) mod server;
 
-pub use insecure::{InsecureChannelCredentials, InsecureServerCredentials};
+pub use insecure::InsecureChannelCredentials;
+pub use insecure::InsecureServerCredentials;
 
 /// Defines the common interface for all live gRPC wire protocols and supported
 /// transport security protocols (e.g., TLS, ALTS).

--- a/grpc/src/credentials/server.rs
+++ b/grpc/src/credentials/server.rs
@@ -24,7 +24,8 @@
 
 use crate::attributes::Attributes;
 use crate::credentials::common::SecurityLevel;
-use crate::rt::{GrpcEndpoint, GrpcRuntime};
+use crate::rt::GrpcEndpoint;
+use crate::rt::GrpcRuntime;
 
 #[trait_variant::make(Send)]
 pub trait ServerCredsInternal {

--- a/grpc/src/inmemory/mod.rs
+++ b/grpc/src/inmemory/mod.rs
@@ -23,23 +23,35 @@
  */
 
 use std::collections::HashMap;
-use std::sync::atomic::{AtomicU32, Ordering};
-use std::sync::{Arc, LazyLock, Mutex};
+use std::sync::atomic::AtomicU32;
+use std::sync::atomic::Ordering;
+use std::sync::Arc;
+use std::sync::LazyLock;
+use std::sync::Mutex;
 
-use crate::{
-    client::{
-        name_resolution::{
-            self, global_registry, Address, ChannelController, Endpoint, Resolver, ResolverBuilder,
-            ResolverOptions, ResolverUpdate,
-        },
-        transport::{self, ConnectedTransport, TransportOptions, GLOBAL_TRANSPORT_REGISTRY},
-    },
-    rt::GrpcRuntime,
-    server,
-    service::{Request, Response, Service},
-};
-use tokio::sync::{mpsc, oneshot, Mutex as AsyncMutex};
+use tokio::sync::mpsc;
+use tokio::sync::oneshot;
+use tokio::sync::Mutex as AsyncMutex;
 use tonic::async_trait;
+
+use crate::client::name_resolution::global_registry;
+use crate::client::name_resolution::Address;
+use crate::client::name_resolution::ChannelController;
+use crate::client::name_resolution::Endpoint;
+use crate::client::name_resolution::Resolver;
+use crate::client::name_resolution::ResolverBuilder;
+use crate::client::name_resolution::ResolverOptions;
+use crate::client::name_resolution::ResolverUpdate;
+use crate::client::name_resolution::{self};
+use crate::client::transport::ConnectedTransport;
+use crate::client::transport::TransportOptions;
+use crate::client::transport::GLOBAL_TRANSPORT_REGISTRY;
+use crate::client::transport::{self};
+use crate::rt::GrpcRuntime;
+use crate::server;
+use crate::service::Request;
+use crate::service::Response;
+use crate::service::Service;
 
 pub struct Listener {
     id: String,

--- a/grpc/src/lib.rs
+++ b/grpc/src/lib.rs
@@ -36,7 +36,9 @@ pub mod credentials;
 pub mod inmemory;
 mod macros;
 mod status;
-pub use status::{ServerStatus, Status, StatusCode};
+pub use status::ServerStatus;
+pub use status::Status;
+pub use status::StatusCode;
 pub mod server;
 pub mod service;
 

--- a/grpc/src/rt/hyper_wrapper.rs
+++ b/grpc/src/rt/hyper_wrapper.rs
@@ -22,12 +22,22 @@
  *
  */
 
-use super::{GrpcEndpoint, GrpcRuntime};
-use hyper::rt::{Executor, Timer};
+use std::future::Future;
+use std::io;
+use std::pin::Pin;
+use std::task::Context;
+use std::task::Poll;
+use std::time::Instant;
+
+use hyper::rt::Executor;
+use hyper::rt::Timer;
 use pin_project_lite::pin_project;
-use std::task::{Context, Poll};
-use std::{future::Future, io, pin::Pin, time::Instant};
-use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
+use tokio::io::AsyncRead;
+use tokio::io::AsyncWrite;
+use tokio::io::ReadBuf;
+
+use crate::rt::GrpcEndpoint;
+use crate::rt::GrpcRuntime;
 
 /// Adapts a runtime to a hyper compatible executor.
 #[derive(Clone)]

--- a/grpc/src/rt/mod.rs
+++ b/grpc/src/rt/mod.rs
@@ -23,7 +23,11 @@
  */
 
 use std::fmt::Debug;
-use std::{future::Future, net::SocketAddr, pin::Pin, sync::Arc, time::Duration};
+use std::future::Future;
+use std::net::SocketAddr;
+use std::pin::Pin;
+use std::sync::Arc;
+use std::time::Duration;
 
 pub(crate) mod hyper_wrapper;
 #[cfg(feature = "_runtime-tokio")]

--- a/grpc/src/rt/tokio/hickory_resolver.rs
+++ b/grpc/src/rt/tokio/hickory_resolver.rs
@@ -24,13 +24,15 @@
 
 use std::net::IpAddr;
 
-use hickory_resolver::{
-    config::{LookupIpStrategy, NameServerConfigGroup, ResolverConfig, ResolverOpts},
-    name_server::TokioConnectionProvider,
-    TokioResolver,
-};
+use hickory_resolver::config::LookupIpStrategy;
+use hickory_resolver::config::NameServerConfigGroup;
+use hickory_resolver::config::ResolverConfig;
+use hickory_resolver::config::ResolverOpts;
+use hickory_resolver::name_server::TokioConnectionProvider;
+use hickory_resolver::TokioResolver;
 
-use crate::rt::{self, ResolverOptions};
+use crate::rt::ResolverOptions;
+use crate::rt::{self};
 
 /// A DNS resolver that uses hickory with the tokio runtime. This supports txt
 /// lookups in addition to A and AAAA record lookups. It also supports using
@@ -93,24 +95,27 @@ impl DnsResolver {
 
 #[cfg(test)]
 mod tests {
-    use std::{
-        net::{Ipv4Addr, SocketAddr},
-        sync::Arc,
-    };
+    use std::net::Ipv4Addr;
+    use std::net::SocketAddr;
+    use std::sync::Arc;
 
     use hickory_resolver::Name;
-    use hickory_server::{
-        authority::{Catalog, ZoneType},
-        proto::rr::{
-            rdata::{A, TXT},
-            LowerName, RData, Record,
-        },
-        store::in_memory::InMemoryAuthority,
-        ServerFuture,
-    };
-    use tokio::{net::UdpSocket, sync::oneshot, task::JoinHandle};
+    use hickory_server::authority::Catalog;
+    use hickory_server::authority::ZoneType;
+    use hickory_server::proto::rr::rdata::A;
+    use hickory_server::proto::rr::rdata::TXT;
+    use hickory_server::proto::rr::LowerName;
+    use hickory_server::proto::rr::RData;
+    use hickory_server::proto::rr::Record;
+    use hickory_server::store::in_memory::InMemoryAuthority;
+    use hickory_server::ServerFuture;
+    use tokio::net::UdpSocket;
+    use tokio::sync::oneshot;
+    use tokio::task::JoinHandle;
 
-    use crate::rt::{tokio::TokioDefaultDnsResolver, DnsResolver, ResolverOptions};
+    use crate::rt::tokio::TokioDefaultDnsResolver;
+    use crate::rt::DnsResolver;
+    use crate::rt::ResolverOptions;
 
     #[tokio::test]
     async fn compare_hickory_and_default() {

--- a/grpc/src/rt/tokio/mod.rs
+++ b/grpc/src/rt/tokio/mod.rs
@@ -23,20 +23,28 @@
  */
 
 use std::future::Future;
-use std::net::{IpAddr, SocketAddr};
+use std::net::IpAddr;
+use std::net::SocketAddr;
 use std::pin::Pin;
 use std::time::Duration;
 
-use tokio::io::{AsyncRead, AsyncWrite};
+use tokio::io::AsyncRead;
+use tokio::io::AsyncWrite;
 use tokio::net::TcpStream;
 use tokio::task::JoinHandle;
 
-use crate::rt::{BoxEndpoint, BoxFuture, ScopedBoxFuture, TcpOptions};
-
-use super::{
-    endpoint, BoxedTaskHandle, DnsResolver, GrpcEndpoint, ResolverOptions, Runtime, Sleep,
-    TaskHandle,
-};
+use crate::rt::endpoint;
+use crate::rt::BoxEndpoint;
+use crate::rt::BoxFuture;
+use crate::rt::BoxedTaskHandle;
+use crate::rt::DnsResolver;
+use crate::rt::GrpcEndpoint;
+use crate::rt::ResolverOptions;
+use crate::rt::Runtime;
+use crate::rt::ScopedBoxFuture;
+use crate::rt::Sleep;
+use crate::rt::TaskHandle;
+use crate::rt::TcpOptions;
 
 #[cfg(feature = "dns")]
 mod hickory_resolver;
@@ -253,7 +261,11 @@ impl super::TcpListener for TokioListener {
 
 #[cfg(test)]
 mod tests {
-    use super::{DnsResolver, ResolverOptions, Runtime, TokioDefaultDnsResolver, TokioRuntime};
+    use super::DnsResolver;
+    use super::ResolverOptions;
+    use super::Runtime;
+    use super::TokioDefaultDnsResolver;
+    use super::TokioRuntime;
 
     #[tokio::test]
     async fn lookup_hostname() {

--- a/grpc/src/send_future.rs
+++ b/grpc/src/send_future.rs
@@ -22,6 +22,8 @@
  *
  */
 
+use core::future::Future;
+
 /// A helper trait to enforce and explicitly bound a [`Future`] as [`Send`].
 ///
 /// This trait provides a mechanism to work around specific Rust compiler
@@ -62,14 +64,14 @@
 /// [#96865]: https://github.com/rust-lang/rust/issues/96865
 /// [`Future`]: core::future::Future
 /// [`Send`]: core::marker::Send
-pub trait SendFuture: core::future::Future {
+pub trait SendFuture: Future {
     /// Consumes the future and returns it as an opaque type that is guaranteed
     /// to be [`Send`].
     ///
     /// This is a zero-cost abstraction (it simply returns `self`) used primarily
     /// to help the compiler resolve auto-traits or to produce better error
     /// diagnostics.
-    fn make_send(self) -> impl core::future::Future<Output = Self::Output> + Send
+    fn make_send(self) -> impl Future<Output = Self::Output> + Send
     where
         Self: Sized + Send,
     {
@@ -77,4 +79,4 @@ pub trait SendFuture: core::future::Future {
     }
 }
 
-impl<T: core::future::Future> SendFuture for T {}
+impl<T: Future> SendFuture for T {}

--- a/grpc/src/server/mod.rs
+++ b/grpc/src/server/mod.rs
@@ -27,7 +27,9 @@ use std::sync::Arc;
 use tokio::sync::oneshot;
 use tonic::async_trait;
 
-use crate::service::{Request, Response, Service};
+use crate::service::Request;
+use crate::service::Response;
+use crate::service::Service;
 
 pub struct Server {
     handler: Option<Arc<dyn Service>>,

--- a/grpc/src/service.rs
+++ b/grpc/src/service.rs
@@ -22,10 +22,15 @@
  *
  */
 
-use std::{any::Any, fmt::Debug, pin::Pin};
+use std::any::Any;
+use std::fmt::Debug;
+use std::pin::Pin;
 
 use tokio_stream::Stream;
-use tonic::{async_trait, Request as TonicRequest, Response as TonicResponse, Status};
+use tonic::async_trait;
+use tonic::Request as TonicRequest;
+use tonic::Response as TonicResponse;
+use tonic::Status;
 
 pub type Request = TonicRequest<Pin<Box<dyn Stream<Item = Box<dyn Message>> + Send + Sync>>>;
 pub type Response =

--- a/grpc/src/status/server_status.rs
+++ b/grpc/src/status/server_status.rs
@@ -22,8 +22,8 @@
  *
  */
 
-use super::status_code::StatusCode;
-use super::Status;
+use crate::status::status_code::StatusCode;
+use crate::status::Status;
 
 /// Represents a gRPC status on the server.
 ///


### PR DESCRIPTION
This PR is based on top of #2513, and applies a standard ordering to all our imports.