### PR TITLE
transport: add max_frame_size to client Endpoint

### DIFF
--- a/tests/integration_tests/tests/max_frame_size.rs
+++ b/tests/integration_tests/tests/max_frame_size.rs
@@ -1,0 +1,52 @@
+use tokio::net::TcpListener;
+use tokio::sync::oneshot;
+
+use integration_tests::pb::{test_client::TestClient, test_server, Input, Output};
+use tonic::transport::{server::TcpIncoming, Channel, Server};
+use tonic::{Request, Response, Status};
+
+struct Svc;
+
+#[tonic::async_trait]
+impl test_server::Test for Svc {
+    async fn unary_call(&self, _: Request<Input>) -> Result<Response<Output>, Status> {
+        Ok(Response::new(Output {}))
+    }
+}
+
+#[tokio::test]
+async fn max_frame_size_on_client_endpoint() {
+    let svc = test_server::TestServer::new(Svc {});
+    let (tx, rx) = oneshot::channel::<()>();
+
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let incoming = TcpIncoming::from(listener).with_nodelay(Some(true));
+
+    let jh = tokio::spawn(async move {
+        Server::builder()
+            .max_frame_size(1024 * 1024u32) // 1 MB
+            .add_service(svc)
+            .serve_with_incoming_shutdown(incoming, async { drop(rx.await) })
+            .await
+            .unwrap();
+    });
+
+    tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+
+    // Set client-side max_frame_size to match server
+    let channel = Channel::from_shared(format!("http://{addr}"))
+        .unwrap()
+        .max_frame_size(1024 * 1024u32)
+        .connect()
+        .await
+        .unwrap();
+    let mut client = TestClient::new(channel);
+
+    let res = client.unary_call(Request::new(Input {})).await;
+
+    assert!(res.is_ok());
+
+    tx.send(()).unwrap();
+    jh.await.unwrap();
+}

--- a/tonic/src/transport/channel/endpoint.rs
+++ b/tonic/src/transport/channel/endpoint.rs
@@ -38,6 +38,7 @@ pub struct Endpoint {
     pub(crate) buffer_size: Option<usize>,
     pub(crate) init_stream_window_size: Option<u32>,
     pub(crate) init_connection_window_size: Option<u32>,
+    pub(crate) max_frame_size: Option<u32>,
     pub(crate) tcp_keepalive: Option<Duration>,
     pub(crate) tcp_keepalive_interval: Option<Duration>,
     pub(crate) tcp_keepalive_retries: Option<u32>,
@@ -85,6 +86,7 @@ impl Endpoint {
             buffer_size: None,
             init_stream_window_size: None,
             init_connection_window_size: None,
+            max_frame_size: None,
             tcp_keepalive: None,
             tcp_keepalive_interval: None,
             tcp_keepalive_retries: None,
@@ -114,6 +116,7 @@ impl Endpoint {
             buffer_size: None,
             init_stream_window_size: None,
             init_connection_window_size: None,
+            max_frame_size: None,
             tcp_keepalive: None,
             tcp_keepalive_interval: None,
             tcp_keepalive_retries: None,
@@ -420,6 +423,27 @@ impl Endpoint {
     pub fn http2_max_header_list_size(self, size: u32) -> Self {
         Endpoint {
             http2_max_header_list_size: Some(size),
+            ..self
+        }
+    }
+
+    /// Sets the maximum frame size to use for HTTP2.
+    ///
+    /// Passing `None` will do nothing.
+    ///
+    /// If not set, will default from underlying transport.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use tonic::transport::Endpoint;
+    /// # let builder = Endpoint::from_static("https://example.com");
+    /// let endpoint = builder.max_frame_size(1024 * 1024u32);
+    /// ```
+    #[must_use]
+    pub fn max_frame_size(self, frame_size: impl Into<Option<u32>>) -> Self {
+        Endpoint {
+            max_frame_size: frame_size.into(),
             ..self
         }
     }

--- a/tonic/src/transport/channel/service/connection.rs
+++ b/tonic/src/transport/channel/service/connection.rs
@@ -39,6 +39,10 @@ impl Connection {
             .timer(TokioTimer::new())
             .clone();
 
+        if let Some(val) = endpoint.max_frame_size {
+            settings.max_frame_size(val);
+        }
+
         if let Some(val) = endpoint.http2_keep_alive_timeout {
             settings.keep_alive_timeout(val);
         }


### PR DESCRIPTION
## Motivation

tonic already exposes `Server::max_frame_size()` to let servers configure this parameter, but the
client-side `Endpoint` struct has no equivalent API. The underlying hyper HTTP/2 `Builder` already
supports `.max_frame_size()`, so this change simply wires it through from the client-side endpoint
configuration.

I've seen production speedup in our gRPC service by increasing this client-side `max_frame_size` to allow the server to send a large response (multi-MB) without excessive framing overheads caused by the default 16 KiB setting.

## Solution

Add a new `max_frame_size` field to the `Endpoint` struct and expose it via a public builder method,
mirroring the server-side pattern:

- Add `max_frame_size: Option<u32>` field to `Endpoint`
- Add public `pub fn max_frame_size(self, frame_size: impl Into<Option<u32>>) -> Self` builder method
- Wire the field through to hyper's `Builder::max_frame_size()` in `connection.rs`
- Include integration test verifying the feature works end-to-end

Refs: #264
