### PR TITLE
tonic-xds: ignore status::Ok in the retriable code list

### DIFF
--- a/tonic-xds/src/client/retry.rs
+++ b/tonic-xds/src/client/retry.rs
@@ -441,7 +441,8 @@ mod tests {
 
     #[test]
     fn test_ok_should_not_be_retried() {
-        assert!(!is_retryable_grpc_status_code(tonic::Code::Ok, &[]))
+        let codes = vec![tonic::Code::Ok];
+        assert!(!is_retryable_grpc_status_code(tonic::Code::Ok, &codes))
     }
 
     #[test]

--- a/tonic-xds/src/client/retry.rs
+++ b/tonic-xds/src/client/retry.rs
@@ -42,7 +42,7 @@ pub(crate) fn is_retryable_grpc_status_code(
     code: tonic::Code,
     retryable_codes: &[tonic::Code],
 ) -> bool {
-    retryable_codes.contains(&code)
+    code != tonic::Code::Ok && retryable_codes.contains(&code)
 }
 
 /// Check if a request should be retried, either because of a retryable connection error
@@ -437,6 +437,11 @@ mod tests {
     fn test_ok_is_not_retryable() {
         let codes = vec![tonic::Code::Unavailable, tonic::Code::Cancelled];
         assert!(!is_retryable_grpc_status_code(tonic::Code::Ok, &codes));
+    }
+
+    #[test]
+    fn test_ok_should_not_be_retried() {
+        assert!(!is_retryable_grpc_status_code(tonic::Code::Ok, &[]))
     }
 
     #[test]

--- a/tonic-xds/src/xds/resource/route_config.rs
+++ b/tonic-xds/src/xds/resource/route_config.rs
@@ -268,6 +268,7 @@ fn validate_header_matcher(
     use envoy_types::pb::envoy::config::route::v3::header_matcher::HeaderMatchSpecifier;
     use envoy_types::pb::envoy::r#type::matcher::v3::string_matcher::MatchPattern;
 
+    // It's common that some xDS features are marked as deprecated while they are still widely in-use.
     #[allow(deprecated)]
     let match_specifier = match hm.header_match_specifier {
         Some(HeaderMatchSpecifier::ExactMatch(v)) => HeaderMatchSpecifierConfig::Exact {

--- a/tonic-xds/src/xds/resource/route_config.rs
+++ b/tonic-xds/src/xds/resource/route_config.rs
@@ -268,6 +268,7 @@ fn validate_header_matcher(
     use envoy_types::pb::envoy::config::route::v3::header_matcher::HeaderMatchSpecifier;
     use envoy_types::pb::envoy::r#type::matcher::v3::string_matcher::MatchPattern;
 
+    #[allow(deprecated)]
     let match_specifier = match hm.header_match_specifier {
         Some(HeaderMatchSpecifier::ExactMatch(v)) => HeaderMatchSpecifierConfig::Exact {
             value: v,


### PR DESCRIPTION
Small fix for xds retry: ignore ok status code all the time.

## Motivation
In case "Ok" is misconfigured in the xDS config, the retry layer will not attempt retries on the successful calls.

## Solution
Fix the condition in is_retryable_grpc_status_code()

