### PR TITLE
Modify the ServerMessage abstractions and Generic Streams API

### DIFF
--- a/grpc/examples/inmemory.rs
+++ b/grpc/examples/inmemory.rs
@@ -80,6 +80,7 @@ impl Handle for Handler {
     async fn handle(
         &self,
         headers: RequestHeaders,
+        _options: CallOptions,
         tx: &mut impl server::SendStream,
         mut rx: impl server::RecvStream + 'static,
     ) {
@@ -94,7 +95,7 @@ impl Handle for Handler {
             .await;
 
         let mut req_msg = MyReqMessage::default();
-        while rx.next(&mut req_msg).await.is_ok() {
+        while let Some(Ok(())) = rx.next(&mut req_msg).await {
             let res_msg = MyResMessage(format!(
                 "Server {}: responding to: {}; msg: {}",
                 id, method, req_msg.0,

--- a/grpc/src/core/mod.rs
+++ b/grpc/src/core/mod.rs
@@ -129,9 +129,15 @@ pub enum ResponseStreamItem<M> {
 /// void as the received message is passed in via the `next` method.
 pub type ClientResponseStreamItem = ResponseStreamItem<()>;
 
-/// The server's view of a ResponseStream in a SendStream: the message type is
-/// part of the payload provided to the `send` method.
-pub type ServerResponseStreamItem<'a> = ResponseStreamItem<&'a dyn SendMessage>;
+/// The server's view of a ResponseStream in a SendStream, using references to avoid allocations.
+pub enum ServerResponseStreamItem<'a> {
+    /// Indicates the headers for the stream.
+    Headers(ResponseHeaders),
+    /// Indicates a message on the stream.
+    Message(&'a dyn SendMessage),
+    /// Indicates trailers were received on the stream and includes the trailers.
+    Trailers(Trailers),
+}
 
 /// Contains all information transmitted in the response headers of an RPC.
 #[derive(Debug, Clone, Default)]

--- a/grpc/src/inmemory/mod.rs
+++ b/grpc/src/inmemory/mod.rs
@@ -61,8 +61,8 @@ use crate::core::ClientResponseStreamItem;
 use crate::core::RecvMessage;
 use crate::core::RequestHeaders;
 use crate::core::ResponseHeaders;
-use crate::core::ResponseStreamItem;
 use crate::core::SendMessage;
+use crate::core::ServerResponseStreamItem;
 use crate::core::Trailers;
 use crate::credentials::SecurityLevel;
 use crate::credentials::client::ClientConnectionSecurityContext;
@@ -195,17 +195,16 @@ pub struct InMemoryServerSendStream {
 impl ServerSendStream for InMemoryServerSendStream {
     async fn send<'a>(
         &mut self,
-        item: crate::core::ServerResponseStreamItem<'a>,
+        item: ServerResponseStreamItem<'a>,
         _options: ServerSendOptions,
     ) -> Result<(), ()> {
         let inmemory_item = match item {
-            ResponseStreamItem::Headers(h) => InMemoryResponseStreamItem::Headers(h),
-            ResponseStreamItem::Message(m) => {
+            ServerResponseStreamItem::Headers(h) => InMemoryResponseStreamItem::Headers(h),
+            ServerResponseStreamItem::Message(m) => {
                 let buf = m.encode().map_err(|_| ())?;
                 InMemoryResponseStreamItem::Message(buf)
             }
-            ResponseStreamItem::Trailers(t) => InMemoryResponseStreamItem::Trailers(t),
-            ResponseStreamItem::StreamClosed => InMemoryResponseStreamItem::StreamClosed,
+            ServerResponseStreamItem::Trailers(t) => InMemoryResponseStreamItem::Trailers(t),
         };
 
         self.tx.send(inmemory_item).map_err(|_| ())
@@ -217,12 +216,16 @@ pub struct InMemoryServerRecvStream {
 }
 
 impl ServerRecvStream for InMemoryServerRecvStream {
-    async fn next(&mut self, msg: &mut dyn RecvMessage) -> Result<(), ()> {
+    async fn next(&mut self, msg: &mut dyn RecvMessage) -> Option<Result<(), ()>> {
         match self.rx.recv().await {
             Some(InMemoryRequestStreamItem::Message(mut buf)) => {
-                msg.decode(&mut buf).map_err(|_| ())
+                if msg.decode(&mut buf).is_err() {
+                    return Some(Err(()));
+                }
+                Some(Ok(()))
             }
-            _ => Err(()),
+            Some(InMemoryRequestStreamItem::StreamClosed) => None,
+            None => None,
         }
     }
 }

--- a/grpc/src/server/mod.rs
+++ b/grpc/src/server/mod.rs
@@ -23,9 +23,9 @@
  */
 
 use std::sync::Arc;
-
 use tonic::async_trait;
 
+use crate::client::CallOptions;
 use crate::core::RecvMessage;
 use crate::core::RequestHeaders;
 use crate::core::ServerResponseStreamItem;
@@ -62,11 +62,12 @@ impl Server {
     pub async fn serve(&self, l: &impl Listener) {
         while let Some(call) = l.accept().await {
             let mut send: Box<dyn DynSendStream> = Box::new(call.send);
-            let recv: Box<dyn DynRecvStream> = Box::new(call.recv);
+            let recv = BoxedRecvStream(Box::new(call.recv));
+            let options = CallOptions::default();
             self.handler
                 .as_ref()
                 .unwrap()
-                .dyn_handle(call.headers, &mut *send, BoxedRecvStream(recv))
+                .dyn_handle(call.headers, options, &mut *send, recv)
                 .await;
         }
     }
@@ -88,6 +89,7 @@ pub trait Handle: Send + Sync {
     async fn handle(
         &self,
         headers: RequestHeaders,
+        options: CallOptions,
         tx: &mut impl SendStream,
         rx: impl RecvStream + 'static,
     );
@@ -98,21 +100,22 @@ trait DynHandle: Send + Sync {
     async fn dyn_handle(
         &self,
         headers: RequestHeaders,
+        options: CallOptions,
         tx: &mut dyn DynSendStream,
         rx: BoxedRecvStream,
     );
 }
+
 #[async_trait]
 impl<T: Handle> DynHandle for T {
     async fn dyn_handle(
         &self,
         headers: RequestHeaders,
+        options: CallOptions,
         mut tx: &mut dyn DynSendStream,
         rx: BoxedRecvStream,
     ) {
-        // Wrap `rx` in BoxedRecvStream here
-        self.handle(headers, &mut tx, BoxedRecvStream(Box::new(rx)))
-            .await
+        self.handle(headers, options, &mut tx, rx).await
     }
 }
 
@@ -131,7 +134,7 @@ struct BoxedRecvStream(Box<dyn DynRecvStream + 'static>);
 
 // Implement RecvStream for the wrapper instead of the Box directly
 impl RecvStream for BoxedRecvStream {
-    async fn next(&mut self, msg: &mut dyn RecvMessage) -> Result<(), ()> {
+    async fn next(&mut self, msg: &mut dyn RecvMessage) -> Option<Result<(), ()>> {
         self.0.dyn_next(msg).await
     }
 }
@@ -141,7 +144,12 @@ impl RecvStream for BoxedRecvStream {
 /// order in which they must be sent.
 #[trait_variant::make(Send)]
 pub trait SendStream {
-    /// Sends the next item on the stream.
+    /// Sends the next item on the stream. Returns `Ok(())` on success, or
+    /// `Err(())` on failure. `Err(())` is a terminal state.
+    /// Sending is also considered complete after successfully sending
+    /// `ServerResponseStreamItem::Trailers`.
+    /// Calling this method after an error or after sending trailers should be
+    /// avoided and is unspecified.
     ///
     /// # Cancel safety
     ///
@@ -209,31 +217,35 @@ pub struct SendOptions {
 /// Represents the receiving side of a server stream.
 #[trait_variant::make(Send)]
 pub trait RecvStream {
-    /// Returns the next message on the stream.  If an error is returned, the
-    /// stream ended or the client closed the send side of the request stream.
+    /// Returns the next message on the stream. Returns `Some(Ok(()))` on
+    /// success, `None` on normal stream end, or `Some(Err(()))` if the stream
+    /// encountered an error before the client's final request message. Both
+    /// `None` and `Some(Err(()))` are terminal states.
+    /// Calling this method again after reaching a terminal state is unspecified
+    /// and should be avoided.
     ///
     /// # Cancel safety
     ///
     /// This method is not intended to be cancellation safe.  If the returned
     /// future is not polled to completion, the behavior of any subsequent calls
     /// to the RecvStream are undefined and data may be lost.
-    async fn next(&mut self, msg: &mut dyn RecvMessage) -> Result<(), ()>;
+    async fn next(&mut self, msg: &mut dyn RecvMessage) -> Option<Result<(), ()>>;
 }
 
 #[async_trait]
 trait DynRecvStream: Send {
-    async fn dyn_next(&mut self, msg: &mut dyn RecvMessage) -> Result<(), ()>;
+    async fn dyn_next(&mut self, msg: &mut dyn RecvMessage) -> Option<Result<(), ()>>;
 }
 
 #[async_trait]
 impl<T: RecvStream> DynRecvStream for T {
-    async fn dyn_next(&mut self, msg: &mut dyn RecvMessage) -> Result<(), ()> {
+    async fn dyn_next(&mut self, msg: &mut dyn RecvMessage) -> Option<Result<(), ()>> {
         self.next(msg).await
     }
 }
 
 impl<'a> RecvStream for Box<dyn DynRecvStream + 'a> {
-    async fn next(&mut self, msg: &mut dyn RecvMessage) -> Result<(), ()> {
+    async fn next(&mut self, msg: &mut dyn RecvMessage) -> Option<Result<(), ()>> {
         (**self).dyn_next(msg).await
     }
 }


### PR DESCRIPTION
- Add a new type `SendMessage`. Mostly the same as client `RecvStream` without the `StreamClosed` because that isn't needed.
- Change the API for RecvStream `next` to return Option<Result<(),()>> .
   - `Some(OK())` - Successful next
   - `Some(Err())` - End of stream with error
   - `None` - Eos 
   - Subsequent calls after end stream result in error.
- Change the API for SendStream to return `Result<(),()>` 
- All CallOptions to the `Handle` and friends.
