### PR TITLE
feat(tonic-xds): gRFC A29 TLS foundation - cert provider & control plane TLS

### DIFF
--- a/tonic-xds/Cargo.toml
+++ b/tonic-xds/Cargo.toml
@@ -59,9 +59,14 @@ tonic = { version = "0.14", features = [ "server", "channel", "tls-ring" ] }
 tonic-prost = "0.14"
 tonic-prost-build = "0.14"
 async-stream = "0.3"
+tempfile = "3.27.0"
 
 [features]
 testutil = ["dep:tonic-prost"]
+
+# TLS crypto backend — pick exactly one.
+tls-ring = ["tonic/tls-ring", "xds-client/tonic-tls-ring"]
+tls-aws-lc = ["tonic/tls-aws-lc", "xds-client/tonic-tls-aws-lc"]
 
 [[example]]
 name = "channel"

--- a/tonic-xds/src/client/channel.rs
+++ b/tonic-xds/src/client/channel.rs
@@ -162,15 +162,31 @@ impl XdsChannelBuilder {
         let listener_name = self.config.target_uri.target.clone();
 
         let server_uri = bootstrap.server_uri().to_owned();
+
+        #[allow(unused_mut)]
+        let mut transport_builder = TonicTransportBuilder::new();
+        #[cfg(any(feature = "tls-ring", feature = "tls-aws-lc"))]
+        if bootstrap.use_tls() {
+            transport_builder = transport_builder
+                .with_tls_config(tonic::transport::ClientTlsConfig::new().with_enabled_roots());
+        }
+        #[cfg(not(any(feature = "tls-ring", feature = "tls-aws-lc")))]
+        if bootstrap.use_tls() {
+            return Err(BuildError::Bootstrap(BootstrapError::Validation(
+                "TLS requested by bootstrap but no TLS feature enabled \
+                 (enable tls-ring or tls-aws-lc)"
+                    .into(),
+            )));
+        }
+
+        // TODO(PR2/A29): Build CertProviderRegistry from bootstrap.certificate_providers
+        // and pass it to XdsClusterDiscovery so data-plane connections can use
+        // TLS/mTLS when CDS clusters specify UpstreamTlsContext.
+
         let node = Node::from(bootstrap.node);
-        let client_config = ClientConfig::new(node, server_uri);
-        let xds_client = XdsClient::builder(
-            client_config,
-            TonicTransportBuilder::default(),
-            ProstCodec,
-            TokioRuntime,
-        )
-        .build();
+        let client_config = ClientConfig::new(node, &server_uri);
+        let xds_client =
+            XdsClient::builder(client_config, transport_builder, ProstCodec, TokioRuntime).build();
 
         let cache = Arc::new(XdsCache::new());
         let resource_manager =

--- a/tonic-xds/src/xds/bootstrap.rs
+++ b/tonic-xds/src/xds/bootstrap.rs
@@ -54,6 +54,7 @@ pub struct BootstrapConfig {
     ///
     /// [`CertificateProviderPluginInstance`]: https://github.com/envoyproxy/envoy/blob/main/api/envoy/extensions/transport_sockets/tls/v3/common.proto
     #[serde(default)]
+    #[allow(dead_code)] // Consumed when CertProviderRegistry is wired in (PR2/A29).
     pub(crate) certificate_providers: HashMap<String, CertProviderPluginConfig>,
 }
 
@@ -67,6 +68,8 @@ pub(crate) struct XdsServerConfig {
     pub channel_creds: Vec<ChannelCredentialConfig>,
     /// Server features (e.g., `["xds_v3"]`).
     #[serde(default)]
+    #[allow(dead_code)]
+    // Parsed for completeness; used when server feature negotiation is added.
     pub server_features: Vec<String>,
 }
 

--- a/tonic-xds/src/xds/bootstrap.rs
+++ b/tonic-xds/src/xds/bootstrap.rs
@@ -4,6 +4,8 @@
 //! `GRPC_XDS_BOOTSTRAP_CONFIG` (inline JSON) environment variables,
 //! per gRFC A27.
 
+use std::collections::HashMap;
+
 use serde::Deserialize;
 use xds_client::message::{Locality, Node};
 
@@ -44,11 +46,19 @@ pub struct BootstrapConfig {
     /// Node identity sent to the xDS server.
     #[serde(default)]
     pub(crate) node: NodeConfig,
+    /// Certificate provider plugin instances, keyed by instance name.
+    ///
+    /// Referenced by [`CertificateProviderPluginInstance`] in CDS/LDS
+    /// `UpstreamTlsContext` / `DownstreamTlsContext` resources.
+    /// See gRFC A29 for details.
+    ///
+    /// [`CertificateProviderPluginInstance`]: https://github.com/envoyproxy/envoy/blob/main/api/envoy/extensions/transport_sockets/tls/v3/common.proto
+    #[serde(default)]
+    pub(crate) certificate_providers: HashMap<String, CertProviderPluginConfig>,
 }
 
 /// Configuration for a single xDS management server.
 #[derive(Debug, Clone, Deserialize)]
-#[allow(dead_code)] // Fields consumed when TLS support is added (A29).
 pub(crate) struct XdsServerConfig {
     /// URI of the xDS server (e.g., `"xds.example.com:443"`).
     pub server_uri: String,
@@ -62,7 +72,6 @@ pub(crate) struct XdsServerConfig {
 
 /// A channel credential entry from the bootstrap config.
 #[derive(Debug, Clone, Deserialize)]
-#[allow(dead_code)] // Used when TLS support is added (A29).
 pub(crate) struct ChannelCredentialConfig {
     /// Credential type (e.g., `"insecure"`, `"tls"`, `"google_default"`).
     #[serde(rename = "type")]
@@ -80,6 +89,23 @@ pub(crate) enum ChannelCredentialType {
     Tls,
     #[serde(untagged)]
     Unsupported(String),
+}
+
+/// A certificate provider plugin entry from the bootstrap config.
+///
+/// Holds the `plugin_name` and an opaque `config` blob. The cert provider
+/// module is responsible for dispatching on `plugin_name` and deserializing
+/// `config` into the appropriate plugin-specific type.
+///
+/// Referenced by `instance_name` in CDS/LDS `CertificateProviderPluginInstance`
+/// fields. See [gRFC A29].
+///
+/// [gRFC A29]: https://github.com/grpc/proposal/blob/master/A29-xds-tls-security.md
+#[derive(Debug, Clone, Deserialize)]
+pub(crate) struct CertProviderPluginConfig {
+    pub plugin_name: String,
+    #[serde(default)]
+    pub config: serde_json::Value,
 }
 
 /// Node identity configuration from bootstrap JSON.
@@ -134,7 +160,11 @@ impl BootstrapConfig {
         xds_servers: Vec<XdsServerConfig>,
         node: NodeConfig,
     ) -> Result<Self, BootstrapError> {
-        let config = Self { xds_servers, node };
+        let config = Self {
+            xds_servers,
+            node,
+            certificate_providers: HashMap::new(),
+        };
         config.validate()?;
         Ok(config)
     }
@@ -192,7 +222,6 @@ impl BootstrapConfig {
     ///
     /// Per gRFC A27, the client stops at the first credential type it supports.
     /// Returns `None` if no supported credential type is found.
-    #[allow(dead_code)] // Used when TLS support is added (A29).
     pub(crate) fn selected_credential(&self) -> Option<&ChannelCredentialType> {
         self.xds_servers
             .first()?
@@ -205,6 +234,11 @@ impl BootstrapConfig {
                     ChannelCredentialType::Insecure | ChannelCredentialType::Tls
                 )
             })
+    }
+
+    /// Returns `true` if the first server's selected credential is TLS.
+    pub(crate) fn use_tls(&self) -> bool {
+        self.selected_credential() == Some(&ChannelCredentialType::Tls)
     }
 }
 
@@ -396,5 +430,69 @@ mod tests {
         let config = BootstrapConfig::from_json(json).unwrap();
         let node = Node::from(config.node);
         assert!(node.id.is_none());
+    }
+
+    #[test]
+    fn parse_certificate_providers() {
+        let json = r#"{
+            "xds_servers": [{"server_uri": "localhost:5000"}],
+            "certificate_providers": {
+                "google_cloud_private_spiffe": {
+                    "plugin_name": "file_watcher",
+                    "config": {
+                        "certificate_file": "/var/run/certs/certificates.pem",
+                        "private_key_file": "/var/run/certs/private_key.pem",
+                        "ca_certificate_file": "/var/run/certs/ca_certificates.pem",
+                        "refresh_interval": "60s"
+                    }
+                }
+            }
+        }"#;
+        let config = BootstrapConfig::from_json(json).unwrap();
+        assert_eq!(config.certificate_providers.len(), 1);
+
+        let plugin = &config.certificate_providers["google_cloud_private_spiffe"];
+        assert_eq!(plugin.plugin_name, "file_watcher");
+        assert_eq!(
+            plugin.config["certificate_file"],
+            "/var/run/certs/certificates.pem"
+        );
+        assert_eq!(
+            plugin.config["ca_certificate_file"],
+            "/var/run/certs/ca_certificates.pem"
+        );
+        assert_eq!(plugin.config["refresh_interval"], "60s");
+    }
+
+    #[test]
+    fn missing_certificate_providers_defaults_to_empty() {
+        let config = BootstrapConfig::from_json(minimal_json()).unwrap();
+        assert!(config.certificate_providers.is_empty());
+    }
+
+    #[test]
+    fn multiple_certificate_provider_instances() {
+        let json = r#"{
+            "xds_servers": [{"server_uri": "localhost:5000"}],
+            "certificate_providers": {
+                "identity": {
+                    "plugin_name": "file_watcher",
+                    "config": {
+                        "certificate_file": "/certs/cert.pem",
+                        "private_key_file": "/certs/key.pem"
+                    }
+                },
+                "root_ca": {
+                    "plugin_name": "file_watcher",
+                    "config": {
+                        "ca_certificate_file": "/certs/ca.pem"
+                    }
+                }
+            }
+        }"#;
+        let config = BootstrapConfig::from_json(json).unwrap();
+        assert_eq!(config.certificate_providers.len(), 2);
+        assert!(config.certificate_providers.contains_key("identity"));
+        assert!(config.certificate_providers.contains_key("root_ca"));
     }
 }

--- a/tonic-xds/src/xds/cert_provider/file_watcher.rs
+++ b/tonic-xds/src/xds/cert_provider/file_watcher.rs
@@ -1,0 +1,383 @@
+//! `file_watcher` certificate provider plugin.
+//!
+//! Reads PEM-encoded certificates and keys from local files. This is the
+//! only built-in certificate provider plugin per gRFC A29.
+//!
+//! # Bootstrap configuration
+//!
+//! ```json
+//! {
+//!   "plugin_name": "file_watcher",
+//!   "config": {
+//!     "certificate_file": "/path/to/cert.pem",
+//!     "private_key_file": "/path/to/key.pem",
+//!     "ca_certificate_file": "/path/to/ca.pem",
+//!     "refresh_interval": "60s"
+//!   }
+//! }
+//! ```
+
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use std::time::Duration;
+
+use arc_swap::ArcSwap;
+use serde::Deserialize;
+
+use super::{CertProviderError, CertificateData, CertificateProvider};
+
+/// Plugin name used in the bootstrap `certificate_providers` JSON.
+pub(crate) const PLUGIN_NAME: &str = "file_watcher";
+
+/// Configuration for the `file_watcher` certificate provider.
+#[derive(Debug, Clone, Default, Deserialize)]
+pub(crate) struct FileWatcherConfig {
+    /// Path to PEM X.509 identity certificate or certificate chain.
+    #[serde(default)]
+    pub certificate_file: Option<PathBuf>,
+    /// Path to PEM PKCS private key.
+    #[serde(default)]
+    pub private_key_file: Option<PathBuf>,
+    /// Path to PEM X.509 CA trust bundle (root certificates).
+    #[serde(default)]
+    pub ca_certificate_file: Option<PathBuf>,
+    /// How often to re-read the files. Default: 600s.
+    /// Parsed from protobuf JSON duration format (e.g., `"60s"`, `"0.5s"`).
+    #[serde(default, deserialize_with = "deserialize_proto_duration")]
+    pub refresh_interval: Option<Duration>,
+}
+
+/// Deserialize a protobuf JSON duration string (e.g., `"60s"`, `"0.5s"`) into a `Duration`.
+fn deserialize_proto_duration<'de, D>(deserializer: D) -> Result<Option<Duration>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let Some(s) = Option::<String>::deserialize(deserializer)? else {
+        return Ok(None);
+    };
+    let num = s.strip_suffix('s').ok_or_else(|| {
+        serde::de::Error::custom(format!("invalid duration '{s}': must end with 's'"))
+    })?;
+    let secs: f64 = num
+        .parse()
+        .map_err(|_| serde::de::Error::custom(format!("invalid duration number: '{num}'")))?;
+    if secs < 0.0 {
+        return Err(serde::de::Error::custom(format!(
+            "invalid duration '{s}': must not be negative"
+        )));
+    }
+    Ok(Some(Duration::from_secs_f64(secs)))
+}
+
+/// A certificate provider that reads PEM files from disk.
+///
+/// On construction, reads all configured files and caches the results.
+/// The `fetch()` method returns the cached data.
+// TODO(PR3/A29): Spawn a background task that calls `refresh()` on a timer
+// driven by `config.refresh_interval` (default 600s). The task should be
+// started in `new()` and cancelled on drop (e.g., via a JoinHandle +
+// AbortHandle or a CancellationToken).
+pub(crate) struct FileWatcherProvider {
+    config: FileWatcherConfig,
+    cached: ArcSwap<CertificateData>,
+}
+
+impl FileWatcherProvider {
+    /// Create a new provider from a parsed `FileWatcherConfig`.
+    pub(crate) fn new(config: FileWatcherConfig) -> Result<Self, CertProviderError> {
+        let data = read_certificate_data(&config)?;
+
+        Ok(Self {
+            config,
+            cached: ArcSwap::from_pointee(data),
+        })
+    }
+
+    /// Re-read files from disk and update the cache.
+    ///
+    /// Returns `Ok(())` if the files were successfully read, or an error
+    /// if any configured file could not be read. On error the cache retains
+    /// the previous good data.
+    #[allow(dead_code)] // Used when background refresh is added.
+    pub(crate) fn refresh(&self) -> Result<(), CertProviderError> {
+        let data = read_certificate_data(&self.config)?;
+        self.cached.store(Arc::new(data));
+        Ok(())
+    }
+}
+
+impl CertificateProvider for FileWatcherProvider {
+    fn fetch(&self) -> Result<Arc<CertificateData>, CertProviderError> {
+        Ok(self.cached.load_full())
+    }
+}
+
+/// Read certificate data from the files specified in the config.
+fn read_certificate_data(config: &FileWatcherConfig) -> Result<CertificateData, CertProviderError> {
+    let root_certs = config
+        .ca_certificate_file
+        .as_deref()
+        .map(read_file)
+        .transpose()?;
+
+    let identity_cert_chain = config
+        .certificate_file
+        .as_deref()
+        .map(read_file)
+        .transpose()?;
+
+    let identity_key = config
+        .private_key_file
+        .as_deref()
+        .map(read_file)
+        .transpose()?;
+
+    Ok(CertificateData {
+        root_certs,
+        identity_cert_chain,
+        identity_key,
+    })
+}
+
+fn read_file(path: &Path) -> Result<Vec<u8>, CertProviderError> {
+    std::fs::read(path).map_err(|e| CertProviderError::FileRead {
+        path: path.display().to_string(),
+        source: e,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+    use tempfile::NamedTempFile;
+
+    fn write_temp_file(content: &[u8]) -> NamedTempFile {
+        let mut f = NamedTempFile::new().unwrap();
+        f.write_all(content).unwrap();
+        f
+    }
+
+    fn make_config(ca: Option<&str>, cert: Option<&str>, key: Option<&str>) -> FileWatcherConfig {
+        FileWatcherConfig {
+            certificate_file: cert.map(Into::into),
+            private_key_file: key.map(Into::into),
+            ca_certificate_file: ca.map(Into::into),
+            refresh_interval: None,
+        }
+    }
+
+    #[test]
+    fn reads_ca_certificate() {
+        let ca_file =
+            write_temp_file(b"-----BEGIN CERTIFICATE-----\ntest-ca\n-----END CERTIFICATE-----\n");
+
+        let provider =
+            FileWatcherProvider::new(make_config(ca_file.path().to_str(), None, None)).unwrap();
+        let data = provider.fetch().unwrap();
+
+        assert!(
+            data.root_certs
+                .as_ref()
+                .unwrap()
+                .starts_with(b"-----BEGIN CERTIFICATE-----")
+        );
+        assert!(data.identity_cert_chain.is_none());
+        assert!(data.identity_key.is_none());
+    }
+
+    #[test]
+    fn reads_identity_cert_and_key() {
+        let cert_file = write_temp_file(b"cert-chain-pem");
+        let key_file = write_temp_file(b"private-key-pem");
+
+        let provider = FileWatcherProvider::new(make_config(
+            None,
+            cert_file.path().to_str(),
+            key_file.path().to_str(),
+        ))
+        .unwrap();
+        let data = provider.fetch().unwrap();
+
+        assert_eq!(
+            data.identity_cert_chain.as_deref(),
+            Some(b"cert-chain-pem".as_slice())
+        );
+        assert_eq!(
+            data.identity_key.as_deref(),
+            Some(b"private-key-pem".as_slice())
+        );
+        assert!(data.root_certs.is_none());
+    }
+
+    #[test]
+    fn reads_all_files() {
+        let ca_file = write_temp_file(b"ca-pem");
+        let cert_file = write_temp_file(b"cert-pem");
+        let key_file = write_temp_file(b"key-pem");
+
+        let provider = FileWatcherProvider::new(make_config(
+            ca_file.path().to_str(),
+            cert_file.path().to_str(),
+            key_file.path().to_str(),
+        ))
+        .unwrap();
+        let data = provider.fetch().unwrap();
+
+        assert_eq!(data.root_certs.as_deref(), Some(b"ca-pem".as_slice()));
+        assert_eq!(
+            data.identity_cert_chain.as_deref(),
+            Some(b"cert-pem".as_slice())
+        );
+        assert_eq!(data.identity_key.as_deref(), Some(b"key-pem".as_slice()));
+    }
+
+    #[test]
+    fn empty_config_returns_empty_data() {
+        let provider = FileWatcherProvider::new(make_config(None, None, None)).unwrap();
+        let data = provider.fetch().unwrap();
+
+        assert!(data.root_certs.is_none());
+        assert!(data.identity_cert_chain.is_none());
+        assert!(data.identity_key.is_none());
+    }
+
+    #[test]
+    fn missing_file_returns_error() {
+        let result =
+            FileWatcherProvider::new(make_config(Some("/nonexistent/path/ca.pem"), None, None));
+        assert!(result.is_err());
+        assert!(
+            result
+                .err()
+                .unwrap()
+                .to_string()
+                .contains("/nonexistent/path/ca.pem")
+        );
+    }
+
+    #[test]
+    fn refresh_updates_cached_data() {
+        let mut ca_file = NamedTempFile::new().unwrap();
+        ca_file.write_all(b"old-ca").unwrap();
+
+        let provider =
+            FileWatcherProvider::new(make_config(ca_file.path().to_str(), None, None)).unwrap();
+        assert_eq!(
+            provider.fetch().unwrap().root_certs.as_deref(),
+            Some(b"old-ca".as_slice())
+        );
+
+        std::fs::write(ca_file.path(), b"new-ca").unwrap();
+        provider.refresh().unwrap();
+        assert_eq!(
+            provider.fetch().unwrap().root_certs.as_deref(),
+            Some(b"new-ca".as_slice())
+        );
+    }
+
+    #[test]
+    fn refresh_keeps_old_data_on_failure() {
+        let ca_file = write_temp_file(b"good-ca");
+        let path = ca_file.path().to_str().unwrap().to_string();
+
+        let provider = FileWatcherProvider::new(make_config(Some(&path), None, None)).unwrap();
+        assert_eq!(
+            provider.fetch().unwrap().root_certs.as_deref(),
+            Some(b"good-ca".as_slice())
+        );
+
+        // Delete the file — refresh should fail.
+        drop(ca_file);
+        assert!(provider.refresh().is_err());
+
+        // Cached data should still be the old value.
+        assert_eq!(
+            provider.fetch().unwrap().root_certs.as_deref(),
+            Some(b"good-ca".as_slice())
+        );
+    }
+
+    #[test]
+    fn parse_refresh_interval_seconds() {
+        let config: FileWatcherConfig =
+            serde_json::from_value(serde_json::json!({"refresh_interval": "60s"})).unwrap();
+        assert_eq!(config.refresh_interval, Some(Duration::from_secs(60)));
+    }
+
+    #[test]
+    fn parse_refresh_interval_fractional() {
+        let config: FileWatcherConfig =
+            serde_json::from_value(serde_json::json!({"refresh_interval": "0.5s"})).unwrap();
+        assert_eq!(config.refresh_interval, Some(Duration::from_millis(500)));
+    }
+
+    #[test]
+    fn parse_refresh_interval_absent() {
+        let config: FileWatcherConfig = serde_json::from_value(serde_json::json!({})).unwrap();
+        assert_eq!(config.refresh_interval, None);
+    }
+
+    #[test]
+    fn parse_refresh_interval_missing_suffix() {
+        let err = serde_json::from_value::<FileWatcherConfig>(
+            serde_json::json!({"refresh_interval": "60"}),
+        );
+        assert!(err.is_err());
+        assert!(err.unwrap_err().to_string().contains("must end with 's'"));
+    }
+
+    #[test]
+    fn parse_refresh_interval_not_a_number() {
+        let err = serde_json::from_value::<FileWatcherConfig>(
+            serde_json::json!({"refresh_interval": "60ms"}),
+        );
+        assert!(err.is_err());
+        assert!(
+            err.unwrap_err()
+                .to_string()
+                .contains("invalid duration number")
+        );
+    }
+
+    #[test]
+    fn parse_refresh_interval_negative() {
+        let err = serde_json::from_value::<FileWatcherConfig>(
+            serde_json::json!({"refresh_interval": "-1s"}),
+        );
+        assert!(err.is_err());
+        assert!(
+            err.unwrap_err()
+                .to_string()
+                .contains("must not be negative")
+        );
+    }
+
+    #[test]
+    fn registry_integration() {
+        use crate::xds::bootstrap::CertProviderPluginConfig;
+        use crate::xds::cert_provider::CertProviderRegistry;
+        use std::collections::HashMap;
+
+        let ca_file = write_temp_file(b"ca-data");
+
+        let mut configs = HashMap::new();
+        configs.insert(
+            "my_certs".to_string(),
+            CertProviderPluginConfig {
+                plugin_name: "file_watcher".to_string(),
+                config: serde_json::json!({
+                    "ca_certificate_file": ca_file.path().to_str().unwrap(),
+                }),
+            },
+        );
+
+        let registry = CertProviderRegistry::from_bootstrap(&configs).unwrap();
+        assert!(registry.contains("my_certs"));
+        assert!(!registry.contains("other"));
+
+        let provider = registry.get("my_certs").unwrap();
+        let data = provider.fetch().unwrap();
+        assert_eq!(data.root_certs.as_deref(), Some(b"ca-data".as_slice()));
+    }
+}

--- a/tonic-xds/src/xds/cert_provider/file_watcher.rs
+++ b/tonic-xds/src/xds/cert_provider/file_watcher.rs
@@ -24,7 +24,7 @@ use std::time::Duration;
 use arc_swap::ArcSwap;
 use serde::Deserialize;
 
-use super::{CertProviderError, CertificateData, CertificateProvider};
+use super::{CertProviderError, CertificateData, CertificateProvider, Identity};
 
 /// Plugin name used in the bootstrap `certificate_providers` JSON.
 pub(crate) const PLUGIN_NAME: &str = "file_watcher";
@@ -113,30 +113,34 @@ impl CertificateProvider for FileWatcherProvider {
 }
 
 /// Read certificate data from the files specified in the config.
+///
+/// This function is the single validation boundary between the permissive
+/// JSON-parsed [`FileWatcherConfig`] and the invariant-enforcing
+/// [`CertificateData`]. It checks both A65 rules:
+/// - cert/key pairing (first match)
+/// - at least one of identity/roots is set (second match)
 fn read_certificate_data(config: &FileWatcherConfig) -> Result<CertificateData, CertProviderError> {
-    let root_certs = config
+    let roots = config
         .ca_certificate_file
         .as_deref()
         .map(read_file)
         .transpose()?;
 
-    let identity_cert_chain = config
-        .certificate_file
-        .as_deref()
-        .map(read_file)
-        .transpose()?;
+    let identity = match (&config.certificate_file, &config.private_key_file) {
+        (Some(cert_path), Some(key_path)) => Some(Identity {
+            cert_chain: read_file(cert_path)?,
+            key: read_file(key_path)?,
+        }),
+        (None, None) => None,
+        (Some(_), None) | (None, Some(_)) => return Err(CertProviderError::UnpairedCertKey),
+    };
 
-    let identity_key = config
-        .private_key_file
-        .as_deref()
-        .map(read_file)
-        .transpose()?;
-
-    Ok(CertificateData {
-        root_certs,
-        identity_cert_chain,
-        identity_key,
-    })
+    match (roots, identity) {
+        (Some(roots), Some(identity)) => Ok(CertificateData::Both { roots, identity }),
+        (Some(roots), None) => Ok(CertificateData::RootsOnly { roots }),
+        (None, Some(identity)) => Ok(CertificateData::IdentityOnly { identity }),
+        (None, None) => Err(CertProviderError::EmptyConfig),
+    }
 }
 
 fn read_file(path: &Path) -> Result<Vec<u8>, CertProviderError> {
@@ -176,14 +180,13 @@ mod tests {
             FileWatcherProvider::new(make_config(ca_file.path().to_str(), None, None)).unwrap();
         let data = provider.fetch().unwrap();
 
+        assert!(matches!(*data, CertificateData::RootsOnly { .. }));
         assert!(
-            data.root_certs
-                .as_ref()
+            data.roots()
                 .unwrap()
                 .starts_with(b"-----BEGIN CERTIFICATE-----")
         );
-        assert!(data.identity_cert_chain.is_none());
-        assert!(data.identity_key.is_none());
+        assert!(data.identity().is_none());
     }
 
     #[test]
@@ -199,15 +202,11 @@ mod tests {
         .unwrap();
         let data = provider.fetch().unwrap();
 
-        assert_eq!(
-            data.identity_cert_chain.as_deref(),
-            Some(b"cert-chain-pem".as_slice())
-        );
-        assert_eq!(
-            data.identity_key.as_deref(),
-            Some(b"private-key-pem".as_slice())
-        );
-        assert!(data.root_certs.is_none());
+        assert!(matches!(*data, CertificateData::IdentityOnly { .. }));
+        let identity = data.identity().unwrap();
+        assert_eq!(identity.cert_chain.as_slice(), b"cert-chain-pem");
+        assert_eq!(identity.key.as_slice(), b"private-key-pem");
+        assert!(data.roots().is_none());
     }
 
     #[test]
@@ -224,22 +223,37 @@ mod tests {
         .unwrap();
         let data = provider.fetch().unwrap();
 
-        assert_eq!(data.root_certs.as_deref(), Some(b"ca-pem".as_slice()));
-        assert_eq!(
-            data.identity_cert_chain.as_deref(),
-            Some(b"cert-pem".as_slice())
-        );
-        assert_eq!(data.identity_key.as_deref(), Some(b"key-pem".as_slice()));
+        assert!(matches!(*data, CertificateData::Both { .. }));
+        assert_eq!(data.roots(), Some(b"ca-pem".as_slice()));
+        let identity = data.identity().unwrap();
+        assert_eq!(identity.cert_chain.as_slice(), b"cert-pem");
+        assert_eq!(identity.key.as_slice(), b"key-pem");
     }
 
     #[test]
-    fn empty_config_returns_empty_data() {
-        let provider = FileWatcherProvider::new(make_config(None, None, None)).unwrap();
-        let data = provider.fetch().unwrap();
+    fn empty_config_returns_error() {
+        let err = FileWatcherProvider::new(make_config(None, None, None))
+            .err()
+            .unwrap();
+        assert!(matches!(err, CertProviderError::EmptyConfig));
+    }
 
-        assert!(data.root_certs.is_none());
-        assert!(data.identity_cert_chain.is_none());
-        assert!(data.identity_key.is_none());
+    #[test]
+    fn cert_without_key_returns_error() {
+        let cert_file = write_temp_file(b"cert-pem");
+        let err = FileWatcherProvider::new(make_config(None, cert_file.path().to_str(), None))
+            .err()
+            .unwrap();
+        assert!(matches!(err, CertProviderError::UnpairedCertKey));
+    }
+
+    #[test]
+    fn key_without_cert_returns_error() {
+        let key_file = write_temp_file(b"key-pem");
+        let err = FileWatcherProvider::new(make_config(None, None, key_file.path().to_str()))
+            .err()
+            .unwrap();
+        assert!(matches!(err, CertProviderError::UnpairedCertKey));
     }
 
     #[test]
@@ -264,14 +278,14 @@ mod tests {
         let provider =
             FileWatcherProvider::new(make_config(ca_file.path().to_str(), None, None)).unwrap();
         assert_eq!(
-            provider.fetch().unwrap().root_certs.as_deref(),
+            provider.fetch().unwrap().roots(),
             Some(b"old-ca".as_slice())
         );
 
         std::fs::write(ca_file.path(), b"new-ca").unwrap();
         provider.refresh().unwrap();
         assert_eq!(
-            provider.fetch().unwrap().root_certs.as_deref(),
+            provider.fetch().unwrap().roots(),
             Some(b"new-ca".as_slice())
         );
     }
@@ -283,7 +297,7 @@ mod tests {
 
         let provider = FileWatcherProvider::new(make_config(Some(&path), None, None)).unwrap();
         assert_eq!(
-            provider.fetch().unwrap().root_certs.as_deref(),
+            provider.fetch().unwrap().roots(),
             Some(b"good-ca".as_slice())
         );
 
@@ -293,7 +307,7 @@ mod tests {
 
         // Cached data should still be the old value.
         assert_eq!(
-            provider.fetch().unwrap().root_certs.as_deref(),
+            provider.fetch().unwrap().roots(),
             Some(b"good-ca".as_slice())
         );
     }
@@ -378,6 +392,6 @@ mod tests {
 
         let provider = registry.get("my_certs").unwrap();
         let data = provider.fetch().unwrap();
-        assert_eq!(data.root_certs.as_deref(), Some(b"ca-data".as_slice()));
+        assert_eq!(data.roots(), Some(b"ca-data".as_slice()));
     }
 }

--- a/tonic-xds/src/xds/cert_provider/mod.rs
+++ b/tonic-xds/src/xds/cert_provider/mod.rs
@@ -1,0 +1,162 @@
+// TODO: remove once A29 data plane TLS consumes all types.
+#![allow(dead_code)]
+//! Certificate provider plugin framework for gRFC A29.
+//!
+//! The xDS control plane references certificate providers by instance name
+//! (via [`CertificateProviderPluginInstance`]). Each instance maps to a plugin
+//! implementation configured in the bootstrap `certificate_providers` field.
+//!
+//! gRPC currently supports one built-in plugin: [`file_watcher`].
+//!
+//! [`CertificateProviderPluginInstance`]: https://github.com/envoyproxy/envoy/blob/main/api/envoy/extensions/transport_sockets/tls/v3/common.proto
+
+pub(crate) mod file_watcher;
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use serde::Deserialize;
+
+use crate::xds::bootstrap::CertProviderPluginConfig;
+
+/// Certificate material returned by a [`CertificateProvider`] plugin.
+#[derive(Debug, Clone)]
+pub(crate) struct CertificateData {
+    /// PEM-encoded CA certificate(s) for validating peer certificates.
+    pub root_certs: Option<Vec<u8>>,
+    /// PEM-encoded identity certificate chain.
+    pub identity_cert_chain: Option<Vec<u8>>,
+    /// PEM-encoded private key for the identity certificate.
+    pub identity_key: Option<Vec<u8>>,
+}
+
+/// Errors from certificate provider operations.
+#[derive(Debug, thiserror::Error)]
+pub(crate) enum CertProviderError {
+    #[error("failed to read certificate file '{path}': {source}")]
+    FileRead {
+        path: String,
+        source: std::io::Error,
+    },
+    #[error("unknown certificate provider plugin: {0}")]
+    UnknownPlugin(String),
+    #[error("invalid config for plugin '{plugin}': {source}")]
+    InvalidPluginConfig {
+        plugin: String,
+        source: serde_json::Error,
+    },
+}
+
+/// A certificate provider plugin.
+///
+/// Implementations obtain certificates from some source (local files, remote CA,
+/// etc.) and deliver them to consumers. Providers cache their last successful
+/// result and may refresh periodically.
+pub(crate) trait CertificateProvider: Send + Sync {
+    /// Fetch the current certificate data.
+    ///
+    /// Returns the most recently cached certificate material. This is called
+    /// each time a new TLS connection is established. Returns an `Arc` to
+    /// avoid deep-cloning certificate bytes on every call.
+    fn fetch(&self) -> Result<Arc<CertificateData>, CertProviderError>;
+}
+
+/// Registry of certificate provider instances built from the bootstrap config.
+///
+/// Maps instance names to their provider implementations. Used during CDS
+/// validation to verify that referenced instances exist, and at connection
+/// time to fetch certificate material.
+pub(crate) struct CertProviderRegistry {
+    providers: HashMap<String, Arc<dyn CertificateProvider>>,
+}
+
+impl std::fmt::Debug for CertProviderRegistry {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("CertProviderRegistry")
+            .field("providers", &self.providers.keys().collect::<Vec<_>>())
+            .finish()
+    }
+}
+
+impl CertProviderRegistry {
+    /// Build a registry from the bootstrap `certificate_providers` map.
+    ///
+    /// Dispatches on `plugin_name` and deserializes the opaque `config`
+    /// into the appropriate plugin-specific type. Unknown plugin names
+    /// are rejected here.
+    pub(crate) fn from_bootstrap(
+        configs: &HashMap<String, CertProviderPluginConfig>,
+    ) -> Result<Self, CertProviderError> {
+        let mut providers: HashMap<String, Arc<dyn CertificateProvider>> =
+            HashMap::with_capacity(configs.len());
+
+        for (instance_name, entry) in configs {
+            let provider = Self::create_provider(entry)?;
+            providers.insert(instance_name.clone(), provider);
+        }
+
+        Ok(Self { providers })
+    }
+
+    fn create_provider(
+        entry: &CertProviderPluginConfig,
+    ) -> Result<Arc<dyn CertificateProvider>, CertProviderError> {
+        match entry.plugin_name.as_str() {
+            file_watcher::PLUGIN_NAME => {
+                let config =
+                    file_watcher::FileWatcherConfig::deserialize(&entry.config).map_err(|e| {
+                        CertProviderError::InvalidPluginConfig {
+                            plugin: entry.plugin_name.clone(),
+                            source: e,
+                        }
+                    })?;
+                Ok(Arc::new(file_watcher::FileWatcherProvider::new(config)?))
+            }
+            other => Err(CertProviderError::UnknownPlugin(other.to_string())),
+        }
+    }
+
+    /// Look up a provider instance by name.
+    pub(crate) fn get(&self, instance_name: &str) -> Option<&Arc<dyn CertificateProvider>> {
+        self.providers.get(instance_name)
+    }
+
+    /// Returns `true` if the given instance name is configured.
+    pub(crate) fn contains(&self, instance_name: &str) -> bool {
+        self.providers.contains_key(instance_name)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[test]
+    fn empty_bootstrap_creates_empty_registry() {
+        let configs = HashMap::new();
+        let registry = CertProviderRegistry::from_bootstrap(&configs).unwrap();
+        assert!(registry.get("anything").is_none());
+    }
+
+    #[test]
+    fn unknown_plugin_rejected_at_registry_build() {
+        let json = r#"{
+            "xds_servers": [{"server_uri": "localhost:5000"}],
+            "certificate_providers": {
+                "test": {
+                    "plugin_name": "unknown_plugin",
+                    "config": {}
+                }
+            }
+        }"#;
+        let config = crate::xds::bootstrap::BootstrapConfig::from_json(json).unwrap();
+        let err = CertProviderRegistry::from_bootstrap(&config.certificate_providers);
+        assert!(err.is_err());
+        assert!(err.unwrap_err().to_string().contains("unknown_plugin"));
+    }
+
+    #[test]
+    fn contains_returns_false_for_missing_instance() {
+        let registry = CertProviderRegistry::from_bootstrap(&HashMap::new()).unwrap();
+        assert!(!registry.contains("nonexistent"));
+    }
+}

--- a/tonic-xds/src/xds/cert_provider/mod.rs
+++ b/tonic-xds/src/xds/cert_provider/mod.rs
@@ -19,15 +19,57 @@ use serde::Deserialize;
 
 use crate::xds::bootstrap::CertProviderPluginConfig;
 
-/// Certificate material returned by a [`CertificateProvider`] plugin.
+/// PEM-encoded identity (a cert chain paired with its private key).
 #[derive(Debug, Clone)]
-pub(crate) struct CertificateData {
-    /// PEM-encoded CA certificate(s) for validating peer certificates.
-    pub root_certs: Option<Vec<u8>>,
-    /// PEM-encoded identity certificate chain.
-    pub identity_cert_chain: Option<Vec<u8>>,
-    /// PEM-encoded private key for the identity certificate.
-    pub identity_key: Option<Vec<u8>>,
+pub(crate) struct Identity {
+    pub(crate) cert_chain: Vec<u8>,
+    pub(crate) key: Vec<u8>,
+}
+
+/// Certificate material returned by a [`CertificateProvider`] plugin.
+///
+/// The variants encode two invariants from gRFC A29 and A65 at the type level:
+///
+/// 1. **Cert/key pairing** (A65): identity cert and private key are paired or
+///    absent — never one without the other. Guaranteed by [`Identity`].
+/// 2. **At least one present** (A65, for `file_watcher`): at least one of
+///    CA roots or identity must be set. Guaranteed by the absence of a
+///    `Neither` variant — every value carries roots, identity, or both.
+///
+/// Spec references:
+/// - A29: <https://github.com/grpc/proposal/blob/master/A29-xds-tls-security.md>
+/// - A65: <https://github.com/grpc/proposal/blob/master/A65-xds-mtls-creds-in-bootstrap.md>
+///   ("in the file-watcher certificate provider, at least one of the
+///   `certificate_file` or `ca_certificate_file` fields must be specified")
+#[derive(Debug, Clone)]
+pub(crate) enum CertificateData {
+    /// CA trust bundle only — used by TLS clients that don't present an
+    /// identity.
+    RootsOnly { roots: Vec<u8> },
+    /// Identity only — used by TLS servers that don't validate peers
+    /// (non-mTLS). Peer validation falls back to system roots at the
+    /// consumer layer if needed.
+    IdentityOnly { identity: Identity },
+    /// Both roots and identity — used for mTLS on either end.
+    Both { roots: Vec<u8>, identity: Identity },
+}
+
+impl CertificateData {
+    /// PEM-encoded CA trust bundle, if present.
+    pub(crate) fn roots(&self) -> Option<&[u8]> {
+        match self {
+            Self::RootsOnly { roots } | Self::Both { roots, .. } => Some(roots),
+            Self::IdentityOnly { .. } => None,
+        }
+    }
+
+    /// Identity cert chain and private key, if present.
+    pub(crate) fn identity(&self) -> Option<&Identity> {
+        match self {
+            Self::IdentityOnly { identity } | Self::Both { identity, .. } => Some(identity),
+            Self::RootsOnly { .. } => None,
+        }
+    }
 }
 
 /// Errors from certificate provider operations.
@@ -45,6 +87,16 @@ pub(crate) enum CertProviderError {
         plugin: String,
         source: serde_json::Error,
     },
+    #[error(
+        "invalid file_watcher config: 'certificate_file' and 'private_key_file' must both be \
+         set or both be unset"
+    )]
+    UnpairedCertKey,
+    #[error(
+        "invalid file_watcher config: at least one of 'certificate_file' or \
+         'ca_certificate_file' must be specified"
+    )]
+    EmptyConfig,
 }
 
 /// A certificate provider plugin.

--- a/tonic-xds/src/xds/cluster_discovery.rs
+++ b/tonic-xds/src/xds/cluster_discovery.rs
@@ -49,8 +49,14 @@ impl ClusterDiscovery<EndpointAddress, EndpointChannel<Channel>> for XdsClusterD
 /// Default connector that creates a lazily-connected [`EndpointChannel`] for
 /// each endpoint address.
 ///
-/// Uses insecure (plaintext) connections. TLS support will be added as part
-/// of gRFC A29.
+/// Uses insecure (plaintext) connections.
+// TODO(PR2/A29): Replace this with a TLS-aware connector that receives the
+// CertProviderRegistry and per-cluster UpstreamTlsContext (from ClusterResource).
+// When a cluster has transport_socket configured, the connector should:
+//   1. Look up root + identity cert provider instances from the registry
+//   2. Build ClientTlsConfig with the fetched CertificateData
+//   3. Apply SAN matching for server authorization
+//   4. Use connect() instead of connect_lazy() for TLS handshake
 pub(crate) fn default_endpoint_connector(addr: &EndpointAddress) -> EndpointChannel<Channel> {
     let uri = format!("http://{addr}");
     // Safety: EndpointAddress only holds validated Ipv4/Ipv6/Hostname + u16 port,

--- a/tonic-xds/src/xds/mod.rs
+++ b/tonic-xds/src/xds/mod.rs
@@ -1,5 +1,6 @@
 pub(crate) mod bootstrap;
 pub(crate) mod cache;
+pub(crate) mod cert_provider;
 pub(crate) mod cluster_discovery;
 pub(crate) mod endpoint_manager;
 pub(crate) mod resource;

--- a/tonic-xds/src/xds/resource/cluster.rs
+++ b/tonic-xds/src/xds/resource/cluster.rs
@@ -61,6 +61,11 @@ impl Resource for ClusterResource {
             }
         };
 
+        // TODO(PR2/A29): Parse transport_socket → UpstreamTlsContext from the Cluster
+        // message. Extract CertificateProviderPluginInstance references (root + identity),
+        // SAN matchers, and require_client_certificate. NACK if validation_context
+        // is missing or uses unsupported fields per A29 field processing rules.
+
         Ok(ClusterResource {
             name,
             eds_service_name,

--- a/xds-client/Cargo.toml
+++ b/xds-client/Cargo.toml
@@ -34,6 +34,8 @@ transport-tonic = [
     "dep:tokio-stream",
     "dep:http",
 ]
+tonic-tls-ring = ["transport-tonic", "tonic/tls-ring"]
+tonic-tls-aws-lc = ["transport-tonic", "tonic/tls-aws-lc"]
 rt-tokio = ["tokio/rt", "tokio/time"]
 codegen-prost = ["dep:envoy-types", "dep:prost"]
 test-util = []
@@ -44,7 +46,7 @@ tokio = { version = "1", features = [
     "macros",
     "net",
 ] }
-tonic = { version = "0.14", features = ["tls-ring"] }
+tonic = { version = "0.14" }
 async-stream = "0.3"
 envoy-types = "0.7"
 prost = "0.14"
@@ -52,6 +54,7 @@ prost = "0.14"
 [[example]]
 name = "basic"
 path = "examples/basic.rs"
+required-features = ["tonic-tls-ring"]
 
 [package.metadata.cargo_check_external_types]
 allowed_external_types = [

--- a/xds-client/examples/basic.rs
+++ b/xds-client/examples/basic.rs
@@ -39,12 +39,12 @@ use envoy_types::pb::envoy::extensions::filters::network::http_connection_manage
     HttpConnectionManager, http_connection_manager::RouteSpecifier,
 };
 use prost::Message;
-use tonic::transport::{Certificate, Channel, ClientTlsConfig, Identity};
+use tonic::transport::{Certificate, ClientTlsConfig, Identity};
 
 use xds_client::resource::TypeUrl;
 use xds_client::{
-    ClientConfig, Node, ProstCodec, Resource, ResourceEvent, Result as XdsResult, ServerConfig,
-    TokioRuntime, TonicTransport, TonicTransportBuilder, TransportBuilder, XdsClient,
+    ClientConfig, Node, ProstCodec, Resource, ResourceEvent, TokioRuntime, TonicTransportBuilder,
+    XdsClient,
 };
 
 struct Args {
@@ -101,31 +101,6 @@ pub struct Listener {
     pub rds_route_config_name: Option<String>,
 }
 
-/// Custom transport builder that configures TLS on the channel.
-///
-/// This demonstrates how to implement a custom [`TransportBuilder`] when you need
-/// TLS or other custom channel configuration. The default [`TonicTransportBuilder`]
-/// creates plain (non-TLS) connections.
-struct TlsTransportBuilder {
-    tls_config: ClientTlsConfig,
-}
-
-impl TransportBuilder for TlsTransportBuilder {
-    type Transport = TonicTransport;
-
-    async fn build(&self, server: &ServerConfig) -> XdsResult<Self::Transport> {
-        let channel = Channel::from_shared(server.uri().to_string())
-            .map_err(|e| xds_client::Error::Connection(e.to_string()))?
-            .tls_config(self.tls_config.clone())
-            .map_err(|e| xds_client::Error::Connection(e.to_string()))?
-            .connect()
-            .await
-            .map_err(|e| xds_client::Error::Connection(e.to_string()))?;
-
-        Ok(TonicTransport::from_channel(channel))
-    }
-}
-
 impl Resource for Listener {
     type Message = ListenerProto;
 
@@ -167,28 +142,21 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let node = Node::new("grpc", "1.0").with_id("example-node");
     let config = ClientConfig::new(node, &args.server);
 
-    let client = match &args.ca_cert {
-        Some(ca_path) => {
-            let ca_cert = std::fs::read_to_string(ca_path)?;
-            let mut tls = ClientTlsConfig::new().ca_certificate(Certificate::from_pem(&ca_cert));
+    let mut transport_builder = TonicTransportBuilder::new();
+    if let Some(ca_path) = &args.ca_cert {
+        let ca_cert = std::fs::read_to_string(ca_path)?;
+        let mut tls = ClientTlsConfig::new().ca_certificate(Certificate::from_pem(&ca_cert));
 
-            if let (Some(cert_path), Some(key_path)) = (&args.client_cert, &args.client_key) {
-                let client_cert = std::fs::read_to_string(cert_path)?;
-                let client_key = std::fs::read_to_string(key_path)?;
-                tls = tls.identity(Identity::from_pem(client_cert, client_key));
-            }
-
-            let tls_builder = TlsTransportBuilder { tls_config: tls };
-            XdsClient::builder(config, tls_builder, ProstCodec, TokioRuntime).build()
+        if let (Some(cert_path), Some(key_path)) = (&args.client_cert, &args.client_key) {
+            let client_cert = std::fs::read_to_string(cert_path)?;
+            let client_key = std::fs::read_to_string(key_path)?;
+            tls = tls.identity(Identity::from_pem(client_cert, client_key));
         }
-        None => XdsClient::builder(
-            config,
-            TonicTransportBuilder::new(),
-            ProstCodec,
-            TokioRuntime,
-        )
-        .build(),
-    };
+
+        transport_builder = transport_builder.with_tls_config(tls);
+    }
+
+    let client = XdsClient::builder(config, transport_builder, ProstCodec, TokioRuntime).build();
 
     println!("Starting watchers...\n");
 

--- a/xds-client/src/transport/tonic.rs
+++ b/xds-client/src/transport/tonic.rs
@@ -111,13 +111,8 @@ impl TonicTransport {
     ///
     /// For custom configuration (TLS, timeouts, etc.), use [`from_channel`](Self::from_channel).
     pub async fn connect(uri: impl Into<String>) -> Result<Self> {
-        let uri: String = uri.into();
-        let channel = Channel::from_shared(uri)
-            .map_err(|e| Error::Connection(e.to_string()))?
-            .connect()
-            .await
-            .map_err(|e| Error::Connection(e.to_string()))?;
-        Ok(Self { channel })
+        let server = ServerConfig::new(uri.into());
+        TonicTransportBuilder::new().build(&server).await
     }
 }
 
@@ -125,9 +120,6 @@ impl TonicTransport {
 ///
 /// This implements [`TransportBuilder`] and can be used with
 /// [`XdsClientBuilder`](crate::XdsClientBuilder) to enable server fallback support.
-///
-/// For connections requiring TLS or custom channel configuration, see the
-/// example in [`TonicTransport::from_channel`].
 ///
 /// # Example
 ///
@@ -138,20 +130,43 @@ impl TonicTransport {
 /// let config = ClientConfig::new(node, "http://xds.example.com:18000");
 /// let client = XdsClient::builder(config, transport_builder, codec, runtime).build();
 /// ```
+///
+/// # TLS
+///
+/// Enable the `tls-ring` or `tls-aws-lc` feature and call [`with_tls_config`](Self::with_tls_config):
+///
+/// ```ignore
+/// use tonic::transport::ClientTlsConfig;
+/// use xds_client::TonicTransportBuilder;
+///
+/// let builder = TonicTransportBuilder::new()
+///     .with_tls_config(ClientTlsConfig::new().with_enabled_roots());
+/// ```
 #[derive(Debug, Clone, Default)]
 pub struct TonicTransportBuilder {
     // Future extensions:
-    // - TLS configuration (requires tonic TLS feature)
     // - Connection timeout settings
     // - Keep-alive configuration
     // - Connection pooling settings
     // - Per-server credential overrides (via ServerConfig.extensions)
+    #[cfg(any(feature = "tonic-tls-ring", feature = "tonic-tls-aws-lc"))]
+    tls_config: Option<tonic::transport::ClientTlsConfig>,
 }
 
 impl TonicTransportBuilder {
-    /// Create a new transport builder with default settings.
+    /// Create a new transport builder with default (plaintext) settings.
     pub fn new() -> Self {
         Self::default()
+    }
+
+    /// Set the TLS configuration for connections to the xDS server.
+    ///
+    /// When set, all connections created by this builder will use TLS
+    /// with the provided configuration.
+    #[cfg(any(feature = "tonic-tls-ring", feature = "tonic-tls-aws-lc"))]
+    pub fn with_tls_config(mut self, tls_config: tonic::transport::ClientTlsConfig) -> Self {
+        self.tls_config = Some(tls_config);
+        self
     }
 }
 
@@ -159,8 +174,18 @@ impl TransportBuilder for TonicTransportBuilder {
     type Transport = TonicTransport;
 
     async fn build(&self, server: &ServerConfig) -> Result<Self::Transport> {
-        let channel = Channel::from_shared(server.uri().to_string())
-            .map_err(|e| Error::Connection(e.to_string()))?
+        let endpoint = Channel::from_shared(server.uri().to_string())
+            .map_err(|e| Error::Connection(e.to_string()))?;
+
+        #[cfg(any(feature = "tonic-tls-ring", feature = "tonic-tls-aws-lc"))]
+        let endpoint = match &self.tls_config {
+            Some(tls) => endpoint
+                .tls_config(tls.clone())
+                .map_err(|e| Error::Connection(e.to_string()))?,
+            None => endpoint,
+        };
+
+        let channel = endpoint
             .connect()
             .await
             .map_err(|e| Error::Connection(e.to_string()))?;


### PR DESCRIPTION
## Motivation

Ref: #2444

PR 1 of 3 to implement [gRFC A29 xDS TLS security](https://github.com/grpc/proposal/blob/master/A29-xds-tls-security.md) support in `tonic-xds`.

## Solution

1. Add `CertificateProvider` trait and outline `file_watcher` plugin with its config shape. Background file watch refresher is not implemented yet.
2. Feature flags gating setup in `xds-client` and `tonic-xds`. Allow optional use of one of the crypto backends from `tonic`.
3. Extend `TonicTransportBuilder` with `with_tls_config()` to allow subsequent TLS changes.
4. Parse bootstrap `certificate_providers` and enable TLS in xDS connection to xDS management server conditionally. Currently because the file watcher is not fully implemented, the setup only enables TLS with system root CA only, no custom certs yet.

## Next Steps

Two more PRs are in plan to complete A29:

1. PR 2: data-plane endpoint connection TLS support, by supporting CDS `UpstreamTlsContext` and SAN matching.
2. PR 3: Background cert refresh to complete `file_watcher`.
