### PR TITLE
tonic-xds: Implement subchannel state machine

### DIFF
--- a/tonic-xds/Cargo.toml
+++ b/tonic-xds/Cargo.toml
@@ -30,6 +30,7 @@ dashmap = "6.1"
 thiserror = "2.0.17"
 url = "2.5.8"
 futures-core = "0.3.31"
+futures-util = "0.3"
 bytes = "1"
 xds-client = { version = "0.1.0-alpha.1", path = "../xds-client" }
 serde = { version = "1", features = ["derive"] }
@@ -42,6 +43,7 @@ tokio = { version = "1", features = ["sync", "time"] }
 # cryptographic security, only statistical uniformity for traffic distribution.
 fastrand = "2"
 tokio-stream = "0.1"
+tokio-util = "0.7"
 backoff = "0.4"
 shared_http_body = "0.1"
 tonic-prost = { version = "0.14", optional = true }

--- a/tonic-xds/Cargo.toml
+++ b/tonic-xds/Cargo.toml
@@ -37,7 +37,7 @@ serde_json = "1"
 envoy-types = "0.7"
 prost = "0.14"
 regex = "1"
-tokio = { version = "1", features = ["sync"] }
+tokio = { version = "1", features = ["sync", "time"] }
 # Used for weighted cluster selection and fractional route matching — does not need
 # cryptographic security, only statistical uniformity for traffic distribution.
 fastrand = "2"
@@ -51,7 +51,7 @@ workspace = true
 
 [dev-dependencies]
 xds-client = { version = "0.1.0-alpha.1", path = "../xds-client", features = ["test-util"] }
-tokio = { version = "1", features = ["rt-multi-thread", "macros", "net"] }
+tokio = { version = "1", features = ["rt-multi-thread", "macros", "net", "test-util"] }
 tonic = { version = "0.14", features = [ "server", "channel", "tls-ring" ] }
 tonic-prost = "0.14"
 tonic-prost-build = "0.14"

--- a/tonic-xds/Cargo.toml
+++ b/tonic-xds/Cargo.toml
@@ -24,6 +24,7 @@ exclude = ["proto/test/*"]
 tonic = "0.14"
 http = "1"
 http-body = "1"
+pin-project-lite = "0.2"
 tower = { version = "0.5", default-features = false, features = ["discover", "retry"] }
 arc-swap = "1"
 dashmap = "6.1"

--- a/tonic-xds/src/client/endpoint.rs
+++ b/tonic-xds/src/client/endpoint.rs
@@ -153,3 +153,20 @@ impl<S> Load for EndpointChannel<S> {
         self.in_flight.load(Ordering::Relaxed)
     }
 }
+
+/// Factory for creating connections to endpoints.
+///
+/// Implementations capture cluster-level config (TLS, HTTP/2 settings, timeouts)
+/// at construction time. The implementation handles retries and concurrency
+/// internally — the returned future resolves when a connection is established
+/// (or is cancelled by dropping).
+pub(crate) trait Connector {
+    /// The service type produced by this connector.
+    type Service;
+
+    /// Connect to the given endpoint address.
+    fn connect(
+        &self,
+        addr: &EndpointAddress,
+    ) -> crate::common::async_util::BoxFuture<Self::Service>;
+}

--- a/tonic-xds/src/client/loadbalance/channel.rs
+++ b/tonic-xds/src/client/loadbalance/channel.rs
@@ -1,14 +1,16 @@
 //! LbChannel: an instrumented channel wrapper with in-flight request tracking.
 
+use std::future::Future;
+use std::pin::Pin;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::task::{Context, Poll};
 
+use pin_project_lite::pin_project;
+use tower::Service;
 use tower::load::Load;
-use tower::{BoxError, Service};
 
 use crate::client::endpoint::EndpointAddress;
-use crate::common::async_util::BoxFuture;
 
 /// RAII guard that increments an in-flight counter on creation and decrements on drop.
 /// Ensures accurate tracking even when futures are cancelled.
@@ -26,6 +28,25 @@ impl InFlightGuard {
 impl Drop for InFlightGuard {
     fn drop(&mut self) {
         self.counter.fetch_sub(1, Ordering::Relaxed);
+    }
+}
+
+pin_project! {
+    /// A future that holds an [`InFlightGuard`] for the duration of a request.
+    ///
+    /// Preserves the inner future's output type — no boxing or error mapping.
+    pub(crate) struct InFlightFuture<F> {
+        #[pin]
+        inner: F,
+        _guard: InFlightGuard,
+    }
+}
+
+impl<F: Future> Future for InFlightFuture<F> {
+    type Output = F::Output;
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        self.project().inner.poll(cx)
     }
 }
 
@@ -76,27 +97,22 @@ impl<S: Clone> Clone for LbChannel<S> {
 
 impl<S, Req> Service<Req> for LbChannel<S>
 where
-    S: Service<Req> + Clone + Send + 'static,
-    S::Future: Send + 'static,
-    S::Error: Into<BoxError>,
-    Req: Send + 'static,
+    S: Service<Req>,
 {
     type Response = S::Response;
-    type Error = BoxError;
-    type Future = BoxFuture<Result<S::Response, BoxError>>;
+    type Error = S::Error;
+    type Future = InFlightFuture<S::Future>;
 
     fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
-        self.inner.poll_ready(cx).map_err(Into::into)
+        self.inner.poll_ready(cx)
     }
 
     fn call(&mut self, req: Req) -> Self::Future {
-        let mut inner = self.inner.clone();
         let guard = InFlightGuard::acquire(self.in_flight.clone());
-
-        Box::pin(async move {
-            let _guard = guard;
-            inner.call(req).await.map_err(Into::into)
-        })
+        InFlightFuture {
+            inner: self.inner.call(req),
+            _guard: guard,
+        }
     }
 }
 
@@ -123,8 +139,8 @@ mod tests {
 
     impl Service<&'static str> for MockService {
         type Response = &'static str;
-        type Error = BoxError;
-        type Future = future::Ready<Result<&'static str, BoxError>>;
+        type Error = &'static str;
+        type Future = future::Ready<Result<&'static str, &'static str>>;
 
         fn poll_ready(&mut self, _cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
             Poll::Ready(Ok(()))

--- a/tonic-xds/src/client/loadbalance/channel.rs
+++ b/tonic-xds/src/client/loadbalance/channel.rs
@@ -1,0 +1,183 @@
+//! LbChannel: an instrumented channel wrapper with in-flight request tracking.
+
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::task::{Context, Poll};
+
+use tower::load::Load;
+use tower::{BoxError, Service};
+
+use crate::client::endpoint::EndpointAddress;
+use crate::common::async_util::BoxFuture;
+
+/// RAII guard that increments an in-flight counter on creation and decrements on drop.
+/// Ensures accurate tracking even when futures are cancelled.
+struct InFlightGuard {
+    counter: Arc<AtomicU64>,
+}
+
+impl InFlightGuard {
+    fn acquire(counter: Arc<AtomicU64>) -> Self {
+        counter.fetch_add(1, Ordering::Relaxed);
+        Self { counter }
+    }
+}
+
+impl Drop for InFlightGuard {
+    fn drop(&mut self) {
+        self.counter.fetch_sub(1, Ordering::Relaxed);
+    }
+}
+
+/// A channel wrapper that tracks in-flight requests for load balancing.
+///
+/// `LbChannel` wraps an inner service `S` and maintains an atomic counter of
+/// in-flight requests. This counter is used by P2C load balancers (via the
+/// [`Load`] trait) to prefer endpoints with fewer active requests.
+///
+/// All clones of an `LbChannel` share the same in-flight counter.
+pub(crate) struct LbChannel<S> {
+    addr: EndpointAddress,
+    inner: S,
+    in_flight: Arc<AtomicU64>,
+}
+
+impl<S> LbChannel<S> {
+    /// Create a new `LbChannel` wrapping the given service.
+    pub(crate) fn new(addr: EndpointAddress, inner: S) -> Self {
+        Self {
+            addr,
+            inner,
+            in_flight: Arc::new(AtomicU64::new(0)),
+        }
+    }
+
+    /// Returns the endpoint address.
+    pub(crate) fn addr(&self) -> &EndpointAddress {
+        &self.addr
+    }
+
+    /// Returns the current number of in-flight requests.
+    #[cfg(test)]
+    pub(crate) fn in_flight(&self) -> u64 {
+        self.in_flight.load(Ordering::Relaxed)
+    }
+}
+
+impl<S: Clone> Clone for LbChannel<S> {
+    fn clone(&self) -> Self {
+        Self {
+            addr: self.addr.clone(),
+            inner: self.inner.clone(),
+            in_flight: self.in_flight.clone(),
+        }
+    }
+}
+
+impl<S, Req> Service<Req> for LbChannel<S>
+where
+    S: Service<Req> + Clone + Send + 'static,
+    S::Future: Send + 'static,
+    S::Error: Into<BoxError>,
+    Req: Send + 'static,
+{
+    type Response = S::Response;
+    type Error = BoxError;
+    type Future = BoxFuture<Result<S::Response, BoxError>>;
+
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.inner.poll_ready(cx).map_err(Into::into)
+    }
+
+    fn call(&mut self, req: Req) -> Self::Future {
+        let mut inner = self.inner.clone();
+        let guard = InFlightGuard::acquire(self.in_flight.clone());
+
+        Box::pin(async move {
+            let _guard = guard;
+            inner.call(req).await.map_err(Into::into)
+        })
+    }
+}
+
+impl<S> Load for LbChannel<S> {
+    type Metric = u64;
+
+    fn load(&self) -> Self::Metric {
+        self.in_flight.load(Ordering::Relaxed)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::future;
+    use std::task::Poll;
+
+    fn test_addr() -> EndpointAddress {
+        EndpointAddress::new("127.0.0.1", 8080)
+    }
+
+    #[derive(Clone)]
+    struct MockService;
+
+    impl Service<&'static str> for MockService {
+        type Response = &'static str;
+        type Error = BoxError;
+        type Future = future::Ready<Result<&'static str, BoxError>>;
+
+        fn poll_ready(&mut self, _cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+            Poll::Ready(Ok(()))
+        }
+
+        fn call(&mut self, _req: &'static str) -> Self::Future {
+            future::ready(Ok("ok"))
+        }
+    }
+
+    #[tokio::test]
+    async fn test_in_flight_increments_and_decrements() {
+        let mut ch = LbChannel::new(test_addr(), MockService);
+        assert_eq!(ch.in_flight(), 0);
+
+        let fut = ch.call("hello");
+        assert_eq!(ch.in_flight(), 1);
+
+        let resp = fut.await.unwrap();
+        assert_eq!(resp, "ok");
+        assert_eq!(ch.in_flight(), 0);
+    }
+
+    #[tokio::test]
+    async fn test_in_flight_on_future_drop() {
+        let mut ch = LbChannel::new(test_addr(), MockService);
+        let fut = ch.call("hello");
+        assert_eq!(ch.in_flight(), 1);
+
+        drop(fut);
+        assert_eq!(ch.in_flight(), 0);
+    }
+
+    #[tokio::test]
+    async fn test_clone_shares_in_flight() {
+        let mut ch1 = LbChannel::new(test_addr(), MockService);
+        let ch2 = ch1.clone();
+
+        let fut = ch1.call("hello");
+        assert_eq!(ch1.in_flight(), 1);
+        assert_eq!(ch2.in_flight(), 1);
+
+        let _ = fut.await;
+        assert_eq!(ch1.in_flight(), 0);
+        assert_eq!(ch2.in_flight(), 0);
+    }
+
+    #[test]
+    fn test_load_returns_in_flight() {
+        let ch = LbChannel::new(test_addr(), MockService);
+        assert_eq!(Load::load(&ch), 0);
+
+        ch.in_flight.fetch_add(3, Ordering::Relaxed);
+        assert_eq!(Load::load(&ch), 3);
+    }
+}

--- a/tonic-xds/src/client/loadbalance/channel_state.rs
+++ b/tonic-xds/src/client/loadbalance/channel_state.rs
@@ -4,16 +4,17 @@
 //! This prevents using a channel in an invalid state at compile time.
 //!
 //! ```text
-//!                +---reconnect---+
-//!                |               |
-//!                v               |
-//! Idle --> Connecting --> Ready --+--eject--> Ejected
-//!                ^                               |
-//!                +----------reconnect------------+
+//!                +-----------+
+//!                |           |
+//!                v           |
+//! Idle --> Connecting --> Ready <--+--> Ejected
+//!                ^                       |
+//!                |                       |
+//!                +-----------------------+
 //! ```
 //!
-//! State changes are all one-shot: [`ConnectingChannel`] and [`EjectedChannel`] are
-//! [`Future`]s, not streams. The caller (typically a pool) uses [`KeyedFutures`] to
+//! State changes are all one-shot. [`ConnectingChannel`] and [`EjectedChannel`] are
+//! [`Future`]. The caller (typically a pool) uses [`KeyedFutures`] to
 //! manage multiple in-flight state changes and handle cancellation by key.
 //!
 //! [`KeyedFutures`]: crate::client::loadbalance::keyed_futures::KeyedFutures
@@ -36,7 +37,7 @@ use crate::common::async_util::BoxFuture;
 pub(crate) struct EjectionConfig {
     /// How long the channel is ejected before it can return to service.
     pub timeout: Duration,
-    /// Whether the channel needs a fresh connection after ejection expires.
+    /// Whether the channel needs a fresh connection after ejection expires (e.g. after consecutive timeouts).
     pub needs_reconnect: bool,
 }
 
@@ -116,6 +117,8 @@ impl<S: Send + 'static> Future for ConnectingChannel<S> {
 ///
 /// Wraps an [`LbChannel`] and delegates [`Service`] and [`Load`] to it.
 /// State transitions consume `self` to prevent use-after-transition.
+/// ReadyChannel is `Clone` to allow reusing the same channel in load balancer.
+#[derive(Clone)]
 pub(crate) struct ReadyChannel<S> {
     pub(super) channel: LbChannel<S>,
 }
@@ -203,6 +206,7 @@ impl<S: Clone + Unpin + Send + 'static> Future for EjectedChannel<S> {
     type Output = UnejectedChannel<S>;
 
     fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        // get_mut() requires EjectedChannel to be Unpin, which requires S to be Unpin.
         let this = self.get_mut();
         match this.ejection_timer.as_mut().poll(cx) {
             Poll::Ready(()) => {
@@ -300,7 +304,9 @@ mod tests {
     #[tokio::test]
     async fn test_ready_to_connecting_via_reconnect() {
         let connector = MockConnector::new();
-        let ready = IdleChannel::new(test_addr()).connect(connector.clone()).await;
+        let ready = IdleChannel::new(test_addr())
+            .connect(connector.clone())
+            .await;
         let _reconnecting = ready.reconnect(connector.clone());
         assert_eq!(connector.connect_count.load(Ordering::SeqCst), 2);
     }
@@ -313,8 +319,7 @@ mod tests {
         let connecting =
             ConnectingChannel::new(Box::pin(async move { rx.await.unwrap() }), test_addr());
 
-        let mut set: KeyedFutures<EndpointAddress, ReadyChannel<MockService>> =
-            KeyedFutures::new();
+        let mut set: KeyedFutures<EndpointAddress, ReadyChannel<MockService>> = KeyedFutures::new();
         set.add(test_addr(), connecting).unwrap();
 
         // Before send: pending.
@@ -331,23 +336,18 @@ mod tests {
 
     #[tokio::test]
     async fn test_connecting_cancelled_via_keyed_futures() {
-        let connecting = ConnectingChannel::new(
-            Box::pin(future::pending::<MockService>()),
-            test_addr(),
-        );
+        let connecting =
+            ConnectingChannel::new(Box::pin(future::pending::<MockService>()), test_addr());
 
-        let mut set: KeyedFutures<EndpointAddress, ReadyChannel<MockService>> =
-            KeyedFutures::new();
+        let mut set: KeyedFutures<EndpointAddress, ReadyChannel<MockService>> = KeyedFutures::new();
         set.add(test_addr(), connecting).unwrap();
 
         assert!(matches!(set.poll_next(&mut noop_cx()), Poll::Pending));
 
         set.cancel(&test_addr()).unwrap();
-        for _ in 0..10 {
-            match set.poll_next(&mut noop_cx()) {
-                Poll::Ready(None) => return,
-                _ => tokio::task::yield_now().await,
-            }
+        match set.poll_next(&mut noop_cx()) {
+            Poll::Ready(None) => return,
+            _ => tokio::task::yield_now().await,
         }
         panic!("expected set to be empty after cancel");
     }
@@ -355,7 +355,9 @@ mod tests {
     #[tokio::test(start_paused = true)]
     async fn test_ejected_in_keyed_futures_ready() {
         let connector = MockConnector::new();
-        let ready = IdleChannel::new(test_addr()).connect(connector.clone()).await;
+        let ready = IdleChannel::new(test_addr())
+            .connect(connector.clone())
+            .await;
         let ejected = ready.eject(
             EjectionConfig {
                 timeout: Duration::from_secs(5),
@@ -379,7 +381,9 @@ mod tests {
     #[tokio::test(start_paused = true)]
     async fn test_ejected_in_keyed_futures_needs_reconnect() {
         let connector = MockConnector::new();
-        let ready = IdleChannel::new(test_addr()).connect(connector.clone()).await;
+        let ready = IdleChannel::new(test_addr())
+            .connect(connector.clone())
+            .await;
         let ejected = ready.eject(
             EjectionConfig {
                 timeout: Duration::from_secs(5),

--- a/tonic-xds/src/client/loadbalance/channel_state.rs
+++ b/tonic-xds/src/client/loadbalance/channel_state.rs
@@ -1,0 +1,358 @@
+//! Type-state wrappers for LbChannel lifecycle management.
+//!
+//! Each state is a separate struct, and transitions consume the old state (move semantics).
+//! This prevents using a channel in an invalid state at compile time.
+//!
+//! ```text
+//! Idle → Connecting → Ready ⇄ Ejected
+//!                       ↓        ↓
+//!                   Connecting  Connecting (via reconnect)
+//! ```
+
+use std::pin::Pin;
+use std::sync::Arc;
+use std::task::{Context, Poll};
+use std::time::Duration;
+
+use futures_core::Stream;
+use tower::load::Load;
+use tower::{BoxError, Service};
+
+use crate::client::endpoint::{Connector, EndpointAddress};
+use crate::client::loadbalance::channel::LbChannel;
+use crate::common::async_util::BoxFuture;
+
+/// Configuration for an ejected channel.
+#[derive(Debug, Clone)]
+pub(crate) struct EjectionConfig {
+    /// How long the channel is ejected before it can return to service.
+    pub timeout: Duration,
+    /// Whether the channel needs a fresh connection after ejection expires.
+    pub needs_reconnect: bool,
+}
+
+/// Result of an ejection expiring.
+pub(crate) enum UnejectedChannel<S> {
+    /// The channel is ready to serve again (ejection expired, no reconnect needed).
+    Ready(ReadyLbChannel<S>),
+    /// A fresh connection has been started.
+    Connecting(ConnectingLbChannel<S>),
+}
+
+// ---------------------------------------------------------------------------
+// IdleLbChannel
+// ---------------------------------------------------------------------------
+
+/// An idle channel that only stores an address. It is the entry point for
+/// starting a connection attempt.
+pub(crate) struct IdleLbChannel {
+    addr: EndpointAddress,
+}
+
+impl IdleLbChannel {
+    pub(crate) fn new(addr: EndpointAddress) -> Self {
+        Self { addr }
+    }
+
+    /// Start connecting to the endpoint. Consumes the idle channel.
+    pub(crate) fn connect<C: Connector>(
+        self,
+        connector: Arc<C>,
+    ) -> ConnectingLbChannel<C::Service> {
+        let fut = connector.connect(&self.addr);
+        ConnectingLbChannel {
+            addr: self.addr,
+            fut: Some(fut),
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// ConnectingLbChannel
+// ---------------------------------------------------------------------------
+
+/// A channel that is in the process of connecting.
+///
+/// Implements [`Stream`] for integration with `StreamMap`. The stream yields
+/// exactly one item — `ReadyLbChannel` on success — then terminates.
+/// If dropped (e.g., removed from StreamMap), the connection attempt is cancelled.
+pub(crate) struct ConnectingLbChannel<S> {
+    addr: EndpointAddress,
+    fut: Option<BoxFuture<S>>,
+}
+
+impl<S: Send + 'static> Stream for ConnectingLbChannel<S> {
+    type Item = ReadyLbChannel<S>;
+
+    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        let this = self.get_mut();
+        let Some(fut) = this.fut.as_mut() else {
+            return Poll::Ready(None);
+        };
+        match fut.as_mut().poll(cx) {
+            Poll::Ready(svc) => {
+                this.fut = None;
+                Poll::Ready(Some(ReadyLbChannel {
+                    channel: LbChannel::new(this.addr.clone(), svc),
+                }))
+            }
+            Poll::Pending => Poll::Pending,
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// ReadyLbChannel
+// ---------------------------------------------------------------------------
+
+/// A channel that is connected and ready to serve requests.
+///
+/// Wraps an [`LbChannel`] and delegates [`Service`] and [`Load`] to it.
+/// State transitions consume `self` to prevent use-after-transition.
+pub(crate) struct ReadyLbChannel<S> {
+    channel: LbChannel<S>,
+}
+
+impl<S> ReadyLbChannel<S> {
+    /// Eject this channel (e.g., due to outlier detection). Consumes self.
+    pub(crate) fn eject<C>(self, config: EjectionConfig, connector: Arc<C>) -> EjectedLbChannel<S>
+    where
+        C: Connector<Service = S> + 'static,
+    {
+        let ejection_timer = Box::pin(tokio::time::sleep(config.timeout));
+        EjectedLbChannel {
+            channel: Some(self.channel),
+            config,
+            connector,
+            ejection_timer,
+        }
+    }
+
+    /// Start reconnecting this channel. Consumes self, dropping the old connection.
+    pub(crate) fn reconnect<C: Connector<Service = S>>(
+        self,
+        connector: Arc<C>,
+    ) -> ConnectingLbChannel<S> {
+        let addr = self.channel.addr().clone();
+        let fut = connector.connect(&addr);
+        ConnectingLbChannel {
+            addr,
+            fut: Some(fut),
+        }
+    }
+}
+
+impl<S, Req> Service<Req> for ReadyLbChannel<S>
+where
+    S: Service<Req> + Clone + Send + 'static,
+    S::Future: Send + 'static,
+    S::Error: Into<BoxError>,
+    Req: Send + 'static,
+{
+    type Response = S::Response;
+    type Error = BoxError;
+    type Future = BoxFuture<Result<S::Response, BoxError>>;
+
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.channel.poll_ready(cx)
+    }
+
+    fn call(&mut self, req: Req) -> Self::Future {
+        self.channel.call(req)
+    }
+}
+
+impl<S> Load for ReadyLbChannel<S> {
+    type Metric = u64;
+
+    fn load(&self) -> Self::Metric {
+        self.channel.load()
+    }
+}
+
+// ---------------------------------------------------------------------------
+// EjectedLbChannel
+// ---------------------------------------------------------------------------
+
+/// A channel that has been ejected and is cooling down.
+///
+/// The underlying connection is kept alive but cannot serve requests.
+/// Implements [`Stream`] for integration with `StreamMap`. After the ejection
+/// timer expires, yields either:
+/// - [`UnejectedChannel::Ready`] if no reconnect is needed
+/// - [`UnejectedChannel::Connecting`] if a fresh connection is required
+///
+/// This is a one-shot stream — it yields exactly one item then terminates.
+pub(crate) struct EjectedLbChannel<S> {
+    /// Option to allow moving the channel out via `take()` in `poll_next`.
+    channel: Option<LbChannel<S>>,
+    config: EjectionConfig,
+    connector: Arc<dyn Connector<Service = S>>,
+    ejection_timer: Pin<Box<tokio::time::Sleep>>,
+}
+
+impl<S: Clone + Unpin> Stream for EjectedLbChannel<S> {
+    type Item = UnejectedChannel<S>;
+
+    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        let this = self.get_mut();
+        let Some(channel) = this.channel.as_ref() else {
+            return Poll::Ready(None);
+        };
+        match this.ejection_timer.as_mut().poll(cx) {
+            Poll::Ready(()) => {
+                if this.config.needs_reconnect {
+                    let addr = channel.addr().clone();
+                    this.channel = None;
+                    let fut = this.connector.connect(&addr);
+                    Poll::Ready(Some(UnejectedChannel::Connecting(ConnectingLbChannel {
+                        addr,
+                        fut: Some(fut),
+                    })))
+                } else {
+                    match this.channel.take() {
+                        Some(channel) => {
+                            Poll::Ready(Some(UnejectedChannel::Ready(ReadyLbChannel { channel })))
+                        }
+                        None => Poll::Ready(None),
+                    }
+                }
+            }
+            Poll::Pending => Poll::Pending,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::future;
+    use std::sync::atomic::{AtomicU32, Ordering};
+    use tokio_stream::StreamExt;
+
+    #[derive(Clone)]
+    struct MockService;
+
+    impl Service<&'static str> for MockService {
+        type Response = &'static str;
+        type Error = BoxError;
+        type Future = future::Ready<Result<&'static str, BoxError>>;
+
+        fn poll_ready(&mut self, _cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+            Poll::Ready(Ok(()))
+        }
+
+        fn call(&mut self, _req: &'static str) -> Self::Future {
+            future::ready(Ok("ok"))
+        }
+    }
+
+    struct MockConnector {
+        connect_count: Arc<AtomicU32>,
+    }
+
+    impl MockConnector {
+        fn new() -> Arc<Self> {
+            Arc::new(Self {
+                connect_count: Arc::new(AtomicU32::new(0)),
+            })
+        }
+    }
+
+    impl Connector for MockConnector {
+        type Service = MockService;
+
+        fn connect(&self, _addr: &EndpointAddress) -> BoxFuture<Self::Service> {
+            self.connect_count.fetch_add(1, Ordering::SeqCst);
+            Box::pin(future::ready(MockService))
+        }
+    }
+
+    fn test_addr() -> EndpointAddress {
+        EndpointAddress::new("127.0.0.1", 8080)
+    }
+
+    #[tokio::test]
+    async fn test_idle_to_connecting() {
+        let connector = MockConnector::new();
+        let idle = IdleLbChannel::new(test_addr());
+        let _connecting = idle.connect(connector.clone());
+        assert_eq!(connector.connect_count.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn test_connecting_stream_yields_ready() {
+        let connector = MockConnector::new();
+        let mut connecting = IdleLbChannel::new(test_addr()).connect(connector);
+        assert!(connecting.next().await.is_some());
+    }
+
+    #[tokio::test]
+    async fn test_connecting_stream_is_one_shot() {
+        let connector = MockConnector::new();
+        let mut connecting = IdleLbChannel::new(test_addr()).connect(connector);
+        let _ = connecting.next().await;
+        assert!(connecting.next().await.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_ready_service_delegates() {
+        let connector = MockConnector::new();
+        let mut connecting = IdleLbChannel::new(test_addr()).connect(connector);
+        let mut ready = connecting.next().await.unwrap();
+
+        let resp = ready.call("hello").await.unwrap();
+        assert_eq!(resp, "ok");
+    }
+
+    #[tokio::test]
+    async fn test_ready_to_connecting_via_reconnect() {
+        let connector = MockConnector::new();
+        let mut connecting = IdleLbChannel::new(test_addr()).connect(connector.clone());
+        let ready = connecting.next().await.unwrap();
+
+        let mut reconnecting = ready.reconnect(connector.clone());
+        assert_eq!(connector.connect_count.load(Ordering::SeqCst), 2);
+        assert!(reconnecting.next().await.is_some());
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn test_ejected_yields_ready_after_timeout() {
+        let connector = MockConnector::new();
+        let mut connecting = IdleLbChannel::new(test_addr()).connect(connector.clone());
+        let ready = connecting.next().await.unwrap();
+
+        let config = EjectionConfig {
+            timeout: Duration::from_secs(5),
+            needs_reconnect: false,
+        };
+        let mut ejected = ready.eject(config, connector);
+
+        let result = ejected.next().await.unwrap();
+        assert!(matches!(result, UnejectedChannel::Ready(_)));
+        assert!(ejected.next().await.is_none());
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn test_ejected_yields_connecting_when_needs_reconnect() {
+        let connector = MockConnector::new();
+        let mut connecting = IdleLbChannel::new(test_addr()).connect(connector.clone());
+        let ready = connecting.next().await.unwrap();
+
+        let config = EjectionConfig {
+            timeout: Duration::from_secs(5),
+            needs_reconnect: true,
+        };
+        let mut ejected = ready.eject(config, connector.clone());
+
+        let result = ejected.next().await.unwrap();
+        match result {
+            UnejectedChannel::Connecting(mut c) => {
+                assert!(c.next().await.is_some());
+                assert_eq!(connector.connect_count.load(Ordering::SeqCst), 2);
+            }
+            _ => panic!("expected UnejectedChannel::Connecting"),
+        }
+        assert!(ejected.next().await.is_none());
+    }
+}

--- a/tonic-xds/src/client/loadbalance/channel_state.rs
+++ b/tonic-xds/src/client/loadbalance/channel_state.rs
@@ -117,7 +117,7 @@ impl<S> ReadyLbChannel<S> {
     /// Eject this channel (e.g., due to outlier detection). Consumes self.
     pub(crate) fn eject<C>(self, config: EjectionConfig, connector: Arc<C>) -> EjectedLbChannel<S>
     where
-        C: Connector<Service = S> + 'static,
+        C: Connector<Service = S> + Send + Sync + 'static,
     {
         let ejection_timer = Box::pin(tokio::time::sleep(config.timeout));
         EjectedLbChannel {
@@ -187,7 +187,10 @@ pub(crate) struct EjectedLbChannel<S> {
     /// Option to allow moving the channel out via `take()` in `poll_next`.
     channel: Option<LbChannel<S>>,
     config: EjectionConfig,
-    connector: Arc<dyn Connector<Service = S>>,
+    /// Trait object for the connector. The `Send + Sync` bounds ensure
+    /// `EjectedLbChannel<S>` is `Send + Sync` when `S` is (e.g. `tonic::Channel`),
+    /// enabling use with `StreamMap` across async task boundaries.
+    connector: Arc<dyn Connector<Service = S> + Send + Sync>,
     ejection_timer: Pin<Box<tokio::time::Sleep>>,
 }
 
@@ -354,5 +357,68 @@ mod tests {
             _ => panic!("expected UnejectedChannel::Connecting"),
         }
         assert!(ejected.next().await.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_connecting_in_stream_map() {
+        use tokio_stream::StreamMap;
+
+        let connector = MockConnector::new();
+        let connecting = IdleLbChannel::new(test_addr()).connect(connector.clone());
+
+        let mut map: StreamMap<&str, ConnectingLbChannel<MockService>> = StreamMap::new();
+        map.insert("endpoint-1", connecting);
+
+        let (key, _ready) = map.next().await.unwrap();
+        assert_eq!(key, "endpoint-1");
+        // Stream is done, removed from map — map is now empty.
+        assert!(map.next().await.is_none());
+
+        // Map can be reused: insert a new stream and it yields correctly.
+        let connecting2 = IdleLbChannel::new(test_addr()).connect(connector);
+        map.insert("endpoint-2", connecting2);
+        let (key2, _ready2) = map.next().await.unwrap();
+        assert_eq!(key2, "endpoint-2");
+        assert!(map.next().await.is_none());
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn test_ejected_in_stream_map() {
+        use tokio_stream::StreamMap;
+
+        let connector = MockConnector::new();
+        let mut connecting = IdleLbChannel::new(test_addr()).connect(connector.clone());
+        let ready = connecting.next().await.unwrap();
+
+        let config = EjectionConfig {
+            timeout: Duration::from_secs(5),
+            needs_reconnect: false,
+        };
+        let ejected = ready.eject(config, connector.clone());
+
+        let mut map: StreamMap<&str, EjectedLbChannel<MockService>> = StreamMap::new();
+        map.insert("endpoint-1", ejected);
+
+        let (key, unejected) = map.next().await.unwrap();
+        assert_eq!(key, "endpoint-1");
+        assert!(matches!(unejected, UnejectedChannel::Ready(_)));
+        // Stream is done, removed from map — map is now empty.
+        assert!(map.next().await.is_none());
+
+        // Map can be reused: insert a new ejected stream and it yields correctly.
+        let mut connecting2 = IdleLbChannel::new(test_addr()).connect(connector.clone());
+        let ready2 = connecting2.next().await.unwrap();
+        let ejected2 = ready2.eject(
+            EjectionConfig {
+                timeout: Duration::from_secs(5),
+                needs_reconnect: false,
+            },
+            connector,
+        );
+        map.insert("endpoint-2", ejected2);
+        let (key2, unejected2) = map.next().await.unwrap();
+        assert_eq!(key2, "endpoint-2");
+        assert!(matches!(unejected2, UnejectedChannel::Ready(_)));
+        assert!(map.next().await.is_none());
     }
 }

--- a/tonic-xds/src/client/loadbalance/channel_state.rs
+++ b/tonic-xds/src/client/loadbalance/channel_state.rs
@@ -122,7 +122,7 @@ impl<S: Send + 'static> Future for ConnectingChannel<S> {
 #[derive(Clone)]
 pub(crate) struct ReadyChannel<S> {
     addr: EndpointAddress,
-    pub(super) inner: S,
+    inner: S,
 }
 
 impl<S> ReadyChannel<S> {

--- a/tonic-xds/src/client/loadbalance/channel_state.rs
+++ b/tonic-xds/src/client/loadbalance/channel_state.rs
@@ -17,7 +17,11 @@
 //! [`Future`]. The caller (typically a pool) uses [`KeyedFutures`] to
 //! manage multiple in-flight state changes and handle cancellation by key.
 //!
+//! The state types hold the raw service `S` directly. In-flight tracking and
+//! load reporting are handled separately by [`LbChannel`] at the pool level.
+//!
 //! [`KeyedFutures`]: crate::client::loadbalance::keyed_futures::KeyedFutures
+//! [`LbChannel`]: crate::client::loadbalance::channel::LbChannel
 
 use std::future::Future;
 use std::pin::Pin;
@@ -25,11 +29,10 @@ use std::sync::Arc;
 use std::task::{Context, Poll};
 use std::time::Duration;
 
-use tower::load::Load;
-use tower::{BoxError, Service};
+use pin_project_lite::pin_project;
+use tower::Service;
 
 use crate::client::endpoint::{Connector, EndpointAddress};
-use crate::client::loadbalance::channel::LbChannel;
 use crate::common::async_util::BoxFuture;
 
 /// Configuration for an ejected channel.
@@ -79,9 +82,8 @@ impl IdleChannel {
 
 /// A channel that is in the process of connecting.
 ///
-/// Implements [`Future`] -- resolves to `ReadyChannel` when the connection
-/// is established. Cancellation is handled externally by the caller
-/// (e.g., via [`KeyedFutures::cancel`]).
+/// Implements [`Future`] -- resolves to [`ReadyChannel`] when connected.
+/// Cancellation is handled externally via [`KeyedFutures::cancel`].
 ///
 /// [`KeyedFutures::cancel`]: crate::client::loadbalance::keyed_futures::KeyedFutures::cancel
 pub(crate) struct ConnectingChannel<S> {
@@ -92,9 +94,9 @@ impl<S: Send + 'static> ConnectingChannel<S> {
     pub(crate) fn new(fut: BoxFuture<S>, addr: EndpointAddress) -> Self {
         Self {
             inner: Box::pin(async move {
-                let svc = fut.await;
                 ReadyChannel {
-                    channel: LbChannel::new(addr, svc),
+                    addr,
+                    inner: fut.await,
                 }
             }),
         }
@@ -115,12 +117,12 @@ impl<S: Send + 'static> Future for ConnectingChannel<S> {
 
 /// A channel that is connected and ready to serve requests.
 ///
-/// Wraps an [`LbChannel`] and delegates [`Service`] and [`Load`] to it.
-/// State transitions consume `self` to prevent use-after-transition.
-/// ReadyChannel is `Clone` to allow reusing the same channel in load balancer.
+/// Holds the raw service `S` and delegates [`Service`] calls directly,
+/// preserving `S::Future` and `S::Error` with no wrapping or type erasure.
 #[derive(Clone)]
 pub(crate) struct ReadyChannel<S> {
-    pub(super) channel: LbChannel<S>,
+    addr: EndpointAddress,
+    pub(super) inner: S,
 }
 
 impl<S> ReadyChannel<S> {
@@ -129,16 +131,17 @@ impl<S> ReadyChannel<S> {
     where
         C: Connector<Service = S> + Send + Sync + 'static,
     {
-        let ejection_timer = Box::pin(tokio::time::sleep(config.timeout));
+        let ejection_timer = tokio::time::sleep(config.timeout);
         EjectedChannel {
-            channel: self.channel,
+            addr: self.addr,
+            inner: self.inner,
             config,
             connector,
             ejection_timer,
         }
     }
 
-    /// Start reconnecting this channel. Consumes self, dropping the old connection.
+    /// Start reconnecting. Consumes self, dropping the old connection.
     pub(crate) fn reconnect<C: Connector<Service = S>>(
         self,
         connector: Arc<C>,
@@ -146,36 +149,24 @@ impl<S> ReadyChannel<S> {
     where
         S: Send + 'static,
     {
-        let addr = self.channel.addr().clone();
-        ConnectingChannel::new(connector.connect(&addr), addr)
+        ConnectingChannel::new(connector.connect(&self.addr), self.addr)
     }
 }
 
 impl<S, Req> Service<Req> for ReadyChannel<S>
 where
-    S: Service<Req> + Clone + Send + 'static,
-    S::Future: Send + 'static,
-    S::Error: Into<BoxError>,
-    Req: Send + 'static,
+    S: Service<Req>,
 {
     type Response = S::Response;
-    type Error = BoxError;
-    type Future = BoxFuture<Result<S::Response, BoxError>>;
+    type Error = S::Error;
+    type Future = S::Future;
 
     fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
-        self.channel.poll_ready(cx)
+        self.inner.poll_ready(cx)
     }
 
     fn call(&mut self, req: Req) -> Self::Future {
-        self.channel.call(req)
-    }
-}
-
-impl<S> Load for ReadyChannel<S> {
-    type Metric = u64;
-
-    fn load(&self) -> Self::Metric {
-        self.channel.load()
+        self.inner.call(req)
     }
 }
 
@@ -183,42 +174,41 @@ impl<S> Load for ReadyChannel<S> {
 // EjectedChannel
 // ---------------------------------------------------------------------------
 
-/// A channel that has been ejected and is cooling down.
-///
-/// The underlying connection is kept alive but cannot serve requests.
-/// Implements [`Future`] -- resolves once the ejection timer expires to either:
-/// - [`UnejectedChannel::Ready`] if no reconnect is needed (clones the channel)
-/// - [`UnejectedChannel::Connecting`] if a fresh connection is required
-///
-/// Cancellation is handled externally by the caller via [`KeyedFutures::cancel`].
-///
-/// [`KeyedFutures::cancel`]: crate::client::loadbalance::keyed_futures::KeyedFutures::cancel
-pub(crate) struct EjectedChannel<S> {
-    channel: LbChannel<S>,
-    config: EjectionConfig,
-    /// `Send + Sync` bounds ensure `EjectedChannel<S>` is `Send + Sync` when `S` is,
-    /// enabling use with `KeyedFutures` across async task boundaries.
-    connector: Arc<dyn Connector<Service = S> + Send + Sync>,
-    ejection_timer: Pin<Box<tokio::time::Sleep>>,
+pin_project! {
+    /// A channel that has been ejected and is cooling down.
+    ///
+    /// The underlying connection is kept alive but cannot serve requests.
+    /// Implements [`Future`] -- resolves once the ejection timer expires to either:
+    /// - [`UnejectedChannel::Ready`] if no reconnect is needed
+    /// - [`UnejectedChannel::Connecting`] if a fresh connection is required
+    pub(crate) struct EjectedChannel<S> {
+        addr: EndpointAddress,
+        inner: S,
+        config: EjectionConfig,
+        connector: Arc<dyn Connector<Service = S> + Send + Sync>,
+        #[pin]
+        ejection_timer: tokio::time::Sleep,
+    }
 }
 
-impl<S: Clone + Unpin + Send + 'static> Future for EjectedChannel<S> {
+impl<S: Clone + Send + 'static> Future for EjectedChannel<S> {
     type Output = UnejectedChannel<S>;
 
     fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
-        // get_mut() requires EjectedChannel to be Unpin, which requires S to be Unpin.
-        let this = self.get_mut();
-        match this.ejection_timer.as_mut().poll(cx) {
+        let this = self.project();
+        match this.ejection_timer.poll(cx) {
             Poll::Ready(()) => {
                 if this.config.needs_reconnect {
-                    let addr = this.channel.addr().clone();
-                    let fut = this.connector.connect(&addr);
+                    let fut = this.connector.connect(this.addr);
                     Poll::Ready(UnejectedChannel::Connecting(ConnectingChannel::new(
-                        fut, addr,
+                        fut,
+                        this.addr.clone(),
                     )))
                 } else {
-                    let channel = this.channel.clone();
-                    Poll::Ready(UnejectedChannel::Ready(ReadyChannel { channel }))
+                    Poll::Ready(UnejectedChannel::Ready(ReadyChannel {
+                        addr: this.addr.clone(),
+                        inner: this.inner.clone(),
+                    }))
                 }
             }
             Poll::Pending => Poll::Pending,
@@ -239,8 +229,8 @@ mod tests {
 
     impl Service<&'static str> for MockService {
         type Response = &'static str;
-        type Error = BoxError;
-        type Future = future::Ready<Result<&'static str, BoxError>>;
+        type Error = &'static str;
+        type Future = future::Ready<Result<&'static str, &'static str>>;
 
         fn poll_ready(&mut self, _cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
             Poll::Ready(Ok(()))
@@ -291,14 +281,15 @@ mod tests {
     async fn test_connecting_future_yields_ready() {
         let connector = MockConnector::new();
         let ready = IdleChannel::new(test_addr()).connect(connector).await;
-        assert_eq!(ready.channel.addr(), &test_addr());
+        assert_eq!(ready.addr, test_addr());
     }
 
     #[tokio::test]
     async fn test_ready_service_delegates() {
         let connector = MockConnector::new();
         let mut ready = IdleChannel::new(test_addr()).connect(connector).await;
-        assert_eq!(ready.call("hello").await.unwrap(), "ok");
+        let resp: &str = ready.call("hello").await.unwrap();
+        assert_eq!(resp, "ok");
     }
 
     #[tokio::test]
@@ -322,12 +313,10 @@ mod tests {
         let mut set: KeyedFutures<EndpointAddress, ReadyChannel<MockService>> = KeyedFutures::new();
         set.add(test_addr(), connecting).unwrap();
 
-        // Before send: pending.
         assert!(matches!(set.poll_next(&mut noop_cx()), Poll::Pending));
 
         tx.send(MockService).unwrap();
 
-        // After send: ready.
         match set.poll_next(&mut noop_cx()) {
             Poll::Ready(Some((addr, _))) => assert_eq!(addr, test_addr()),
             _ => panic!("expected Ready"),
@@ -345,11 +334,7 @@ mod tests {
         assert!(matches!(set.poll_next(&mut noop_cx()), Poll::Pending));
 
         set.cancel(&test_addr()).unwrap();
-        match set.poll_next(&mut noop_cx()) {
-            Poll::Ready(None) => return,
-            _ => tokio::task::yield_now().await,
-        }
-        panic!("expected set to be empty after cancel");
+        assert!(matches!(set.poll_next(&mut noop_cx()), Poll::Ready(None)));
     }
 
     #[tokio::test(start_paused = true)]
@@ -370,7 +355,6 @@ mod tests {
             KeyedFutures::new();
         set.add(test_addr(), ejected).unwrap();
 
-        // Drive via poll_fn so the tokio timer waker is registered properly.
         let (addr, result) = futures_util::future::poll_fn(|cx| set.poll_next(cx))
             .await
             .unwrap();

--- a/tonic-xds/src/client/loadbalance/channel_state.rs
+++ b/tonic-xds/src/client/loadbalance/channel_state.rs
@@ -4,17 +4,26 @@
 //! This prevents using a channel in an invalid state at compile time.
 //!
 //! ```text
-//! Idle → Connecting → Ready ⇄ Ejected
-//!                       ↓        ↓
-//!                   Connecting  Connecting (via reconnect)
+//!                +---reconnect---+
+//!                |               |
+//!                v               |
+//! Idle --> Connecting --> Ready --+--eject--> Ejected
+//!                ^                               |
+//!                +----------reconnect------------+
 //! ```
+//!
+//! State changes are all one-shot: [`ConnectingChannel`] and [`EjectedChannel`] are
+//! [`Future`]s, not streams. The caller (typically a pool) uses [`KeyedFutures`] to
+//! manage multiple in-flight state changes and handle cancellation by key.
+//!
+//! [`KeyedFutures`]: crate::client::loadbalance::keyed_futures::KeyedFutures
 
+use std::future::Future;
 use std::pin::Pin;
 use std::sync::Arc;
 use std::task::{Context, Poll};
 use std::time::Duration;
 
-use futures_core::Stream;
 use tower::load::Load;
 use tower::{BoxError, Service};
 
@@ -34,94 +43,92 @@ pub(crate) struct EjectionConfig {
 /// Result of an ejection expiring.
 pub(crate) enum UnejectedChannel<S> {
     /// The channel is ready to serve again (ejection expired, no reconnect needed).
-    Ready(ReadyLbChannel<S>),
+    Ready(ReadyChannel<S>),
     /// A fresh connection has been started.
-    Connecting(ConnectingLbChannel<S>),
+    Connecting(ConnectingChannel<S>),
 }
 
 // ---------------------------------------------------------------------------
-// IdleLbChannel
+// IdleChannel
 // ---------------------------------------------------------------------------
 
 /// An idle channel that only stores an address. It is the entry point for
 /// starting a connection attempt.
-pub(crate) struct IdleLbChannel {
+pub(crate) struct IdleChannel {
     addr: EndpointAddress,
 }
 
-impl IdleLbChannel {
+impl IdleChannel {
     pub(crate) fn new(addr: EndpointAddress) -> Self {
         Self { addr }
     }
 
     /// Start connecting to the endpoint. Consumes the idle channel.
-    pub(crate) fn connect<C: Connector>(
-        self,
-        connector: Arc<C>,
-    ) -> ConnectingLbChannel<C::Service> {
-        let fut = connector.connect(&self.addr);
-        ConnectingLbChannel {
-            addr: self.addr,
-            fut: Some(fut),
-        }
+    pub(crate) fn connect<C: Connector>(self, connector: Arc<C>) -> ConnectingChannel<C::Service>
+    where
+        C::Service: Send + 'static,
+    {
+        ConnectingChannel::new(connector.connect(&self.addr), self.addr)
     }
 }
 
 // ---------------------------------------------------------------------------
-// ConnectingLbChannel
+// ConnectingChannel
 // ---------------------------------------------------------------------------
 
 /// A channel that is in the process of connecting.
 ///
-/// Implements [`Stream`] for integration with `StreamMap`. The stream yields
-/// exactly one item — `ReadyLbChannel` on success — then terminates.
-/// If dropped (e.g., removed from StreamMap), the connection attempt is cancelled.
-pub(crate) struct ConnectingLbChannel<S> {
-    addr: EndpointAddress,
-    fut: Option<BoxFuture<S>>,
+/// Implements [`Future`] -- resolves to `ReadyChannel` when the connection
+/// is established. Cancellation is handled externally by the caller
+/// (e.g., via [`KeyedFutures::cancel`]).
+///
+/// [`KeyedFutures::cancel`]: crate::client::loadbalance::keyed_futures::KeyedFutures::cancel
+pub(crate) struct ConnectingChannel<S> {
+    inner: Pin<Box<dyn Future<Output = ReadyChannel<S>> + Send>>,
 }
 
-impl<S: Send + 'static> Stream for ConnectingLbChannel<S> {
-    type Item = ReadyLbChannel<S>;
-
-    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
-        let this = self.get_mut();
-        let Some(fut) = this.fut.as_mut() else {
-            return Poll::Ready(None);
-        };
-        match fut.as_mut().poll(cx) {
-            Poll::Ready(svc) => {
-                this.fut = None;
-                Poll::Ready(Some(ReadyLbChannel {
-                    channel: LbChannel::new(this.addr.clone(), svc),
-                }))
-            }
-            Poll::Pending => Poll::Pending,
+impl<S: Send + 'static> ConnectingChannel<S> {
+    pub(crate) fn new(fut: BoxFuture<S>, addr: EndpointAddress) -> Self {
+        Self {
+            inner: Box::pin(async move {
+                let svc = fut.await;
+                ReadyChannel {
+                    channel: LbChannel::new(addr, svc),
+                }
+            }),
         }
     }
 }
 
+impl<S: Send + 'static> Future for ConnectingChannel<S> {
+    type Output = ReadyChannel<S>;
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        self.get_mut().inner.as_mut().poll(cx)
+    }
+}
+
 // ---------------------------------------------------------------------------
-// ReadyLbChannel
+// ReadyChannel
 // ---------------------------------------------------------------------------
 
 /// A channel that is connected and ready to serve requests.
 ///
 /// Wraps an [`LbChannel`] and delegates [`Service`] and [`Load`] to it.
 /// State transitions consume `self` to prevent use-after-transition.
-pub(crate) struct ReadyLbChannel<S> {
-    channel: LbChannel<S>,
+pub(crate) struct ReadyChannel<S> {
+    pub(super) channel: LbChannel<S>,
 }
 
-impl<S> ReadyLbChannel<S> {
+impl<S> ReadyChannel<S> {
     /// Eject this channel (e.g., due to outlier detection). Consumes self.
-    pub(crate) fn eject<C>(self, config: EjectionConfig, connector: Arc<C>) -> EjectedLbChannel<S>
+    pub(crate) fn eject<C>(self, config: EjectionConfig, connector: Arc<C>) -> EjectedChannel<S>
     where
         C: Connector<Service = S> + Send + Sync + 'static,
     {
         let ejection_timer = Box::pin(tokio::time::sleep(config.timeout));
-        EjectedLbChannel {
-            channel: Some(self.channel),
+        EjectedChannel {
+            channel: self.channel,
             config,
             connector,
             ejection_timer,
@@ -132,17 +139,16 @@ impl<S> ReadyLbChannel<S> {
     pub(crate) fn reconnect<C: Connector<Service = S>>(
         self,
         connector: Arc<C>,
-    ) -> ConnectingLbChannel<S> {
+    ) -> ConnectingChannel<S>
+    where
+        S: Send + 'static,
+    {
         let addr = self.channel.addr().clone();
-        let fut = connector.connect(&addr);
-        ConnectingLbChannel {
-            addr,
-            fut: Some(fut),
-        }
+        ConnectingChannel::new(connector.connect(&addr), addr)
     }
 }
 
-impl<S, Req> Service<Req> for ReadyLbChannel<S>
+impl<S, Req> Service<Req> for ReadyChannel<S>
 where
     S: Service<Req> + Clone + Send + 'static,
     S::Future: Send + 'static,
@@ -162,7 +168,7 @@ where
     }
 }
 
-impl<S> Load for ReadyLbChannel<S> {
+impl<S> Load for ReadyChannel<S> {
     type Metric = u64;
 
     fn load(&self) -> Self::Metric {
@@ -171,54 +177,44 @@ impl<S> Load for ReadyLbChannel<S> {
 }
 
 // ---------------------------------------------------------------------------
-// EjectedLbChannel
+// EjectedChannel
 // ---------------------------------------------------------------------------
 
 /// A channel that has been ejected and is cooling down.
 ///
 /// The underlying connection is kept alive but cannot serve requests.
-/// Implements [`Stream`] for integration with `StreamMap`. After the ejection
-/// timer expires, yields either:
-/// - [`UnejectedChannel::Ready`] if no reconnect is needed
+/// Implements [`Future`] -- resolves once the ejection timer expires to either:
+/// - [`UnejectedChannel::Ready`] if no reconnect is needed (clones the channel)
 /// - [`UnejectedChannel::Connecting`] if a fresh connection is required
 ///
-/// This is a one-shot stream — it yields exactly one item then terminates.
-pub(crate) struct EjectedLbChannel<S> {
-    /// Option to allow moving the channel out via `take()` in `poll_next`.
-    channel: Option<LbChannel<S>>,
+/// Cancellation is handled externally by the caller via [`KeyedFutures::cancel`].
+///
+/// [`KeyedFutures::cancel`]: crate::client::loadbalance::keyed_futures::KeyedFutures::cancel
+pub(crate) struct EjectedChannel<S> {
+    channel: LbChannel<S>,
     config: EjectionConfig,
-    /// Trait object for the connector. The `Send + Sync` bounds ensure
-    /// `EjectedLbChannel<S>` is `Send + Sync` when `S` is (e.g. `tonic::Channel`),
-    /// enabling use with `StreamMap` across async task boundaries.
+    /// `Send + Sync` bounds ensure `EjectedChannel<S>` is `Send + Sync` when `S` is,
+    /// enabling use with `KeyedFutures` across async task boundaries.
     connector: Arc<dyn Connector<Service = S> + Send + Sync>,
     ejection_timer: Pin<Box<tokio::time::Sleep>>,
 }
 
-impl<S: Clone + Unpin> Stream for EjectedLbChannel<S> {
-    type Item = UnejectedChannel<S>;
+impl<S: Clone + Unpin + Send + 'static> Future for EjectedChannel<S> {
+    type Output = UnejectedChannel<S>;
 
-    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         let this = self.get_mut();
-        let Some(channel) = this.channel.as_ref() else {
-            return Poll::Ready(None);
-        };
         match this.ejection_timer.as_mut().poll(cx) {
             Poll::Ready(()) => {
                 if this.config.needs_reconnect {
-                    let addr = channel.addr().clone();
-                    this.channel = None;
+                    let addr = this.channel.addr().clone();
                     let fut = this.connector.connect(&addr);
-                    Poll::Ready(Some(UnejectedChannel::Connecting(ConnectingLbChannel {
-                        addr,
-                        fut: Some(fut),
-                    })))
+                    Poll::Ready(UnejectedChannel::Connecting(ConnectingChannel::new(
+                        fut, addr,
+                    )))
                 } else {
-                    match this.channel.take() {
-                        Some(channel) => {
-                            Poll::Ready(Some(UnejectedChannel::Ready(ReadyLbChannel { channel })))
-                        }
-                        None => Poll::Ready(None),
-                    }
+                    let channel = this.channel.clone();
+                    Poll::Ready(UnejectedChannel::Ready(ReadyChannel { channel }))
                 }
             }
             Poll::Pending => Poll::Pending,
@@ -229,11 +225,12 @@ impl<S: Clone + Unpin> Stream for EjectedLbChannel<S> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::client::loadbalance::keyed_futures::KeyedFutures;
+    use futures_util::task::noop_waker;
     use std::future;
     use std::sync::atomic::{AtomicU32, Ordering};
-    use tokio_stream::StreamExt;
 
-    #[derive(Clone)]
+    #[derive(Clone, Debug)]
     struct MockService;
 
     impl Service<&'static str> for MockService {
@@ -275,150 +272,131 @@ mod tests {
         EndpointAddress::new("127.0.0.1", 8080)
     }
 
+    fn noop_cx() -> Context<'static> {
+        Context::from_waker(Box::leak(Box::new(noop_waker())))
+    }
+
     #[tokio::test]
     async fn test_idle_to_connecting() {
         let connector = MockConnector::new();
-        let idle = IdleLbChannel::new(test_addr());
-        let _connecting = idle.connect(connector.clone());
+        let _connecting = IdleChannel::new(test_addr()).connect(connector.clone());
         assert_eq!(connector.connect_count.load(Ordering::SeqCst), 1);
     }
 
     #[tokio::test]
-    async fn test_connecting_stream_yields_ready() {
+    async fn test_connecting_future_yields_ready() {
         let connector = MockConnector::new();
-        let mut connecting = IdleLbChannel::new(test_addr()).connect(connector);
-        assert!(connecting.next().await.is_some());
-    }
-
-    #[tokio::test]
-    async fn test_connecting_stream_is_one_shot() {
-        let connector = MockConnector::new();
-        let mut connecting = IdleLbChannel::new(test_addr()).connect(connector);
-        let _ = connecting.next().await;
-        assert!(connecting.next().await.is_none());
+        let ready = IdleChannel::new(test_addr()).connect(connector).await;
+        assert_eq!(ready.channel.addr(), &test_addr());
     }
 
     #[tokio::test]
     async fn test_ready_service_delegates() {
         let connector = MockConnector::new();
-        let mut connecting = IdleLbChannel::new(test_addr()).connect(connector);
-        let mut ready = connecting.next().await.unwrap();
-
-        let resp = ready.call("hello").await.unwrap();
-        assert_eq!(resp, "ok");
+        let mut ready = IdleChannel::new(test_addr()).connect(connector).await;
+        assert_eq!(ready.call("hello").await.unwrap(), "ok");
     }
 
     #[tokio::test]
     async fn test_ready_to_connecting_via_reconnect() {
         let connector = MockConnector::new();
-        let mut connecting = IdleLbChannel::new(test_addr()).connect(connector.clone());
-        let ready = connecting.next().await.unwrap();
-
-        let mut reconnecting = ready.reconnect(connector.clone());
+        let ready = IdleChannel::new(test_addr()).connect(connector.clone()).await;
+        let _reconnecting = ready.reconnect(connector.clone());
         assert_eq!(connector.connect_count.load(Ordering::SeqCst), 2);
-        assert!(reconnecting.next().await.is_some());
     }
 
-    #[tokio::test(start_paused = true)]
-    async fn test_ejected_yields_ready_after_timeout() {
-        let connector = MockConnector::new();
-        let mut connecting = IdleLbChannel::new(test_addr()).connect(connector.clone());
-        let ready = connecting.next().await.unwrap();
+    // --- KeyedFutures integration ---
 
-        let config = EjectionConfig {
-            timeout: Duration::from_secs(5),
-            needs_reconnect: false,
-        };
-        let mut ejected = ready.eject(config, connector);
+    #[tokio::test]
+    async fn test_connecting_in_keyed_futures() {
+        let (tx, rx) = tokio::sync::oneshot::channel::<MockService>();
+        let connecting =
+            ConnectingChannel::new(Box::pin(async move { rx.await.unwrap() }), test_addr());
 
-        let result = ejected.next().await.unwrap();
-        assert!(matches!(result, UnejectedChannel::Ready(_)));
-        assert!(ejected.next().await.is_none());
-    }
+        let mut set: KeyedFutures<EndpointAddress, ReadyChannel<MockService>> =
+            KeyedFutures::new();
+        set.add(test_addr(), connecting).unwrap();
 
-    #[tokio::test(start_paused = true)]
-    async fn test_ejected_yields_connecting_when_needs_reconnect() {
-        let connector = MockConnector::new();
-        let mut connecting = IdleLbChannel::new(test_addr()).connect(connector.clone());
-        let ready = connecting.next().await.unwrap();
+        // Before send: pending.
+        assert!(matches!(set.poll_next(&mut noop_cx()), Poll::Pending));
 
-        let config = EjectionConfig {
-            timeout: Duration::from_secs(5),
-            needs_reconnect: true,
-        };
-        let mut ejected = ready.eject(config, connector.clone());
+        tx.send(MockService).unwrap();
 
-        let result = ejected.next().await.unwrap();
-        match result {
-            UnejectedChannel::Connecting(mut c) => {
-                assert!(c.next().await.is_some());
-                assert_eq!(connector.connect_count.load(Ordering::SeqCst), 2);
-            }
-            _ => panic!("expected UnejectedChannel::Connecting"),
+        // After send: ready.
+        match set.poll_next(&mut noop_cx()) {
+            Poll::Ready(Some((addr, _))) => assert_eq!(addr, test_addr()),
+            _ => panic!("expected Ready"),
         }
-        assert!(ejected.next().await.is_none());
     }
 
     #[tokio::test]
-    async fn test_connecting_in_stream_map() {
-        use tokio_stream::StreamMap;
+    async fn test_connecting_cancelled_via_keyed_futures() {
+        let connecting = ConnectingChannel::new(
+            Box::pin(future::pending::<MockService>()),
+            test_addr(),
+        );
 
-        let connector = MockConnector::new();
-        let connecting = IdleLbChannel::new(test_addr()).connect(connector.clone());
+        let mut set: KeyedFutures<EndpointAddress, ReadyChannel<MockService>> =
+            KeyedFutures::new();
+        set.add(test_addr(), connecting).unwrap();
 
-        let mut map: StreamMap<&str, ConnectingLbChannel<MockService>> = StreamMap::new();
-        map.insert("endpoint-1", connecting);
+        assert!(matches!(set.poll_next(&mut noop_cx()), Poll::Pending));
 
-        let (key, _ready) = map.next().await.unwrap();
-        assert_eq!(key, "endpoint-1");
-        // Stream is done, removed from map — map is now empty.
-        assert!(map.next().await.is_none());
-
-        // Map can be reused: insert a new stream and it yields correctly.
-        let connecting2 = IdleLbChannel::new(test_addr()).connect(connector);
-        map.insert("endpoint-2", connecting2);
-        let (key2, _ready2) = map.next().await.unwrap();
-        assert_eq!(key2, "endpoint-2");
-        assert!(map.next().await.is_none());
+        set.cancel(&test_addr()).unwrap();
+        for _ in 0..10 {
+            match set.poll_next(&mut noop_cx()) {
+                Poll::Ready(None) => return,
+                _ => tokio::task::yield_now().await,
+            }
+        }
+        panic!("expected set to be empty after cancel");
     }
 
     #[tokio::test(start_paused = true)]
-    async fn test_ejected_in_stream_map() {
-        use tokio_stream::StreamMap;
-
+    async fn test_ejected_in_keyed_futures_ready() {
         let connector = MockConnector::new();
-        let mut connecting = IdleLbChannel::new(test_addr()).connect(connector.clone());
-        let ready = connecting.next().await.unwrap();
-
-        let config = EjectionConfig {
-            timeout: Duration::from_secs(5),
-            needs_reconnect: false,
-        };
-        let ejected = ready.eject(config, connector.clone());
-
-        let mut map: StreamMap<&str, EjectedLbChannel<MockService>> = StreamMap::new();
-        map.insert("endpoint-1", ejected);
-
-        let (key, unejected) = map.next().await.unwrap();
-        assert_eq!(key, "endpoint-1");
-        assert!(matches!(unejected, UnejectedChannel::Ready(_)));
-        // Stream is done, removed from map — map is now empty.
-        assert!(map.next().await.is_none());
-
-        // Map can be reused: insert a new ejected stream and it yields correctly.
-        let mut connecting2 = IdleLbChannel::new(test_addr()).connect(connector.clone());
-        let ready2 = connecting2.next().await.unwrap();
-        let ejected2 = ready2.eject(
+        let ready = IdleChannel::new(test_addr()).connect(connector.clone()).await;
+        let ejected = ready.eject(
             EjectionConfig {
                 timeout: Duration::from_secs(5),
                 needs_reconnect: false,
             },
             connector,
         );
-        map.insert("endpoint-2", ejected2);
-        let (key2, unejected2) = map.next().await.unwrap();
-        assert_eq!(key2, "endpoint-2");
-        assert!(matches!(unejected2, UnejectedChannel::Ready(_)));
-        assert!(map.next().await.is_none());
+
+        let mut set: KeyedFutures<EndpointAddress, UnejectedChannel<MockService>> =
+            KeyedFutures::new();
+        set.add(test_addr(), ejected).unwrap();
+
+        // Drive via poll_fn so the tokio timer waker is registered properly.
+        let (addr, result) = futures_util::future::poll_fn(|cx| set.poll_next(cx))
+            .await
+            .unwrap();
+        assert_eq!(addr, test_addr());
+        assert!(matches!(result, UnejectedChannel::Ready(_)));
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn test_ejected_in_keyed_futures_needs_reconnect() {
+        let connector = MockConnector::new();
+        let ready = IdleChannel::new(test_addr()).connect(connector.clone()).await;
+        let ejected = ready.eject(
+            EjectionConfig {
+                timeout: Duration::from_secs(5),
+                needs_reconnect: true,
+            },
+            connector.clone(),
+        );
+
+        let mut set: KeyedFutures<EndpointAddress, UnejectedChannel<MockService>> =
+            KeyedFutures::new();
+        set.add(test_addr(), ejected).unwrap();
+
+        let (addr, result) = futures_util::future::poll_fn(|cx| set.poll_next(cx))
+            .await
+            .unwrap();
+        assert_eq!(addr, test_addr());
+        assert!(matches!(result, UnejectedChannel::Connecting(_)));
+        assert_eq!(connector.connect_count.load(Ordering::SeqCst), 2);
     }
 }

--- a/tonic-xds/src/client/loadbalance/keyed_futures.rs
+++ b/tonic-xds/src/client/loadbalance/keyed_futures.rs
@@ -51,11 +51,7 @@ where
 
     /// Add a future keyed by `key`. Returns `Err(DuplicateKey)` if a future
     /// for this key is already running.
-    pub(crate) fn add<F>(
-        &mut self,
-        key: K,
-        fut: F,
-    ) -> Result<(), KeyedFuturesError<K>>
+    pub(crate) fn add<F>(&mut self, key: K, fut: F) -> Result<(), KeyedFuturesError<K>>
     where
         F: Future<Output = T> + Send + 'static,
     {
@@ -157,10 +153,7 @@ mod tests {
         tx.send(42).unwrap();
 
         // FuturesUnordered's internal waker was notified; next poll sees result.
-        assert_eq!(
-            set.poll_next(&mut noop_cx()),
-            Poll::Ready(Some(("a", 42)))
-        );
+        assert_eq!(set.poll_next(&mut noop_cx()), Poll::Ready(Some(("a", 42))));
     }
 
     #[tokio::test]

--- a/tonic-xds/src/client/loadbalance/keyed_futures.rs
+++ b/tonic-xds/src/client/loadbalance/keyed_futures.rs
@@ -1,0 +1,220 @@
+//! [`KeyedFutures`]: a cancellable, keyed set of futures.
+
+use std::collections::HashMap;
+use std::future::Future;
+use std::hash::Hash;
+use std::pin::Pin;
+use std::task::{Context, Poll};
+
+use futures_core::Stream;
+use futures_util::stream::FuturesUnordered;
+use tokio_util::sync::CancellationToken;
+
+use crate::common::async_util::BoxFuture;
+
+/// Errors returned by [`KeyedFutures`].
+#[derive(Debug, thiserror::Error)]
+pub(crate) enum KeyedFuturesError<K: std::fmt::Debug> {
+    /// A future for this key is already running.
+    #[error("key {0:?} already exists")]
+    DuplicateKey(K),
+    /// No future is running for the given key.
+    #[error("key {0:?} not found")]
+    KeyNotFound(K),
+}
+
+/// A cancellable, keyed set of futures.
+///
+/// Each future is associated with a key `K` and produces a value `T`.
+/// Futures can be cancelled individually by key. [`poll_next`] drives all
+/// futures concurrently and yields `(K, T)` when one completes; cancelled
+/// futures are silently skipped.
+///
+/// Intended for use inside [`tower::Service::poll_ready`] to manage large number of
+/// concurrent, cancellable operations (e.g. pending connection attempts).
+pub(crate) struct KeyedFutures<K, T> {
+    cancellations: HashMap<K, CancellationToken>,
+    futures: FuturesUnordered<BoxFuture<(K, Option<T>)>>,
+}
+
+impl<K, T> KeyedFutures<K, T>
+where
+    K: Hash + Eq + Clone + Send + std::fmt::Debug + 'static,
+    T: Send + 'static,
+{
+    pub(crate) fn new() -> Self {
+        Self {
+            cancellations: HashMap::new(),
+            futures: FuturesUnordered::new(),
+        }
+    }
+
+    /// Add a future keyed by `key`. Returns `Err(DuplicateKey)` if a future
+    /// for this key is already running.
+    pub(crate) fn add<F>(
+        &mut self,
+        key: K,
+        fut: F,
+    ) -> Result<(), KeyedFuturesError<K>>
+    where
+        F: Future<Output = T> + Send + 'static,
+    {
+        if self.cancellations.contains_key(&key) {
+            return Err(KeyedFuturesError::DuplicateKey(key));
+        }
+        let token = CancellationToken::new();
+        self.cancellations.insert(key.clone(), token.clone());
+
+        self.futures.push(Box::pin(async move {
+            tokio::select! {
+                biased;
+                _ = token.cancelled() => (key, None),
+                t = fut => (key, Some(t)),
+            }
+        }));
+        Ok(())
+    }
+
+    /// Cancel the future for `key`. Returns `Err(KeyNotFound)` if no future
+    /// is running for the given key.
+    pub(crate) fn cancel(&mut self, key: &K) -> Result<(), KeyedFuturesError<K>> {
+        match self.cancellations.remove(key) {
+            Some(token) => {
+                token.cancel();
+                Ok(())
+            }
+            None => Err(KeyedFuturesError::KeyNotFound(key.clone())),
+        }
+    }
+
+    /// Returns the number of futures currently running (including cancelled
+    /// ones not yet polled to completion).
+    pub(crate) fn len(&self) -> usize {
+        self.futures.len()
+    }
+
+    /// Advance the internal futures. Yields `(K, T)` when a future completes,
+    /// skipping cancelled futures silently.
+    ///
+    /// Returns:
+    /// - `Poll::Ready(Some((key, output)))` — a future completed successfully.
+    /// - `Poll::Pending` — no futures ready yet; the waker will be notified.
+    /// - `Poll::Ready(None)` — all futures have completed or been cancelled.
+    pub(crate) fn poll_next(&mut self, cx: &mut Context<'_>) -> Poll<Option<(K, T)>> {
+        loop {
+            match Pin::new(&mut self.futures).poll_next(cx) {
+                Poll::Ready(Some((key, Some(output)))) => {
+                    self.cancellations.remove(&key);
+                    return Poll::Ready(Some((key, output)));
+                }
+                Poll::Ready(Some((_, None))) => continue, // skip cancelled futures
+                Poll::Ready(None) => return Poll::Ready(None),
+                Poll::Pending => return Poll::Pending,
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use futures_util::task::noop_waker;
+
+    fn noop_cx() -> Context<'static> {
+        // SAFETY: the waker is never dereferenced; used only to satisfy the
+        // Context API. FuturesUnordered manages internal task wakeups
+        // independently of this outer waker.
+        Context::from_waker(Box::leak(Box::new(noop_waker())))
+    }
+
+    #[tokio::test]
+    async fn test_add_and_poll() {
+        let mut set: KeyedFutures<&str, u32> = KeyedFutures::new();
+        set.add("a", async { 1 }).unwrap();
+        set.add("b", async { 2 }).unwrap();
+
+        let mut results = vec![];
+        while let Poll::Ready(Some(item)) = set.poll_next(&mut noop_cx()) {
+            results.push(item);
+        }
+        results.sort();
+        assert_eq!(results, vec![("a", 1), ("b", 2)]);
+    }
+
+    #[tokio::test]
+    async fn test_poll_pending_then_ready() {
+        // Use a oneshot channel so the future is pending until we send.
+        // FuturesUnordered's internal TaskWaker is woken by tx.send(),
+        // so the next poll_next sees the result without needing yield_now().
+        let mut set: KeyedFutures<&str, u32> = KeyedFutures::new();
+        let (tx, rx) = tokio::sync::oneshot::channel::<u32>();
+        set.add("a", async move { rx.await.unwrap() }).unwrap();
+
+        // Before send: pending.
+        assert!(matches!(set.poll_next(&mut noop_cx()), Poll::Pending));
+
+        // Signal the future to complete.
+        tx.send(42).unwrap();
+
+        // FuturesUnordered's internal waker was notified; next poll sees result.
+        assert_eq!(
+            set.poll_next(&mut noop_cx()),
+            Poll::Ready(Some(("a", 42)))
+        );
+    }
+
+    #[tokio::test]
+    async fn test_duplicate_key_rejected() {
+        let mut set: KeyedFutures<&str, u32> = KeyedFutures::new();
+        set.add("a", async { 1 }).unwrap();
+        assert!(matches!(
+            set.add("a", async { 2 }),
+            Err(KeyedFuturesError::DuplicateKey("a"))
+        ));
+    }
+
+    #[tokio::test]
+    async fn test_cancel_skipped_in_poll() {
+        let mut set: KeyedFutures<&str, u32> = KeyedFutures::new();
+        let (tx_a, rx_a) = tokio::sync::oneshot::channel::<u32>();
+        let (tx_b, rx_b) = tokio::sync::oneshot::channel::<u32>();
+
+        set.add("a", async move { rx_a.await.unwrap() }).unwrap();
+        set.add("b", async move { rx_b.await.unwrap() }).unwrap();
+
+        // Both pending.
+        assert!(matches!(set.poll_next(&mut noop_cx()), Poll::Pending));
+
+        // Cancel "a", complete "b".
+        set.cancel(&"a").unwrap();
+        tx_b.send(42).unwrap();
+        drop(tx_a);
+
+        // "a" is silently skipped; only "b" is yielded.
+        assert_eq!(set.poll_next(&mut noop_cx()), Poll::Ready(Some(("b", 42))));
+        assert_eq!(set.poll_next(&mut noop_cx()), Poll::Ready(None));
+    }
+
+    #[tokio::test]
+    async fn test_cancel_nonexistent_returns_error() {
+        let mut set: KeyedFutures<&str, u32> = KeyedFutures::new();
+        assert!(matches!(
+            set.cancel(&"missing"),
+            Err(KeyedFuturesError::KeyNotFound("missing"))
+        ));
+    }
+
+    #[tokio::test]
+    async fn test_reuse_key_after_completion() {
+        let mut set: KeyedFutures<&str, u32> = KeyedFutures::new();
+        let (tx, rx) = tokio::sync::oneshot::channel::<u32>();
+        set.add("a", async move { rx.await.unwrap() }).unwrap();
+
+        tx.send(1).unwrap();
+        assert_eq!(set.poll_next(&mut noop_cx()), Poll::Ready(Some(("a", 1))));
+
+        // Key is free after completion — can be re-added.
+        set.add("a", async { 2 }).unwrap();
+        assert_eq!(set.poll_next(&mut noop_cx()), Poll::Ready(Some(("a", 2))));
+    }
+}

--- a/tonic-xds/src/client/loadbalance/mod.rs
+++ b/tonic-xds/src/client/loadbalance/mod.rs
@@ -1,2 +1,3 @@
 pub(crate) mod channel;
 pub(crate) mod channel_state;
+pub(crate) mod keyed_futures;

--- a/tonic-xds/src/client/loadbalance/mod.rs
+++ b/tonic-xds/src/client/loadbalance/mod.rs
@@ -1,0 +1,2 @@
+pub(crate) mod channel;
+pub(crate) mod channel_state;

--- a/tonic-xds/src/client/mod.rs
+++ b/tonic-xds/src/client/mod.rs
@@ -3,5 +3,6 @@ pub(crate) mod cluster;
 pub(crate) mod endpoint;
 pub(crate) mod lb;
 #[allow(dead_code)]
+pub(crate) mod loadbalance;
 pub(crate) mod retry;
 pub(crate) mod route;

--- a/tonic-xds/src/client/mod.rs
+++ b/tonic-xds/src/client/mod.rs
@@ -4,5 +4,6 @@ pub(crate) mod endpoint;
 pub(crate) mod lb;
 #[allow(dead_code)]
 pub(crate) mod loadbalance;
+#[allow(dead_code)]
 pub(crate) mod retry;
 pub(crate) mod route;


### PR DESCRIPTION
Implement the type-statemachine for load balancer subchannels. This is preparing for implementing the actual load balancer.

Ref: https://github.com/hyperium/tonic/issues/2444

## Motivation

A real world xDS load-balancer needs to deal with outlier detection and reconnects. Therefore, subchannels managed by load balancer needs to implement a state machine. This PR implements it via type-states.

In the next PR, the load balancer tower layer will drive the state transitions in its poll_ready() implementation. This way, we get full control and visibility in to the managed channels. Therefore, we opens up the flexibility of implementing different LB strategies (e.g. sticky, round-robin, etc), compared to the hardcoded P2C stategy offered by tower::balance that we are currently using.

## Solution
Define new type for each state, state transition is implemented by consuming the type for the source state. ConnectingChannel and EjectedChannel needs to be implemented as Streams so that load balancer can use StreamMap to poll them to advance their state transitions.

