### PR TITLE
feat(grpc): Add name resolver for the unix scheme

### DIFF
--- a/grpc/Cargo.toml
+++ b/grpc/Cargo.toml
@@ -85,7 +85,6 @@ async-stream = "0.3.6"
 criterion = "0.5"
 hickory-server = "0.25.2"
 prost = "0.14.0"
-rstest = "0.26"
 rustls = { version = "0.23", default-features = false, features = ["ring"] }
 tempfile = "3.26"
 tonic = { version = "0.14.0", path = "../tonic", default-features = false, features = [

--- a/grpc/Cargo.toml
+++ b/grpc/Cargo.toml
@@ -85,6 +85,7 @@ async-stream = "0.3.6"
 criterion = "0.5"
 hickory-server = "0.25.2"
 prost = "0.14.0"
+rstest = "0.26"
 rustls = { version = "0.23", default-features = false, features = ["ring"] }
 tempfile = "3.26"
 tonic = { version = "0.14.0", path = "../tonic", default-features = false, features = [

--- a/grpc/src/client/name_resolution/dns/mod.rs
+++ b/grpc/src/client/name_resolution/dns/mod.rs
@@ -52,7 +52,6 @@ use crate::client::name_resolution::backoff::BackoffConfig;
 use crate::client::name_resolution::backoff::DEFAULT_EXPONENTIAL_CONFIG;
 use crate::client::name_resolution::backoff::ExponentialBackoff;
 use crate::client::name_resolution::global_registry;
-use crate::client::name_resolution::nop_resolver_for_err;
 use crate::rt::BoxedTaskHandle;
 use crate::rt::{self};
 
@@ -205,7 +204,7 @@ impl ResolverBuilder for Builder {
     fn build(&self, target: &Target, options: ResolverOptions) -> Box<dyn Resolver> {
         let parsed = match parse_endpoint_and_authority(target) {
             Ok(res) => res,
-            Err(err) => return nop_resolver_for_err(err.to_string(), options),
+            Err(err) => return NopResolver::new_with_err(err.to_string(), options),
         };
         let endpoint = parsed.endpoint;
         let host = match endpoint.host {
@@ -222,7 +221,7 @@ impl ResolverBuilder for Builder {
             server_addr: authority,
         }) {
             Ok(dns) => dns,
-            Err(err) => return nop_resolver_for_err(err.to_string(), options),
+            Err(err) => return NopResolver::new_with_err(err.to_string(), options),
         };
         let dns_opts = DnsOptions {
             min_resolution_interval: get_min_resolution_interval(),
@@ -375,18 +374,10 @@ fn parse_host_port(host_and_port: &str, default_port: u16) -> Result<Option<Host
 }
 
 fn nop_resolver_for_ip(ip: IpAddr, port: u16, options: ResolverOptions) -> Box<dyn Resolver> {
-    options.work_scheduler.schedule_work();
-    Box::new(NopResolver {
-        update: ResolverUpdate {
-            endpoints: Ok(vec![Endpoint {
-                addresses: vec![Address {
-                    network_type: TCP_IP_NETWORK_TYPE,
-                    address: ByteStr::from(SocketAddr::new(ip, port).to_string()),
-                    ..Default::default()
-                }],
-                ..Default::default()
-            }]),
-            ..Default::default()
-        },
-    })
+    let addr = Address {
+        network_type: TCP_IP_NETWORK_TYPE,
+        address: ByteStr::from(SocketAddr::new(ip, port).to_string()),
+        ..Default::default()
+    };
+    NopResolver::new_with_addr(addr, options)
 }

--- a/grpc/src/client/name_resolution/dns/mod.rs
+++ b/grpc/src/client/name_resolution/dns/mod.rs
@@ -52,6 +52,7 @@ use crate::client::name_resolution::backoff::BackoffConfig;
 use crate::client::name_resolution::backoff::DEFAULT_EXPONENTIAL_CONFIG;
 use crate::client::name_resolution::backoff::ExponentialBackoff;
 use crate::client::name_resolution::global_registry;
+use crate::client::name_resolution::nop_resolver_for_err;
 use crate::rt::BoxedTaskHandle;
 use crate::rt::{self};
 
@@ -385,16 +386,6 @@ fn nop_resolver_for_ip(ip: IpAddr, port: u16, options: ResolverOptions) -> Box<d
                 }],
                 ..Default::default()
             }]),
-            ..Default::default()
-        },
-    })
-}
-
-fn nop_resolver_for_err(err: String, options: ResolverOptions) -> Box<dyn Resolver> {
-    options.work_scheduler.schedule_work();
-    Box::new(NopResolver {
-        update: ResolverUpdate {
-            endpoints: Err(err),
             ..Default::default()
         },
     })

--- a/grpc/src/client/name_resolution/dns/test.rs
+++ b/grpc/src/client/name_resolution/dns/test.rs
@@ -27,16 +27,12 @@ use std::pin::Pin;
 use std::sync::Arc;
 use std::time::Duration;
 
-use tokio::sync::mpsc::UnboundedSender;
 use tokio::sync::mpsc::{self};
 use url::Host;
 
-use crate::client::name_resolution::ChannelController;
 use crate::client::name_resolution::Resolver;
 use crate::client::name_resolution::ResolverOptions;
-use crate::client::name_resolution::ResolverUpdate;
 use crate::client::name_resolution::Target;
-use crate::client::name_resolution::WorkScheduler;
 use crate::client::name_resolution::backoff::BackoffConfig;
 use crate::client::name_resolution::backoff::DEFAULT_EXPONENTIAL_CONFIG;
 use crate::client::name_resolution::dns::DnsOptions;
@@ -48,7 +44,8 @@ use crate::client::name_resolution::dns::get_resolving_timeout;
 use crate::client::name_resolution::dns::parse_endpoint_and_authority;
 use crate::client::name_resolution::dns::reg;
 use crate::client::name_resolution::global_registry;
-use crate::client::service_config::ServiceConfig;
+use crate::client::name_resolution::test_utils::TestChannelController;
+use crate::client::name_resolution::test_utils::TestWorkScheduler;
 use crate::rt::BoxFuture;
 use crate::rt::GrpcRuntime;
 use crate::rt::TcpOptions;
@@ -173,42 +170,13 @@ pub(crate) fn target_parsing() {
     }
 }
 
-struct FakeWorkScheduler {
-    work_tx: UnboundedSender<()>,
-}
-
-impl WorkScheduler for FakeWorkScheduler {
-    fn schedule_work(&self) {
-        self.work_tx.send(()).unwrap();
-    }
-}
-
-struct FakeChannelController {
-    update_result: Result<(), String>,
-    update_tx: UnboundedSender<ResolverUpdate>,
-}
-
-impl ChannelController for FakeChannelController {
-    fn update(&mut self, update: ResolverUpdate) -> Result<(), String> {
-        println!("Received resolver update: {:?}", &update);
-        self.update_tx.send(update).unwrap();
-        self.update_result.clone()
-    }
-
-    fn parse_service_config(&self, _: &str) -> Result<ServiceConfig, String> {
-        Err("Unimplemented".to_string())
-    }
-}
-
 #[tokio::test]
 pub(crate) async fn dns_basic() {
     reg();
     let builder = global_registry().get("dns").unwrap();
     let target = &"dns:///localhost:1234".parse().unwrap();
     let (work_tx, mut work_rx) = mpsc::unbounded_channel();
-    let work_scheduler = Arc::new(FakeWorkScheduler {
-        work_tx: work_tx.clone(),
-    });
+    let work_scheduler = Arc::new(TestWorkScheduler::new(work_tx.clone()));
     let opts = ResolverOptions {
         authority: "ignored".to_string(),
         runtime: rt::default_runtime(),
@@ -219,10 +187,7 @@ pub(crate) async fn dns_basic() {
     // Wait for schedule work to be called.
     work_rx.recv().await.unwrap();
     let (update_tx, mut update_rx) = mpsc::unbounded_channel();
-    let mut channel_controller = FakeChannelController {
-        update_tx,
-        update_result: Ok(()),
-    };
+    let mut channel_controller = TestChannelController::new(update_tx);
     resolver.work(&mut channel_controller);
     // A successful endpoint update should be received.
     let update = update_rx.recv().await.unwrap();
@@ -235,9 +200,7 @@ pub(crate) async fn invalid_target() {
     let builder = global_registry().get("dns").unwrap();
     let target = &"dns:///:1234".parse().unwrap();
     let (work_tx, mut work_rx) = mpsc::unbounded_channel();
-    let work_scheduler = Arc::new(FakeWorkScheduler {
-        work_tx: work_tx.clone(),
-    });
+    let work_scheduler = Arc::new(TestWorkScheduler::new(work_tx.clone()));
     let opts = ResolverOptions {
         authority: "ignored".to_string(),
         runtime: rt::default_runtime(),
@@ -248,10 +211,7 @@ pub(crate) async fn invalid_target() {
     // Wait for schedule work to be called.
     work_rx.recv().await.unwrap();
     let (update_tx, mut update_rx) = mpsc::unbounded_channel();
-    let mut channel_controller = FakeChannelController {
-        update_tx,
-        update_result: Ok(()),
-    };
+    let mut channel_controller = TestChannelController::new(update_tx);
     resolver.work(&mut channel_controller);
     // An error endpoint update should be received.
     let update = update_rx.recv().await.unwrap();
@@ -327,9 +287,7 @@ pub(crate) async fn dns_lookup_error() {
     let builder = global_registry().get("dns").unwrap();
     let target = &"dns:///grpc.io:1234".parse().unwrap();
     let (work_tx, mut work_rx) = mpsc::unbounded_channel();
-    let work_scheduler = Arc::new(FakeWorkScheduler {
-        work_tx: work_tx.clone(),
-    });
+    let work_scheduler = Arc::new(TestWorkScheduler::new(work_tx.clone()));
     let runtime = FakeRuntime {
         inner: TokioRuntime::default(),
         dns: FakeDns {
@@ -347,10 +305,7 @@ pub(crate) async fn dns_lookup_error() {
     // Wait for schedule work to be called.
     work_rx.recv().await.unwrap();
     let (update_tx, mut update_rx) = mpsc::unbounded_channel();
-    let mut channel_controller = FakeChannelController {
-        update_tx,
-        update_result: Ok(()),
-    };
+    let mut channel_controller = TestChannelController::new(update_tx);
     resolver.work(&mut channel_controller);
     // An error endpoint update should be received.
     let update = update_rx.recv().await.unwrap();
@@ -360,9 +315,7 @@ pub(crate) async fn dns_lookup_error() {
 #[tokio::test]
 pub(crate) async fn dns_lookup_timeout() {
     let (work_tx, mut work_rx) = mpsc::unbounded_channel();
-    let work_scheduler = Arc::new(FakeWorkScheduler {
-        work_tx: work_tx.clone(),
-    });
+    let work_scheduler = Arc::new(TestWorkScheduler::new(work_tx.clone()));
     let runtime = FakeRuntime {
         inner: TokioRuntime::default(),
         dns: FakeDns {
@@ -388,10 +341,7 @@ pub(crate) async fn dns_lookup_timeout() {
     // Wait for schedule work to be called.
     work_rx.recv().await.unwrap();
     let (update_tx, mut update_rx) = mpsc::unbounded_channel();
-    let mut channel_controller = FakeChannelController {
-        update_tx,
-        update_result: Ok(()),
-    };
+    let mut channel_controller = TestChannelController::new(update_tx);
     resolver.work(&mut channel_controller);
 
     // An error endpoint update should be received.
@@ -402,9 +352,7 @@ pub(crate) async fn dns_lookup_timeout() {
 #[tokio::test]
 pub(crate) async fn rate_limit() {
     let (work_tx, mut work_rx) = mpsc::unbounded_channel();
-    let work_scheduler = Arc::new(FakeWorkScheduler {
-        work_tx: work_tx.clone(),
-    });
+    let work_scheduler = Arc::new(TestWorkScheduler::new(work_tx.clone()));
     let opts = ResolverOptions {
         authority: "ignored".to_string(),
         runtime: rt::default_runtime(),
@@ -426,10 +374,7 @@ pub(crate) async fn rate_limit() {
     // Wait for schedule work to be called.
     work_rx.recv().await.unwrap();
     let (update_tx, mut update_rx) = mpsc::unbounded_channel();
-    let mut channel_controller = FakeChannelController {
-        update_tx,
-        update_result: Ok(()),
-    };
+    let mut channel_controller = TestChannelController::new(update_tx);
     resolver.work(&mut channel_controller);
     // A successful endpoint update should be received.
     let update = update_rx.recv().await.unwrap();
@@ -452,9 +397,7 @@ pub(crate) async fn rate_limit() {
 #[tokio::test]
 pub(crate) async fn re_resolution_after_success() {
     let (work_tx, mut work_rx) = mpsc::unbounded_channel();
-    let work_scheduler = Arc::new(FakeWorkScheduler {
-        work_tx: work_tx.clone(),
-    });
+    let work_scheduler = Arc::new(TestWorkScheduler::new(work_tx.clone()));
     let opts = ResolverOptions {
         authority: "ignored".to_string(),
         runtime: rt::default_runtime(),
@@ -476,10 +419,7 @@ pub(crate) async fn re_resolution_after_success() {
     // Wait for schedule work to be called.
     work_rx.recv().await.unwrap();
     let (update_tx, mut update_rx) = mpsc::unbounded_channel();
-    let mut channel_controller = FakeChannelController {
-        update_tx,
-        update_result: Ok(()),
-    };
+    let mut channel_controller = TestChannelController::new(update_tx);
     resolver.work(&mut channel_controller);
     // A successful endpoint update should be received.
     let update = update_rx.recv().await.unwrap();
@@ -496,9 +436,7 @@ pub(crate) async fn re_resolution_after_success() {
 #[tokio::test]
 pub(crate) async fn backoff_on_error() {
     let (work_tx, mut work_rx) = mpsc::unbounded_channel();
-    let work_scheduler = Arc::new(FakeWorkScheduler {
-        work_tx: work_tx.clone(),
-    });
+    let work_scheduler = Arc::new(TestWorkScheduler::new(work_tx.clone()));
     let opts = ResolverOptions {
         authority: "ignored".to_string(),
         runtime: rt::default_runtime(),
@@ -525,10 +463,8 @@ pub(crate) async fn backoff_on_error() {
     let mut resolver = DnsResolver::new(dns_client, opts, dns_opts);
 
     let (update_tx, mut update_rx) = mpsc::unbounded_channel();
-    let mut channel_controller = FakeChannelController {
-        update_tx,
-        update_result: Err("test_error".to_string()),
-    };
+    let mut channel_controller =
+        TestChannelController::new_with_result(update_tx, Err("test_error".to_string()));
 
     // As the channel returned an error to the resolver, the resolver will
     // backoff and re-attempt resolution.

--- a/grpc/src/client/name_resolution/dns/test.rs
+++ b/grpc/src/client/name_resolution/dns/test.rs
@@ -24,7 +24,6 @@
 
 use std::future::Future;
 use std::pin::Pin;
-use std::sync::Arc;
 use std::time::Duration;
 
 use tokio::sync::mpsc::{self};
@@ -173,8 +172,7 @@ pub(crate) async fn dns_basic() {
     reg();
     let builder = global_registry().get("dns").unwrap();
     let target = &"dns:///localhost:1234".parse().unwrap();
-    let (work_tx, mut work_rx) = mpsc::unbounded_channel();
-    let work_scheduler = Arc::new(TestWorkScheduler::new(work_tx.clone()));
+    let (work_scheduler, mut work_rx) = TestWorkScheduler::new_pair();
     let opts = ResolverOptions {
         authority: "ignored".to_string(),
         runtime: rt::default_runtime(),
@@ -197,8 +195,7 @@ pub(crate) async fn invalid_target() {
     reg();
     let builder = global_registry().get("dns").unwrap();
     let target = &"dns:///:1234".parse().unwrap();
-    let (work_tx, mut work_rx) = mpsc::unbounded_channel();
-    let work_scheduler = Arc::new(TestWorkScheduler::new(work_tx.clone()));
+    let (work_scheduler, mut work_rx) = TestWorkScheduler::new_pair();
     let opts = ResolverOptions {
         authority: "ignored".to_string(),
         runtime: rt::default_runtime(),
@@ -276,8 +273,7 @@ pub(crate) async fn dns_lookup_error() {
     reg();
     let builder = global_registry().get("dns").unwrap();
     let target = &"dns:///grpc.io:1234".parse().unwrap();
-    let (work_tx, mut work_rx) = mpsc::unbounded_channel();
-    let work_scheduler = Arc::new(TestWorkScheduler::new(work_tx.clone()));
+    let (work_scheduler, mut work_rx) = TestWorkScheduler::new_pair();
     let runtime = FakeRuntime {
         inner: TokioRuntime::default(),
         dns: FakeDns {
@@ -304,8 +300,7 @@ pub(crate) async fn dns_lookup_error() {
 
 #[tokio::test]
 pub(crate) async fn dns_lookup_timeout() {
-    let (work_tx, mut work_rx) = mpsc::unbounded_channel();
-    let work_scheduler = Arc::new(TestWorkScheduler::new(work_tx.clone()));
+    let (work_scheduler, mut work_rx) = TestWorkScheduler::new_pair();
     let runtime = FakeRuntime {
         inner: TokioRuntime::default(),
         dns: FakeDns {
@@ -341,8 +336,7 @@ pub(crate) async fn dns_lookup_timeout() {
 
 #[tokio::test]
 pub(crate) async fn rate_limit() {
-    let (work_tx, mut work_rx) = mpsc::unbounded_channel();
-    let work_scheduler = Arc::new(TestWorkScheduler::new(work_tx.clone()));
+    let (work_scheduler, mut work_rx) = TestWorkScheduler::new_pair();
     let opts = ResolverOptions {
         authority: "ignored".to_string(),
         runtime: rt::default_runtime(),
@@ -386,8 +380,7 @@ pub(crate) async fn rate_limit() {
 
 #[tokio::test]
 pub(crate) async fn re_resolution_after_success() {
-    let (work_tx, mut work_rx) = mpsc::unbounded_channel();
-    let work_scheduler = Arc::new(TestWorkScheduler::new(work_tx.clone()));
+    let (work_scheduler, mut work_rx) = TestWorkScheduler::new_pair();
     let opts = ResolverOptions {
         authority: "ignored".to_string(),
         runtime: rt::default_runtime(),
@@ -425,8 +418,7 @@ pub(crate) async fn re_resolution_after_success() {
 
 #[tokio::test]
 pub(crate) async fn backoff_on_error() {
-    let (work_tx, mut work_rx) = mpsc::unbounded_channel();
-    let work_scheduler = Arc::new(TestWorkScheduler::new(work_tx.clone()));
+    let (work_scheduler, mut work_rx) = TestWorkScheduler::new_pair();
     let opts = ResolverOptions {
         authority: "ignored".to_string(),
         runtime: rt::default_runtime(),

--- a/grpc/src/client/name_resolution/dns/test.rs
+++ b/grpc/src/client/name_resolution/dns/test.rs
@@ -26,7 +26,6 @@ use std::future::Future;
 use std::pin::Pin;
 use std::time::Duration;
 
-use tokio::sync::mpsc::{self};
 use url::Host;
 
 use crate::client::name_resolution::Resolver;
@@ -182,8 +181,7 @@ pub(crate) async fn dns_basic() {
 
     // Wait for schedule work to be called.
     work_rx.recv().await.unwrap();
-    let (update_tx, mut update_rx) = mpsc::unbounded_channel();
-    let mut channel_controller = TestChannelController::new(update_tx);
+    let (mut channel_controller, mut update_rx) = TestChannelController::new_pair();
     resolver.work(&mut channel_controller);
     // A successful endpoint update should be received.
     let update = update_rx.recv().await.unwrap();
@@ -205,8 +203,7 @@ pub(crate) async fn invalid_target() {
 
     // Wait for schedule work to be called.
     work_rx.recv().await.unwrap();
-    let (update_tx, mut update_rx) = mpsc::unbounded_channel();
-    let mut channel_controller = TestChannelController::new(update_tx);
+    let (mut channel_controller, mut update_rx) = TestChannelController::new_pair();
     resolver.work(&mut channel_controller);
     // An error endpoint update should be received.
     let update = update_rx.recv().await.unwrap();
@@ -290,8 +287,7 @@ pub(crate) async fn dns_lookup_error() {
 
     // Wait for schedule work to be called.
     work_rx.recv().await.unwrap();
-    let (update_tx, mut update_rx) = mpsc::unbounded_channel();
-    let mut channel_controller = TestChannelController::new(update_tx);
+    let (mut channel_controller, mut update_rx) = TestChannelController::new_pair();
     resolver.work(&mut channel_controller);
     // An error endpoint update should be received.
     let update = update_rx.recv().await.unwrap();
@@ -325,8 +321,7 @@ pub(crate) async fn dns_lookup_timeout() {
 
     // Wait for schedule work to be called.
     work_rx.recv().await.unwrap();
-    let (update_tx, mut update_rx) = mpsc::unbounded_channel();
-    let mut channel_controller = TestChannelController::new(update_tx);
+    let (mut channel_controller, mut update_rx) = TestChannelController::new_pair();
     resolver.work(&mut channel_controller);
 
     // An error endpoint update should be received.
@@ -357,8 +352,7 @@ pub(crate) async fn rate_limit() {
 
     // Wait for schedule work to be called.
     work_rx.recv().await.unwrap();
-    let (update_tx, mut update_rx) = mpsc::unbounded_channel();
-    let mut channel_controller = TestChannelController::new(update_tx);
+    let (mut channel_controller, mut update_rx) = TestChannelController::new_pair();
     resolver.work(&mut channel_controller);
     // A successful endpoint update should be received.
     let update = update_rx.recv().await.unwrap();
@@ -401,8 +395,7 @@ pub(crate) async fn re_resolution_after_success() {
 
     // Wait for schedule work to be called.
     work_rx.recv().await.unwrap();
-    let (update_tx, mut update_rx) = mpsc::unbounded_channel();
-    let mut channel_controller = TestChannelController::new(update_tx);
+    let (mut channel_controller, mut update_rx) = TestChannelController::new_pair();
     resolver.work(&mut channel_controller);
     // A successful endpoint update should be received.
     let update = update_rx.recv().await.unwrap();
@@ -444,9 +437,8 @@ pub(crate) async fn backoff_on_error() {
 
     let mut resolver = DnsResolver::new(dns_client, opts, dns_opts);
 
-    let (update_tx, mut update_rx) = mpsc::unbounded_channel();
-    let mut channel_controller =
-        TestChannelController::new_with_result(update_tx, Err("test_error".to_string()));
+    let (mut channel_controller, mut update_rx) = TestChannelController::new_pair();
+    channel_controller.set_update_result(Err("test_error".to_string()));
 
     // As the channel returned an error to the resolver, the resolver will
     // backoff and re-attempt resolution.
@@ -458,7 +450,7 @@ pub(crate) async fn backoff_on_error() {
     }
 
     // This time the channel accepts the resolver update.
-    channel_controller.update_result = Ok(());
+    channel_controller.set_update_result(Ok(()));
     work_rx.recv().await.unwrap();
     resolver.work(&mut channel_controller);
     let update = update_rx.recv().await.unwrap();

--- a/grpc/src/client/name_resolution/dns/test.rs
+++ b/grpc/src/client/name_resolution/dns/test.rs
@@ -291,7 +291,7 @@ pub(crate) async fn dns_lookup_error() {
     resolver.work(&mut channel_controller);
     // An error endpoint update should be received.
     let update = update_rx.recv().await.unwrap();
-    assert!(update.endpoints.err().unwrap().contains("test_error"));
+    assert!(update.endpoints.unwrap_err().contains("test_error"));
 }
 
 #[tokio::test]
@@ -326,7 +326,7 @@ pub(crate) async fn dns_lookup_timeout() {
 
     // An error endpoint update should be received.
     let update = update_rx.recv().await.unwrap();
-    assert!(update.endpoints.err().unwrap().contains("Timed out"));
+    assert!(update.endpoints.unwrap_err().contains("Timed out"));
 }
 
 #[tokio::test]

--- a/grpc/src/client/name_resolution/mod.rs
+++ b/grpc/src/client/name_resolution/mod.rs
@@ -44,6 +44,7 @@ use crate::rt::GrpcRuntime;
 mod backoff;
 pub(crate) mod dns;
 mod registry;
+pub(crate) mod unix;
 pub(crate) use registry::global_registry;
 
 /// Target represents a target for gRPC, as specified in:
@@ -331,6 +332,10 @@ impl Display for Address {
 /// via TCP/IP.
 pub(crate) static TCP_IP_NETWORK_TYPE: &str = "tcp";
 
+/// Indicates the address is a local filesystem path or abstract name that
+/// should be connected to via a UNIX domain socket.
+pub(crate) static UNIX_NETWORK_TYPE: &str = "unix";
+
 // A resolver that returns the same result every time its work method is called.
 // It can be used to return an error to the channel when a resolver fails to
 // build.
@@ -344,6 +349,16 @@ impl Resolver for NopResolver {
     fn work(&mut self, channel_controller: &mut dyn ChannelController) {
         let _ = channel_controller.update(self.update.clone());
     }
+}
+
+fn nop_resolver_for_err(err: String, options: ResolverOptions) -> Box<dyn Resolver> {
+    options.work_scheduler.schedule_work();
+    Box::new(NopResolver {
+        update: ResolverUpdate {
+            endpoints: Err(err),
+            ..Default::default()
+        },
+    })
 }
 
 #[cfg(test)]

--- a/grpc/src/client/name_resolution/mod.rs
+++ b/grpc/src/client/name_resolution/mod.rs
@@ -42,9 +42,16 @@ use crate::client::service_config::ServiceConfig;
 use crate::rt::GrpcRuntime;
 
 mod backoff;
-pub(crate) mod dns;
 mod registry;
+
+#[cfg(test)]
+pub(crate) mod test_utils;
+
+pub(crate) mod dns;
+#[cfg(unix)]
 pub(crate) mod unix;
+#[cfg(target_os = "linux")]
+pub(crate) mod unix_abstract;
 pub(crate) use registry::global_registry;
 
 /// Target represents a target for gRPC, as specified in:
@@ -340,25 +347,42 @@ pub(crate) static UNIX_NETWORK_TYPE: &str = "unix";
 // It can be used to return an error to the channel when a resolver fails to
 // build.
 struct NopResolver {
-    pub update: ResolverUpdate,
+    pub update: Option<ResolverUpdate>,
 }
 
 impl Resolver for NopResolver {
     fn resolve_now(&mut self) {}
 
     fn work(&mut self, channel_controller: &mut dyn ChannelController) {
-        let _ = channel_controller.update(self.update.clone());
+        if let Some(update) = self.update.take() {
+            let _ = channel_controller.update(update);
+        }
     }
 }
 
-fn nop_resolver_for_err(err: String, options: ResolverOptions) -> Box<dyn Resolver> {
-    options.work_scheduler.schedule_work();
-    Box::new(NopResolver {
-        update: ResolverUpdate {
-            endpoints: Err(err),
-            ..Default::default()
-        },
-    })
+impl NopResolver {
+    fn new_with_err(err: String, options: ResolverOptions) -> Box<dyn Resolver> {
+        options.work_scheduler.schedule_work();
+        Box::new(NopResolver {
+            update: Some(ResolverUpdate {
+                endpoints: Err(err),
+                ..Default::default()
+            }),
+        })
+    }
+
+    fn new_with_addr(addr: Address, options: ResolverOptions) -> Box<dyn Resolver> {
+        options.work_scheduler.schedule_work();
+        Box::new(NopResolver {
+            update: Some(ResolverUpdate {
+                endpoints: Ok(vec![Endpoint {
+                    addresses: vec![addr],
+                    ..Default::default()
+                }]),
+                ..Default::default()
+            }),
+        })
+    }
 }
 
 #[cfg(test)]

--- a/grpc/src/client/name_resolution/test_utils.rs
+++ b/grpc/src/client/name_resolution/test_utils.rs
@@ -22,7 +22,9 @@
  *
  */
 
-use tokio::sync::mpsc::UnboundedSender;
+use std::sync::Arc;
+
+use tokio::sync::mpsc;
 
 use crate::client::name_resolution::ChannelController;
 use crate::client::name_resolution::ResolverUpdate;
@@ -31,13 +33,15 @@ use crate::client::service_config::ServiceConfig;
 
 /// A work scheduler for testing.
 pub struct TestWorkScheduler {
-    pub work_tx: UnboundedSender<()>,
+    pub work_tx: mpsc::UnboundedSender<()>,
 }
 
 impl TestWorkScheduler {
     /// Creates a new `TestWorkScheduler`.
-    pub fn new(work_tx: UnboundedSender<()>) -> Self {
-        Self { work_tx }
+    pub fn new_pair() -> (Arc<dyn WorkScheduler>, mpsc::UnboundedReceiver<()>) {
+        let (work_tx, work_rx) = mpsc::unbounded_channel();
+        let sched = Self { work_tx };
+        (Arc::new(sched), work_rx)
     }
 }
 
@@ -50,12 +54,12 @@ impl WorkScheduler for TestWorkScheduler {
 /// A channel controller for testing.
 pub struct TestChannelController {
     pub update_result: Result<(), String>,
-    pub update_tx: UnboundedSender<ResolverUpdate>,
+    pub update_tx: mpsc::UnboundedSender<ResolverUpdate>,
 }
 
 impl TestChannelController {
     /// Creates a new `TestChannelController` that returns `Ok(())` on update.
-    pub fn new(update_tx: UnboundedSender<ResolverUpdate>) -> Self {
+    pub fn new(update_tx: mpsc::UnboundedSender<ResolverUpdate>) -> Self {
         Self {
             update_result: Ok(()),
             update_tx,
@@ -64,7 +68,7 @@ impl TestChannelController {
 
     /// Creates a new `TestChannelController` with a specified update result.
     pub fn new_with_result(
-        update_tx: UnboundedSender<ResolverUpdate>,
+        update_tx: mpsc::UnboundedSender<ResolverUpdate>,
         update_result: Result<(), String>,
     ) -> Self {
         Self {

--- a/grpc/src/client/name_resolution/test_utils.rs
+++ b/grpc/src/client/name_resolution/test_utils.rs
@@ -1,0 +1,87 @@
+/*
+ *
+ * Copyright 2026 gRPC authors.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to
+ * deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ *
+ */
+
+use tokio::sync::mpsc::UnboundedSender;
+
+use crate::client::name_resolution::ChannelController;
+use crate::client::name_resolution::ResolverUpdate;
+use crate::client::name_resolution::WorkScheduler;
+use crate::client::service_config::ServiceConfig;
+
+/// A work scheduler for testing.
+pub struct TestWorkScheduler {
+    pub work_tx: UnboundedSender<()>,
+}
+
+impl TestWorkScheduler {
+    /// Creates a new `TestWorkScheduler`.
+    pub fn new(work_tx: UnboundedSender<()>) -> Self {
+        Self { work_tx }
+    }
+}
+
+impl WorkScheduler for TestWorkScheduler {
+    fn schedule_work(&self) {
+        self.work_tx.send(()).unwrap();
+    }
+}
+
+/// A channel controller for testing.
+pub struct TestChannelController {
+    pub update_result: Result<(), String>,
+    pub update_tx: UnboundedSender<ResolverUpdate>,
+}
+
+impl TestChannelController {
+    /// Creates a new `TestChannelController` that returns `Ok(())` on update.
+    pub fn new(update_tx: UnboundedSender<ResolverUpdate>) -> Self {
+        Self {
+            update_result: Ok(()),
+            update_tx,
+        }
+    }
+
+    /// Creates a new `TestChannelController` with a specified update result.
+    pub fn new_with_result(
+        update_tx: UnboundedSender<ResolverUpdate>,
+        update_result: Result<(), String>,
+    ) -> Self {
+        Self {
+            update_result,
+            update_tx,
+        }
+    }
+}
+
+impl ChannelController for TestChannelController {
+    fn update(&mut self, update: ResolverUpdate) -> Result<(), String> {
+        println!("Received resolver update: {:?}", &update);
+        self.update_tx.send(update).unwrap();
+        self.update_result.clone()
+    }
+
+    fn parse_service_config(&self, _: &str) -> Result<ServiceConfig, String> {
+        Err("Unimplemented".to_string())
+    }
+}

--- a/grpc/src/client/name_resolution/test_utils.rs
+++ b/grpc/src/client/name_resolution/test_utils.rs
@@ -32,13 +32,13 @@ use crate::client::name_resolution::WorkScheduler;
 use crate::client::service_config::ServiceConfig;
 
 /// A work scheduler for testing.
-pub struct TestWorkScheduler {
-    pub work_tx: mpsc::UnboundedSender<()>,
+pub(crate) struct TestWorkScheduler {
+    work_tx: mpsc::UnboundedSender<()>,
 }
 
 impl TestWorkScheduler {
     /// Creates a new `TestWorkScheduler`.
-    pub fn new_pair() -> (Arc<dyn WorkScheduler>, mpsc::UnboundedReceiver<()>) {
+    pub(crate) fn new_pair() -> (Arc<dyn WorkScheduler>, mpsc::UnboundedReceiver<()>) {
         let (work_tx, work_rx) = mpsc::unbounded_channel();
         let sched = Self { work_tx };
         (Arc::new(sched), work_rx)
@@ -52,29 +52,24 @@ impl WorkScheduler for TestWorkScheduler {
 }
 
 /// A channel controller for testing.
-pub struct TestChannelController {
-    pub update_result: Result<(), String>,
-    pub update_tx: mpsc::UnboundedSender<ResolverUpdate>,
+pub(crate) struct TestChannelController {
+    update_result: Result<(), String>,
+    update_tx: mpsc::UnboundedSender<ResolverUpdate>,
 }
 
 impl TestChannelController {
     /// Creates a new `TestChannelController` that returns `Ok(())` on update.
-    pub fn new(update_tx: mpsc::UnboundedSender<ResolverUpdate>) -> Self {
-        Self {
+    pub(crate) fn new_pair() -> (Self, mpsc::UnboundedReceiver<ResolverUpdate>) {
+        let (update_tx, update_rx) = mpsc::unbounded_channel();
+        let cc = Self {
             update_result: Ok(()),
             update_tx,
-        }
+        };
+        (cc, update_rx)
     }
 
-    /// Creates a new `TestChannelController` with a specified update result.
-    pub fn new_with_result(
-        update_tx: mpsc::UnboundedSender<ResolverUpdate>,
-        update_result: Result<(), String>,
-    ) -> Self {
-        Self {
-            update_result,
-            update_tx,
-        }
+    pub(crate) fn set_update_result(&mut self, update_result: Result<(), String>) {
+        self.update_result = update_result
     }
 }
 

--- a/grpc/src/client/name_resolution/unix.rs
+++ b/grpc/src/client/name_resolution/unix.rs
@@ -89,6 +89,7 @@ mod tests {
     use rstest::rstest;
 
     use super::*;
+    use crate::client::name_resolution::Endpoint;
     use crate::client::name_resolution::ResolverOptions;
     use crate::client::name_resolution::test_utils::TestChannelController;
     use crate::client::name_resolution::test_utils::TestWorkScheduler;
@@ -102,7 +103,7 @@ mod tests {
     async fn unix_resolver_success(#[case] input: &str, #[case] want_addr: &str) {
         reg();
 
-        let target: Target = input.parse().expect("Failed to parse target");
+        let target: Target = input.parse().unwrap();
         let (work_scheduler, mut work_rx) = TestWorkScheduler::new_pair();
         let opts = ResolverOptions {
             authority: "ignored".to_string(),
@@ -120,21 +121,26 @@ mod tests {
         resolver.work(&mut channel_controller);
 
         let update = update_rx.recv().await.unwrap();
-        let endpoints = update.endpoints.expect("Should have succeeded");
-        assert_eq!(endpoints.len(), 1);
-
-        let addr = &endpoints[0].addresses[0];
-        assert_eq!(addr.network_type, UNIX_NETWORK_TYPE);
-        assert_eq!(&*addr.address, want_addr);
+        let want_endpoint = Endpoint {
+            addresses: vec![Address {
+                network_type: UNIX_NETWORK_TYPE,
+                address: ByteStr::from(want_addr.to_owned()),
+                ..Default::default()
+            }],
+            ..Default::default()
+        };
+        assert_eq!(
+            update.endpoints,
+            Ok(vec![want_endpoint]),
+            "did not receive expected endpoint"
+        );
     }
 
     #[tokio::test]
-    async fn unix_resolver_failure() {
+    async fn unix_resolver_error_with_authority() {
         reg();
 
-        let target: Target = "unix://authority/path"
-            .parse()
-            .expect("Failed to parse target");
+        let target: Target = "unix://authority/path".parse().unwrap();
         let (work_scheduler, mut work_rx) = TestWorkScheduler::new_pair();
         let opts = ResolverOptions {
             authority: "ignored".to_string(),
@@ -152,7 +158,7 @@ mod tests {
         resolver.work(&mut channel_controller);
 
         let update = update_rx.recv().await.unwrap();
-        let err = update.endpoints.expect_err("Should have failed");
+        let err = update.endpoints.err().unwrap();
         assert!(err.contains("invalid (non-empty) authority"));
     }
 }

--- a/grpc/src/client/name_resolution/unix.rs
+++ b/grpc/src/client/name_resolution/unix.rs
@@ -86,8 +86,6 @@ fn parse_target(target: &Target) -> Result<Address, String> {
 
 #[cfg(test)]
 mod tests {
-    use rstest::rstest;
-
     use super::*;
     use crate::client::name_resolution::Endpoint;
     use crate::client::name_resolution::ResolverOptions;
@@ -95,12 +93,7 @@ mod tests {
     use crate::client::name_resolution::test_utils::TestWorkScheduler;
     use crate::rt;
 
-    #[rstest]
-    #[case::relative_path("unix:path/to/socket", "path/to/socket")]
-    #[case::absolute_path("unix:/absolute/path", "/absolute/path")]
-    #[case::absolute_path_with_slashes("unix:///absolute/path", "/absolute/path")]
-    #[tokio::test]
-    async fn unix_resolver_success(#[case] input: &str, #[case] want_addr: &str) {
+    async fn run_success(input: &str, want_addr: &str) {
         reg();
 
         let target: Target = input.parse().unwrap();
@@ -129,11 +122,27 @@ mod tests {
             }],
             ..Default::default()
         };
+
         assert_eq!(
             update.endpoints,
             Ok(vec![want_endpoint]),
             "did not receive expected endpoint"
         );
+    }
+
+    #[tokio::test]
+    async fn unix_resolver_success_relative_path() {
+        run_success("unix:path/to/socket", "path/to/socket").await;
+    }
+
+    #[tokio::test]
+    async fn unix_resolver_success_absolute_path() {
+        run_success("unix:/absolute/path", "/absolute/path").await;
+    }
+
+    #[tokio::test]
+    async fn unix_resolver_success_absolute_path_with_slashes() {
+        run_success("unix:///absolute/path", "/absolute/path").await;
     }
 
     #[tokio::test]

--- a/grpc/src/client/name_resolution/unix.rs
+++ b/grpc/src/client/name_resolution/unix.rs
@@ -1,0 +1,259 @@
+/*
+ *
+ * Copyright 2026 gRPC authors.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to
+ * deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ *
+ */
+
+use crate::attributes::Attributes;
+use crate::byte_str::ByteStr;
+use crate::client::name_resolution::Address;
+use crate::client::name_resolution::Endpoint;
+use crate::client::name_resolution::NopResolver;
+use crate::client::name_resolution::Resolver;
+use crate::client::name_resolution::ResolverBuilder;
+use crate::client::name_resolution::ResolverOptions;
+use crate::client::name_resolution::ResolverUpdate;
+use crate::client::name_resolution::Target;
+use crate::client::name_resolution::UNIX_NETWORK_TYPE;
+use crate::client::name_resolution::global_registry;
+use crate::client::name_resolution::nop_resolver_for_err;
+
+#[derive(Debug, Copy, Clone)]
+enum UnixScheme {
+    Standard,
+    #[cfg(target_os = "linux")]
+    Abstract,
+}
+
+impl UnixScheme {
+    const fn as_str(&self) -> &'static str {
+        match self {
+            UnixScheme::Standard => "unix",
+            #[cfg(target_os = "linux")]
+            UnixScheme::Abstract => "unix-abstract",
+        }
+    }
+}
+
+pub(crate) fn reg() {
+    global_registry().add_builder(Box::new(Builder {
+        scheme: UnixScheme::Standard,
+    }));
+
+    #[cfg(target_os = "linux")]
+    global_registry().add_builder(Box::new(Builder {
+        scheme: UnixScheme::Abstract,
+    }));
+}
+
+#[derive(Debug)]
+struct Builder {
+    scheme: UnixScheme,
+}
+
+impl ResolverBuilder for Builder {
+    fn build(
+        &self,
+        target: &super::Target,
+        options: super::ResolverOptions,
+    ) -> Box<dyn super::Resolver> {
+        match parse_endpoint_and_authority(target, self.scheme) {
+            Ok(addr) => nop_resolver_for_addr(addr, options),
+            Err(err) => nop_resolver_for_err(err, options),
+        }
+    }
+
+    fn scheme(&self) -> &str {
+        self.scheme.as_str()
+    }
+
+    fn is_valid_uri(&self, uri: &super::Target) -> bool {
+        parse_endpoint_and_authority(uri, self.scheme).is_ok()
+    }
+}
+
+/// Parses a target URI into a standard or abstract UNIX domain socket address.
+///
+/// This function handles two schemes:
+///
+/// ### `unix` (Standard UNIX Domain Sockets)
+/// Valid formats: `unix:path` or `unix:///absolute_path`
+/// - `path` indicates the location of the desired socket on the filesystem.
+/// - In the first form (`unix:path`), the path may be relative or absolute.
+/// - In the second form (`unix:///absolute_path`), the path must be absolute.
+///   The last of the three slashes is treated as the root of the filesystem
+///   path (e.g., `/absolute_path`).
+///
+/// ### `unix-abstract` (Abstract Namespace)
+/// Valid format: `unix-abstract:abstract_path`
+/// - `abstract_path` indicates a socket name in the abstract namespace.
+/// - The name has no connection with filesystem pathnames and bypasses standard
+///   filesystem permissions; any process or user may access the socket.
+/// - The underlying system requires a null byte (`\0`) as the first character.
+///   This function automatically prepends the null byte; it should not be
+///   included it in `abstract_path`.
+/// - Note: Abstract sockets are a Linux-specific kernel feature.
+fn parse_endpoint_and_authority(target: &Target, scheme: UnixScheme) -> Result<Address, String> {
+    let host_port = target.authority_host_port();
+    if !host_port.is_empty() {
+        return Err(format!("invalid (non-empty) authority: {host_port}"));
+    }
+    let addr_string = match scheme {
+        UnixScheme::Standard => target.path().to_owned(),
+        #[cfg(target_os = "linux")]
+        UnixScheme::Abstract => format!("\0{}", target.path()),
+    };
+    Ok(Address {
+        network_type: UNIX_NETWORK_TYPE,
+        address: ByteStr::from(addr_string),
+        attributes: Attributes::new(),
+    })
+}
+
+fn nop_resolver_for_addr(addr: Address, options: ResolverOptions) -> Box<dyn Resolver> {
+    options.work_scheduler.schedule_work();
+    Box::new(NopResolver {
+        update: ResolverUpdate {
+            endpoints: Ok(vec![Endpoint {
+                addresses: vec![addr],
+                ..Default::default()
+            }]),
+            ..Default::default()
+        },
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use tokio::sync::mpsc;
+
+    use super::*;
+    use crate::client::name_resolution::ChannelController;
+    use crate::client::name_resolution::WorkScheduler;
+    use crate::client::service_config::ServiceConfig;
+    use crate::rt;
+
+    struct FakeWorkScheduler {
+        work_tx: mpsc::UnboundedSender<()>,
+    }
+
+    impl WorkScheduler for FakeWorkScheduler {
+        fn schedule_work(&self) {
+            self.work_tx.send(()).unwrap();
+        }
+    }
+
+    struct FakeChannelController {
+        update_tx: mpsc::UnboundedSender<ResolverUpdate>,
+    }
+
+    impl ChannelController for FakeChannelController {
+        fn update(&mut self, update: ResolverUpdate) -> Result<(), String> {
+            self.update_tx.send(update).unwrap();
+            Ok(())
+        }
+
+        fn parse_service_config(&self, _: &str) -> Result<ServiceConfig, String> {
+            Err("Unimplemented".to_string())
+        }
+    }
+
+    #[tokio::test]
+    async fn test_unix_resolver() {
+        reg();
+
+        struct TestCase {
+            input: &'static str,
+            scheme: &'static str,
+            want_addr: &'static str,
+            want_success: bool,
+        }
+
+        let test_cases = vec![
+            TestCase {
+                input: "unix:path/to/socket",
+                scheme: "unix",
+                want_addr: "path/to/socket",
+                want_success: true,
+            },
+            TestCase {
+                input: "unix:/absolute/path",
+                scheme: "unix",
+                want_addr: "/absolute/path",
+                want_success: true,
+            },
+            TestCase {
+                input: "unix:///absolute/path",
+                scheme: "unix",
+                want_addr: "/absolute/path",
+                want_success: true,
+            },
+            #[cfg(target_os = "linux")]
+            TestCase {
+                input: "unix-abstract:abstract_name",
+                scheme: "unix-abstract",
+                want_addr: "\0abstract_name",
+                want_success: true,
+            },
+            TestCase {
+                input: "unix://authority/path",
+                scheme: "unix",
+                want_addr: "",
+                want_success: false,
+            },
+        ];
+
+        for tc in test_cases {
+            let target: Target = tc.input.parse().expect("Failed to parse target");
+            let (work_tx, mut work_rx) = mpsc::unbounded_channel();
+            let work_scheduler = Arc::new(FakeWorkScheduler { work_tx });
+            let opts = ResolverOptions {
+                authority: "ignored".to_string(),
+                runtime: rt::default_runtime(),
+                work_scheduler: work_scheduler.clone(),
+            };
+
+            let builder = global_registry().get(tc.scheme).expect("scheme not found");
+            let mut resolver = builder.build(&target, opts);
+
+            // Wait for work to be scheduled.
+            work_rx.recv().await.unwrap();
+
+            let (update_tx, mut update_rx) = mpsc::unbounded_channel();
+            let mut channel_controller = FakeChannelController { update_tx };
+            resolver.work(&mut channel_controller);
+
+            let update = update_rx.recv().await.unwrap();
+            if tc.want_success {
+                let endpoints = update.endpoints.expect("Should have succeeded");
+                assert_eq!(endpoints.len(), 1);
+                let addr = &endpoints[0].addresses[0];
+                assert_eq!(addr.network_type, UNIX_NETWORK_TYPE);
+                assert_eq!(&*addr.address, tc.want_addr);
+            } else {
+                let err = update.endpoints.expect_err("Should have failed");
+                assert!(err.contains("invalid (non-empty) authority"));
+            }
+        }
+    }
+}

--- a/grpc/src/client/name_resolution/unix.rs
+++ b/grpc/src/client/name_resolution/unix.rs
@@ -167,7 +167,7 @@ mod tests {
         resolver.work(&mut channel_controller);
 
         let update = update_rx.recv().await.unwrap();
-        let err = update.endpoints.err().unwrap();
+        let err = update.endpoints.unwrap_err();
         assert!(err.contains("invalid (non-empty) authority"));
     }
 }

--- a/grpc/src/client/name_resolution/unix.rs
+++ b/grpc/src/client/name_resolution/unix.rs
@@ -86,8 +86,6 @@ fn parse_target(target: &Target) -> Result<Address, String> {
 
 #[cfg(test)]
 mod tests {
-    use tokio::sync::mpsc;
-
     use super::*;
     use crate::client::name_resolution::ResolverOptions;
     use crate::client::name_resolution::test_utils::TestChannelController;
@@ -147,8 +145,7 @@ mod tests {
             // Wait for work to be scheduled.
             work_rx.recv().await.unwrap();
 
-            let (update_tx, mut update_rx) = mpsc::unbounded_channel();
-            let mut channel_controller = TestChannelController::new(update_tx);
+            let (mut channel_controller, mut update_rx) = TestChannelController::new_pair();
             resolver.work(&mut channel_controller);
 
             let update = update_rx.recv().await.unwrap();

--- a/grpc/src/client/name_resolution/unix.rs
+++ b/grpc/src/client/name_resolution/unix.rs
@@ -86,8 +86,6 @@ fn parse_target(target: &Target) -> Result<Address, String> {
 
 #[cfg(test)]
 mod tests {
-    use std::sync::Arc;
-
     use tokio::sync::mpsc;
 
     use super::*;
@@ -136,8 +134,7 @@ mod tests {
 
         for tc in test_cases {
             let target: Target = tc.input.parse().expect("Failed to parse target");
-            let (work_tx, mut work_rx) = mpsc::unbounded_channel();
-            let work_scheduler = Arc::new(TestWorkScheduler::new(work_tx));
+            let (work_scheduler, mut work_rx) = TestWorkScheduler::new_pair();
             let opts = ResolverOptions {
                 authority: "ignored".to_string(),
                 runtime: rt::default_runtime(),

--- a/grpc/src/client/name_resolution/unix.rs
+++ b/grpc/src/client/name_resolution/unix.rs
@@ -88,6 +88,10 @@ impl ResolverBuilder for Builder {
     fn is_valid_uri(&self, uri: &super::Target) -> bool {
         parse_endpoint_and_authority(uri, self.scheme).is_ok()
     }
+
+    fn default_authority(&self, target: &Target) -> String {
+        "localhost".to_owned()
+    }
 }
 
 /// Parses a target URI into a standard or abstract UNIX domain socket address.

--- a/grpc/src/client/name_resolution/unix.rs
+++ b/grpc/src/client/name_resolution/unix.rs
@@ -25,49 +25,18 @@
 use crate::attributes::Attributes;
 use crate::byte_str::ByteStr;
 use crate::client::name_resolution::Address;
-use crate::client::name_resolution::Endpoint;
 use crate::client::name_resolution::NopResolver;
-use crate::client::name_resolution::Resolver;
 use crate::client::name_resolution::ResolverBuilder;
-use crate::client::name_resolution::ResolverOptions;
-use crate::client::name_resolution::ResolverUpdate;
 use crate::client::name_resolution::Target;
 use crate::client::name_resolution::UNIX_NETWORK_TYPE;
 use crate::client::name_resolution::global_registry;
-use crate::client::name_resolution::nop_resolver_for_err;
-
-#[derive(Debug, Copy, Clone)]
-enum UnixScheme {
-    Standard,
-    #[cfg(target_os = "linux")]
-    Abstract,
-}
-
-impl UnixScheme {
-    const fn as_str(&self) -> &'static str {
-        match self {
-            UnixScheme::Standard => "unix",
-            #[cfg(target_os = "linux")]
-            UnixScheme::Abstract => "unix-abstract",
-        }
-    }
-}
 
 pub(crate) fn reg() {
-    global_registry().add_builder(Box::new(Builder {
-        scheme: UnixScheme::Standard,
-    }));
-
-    #[cfg(target_os = "linux")]
-    global_registry().add_builder(Box::new(Builder {
-        scheme: UnixScheme::Abstract,
-    }));
+    global_registry().add_builder(Box::new(Builder {}));
 }
 
 #[derive(Debug)]
-struct Builder {
-    scheme: UnixScheme,
-}
+struct Builder {}
 
 impl ResolverBuilder for Builder {
     fn build(
@@ -75,18 +44,18 @@ impl ResolverBuilder for Builder {
         target: &super::Target,
         options: super::ResolverOptions,
     ) -> Box<dyn super::Resolver> {
-        match parse_endpoint_and_authority(target, self.scheme) {
-            Ok(addr) => nop_resolver_for_addr(addr, options),
-            Err(err) => nop_resolver_for_err(err, options),
+        match parse_target(target) {
+            Ok(addr) => NopResolver::new_with_addr(addr, options),
+            Err(err) => NopResolver::new_with_err(err, options),
         }
     }
 
     fn scheme(&self) -> &str {
-        self.scheme.as_str()
+        "unix"
     }
 
     fn is_valid_uri(&self, uri: &super::Target) -> bool {
-        parse_endpoint_and_authority(uri, self.scheme).is_ok()
+        parse_target(uri).is_ok()
     }
 
     fn default_authority(&self, target: &Target) -> String {
@@ -94,54 +63,24 @@ impl ResolverBuilder for Builder {
     }
 }
 
-/// Parses a target URI into a standard or abstract UNIX domain socket address.
+/// Parses a target URI into a standard domain socket address.
 ///
-/// This function handles two schemes:
-///
-/// ### `unix` (Standard UNIX Domain Sockets)
 /// Valid formats: `unix:path` or `unix:///absolute_path`
 /// - `path` indicates the location of the desired socket on the filesystem.
 /// - In the first form (`unix:path`), the path may be relative or absolute.
 /// - In the second form (`unix:///absolute_path`), the path must be absolute.
 ///   The last of the three slashes is treated as the root of the filesystem
 ///   path (e.g., `/absolute_path`).
-///
-/// ### `unix-abstract` (Abstract Namespace)
-/// Valid format: `unix-abstract:abstract_path`
-/// - `abstract_path` indicates a socket name in the abstract namespace.
-/// - The name has no connection with filesystem pathnames and bypasses standard
-///   filesystem permissions; any process or user may access the socket.
-/// - The underlying system requires a null byte (`\0`) as the first character.
-///   This function automatically prepends the null byte; it should not be
-///   included it in `abstract_path`.
-/// - Note: Abstract sockets are a Linux-specific kernel feature.
-fn parse_endpoint_and_authority(target: &Target, scheme: UnixScheme) -> Result<Address, String> {
+fn parse_target(target: &Target) -> Result<Address, String> {
     let host_port = target.authority_host_port();
     if !host_port.is_empty() {
         return Err(format!("invalid (non-empty) authority: {host_port}"));
     }
-    let addr_string = match scheme {
-        UnixScheme::Standard => target.path().to_owned(),
-        #[cfg(target_os = "linux")]
-        UnixScheme::Abstract => format!("\0{}", target.path()),
-    };
+    let addr_string = target.path().to_owned();
     Ok(Address {
         network_type: UNIX_NETWORK_TYPE,
         address: ByteStr::from(addr_string),
         attributes: Attributes::new(),
-    })
-}
-
-fn nop_resolver_for_addr(addr: Address, options: ResolverOptions) -> Box<dyn Resolver> {
-    options.work_scheduler.schedule_work();
-    Box::new(NopResolver {
-        update: ResolverUpdate {
-            endpoints: Ok(vec![Endpoint {
-                addresses: vec![addr],
-                ..Default::default()
-            }]),
-            ..Default::default()
-        },
     })
 }
 
@@ -152,38 +91,13 @@ mod tests {
     use tokio::sync::mpsc;
 
     use super::*;
-    use crate::client::name_resolution::ChannelController;
-    use crate::client::name_resolution::WorkScheduler;
-    use crate::client::service_config::ServiceConfig;
+    use crate::client::name_resolution::ResolverOptions;
+    use crate::client::name_resolution::test_utils::TestChannelController;
+    use crate::client::name_resolution::test_utils::TestWorkScheduler;
     use crate::rt;
 
-    struct FakeWorkScheduler {
-        work_tx: mpsc::UnboundedSender<()>,
-    }
-
-    impl WorkScheduler for FakeWorkScheduler {
-        fn schedule_work(&self) {
-            self.work_tx.send(()).unwrap();
-        }
-    }
-
-    struct FakeChannelController {
-        update_tx: mpsc::UnboundedSender<ResolverUpdate>,
-    }
-
-    impl ChannelController for FakeChannelController {
-        fn update(&mut self, update: ResolverUpdate) -> Result<(), String> {
-            self.update_tx.send(update).unwrap();
-            Ok(())
-        }
-
-        fn parse_service_config(&self, _: &str) -> Result<ServiceConfig, String> {
-            Err("Unimplemented".to_string())
-        }
-    }
-
     #[tokio::test]
-    async fn test_unix_resolver() {
+    async fn unix_resolver() {
         reg();
 
         struct TestCase {
@@ -212,13 +126,6 @@ mod tests {
                 want_addr: "/absolute/path",
                 want_success: true,
             },
-            #[cfg(target_os = "linux")]
-            TestCase {
-                input: "unix-abstract:abstract_name",
-                scheme: "unix-abstract",
-                want_addr: "\0abstract_name",
-                want_success: true,
-            },
             TestCase {
                 input: "unix://authority/path",
                 scheme: "unix",
@@ -230,7 +137,7 @@ mod tests {
         for tc in test_cases {
             let target: Target = tc.input.parse().expect("Failed to parse target");
             let (work_tx, mut work_rx) = mpsc::unbounded_channel();
-            let work_scheduler = Arc::new(FakeWorkScheduler { work_tx });
+            let work_scheduler = Arc::new(TestWorkScheduler::new(work_tx));
             let opts = ResolverOptions {
                 authority: "ignored".to_string(),
                 runtime: rt::default_runtime(),
@@ -244,7 +151,7 @@ mod tests {
             work_rx.recv().await.unwrap();
 
             let (update_tx, mut update_rx) = mpsc::unbounded_channel();
-            let mut channel_controller = FakeChannelController { update_tx };
+            let mut channel_controller = TestChannelController::new(update_tx);
             resolver.work(&mut channel_controller);
 
             let update = update_rx.recv().await.unwrap();

--- a/grpc/src/client/name_resolution/unix.rs
+++ b/grpc/src/client/name_resolution/unix.rs
@@ -86,79 +86,73 @@ fn parse_target(target: &Target) -> Result<Address, String> {
 
 #[cfg(test)]
 mod tests {
+    use rstest::rstest;
+
     use super::*;
     use crate::client::name_resolution::ResolverOptions;
     use crate::client::name_resolution::test_utils::TestChannelController;
     use crate::client::name_resolution::test_utils::TestWorkScheduler;
     use crate::rt;
 
+    #[rstest]
+    #[case::relative_path("unix:path/to/socket", "path/to/socket")]
+    #[case::absolute_path("unix:/absolute/path", "/absolute/path")]
+    #[case::absolute_path_with_slashes("unix:///absolute/path", "/absolute/path")]
     #[tokio::test]
-    async fn unix_resolver() {
+    async fn unix_resolver_success(#[case] input: &str, #[case] want_addr: &str) {
         reg();
 
-        struct TestCase {
-            input: &'static str,
-            scheme: &'static str,
-            want_addr: &'static str,
-            want_success: bool,
-        }
+        let target: Target = input.parse().expect("Failed to parse target");
+        let (work_scheduler, mut work_rx) = TestWorkScheduler::new_pair();
+        let opts = ResolverOptions {
+            authority: "ignored".to_string(),
+            runtime: rt::default_runtime(),
+            work_scheduler: work_scheduler.clone(),
+        };
 
-        let test_cases = vec![
-            TestCase {
-                input: "unix:path/to/socket",
-                scheme: "unix",
-                want_addr: "path/to/socket",
-                want_success: true,
-            },
-            TestCase {
-                input: "unix:/absolute/path",
-                scheme: "unix",
-                want_addr: "/absolute/path",
-                want_success: true,
-            },
-            TestCase {
-                input: "unix:///absolute/path",
-                scheme: "unix",
-                want_addr: "/absolute/path",
-                want_success: true,
-            },
-            TestCase {
-                input: "unix://authority/path",
-                scheme: "unix",
-                want_addr: "",
-                want_success: false,
-            },
-        ];
+        let builder = global_registry().get("unix").expect("scheme not found");
+        let mut resolver = builder.build(&target, opts);
 
-        for tc in test_cases {
-            let target: Target = tc.input.parse().expect("Failed to parse target");
-            let (work_scheduler, mut work_rx) = TestWorkScheduler::new_pair();
-            let opts = ResolverOptions {
-                authority: "ignored".to_string(),
-                runtime: rt::default_runtime(),
-                work_scheduler: work_scheduler.clone(),
-            };
+        // Wait for work to be scheduled.
+        work_rx.recv().await.unwrap();
 
-            let builder = global_registry().get(tc.scheme).expect("scheme not found");
-            let mut resolver = builder.build(&target, opts);
+        let (mut channel_controller, mut update_rx) = TestChannelController::new_pair();
+        resolver.work(&mut channel_controller);
 
-            // Wait for work to be scheduled.
-            work_rx.recv().await.unwrap();
+        let update = update_rx.recv().await.unwrap();
+        let endpoints = update.endpoints.expect("Should have succeeded");
+        assert_eq!(endpoints.len(), 1);
 
-            let (mut channel_controller, mut update_rx) = TestChannelController::new_pair();
-            resolver.work(&mut channel_controller);
+        let addr = &endpoints[0].addresses[0];
+        assert_eq!(addr.network_type, UNIX_NETWORK_TYPE);
+        assert_eq!(&*addr.address, want_addr);
+    }
 
-            let update = update_rx.recv().await.unwrap();
-            if tc.want_success {
-                let endpoints = update.endpoints.expect("Should have succeeded");
-                assert_eq!(endpoints.len(), 1);
-                let addr = &endpoints[0].addresses[0];
-                assert_eq!(addr.network_type, UNIX_NETWORK_TYPE);
-                assert_eq!(&*addr.address, tc.want_addr);
-            } else {
-                let err = update.endpoints.expect_err("Should have failed");
-                assert!(err.contains("invalid (non-empty) authority"));
-            }
-        }
+    #[tokio::test]
+    async fn unix_resolver_failure() {
+        reg();
+
+        let target: Target = "unix://authority/path"
+            .parse()
+            .expect("Failed to parse target");
+        let (work_scheduler, mut work_rx) = TestWorkScheduler::new_pair();
+        let opts = ResolverOptions {
+            authority: "ignored".to_string(),
+            runtime: rt::default_runtime(),
+            work_scheduler: work_scheduler.clone(),
+        };
+
+        let builder = global_registry().get("unix").expect("scheme not found");
+        let mut resolver = builder.build(&target, opts);
+
+        // Wait for work to be scheduled.
+        work_rx.recv().await.unwrap();
+
+        let (mut channel_controller, mut update_rx) = TestChannelController::new_pair();
+        resolver.work(&mut channel_controller);
+
+        let update = update_rx.recv().await.unwrap();
+        let err = update.endpoints.expect_err("Should have failed");
+        assert!(err.contains("invalid (non-empty) authority"));
     }
 }

--- a/grpc/src/client/name_resolution/unix_abstract.rs
+++ b/grpc/src/client/name_resolution/unix_abstract.rs
@@ -1,0 +1,135 @@
+/*
+ *
+ * Copyright 2026 gRPC authors.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to
+ * deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ *
+ */
+
+use crate::attributes::Attributes;
+use crate::byte_str::ByteStr;
+use crate::client::name_resolution::Address;
+use crate::client::name_resolution::NopResolver;
+use crate::client::name_resolution::ResolverBuilder;
+use crate::client::name_resolution::Target;
+use crate::client::name_resolution::UNIX_NETWORK_TYPE;
+use crate::client::name_resolution::global_registry;
+
+pub(crate) fn reg() {
+    global_registry().add_builder(Box::new(Builder {}));
+}
+
+#[derive(Debug)]
+struct Builder {}
+
+impl ResolverBuilder for Builder {
+    fn build(
+        &self,
+        target: &super::Target,
+        options: super::ResolverOptions,
+    ) -> Box<dyn super::Resolver> {
+        match parse_target(target) {
+            Ok(addr) => NopResolver::new_with_addr(addr, options),
+            Err(err) => NopResolver::new_with_err(err, options),
+        }
+    }
+
+    fn scheme(&self) -> &str {
+        "unix-abstract"
+    }
+
+    fn is_valid_uri(&self, uri: &super::Target) -> bool {
+        parse_target(uri).is_ok()
+    }
+
+    fn default_authority(&self, _target: &Target) -> String {
+        "localhost".to_owned()
+    }
+}
+
+/// Parses a target URI into an abstract UNIX domain socket address.
+///
+/// Valid format: `unix-abstract:abstract_path`
+/// - `abstract_path` indicates a socket name in the abstract namespace.
+/// - The name has no connection with filesystem pathnames and bypasses standard
+///   filesystem permissions; any process or user may access the socket.
+/// - The underlying system requires a null byte (`\0`) as the first character.
+///   This function automatically prepends the null byte; it should not be
+///   included it in `abstract_path`.
+/// - Note: Abstract sockets are a Linux-specific kernel feature.
+fn parse_target(target: &Target) -> Result<Address, String> {
+    let host_port = target.authority_host_port();
+    if !host_port.is_empty() {
+        return Err(format!("invalid (non-empty) authority: {host_port}"));
+    }
+    let addr_string = format!("\0{}", target.path());
+    Ok(Address {
+        network_type: UNIX_NETWORK_TYPE,
+        address: ByteStr::from(addr_string),
+        attributes: Attributes::new(),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use tokio::sync::mpsc;
+
+    use super::*;
+    use crate::client::name_resolution::ResolverOptions;
+    use crate::client::name_resolution::test_utils::TestChannelController;
+    use crate::client::name_resolution::test_utils::TestWorkScheduler;
+    use crate::rt;
+
+    #[tokio::test]
+    async fn unix_abstract_resolver() {
+        reg();
+
+        let target: Target = "unix-abstract:abstract_name"
+            .parse()
+            .expect("Failed to parse target");
+        let (work_tx, mut work_rx) = mpsc::unbounded_channel();
+        let work_scheduler = Arc::new(TestWorkScheduler::new(work_tx));
+        let opts = ResolverOptions {
+            authority: "ignored".to_string(),
+            runtime: rt::default_runtime(),
+            work_scheduler: work_scheduler.clone(),
+        };
+
+        let builder = global_registry()
+            .get("unix-abstract")
+            .expect("scheme not found");
+        let mut resolver = builder.build(&target, opts);
+
+        // Wait for work to be scheduled.
+        work_rx.recv().await.unwrap();
+
+        let (update_tx, mut update_rx) = mpsc::unbounded_channel();
+        let mut channel_controller = TestChannelController::new(update_tx);
+        resolver.work(&mut channel_controller);
+
+        let update = update_rx.recv().await.unwrap();
+        let endpoints = update.endpoints.expect("Should have succeeded");
+        assert_eq!(endpoints.len(), 1);
+        let addr = &endpoints[0].addresses[0];
+        assert_eq!(addr.network_type, UNIX_NETWORK_TYPE);
+        assert_eq!(&*addr.address, "\0abstract_name");
+    }
+}

--- a/grpc/src/client/name_resolution/unix_abstract.rs
+++ b/grpc/src/client/name_resolution/unix_abstract.rs
@@ -88,8 +88,6 @@ fn parse_target(target: &Target) -> Result<Address, String> {
 
 #[cfg(test)]
 mod tests {
-    use tokio::sync::mpsc;
-
     use super::*;
     use crate::client::name_resolution::ResolverOptions;
     use crate::client::name_resolution::test_utils::TestChannelController;
@@ -118,8 +116,7 @@ mod tests {
         // Wait for work to be scheduled.
         work_rx.recv().await.unwrap();
 
-        let (update_tx, mut update_rx) = mpsc::unbounded_channel();
-        let mut channel_controller = TestChannelController::new(update_tx);
+        let (mut channel_controller, mut update_rx) = TestChannelController::new_pair();
         resolver.work(&mut channel_controller);
 
         let update = update_rx.recv().await.unwrap();

--- a/grpc/src/client/name_resolution/unix_abstract.rs
+++ b/grpc/src/client/name_resolution/unix_abstract.rs
@@ -89,6 +89,7 @@ fn parse_target(target: &Target) -> Result<Address, String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::client::name_resolution::Endpoint;
     use crate::client::name_resolution::ResolverOptions;
     use crate::client::name_resolution::test_utils::TestChannelController;
     use crate::client::name_resolution::test_utils::TestWorkScheduler;
@@ -98,9 +99,7 @@ mod tests {
     async fn unix_abstract_resolver() {
         reg();
 
-        let target: Target = "unix-abstract:abstract_name"
-            .parse()
-            .expect("Failed to parse target");
+        let target: Target = "unix-abstract:abstract_name".parse().unwrap();
         let (work_scheduler, mut work_rx) = TestWorkScheduler::new_pair();
         let opts = ResolverOptions {
             authority: "ignored".to_string(),
@@ -120,10 +119,18 @@ mod tests {
         resolver.work(&mut channel_controller);
 
         let update = update_rx.recv().await.unwrap();
-        let endpoints = update.endpoints.expect("Should have succeeded");
-        assert_eq!(endpoints.len(), 1);
-        let addr = &endpoints[0].addresses[0];
-        assert_eq!(addr.network_type, UNIX_NETWORK_TYPE);
-        assert_eq!(&*addr.address, "\0abstract_name");
+        let want_endpoint = Endpoint {
+            addresses: vec![Address {
+                network_type: UNIX_NETWORK_TYPE,
+                address: ByteStr::from("\0abstract_name".to_owned()),
+                ..Default::default()
+            }],
+            ..Default::default()
+        };
+        assert_eq!(
+            update.endpoints,
+            Ok(vec![want_endpoint]),
+            "did not receive expected endpoint"
+        );
     }
 }

--- a/grpc/src/client/name_resolution/unix_abstract.rs
+++ b/grpc/src/client/name_resolution/unix_abstract.rs
@@ -88,8 +88,6 @@ fn parse_target(target: &Target) -> Result<Address, String> {
 
 #[cfg(test)]
 mod tests {
-    use std::sync::Arc;
-
     use tokio::sync::mpsc;
 
     use super::*;
@@ -105,8 +103,7 @@ mod tests {
         let target: Target = "unix-abstract:abstract_name"
             .parse()
             .expect("Failed to parse target");
-        let (work_tx, mut work_rx) = mpsc::unbounded_channel();
-        let work_scheduler = Arc::new(TestWorkScheduler::new(work_tx));
+        let (work_scheduler, mut work_rx) = TestWorkScheduler::new_pair();
         let opts = ResolverOptions {
             authority: "ignored".to_string(),
             runtime: rt::default_runtime(),


### PR DESCRIPTION
This PR adds a name resolver for parsing targets with the `unix` and `unix-abstract` schemes. These formats are specified in the [gRPC naming documentation](https://github.com/grpc/grpc/blob/2ce8152a535f251ed105c957472a1fbded8f22c3/doc/naming.md?plain=1#L37-L50).

Support for connecting to unix sockets will be added in follow-up PRs.