### PR TITLE
chore(ci): Update to actions/checkout@v6

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -312,7 +312,7 @@ jobs:
   doc:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@v6
     - uses: dtolnay/rust-toolchain@nightly
     - uses: dtolnay/install@cargo-docs-rs
     - uses: taiki-e/install-action@cargo-hack


### PR DESCRIPTION
Updates to `actions/checkout@v6`.