### PR TITLE
chore: prepare 0.14.6 release

### DIFF
--- a/tonic-build/Cargo.toml
+++ b/tonic-build/Cargo.toml
@@ -11,7 +11,7 @@ license = "MIT"
 name = "tonic-build"
 readme = "README.md"
 repository = "https://github.com/hyperium/tonic"
-version = "0.14.5"
+version = "0.14.6"
 rust-version = { workspace = true }
 
 [dependencies]

--- a/tonic-health/Cargo.toml
+++ b/tonic-health/Cargo.toml
@@ -11,7 +11,7 @@ license = "MIT"
 name = "tonic-health"
 readme = "README.md"
 repository = "https://github.com/hyperium/tonic"
-version = "0.14.5"
+version = "0.14.6"
 rust-version = { workspace = true }
 
 [dependencies]

--- a/tonic-prost-build/Cargo.toml
+++ b/tonic-prost-build/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tonic-prost-build"
-version = "0.14.5"
+version = "0.14.6"
 authors = ["Lucio Franco <luciofranco14@gmail.com>"]
 edition = "2024"
 license = "MIT"

--- a/tonic-prost/Cargo.toml
+++ b/tonic-prost/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tonic-prost"
-version = "0.14.5"
+version = "0.14.6"
 authors = ["Lucio Franco <luciofranco14@gmail.com>"]
 edition = "2024"
 license = "MIT"

--- a/tonic-reflection/Cargo.toml
+++ b/tonic-reflection/Cargo.toml
@@ -14,7 +14,7 @@ license = "MIT"
 name = "tonic-reflection"
 readme = "README.md"
 repository = "https://github.com/hyperium/tonic"
-version = "0.14.5"
+version = "0.14.6"
 rust-version = { workspace = true }
 
 [package.metadata.docs.rs]

--- a/tonic-types/Cargo.toml
+++ b/tonic-types/Cargo.toml
@@ -14,7 +14,7 @@ license = "MIT"
 name = "tonic-types"
 readme = "README.md"
 repository = "https://github.com/hyperium/tonic"
-version = "0.14.5"
+version = "0.14.6"
 rust-version = { workspace = true }
 
 [dependencies]

--- a/tonic-web/Cargo.toml
+++ b/tonic-web/Cargo.toml
@@ -11,7 +11,7 @@ license = "MIT"
 name = "tonic-web"
 readme = "README.md"
 repository = "https://github.com/hyperium/tonic"
-version = "0.14.5"
+version = "0.14.6"
 rust-version = { workspace = true }
 
 [dependencies]

--- a/tonic/Cargo.toml
+++ b/tonic/Cargo.toml
@@ -15,7 +15,7 @@ keywords = ["rpc", "grpc", "async", "futures", "protobuf"]
 license = "MIT"
 readme = "../README.md"
 repository = "https://github.com/hyperium/tonic"
-version = "0.14.5"
+version = "0.14.6"
 rust-version = {workspace = true}
 exclude = ["benches-disabled"]
 

--- a/tonic/src/status.rs
+++ b/tonic/src/status.rs
@@ -759,6 +759,9 @@ impl fmt::Display for Status {
         if let Some(source) = self.source() {
             write!(f, ", source: {source:?}")?;
         }
+        if let Some(source) = self.source() {
+            write!(f, ", source: {source:?}")?;
+        }
         Ok(())
     }
 }

--- a/tonic/src/status.rs
+++ b/tonic/src/status.rs
@@ -759,9 +759,6 @@ impl fmt::Display for Status {
         if let Some(source) = self.source() {
             write!(f, ", source: {source:?}")?;
         }
-        if let Some(source) = self.source() {
-            write!(f, ", source: {source:?}")?;
-        }
         Ok(())
     }
 }


### PR DESCRIPTION
- [Put source error into the Display impl of Status](https://github.com/hyperium/tonic/pull/2417)
- [Remove metadata from tonic::Status Display impl.](https://github.com/hyperium/tonic/pull/2481)
