### PR TITLE
chore(grpc): remove tcp listener API from the runtime trait

### DIFF
--- a/grpc/src/client/name_resolution/dns/test.rs
+++ b/grpc/src/client/name_resolution/dns/test.rs
@@ -49,11 +49,9 @@ use crate::client::name_resolution::dns::parse_endpoint_and_authority;
 use crate::client::name_resolution::dns::reg;
 use crate::client::name_resolution::global_registry;
 use crate::client::service_config::ServiceConfig;
-use crate::rt::BoxFuture;
+use crate::rt;
 use crate::rt::GrpcRuntime;
-use crate::rt::TcpOptions;
 use crate::rt::tokio::TokioRuntime;
-use crate::rt::{self};
 
 const DEFAULT_TEST_SHORT_TIMEOUT: Duration = Duration::from_millis(10);
 
@@ -310,14 +308,6 @@ impl rt::Runtime for FakeRuntime {
         opts: rt::TcpOptions,
     ) -> Pin<Box<dyn Future<Output = Result<Box<dyn rt::GrpcEndpoint>, String>> + Send>> {
         self.inner.tcp_stream(target, opts)
-    }
-
-    fn listen_tcp(
-        &self,
-        _addr: std::net::SocketAddr,
-        _opts: TcpOptions,
-    ) -> BoxFuture<Result<Box<dyn rt::TcpListener>, String>> {
-        unimplemented!()
     }
 }
 

--- a/grpc/src/credentials/dyn_wrapper.rs
+++ b/grpc/src/credentials/dyn_wrapper.rs
@@ -161,6 +161,7 @@ mod tests {
     use tokio::io::AsyncReadExt;
     use tokio::io::AsyncWriteExt;
     use tokio::net::TcpListener;
+    use tokio::net::TcpStream;
 
     use super::*;
     use crate::credentials::InsecureServerCredentials;
@@ -169,6 +170,7 @@ mod tests {
     use crate::credentials::insecure::InsecureChannelCredentials;
     use crate::rt::AsyncIoAdapter;
     use crate::rt::TcpOptions;
+    use crate::rt::tokio::TokioIoStream;
     use crate::rt::{self};
 
     #[tokio::test]
@@ -234,14 +236,11 @@ mod tests {
 
         let addr = "127.0.0.1:0";
         let runtime = rt::default_runtime();
-        let mut listener = runtime
-            .listen_tcp(addr.parse().unwrap(), TcpOptions::default())
-            .await
-            .unwrap();
-        let server_addr = *listener.local_addr();
+        let listener = TcpListener::bind(addr).await.unwrap();
+        let server_addr = listener.local_addr().unwrap();
 
         let client_handle = tokio::spawn(async move {
-            let mut stream = tokio::net::TcpStream::connect(server_addr).await.unwrap();
+            let mut stream = TcpStream::connect(server_addr).await.unwrap();
             let data = b"hello dynamic grpc server";
             stream.write_all(data).await.unwrap();
 
@@ -250,9 +249,12 @@ mod tests {
             let _ = stream.read(&mut buf).await;
         });
 
-        let (server_stream, _) = listener.accept().await.unwrap();
+        let (stream, _) = listener.accept().await.unwrap();
+        let server_stream = TokioIoStream::new_from_tcp(stream).unwrap();
 
-        let result = dyn_creds.dyn_accept(server_stream, runtime).await;
+        let result = dyn_creds
+            .dyn_accept(Box::new(server_stream) as Box<dyn GrpcEndpoint>, runtime)
+            .await;
 
         assert!(result.is_ok());
         let output = result.unwrap();

--- a/grpc/src/credentials/insecure.rs
+++ b/grpc/src/credentials/insecure.rs
@@ -162,6 +162,7 @@ mod test {
     use crate::rt::AsyncIoAdapter;
     use crate::rt::GrpcEndpoint;
     use crate::rt::TcpOptions;
+    use crate::rt::tokio::TokioIoStream;
     use crate::rt::{self};
 
     #[tokio::test]
@@ -234,11 +235,8 @@ mod test {
 
         let addr = "127.0.0.1:0";
         let runtime = rt::default_runtime();
-        let mut listener = runtime
-            .listen_tcp(addr.parse().unwrap(), TcpOptions::default())
-            .await
-            .unwrap();
-        let server_addr = *listener.local_addr();
+        let listener = TcpListener::bind(addr).await.unwrap();
+        let server_addr = listener.local_addr().unwrap();
 
         let client_handle = tokio::spawn(async move {
             let mut stream = TcpStream::connect(server_addr).await.unwrap();
@@ -250,7 +248,8 @@ mod test {
             let _ = stream.read(&mut buf).await;
         });
 
-        let (server_stream, _) = listener.accept().await.unwrap();
+        let (stream, _) = listener.accept().await.unwrap();
+        let server_stream = TokioIoStream::new_from_tcp(stream).unwrap();
 
         let output = creds
             .accept(server_stream, runtime, private::Internal)

--- a/grpc/src/credentials/local.rs
+++ b/grpc/src/credentials/local.rs
@@ -188,6 +188,7 @@ mod test {
     use crate::rt::AsyncIoAdapter;
     use crate::rt::GrpcEndpoint;
     use crate::rt::TcpOptions;
+    use crate::rt::tokio::TokioIoStream;
 
     #[test]
     fn test_security_level_for_endpoint_success() {
@@ -278,11 +279,8 @@ mod test {
 
         let addr = "127.0.0.1:0";
         let runtime = rt::default_runtime();
-        let mut listener = runtime
-            .listen_tcp(addr.parse().unwrap(), TcpOptions::default())
-            .await
-            .unwrap();
-        let server_addr = *listener.local_addr();
+        let listener = TcpListener::bind(addr).await.unwrap();
+        let server_addr = listener.local_addr().unwrap();
 
         let client_handle = tokio::spawn(async move {
             let mut stream = TcpStream::connect(server_addr).await.unwrap();
@@ -294,7 +292,8 @@ mod test {
             let _ = stream.read(&mut buf).await;
         });
 
-        let (server_stream, _) = listener.accept().await.unwrap();
+        let (stream, _) = listener.accept().await.unwrap();
+        let server_stream = TokioIoStream::new_from_tcp(stream).unwrap();
 
         let output = creds
             .accept(server_stream, runtime, private::Internal)

--- a/grpc/src/credentials/rustls/server/test.rs
+++ b/grpc/src/credentials/rustls/server/test.rs
@@ -32,6 +32,7 @@ use rustls_pki_types::ServerName;
 use tempfile::NamedTempFile;
 use tokio::io::AsyncReadExt;
 use tokio::io::AsyncWriteExt;
+use tokio::net::TcpListener;
 use tokio::net::TcpStream;
 use tokio_rustls::TlsConnector;
 
@@ -45,7 +46,7 @@ use crate::credentials::rustls::server::ServerTlsConfig;
 use crate::credentials::rustls::server::TlsClientCertificateRequestType;
 use crate::private;
 use crate::rt::AsyncIoAdapter;
-use crate::rt::TcpOptions;
+use crate::rt::tokio::TokioIoStream;
 use crate::rt::{self};
 
 static INIT: Once = Once::new();
@@ -67,14 +68,12 @@ async fn test_tls_server_handshake() {
     let creds = RustlsServerTlsCredendials::new(config).unwrap();
 
     let runtime = rt::default_runtime();
-    let mut listener = runtime
-        .listen_tcp("127.0.0.1:0".parse().unwrap(), TcpOptions::default())
-        .await
-        .unwrap();
-    let addr = *listener.local_addr();
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
 
     let server_task = tokio::spawn(async move {
         let (stream, _) = listener.accept().await.unwrap();
+        let stream = TokioIoStream::new_from_tcp(stream).unwrap();
         let result = creds.accept(stream, runtime, private::Internal).await;
         assert!(
             result.is_ok(),
@@ -125,14 +124,12 @@ async fn test_tls_server_handshake_no_alpn() {
     let creds = RustlsServerTlsCredendials::new(config).unwrap();
 
     let runtime = rt::default_runtime();
-    let mut listener = runtime
-        .listen_tcp("127.0.0.1:0".parse().unwrap(), TcpOptions::default())
-        .await
-        .unwrap();
-    let addr = *listener.local_addr();
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
 
     let server_task = tokio::spawn(async move {
         let (stream, _) = listener.accept().await.unwrap();
+        let stream = TokioIoStream::new_from_tcp(stream).unwrap();
         let result = creds.accept(stream, runtime, private::Internal).await;
         assert!(result.is_err(), "Server handshake should have failed");
     });
@@ -170,14 +167,12 @@ async fn test_tls_server_handshake_bad_alpn() {
     let creds = RustlsServerTlsCredendials::new(config).unwrap();
 
     let runtime = rt::default_runtime();
-    let mut listener = runtime
-        .listen_tcp("127.0.0.1:0".parse().unwrap(), TcpOptions::default())
-        .await
-        .unwrap();
-    let addr = *listener.local_addr();
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
 
     let server_task = tokio::spawn(async move {
         let (stream, _) = listener.accept().await.unwrap();
+        let stream = TokioIoStream::new_from_tcp(stream).unwrap();
         let runtime = rt::default_runtime();
         let result = creds.accept(stream, runtime, private::Internal).await;
         assert!(result.is_err(), "Server handshake should have failed");
@@ -209,16 +204,14 @@ async fn test_tls_handshake_alpn_h1_and_h2() {
     let creds = RustlsServerTlsCredendials::new(config).unwrap();
 
     let runtime = rt::default_runtime();
-    let mut listener = runtime
-        .listen_tcp("127.0.0.1:0".parse().unwrap(), TcpOptions::default())
-        .await
-        .unwrap();
-    let addr = *listener.local_addr();
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
 
     let server_task = tokio::spawn(async move {
         let (stream, _) = listener.accept().await.unwrap();
+        let stream = TokioIoStream::new_from_tcp(stream).unwrap();
         let runtime = rt::default_runtime();
-        let result = creds
+        creds
             .accept(stream, runtime, private::Internal)
             .await
             .unwrap();
@@ -258,14 +251,12 @@ async fn test_tls_server_mtls_require_fail() {
     let creds = RustlsServerTlsCredendials::new(config).unwrap();
 
     let runtime = rt::default_runtime();
-    let mut listener = runtime
-        .listen_tcp("127.0.0.1:0".parse().unwrap(), TcpOptions::default())
-        .await
-        .unwrap();
-    let addr = *listener.local_addr();
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
 
     let server_task = tokio::spawn(async move {
         let (stream, _) = listener.accept().await.unwrap();
+        let stream = TokioIoStream::new_from_tcp(stream).unwrap();
         let result = creds.accept(stream, runtime, private::Internal).await;
         assert!(result.is_err(), "Handshake should fail without client cert");
     });
@@ -311,14 +302,12 @@ async fn test_tls_server_mtls_success() {
     let creds = RustlsServerTlsCredendials::new(config).unwrap();
 
     let runtime = rt::default_runtime();
-    let mut listener = runtime
-        .listen_tcp("127.0.0.1:0".parse().unwrap(), TcpOptions::default())
-        .await
-        .unwrap();
-    let addr = *listener.local_addr();
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
 
     let server_task = tokio::spawn(async move {
         let (stream, _) = listener.accept().await.unwrap();
+        let stream = TokioIoStream::new_from_tcp(stream).unwrap();
         let result = creds
             .accept(stream, runtime, private::Internal)
             .await
@@ -373,14 +362,12 @@ async fn test_tls_server_mtls_optional() {
     let creds = RustlsServerTlsCredendials::new(config).unwrap();
 
     let runtime = rt::default_runtime();
-    let mut listener = runtime
-        .listen_tcp("127.0.0.1:0".parse().unwrap(), TcpOptions::default())
-        .await
-        .unwrap();
-    let addr = *listener.local_addr();
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
 
     let server_task = tokio::spawn(async move {
         let (stream, _) = listener.accept().await.unwrap();
+        let stream = TokioIoStream::new_from_tcp(stream).unwrap();
         let result = creds
             .accept(stream, runtime, private::Internal)
             .await
@@ -425,14 +412,12 @@ async fn test_tls_server_key_log() {
     let creds = RustlsServerTlsCredendials::new(config).unwrap();
 
     let runtime = rt::default_runtime();
-    let mut listener = runtime
-        .listen_tcp("127.0.0.1:0".parse().unwrap(), TcpOptions::default())
-        .await
-        .unwrap();
-    let addr = *listener.local_addr();
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
 
     let server_task = tokio::spawn(async move {
         let (stream, _) = listener.accept().await.unwrap();
+        let stream = TokioIoStream::new_from_tcp(stream).unwrap();
         let result = creds
             .accept(stream, runtime, private::Internal)
             .await
@@ -480,15 +465,13 @@ async fn check_resumption_disabled(versions: Vec<&'static rustls::SupportedProto
     let creds = RustlsServerTlsCredendials::new(config).unwrap();
 
     let runtime = rt::default_runtime();
-    let mut listener = runtime
-        .listen_tcp("127.0.0.1:0".parse().unwrap(), TcpOptions::default())
-        .await
-        .unwrap();
-    let addr = *listener.local_addr();
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
 
     let server_task = tokio::spawn(async move {
         for _ in 0..2 {
             let (stream, _) = listener.accept().await.unwrap();
+            let stream = TokioIoStream::new_from_tcp(stream).unwrap();
             let runtime = rt::default_runtime();
             let result = creds.accept(stream, runtime, private::Internal).await;
             assert!(result.is_ok());
@@ -558,15 +541,13 @@ async fn test_tls_server_sni() {
     let creds = RustlsServerTlsCredendials::new(config).unwrap();
 
     let runtime = rt::default_runtime();
-    let mut listener = runtime
-        .listen_tcp("127.0.0.1:0".parse().unwrap(), TcpOptions::default())
-        .await
-        .unwrap();
-    let addr = *listener.local_addr();
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
 
     let server_task = tokio::spawn(async move {
         for _ in 0..2 {
             let (stream, _) = listener.accept().await.unwrap();
+            let stream = TokioIoStream::new_from_tcp(stream).unwrap();
             let runtime = rt::default_runtime();
             let result = creds.accept(stream, runtime, private::Internal).await;
             assert!(

--- a/grpc/src/rt/mod.rs
+++ b/grpc/src/rt/mod.rs
@@ -46,7 +46,6 @@ pub(crate) mod tokio;
 pub type BoxFuture<T> = Pin<Box<dyn Future<Output = T> + Send>>;
 pub type BoxedTaskHandle = Box<dyn TaskHandle>;
 pub type BoxEndpoint = Box<dyn GrpcEndpoint>;
-pub type ScopedBoxFuture<'a, T> = Pin<Box<dyn Future<Output = T> + Send + 'a>>;
 
 /// An abstraction over an asynchronous runtime.
 ///
@@ -74,13 +73,6 @@ pub trait Runtime: Send + Sync + Debug {
         target: SocketAddr,
         opts: TcpOptions,
     ) -> BoxFuture<Result<Box<dyn GrpcEndpoint>, String>>;
-
-    /// Create a new listener for the given address.
-    fn listen_tcp(
-        &self,
-        addr: SocketAddr,
-        opts: TcpOptions,
-    ) -> BoxFuture<Result<Box<dyn TcpListener>, String>>;
 }
 
 /// A future that resolves after a specified duration.
@@ -287,20 +279,6 @@ impl GrpcEndpoint for Box<dyn GrpcEndpoint> {
     }
 }
 
-/// A trait representing a TCP listener capable of accepting incoming
-/// connections.
-pub trait TcpListener: Send + Sync {
-    /// Accepts a new incoming connection.
-    ///
-    /// Returns a future that resolves to a result containing the new
-    /// `GrpcEndpoint` and the remote peer's `SocketAddr`, or an error string
-    /// if acceptance fails.
-    fn accept(&mut self) -> ScopedBoxFuture<'_, Result<(BoxEndpoint, SocketAddr), String>>;
-
-    /// Returns the local socket address this listener is bound to.
-    fn local_addr(&self) -> &SocketAddr;
-}
-
 /// A fake runtime to satisfy the compiler when no runtime is enabled. This will
 ///
 /// # Panics
@@ -327,14 +305,6 @@ impl Runtime for NoOpRuntime {
         target: SocketAddr,
         opts: TcpOptions,
     ) -> Pin<Box<dyn Future<Output = Result<Box<dyn GrpcEndpoint>, String>> + Send>> {
-        unimplemented!()
-    }
-
-    fn listen_tcp(
-        &self,
-        addr: SocketAddr,
-        _opts: TcpOptions,
-    ) -> BoxFuture<Result<Box<dyn TcpListener>, String>> {
         unimplemented!()
     }
 }
@@ -381,13 +351,5 @@ impl GrpcRuntime {
         opts: TcpOptions,
     ) -> BoxFuture<Result<Box<dyn GrpcEndpoint>, String>> {
         self.inner.tcp_stream(target, opts)
-    }
-
-    pub fn listen_tcp(
-        &self,
-        addr: SocketAddr,
-        opts: TcpOptions,
-    ) -> BoxFuture<Result<Box<dyn TcpListener>, String>> {
-        self.inner.listen_tcp(addr, opts)
     }
 }

--- a/grpc/src/rt/tokio/mod.rs
+++ b/grpc/src/rt/tokio/mod.rs
@@ -35,17 +35,12 @@ use tokio::task::JoinHandle;
 
 use crate::client::name_resolution::TCP_IP_NETWORK_TYPE;
 use crate::private;
-use crate::rt::BoxEndpoint;
-use crate::rt::BoxFuture;
 use crate::rt::BoxedTaskHandle;
 use crate::rt::DnsResolver;
-use crate::rt::GrpcEndpoint;
 use crate::rt::ResolverOptions;
 use crate::rt::Runtime;
-use crate::rt::ScopedBoxFuture;
 use crate::rt::Sleep;
 use crate::rt::TaskHandle;
-use crate::rt::TcpOptions;
 
 #[cfg(feature = "dns")]
 mod hickory_resolver;
@@ -126,34 +121,9 @@ impl Runtime for TokioRuntime {
                     .set_tcp_keepalive(&ka)
                     .map_err(|err| err.to_string())?;
             }
-            let stream: Box<dyn super::GrpcEndpoint> = Box::new(TokioTcpStream {
-                peer_addr: target.to_string().into_boxed_str(),
-                local_addr: stream
-                    .local_addr()
-                    .map_err(|err| err.to_string())?
-                    .to_string()
-                    .into_boxed_str(),
-                inner: stream,
-            });
+            let stream: Box<dyn super::GrpcEndpoint> =
+                Box::new(TokioIoStream::new_from_tcp(stream)?);
             Ok(stream)
-        })
-    }
-
-    fn listen_tcp(
-        &self,
-        addr: SocketAddr,
-        _opts: TcpOptions,
-    ) -> BoxFuture<Result<Box<dyn super::TcpListener>, String>> {
-        Box::pin(async move {
-            let listener = tokio::net::TcpListener::bind(addr)
-                .await
-                .map_err(|err| err.to_string())?;
-            let local_addr = listener.local_addr().map_err(|e| e.to_string())?;
-            let listener = TokioListener {
-                inner: listener,
-                local_addr,
-            };
-            Ok(Box::new(listener) as Box<dyn super::TcpListener>)
         })
     }
 }
@@ -167,13 +137,33 @@ impl TokioDefaultDnsResolver {
     }
 }
 
-struct TokioTcpStream {
-    inner: TcpStream,
+pub(crate) struct TokioIoStream<T> {
+    inner: T,
     peer_addr: Box<str>,
     local_addr: Box<str>,
+    network_type: &'static str,
 }
 
-impl super::GrpcEndpoint for TokioTcpStream {
+impl TokioIoStream<TcpStream> {
+    pub(crate) fn new_from_tcp(stream: TcpStream) -> Result<Self, String> {
+        Ok(TokioIoStream {
+            local_addr: stream
+                .local_addr()
+                .map_err(|err| err.to_string())?
+                .to_string()
+                .into_boxed_str(),
+            peer_addr: stream
+                .peer_addr()
+                .map_err(|err| err.to_string())?
+                .to_string()
+                .into_boxed_str(),
+            network_type: TCP_IP_NETWORK_TYPE,
+            inner: stream,
+        })
+    }
+}
+
+impl<T: AsyncRead + AsyncWrite + Unpin + Send + 'static> super::GrpcEndpoint for TokioIoStream<T> {
     fn get_local_address(&self) -> &str {
         &self.local_addr
     }
@@ -183,7 +173,7 @@ impl super::GrpcEndpoint for TokioTcpStream {
     }
 
     fn get_network_type(&self) -> &'static str {
-        TCP_IP_NETWORK_TYPE
+        self.network_type
     }
 
     fn poll_read_private(
@@ -231,35 +221,6 @@ impl super::GrpcEndpoint for TokioTcpStream {
         _token: private::Internal,
     ) -> std::task::Poll<Result<(), std::io::Error>> {
         Pin::new(&mut self.inner).poll_shutdown(cx)
-    }
-}
-
-struct TokioListener {
-    inner: tokio::net::TcpListener,
-    local_addr: SocketAddr,
-}
-
-impl super::TcpListener for TokioListener {
-    fn accept(&mut self) -> ScopedBoxFuture<'_, Result<(BoxEndpoint, SocketAddr), String>> {
-        Box::pin(async move {
-            let (stream, addr) = self.inner.accept().await.map_err(|e| e.to_string())?;
-            Ok((
-                Box::new(TokioTcpStream {
-                    local_addr: stream
-                        .local_addr()
-                        .map_err(|err| err.to_string())?
-                        .to_string()
-                        .into_boxed_str(),
-                    peer_addr: addr.to_string().into_boxed_str(),
-                    inner: stream,
-                }) as Box<dyn GrpcEndpoint>,
-                addr,
-            ))
-        })
-    }
-
-    fn local_addr(&self) -> &SocketAddr {
-        &self.local_addr
     }
 }
 


### PR DESCRIPTION
TCP listener APIs were originally added to the runtime trait to obtain `GrpcEndpoints` for testing server credentials. During team discussions, I realized that servers are provided with a `GrpcEndpoint` when they begin serving, so this does not need to be handled by the runtime. 

This PR removes the TCP listener APIs and instead exposes a `TokioIoStream` adapter for the tests to use. This adapter implements `GrpcEndpoint` for `tokio::net::TcpStream`.