### PR TITLE
interop: support running binaries for non-local target dirs

### DIFF
--- a/interop/test.sh
+++ b/interop/test.sh
@@ -62,10 +62,11 @@ trap cleanup EXIT
 
 sleep 3
 
-./target/debug/client --codec=prost --test_case="${JOINED_TEST_CASES}" "${ARG}"
+TARGET_DIR="$(cargo metadata --format-version 1 | jq -r '.target_directory')"
+"${TARGET_DIR}/debug/client" --codec=prost --test_case="${JOINED_TEST_CASES}" "${ARG}"
 
 # Test a grpc rust client against a Go server.
-./target/debug/client --codec=protobuf --test_case="${JOINED_TEST_CASES}" ${ARG}
+"${TARGET_DIR}/debug/client" --codec=protobuf --test_case="${JOINED_TEST_CASES}" ${ARG}
 
 echo ":; killing test server"; kill "${SERVER_PID}";
 echo "Waiting for test server to exit..."
@@ -77,13 +78,13 @@ CODECS=("prost" "protobuf")
 
 for CODEC in "${CODECS[@]}"; do
     # run the test server
-    ./target/debug/server "${ARG}" --codec "${CODEC}" &
+    "${TARGET_DIR}/debug/server" "${ARG}" --codec "${CODEC}" &
     SERVER_PID=$!
     echo ":; started tonic test server with the ${CODEC} codec."
 
     sleep 3
 
-    ./target/debug/client --codec=prost --test_case="${JOINED_TEST_CASES}" "${ARG}"
+    "${TARGET_DIR}/debug/client" --codec=prost --test_case="${JOINED_TEST_CASES}" "${ARG}"
 
     # Run client test cases
     if [ -n "${ARG:-}" ]; then


### PR DESCRIPTION
I have a local cargo config file that makes my target directory in `/tmp` instead of the local directory.  That makes the interop test script fail.  This should fix that and still work with a local directory, too.