### PR TITLE
feat(grpc): Add server-side stream validators

### DIFF
--- a/grpc/examples/inmemory.rs
+++ b/grpc/examples/inmemory.rs
@@ -41,6 +41,7 @@ use grpc::credentials::InsecureChannelCredentials;
 use grpc::inmemory;
 use grpc::server;
 use grpc::server::Handle;
+use grpc::core::Trailers;
 
 struct Handler {
     id: String,
@@ -84,7 +85,7 @@ impl Handle for Handler {
         _options: CallOptions,
         tx: &mut impl server::SendStream,
         mut rx: impl server::RecvStream + 'static,
-    ) {
+    ) -> Trailers {
         let method = headers.method_name().clone();
         let id = self.id.clone();
         // Send headers
@@ -108,16 +109,8 @@ impl Handle for Handler {
                 )
                 .await;
         }
-        // Send trailers
-        let _ = tx
-            .send(
-                ServerResponseStreamItem::Trailers(grpc::core::Trailers::new(grpc::Status::new(
-                    grpc::StatusCode::Ok,
-                    "OK",
-                ))),
-                server::SendOptions::default(),
-            )
-            .await;
+        // Return trailers
+        Trailers::new(grpc::Status::new(grpc::StatusCode::Ok, "OK"))
     }
 }
 

--- a/grpc/src/core/mod.rs
+++ b/grpc/src/core/mod.rs
@@ -101,8 +101,7 @@ impl dyn RecvMessage + '_ {
     }
 }
 
-/// ResponseStreamItem represents an item in a response stream (either server
-/// sending or client receiving).
+/// ResponseStreamItem represents an item in a response stream from the client's view.
 ///
 /// A response stream must always contain items exactly as follows:
 ///
@@ -135,8 +134,6 @@ pub enum ServerResponseStreamItem<'a> {
     Headers(ResponseHeaders),
     /// Indicates a message on the stream.
     Message(&'a dyn SendMessage),
-    /// Indicates trailers were received on the stream and includes the trailers.
-    Trailers(Trailers),
 }
 
 /// Contains all information transmitted in the response headers of an RPC.

--- a/grpc/src/inmemory/mod.rs
+++ b/grpc/src/inmemory/mod.rs
@@ -85,6 +85,7 @@ struct InMemoryServerCall {
     headers: RequestHeaders,
     req_rx: mpsc::UnboundedReceiver<InMemoryRequestStreamItem>,
     resp_tx: mpsc::UnboundedSender<InMemoryResponseStreamItem>,
+    trailer_tx: oneshot::Sender<Trailers>,
 }
 
 enum InMemoryRequestStreamItem {
@@ -95,7 +96,6 @@ enum InMemoryRequestStreamItem {
 enum InMemoryResponseStreamItem {
     Headers(ResponseHeaders),
     Message(Box<dyn Buf + Send + Sync>),
-    Trailers(Trailers),
     StreamClosed,
 }
 
@@ -179,6 +179,7 @@ impl ServerListener for InMemoryListener {
                     headers: call.headers,
                     send: InMemoryServerSendStream { tx: call.resp_tx },
                     recv: InMemoryServerRecvStream { rx: call.req_rx },
+                    trailers_tx: call.trailer_tx,
                 })
             }
             _ = self.inner.close_notify.notified() => {
@@ -204,7 +205,6 @@ impl ServerSendStream for InMemoryServerSendStream {
                 let buf = m.encode().map_err(|_| ())?;
                 InMemoryResponseStreamItem::Message(buf)
             }
-            ServerResponseStreamItem::Trailers(t) => InMemoryResponseStreamItem::Trailers(t),
         };
 
         self.tx.send(inmemory_item).map_err(|_| ())
@@ -246,18 +246,23 @@ impl Invoke for InMemoryConnection {
     ) -> (Self::SendStream, Self::RecvStream) {
         let (req_tx, req_rx) = mpsc::unbounded_channel::<InMemoryRequestStreamItem>();
         let (resp_tx, resp_rx) = mpsc::unbounded_channel::<InMemoryResponseStreamItem>();
+        let (trailer_tx, trailer_rx) = oneshot::channel();
 
         let call = InMemoryServerCall {
             headers,
             req_rx,
             resp_tx,
+            trailer_tx,
         };
 
-        let _ = self.s.try_send(call);
+        let _ = self.s.send(call).await;
 
         (
             Box::new(InMemoryClientSendStream { tx: Some(req_tx) }),
-            Box::new(InMemoryClientRecvStream { rx: resp_rx }),
+            Box::new(InMemoryClientRecvStream {
+                rx: resp_rx,
+                trailer_rx: Some(trailer_rx)
+            }),
         )
     }
 }
@@ -299,6 +304,7 @@ impl Drop for InMemoryClientSendStream {
 
 pub struct InMemoryClientRecvStream {
     rx: mpsc::UnboundedReceiver<InMemoryResponseStreamItem>,
+    trailer_rx: Option<oneshot::Receiver<Trailers>>,
 }
 
 impl ClientRecvStream for InMemoryClientRecvStream {
@@ -309,8 +315,14 @@ impl ClientRecvStream for InMemoryClientRecvStream {
                 msg.decode(&mut buf).unwrap();
                 ClientResponseStreamItem::Message(())
             }
-            Some(InMemoryResponseStreamItem::Trailers(t)) => ClientResponseStreamItem::Trailers(t),
-            _ => ClientResponseStreamItem::StreamClosed,
+            _ => {
+                if let Some(trailer_rx) = self.trailer_rx.take() {
+                    if let Ok(trailers) = trailer_rx.await {
+                        return ClientResponseStreamItem::Trailers(trailers);
+                    }
+                }
+                ClientResponseStreamItem::StreamClosed
+            }
         }
     }
 }

--- a/grpc/src/server/mod.rs
+++ b/grpc/src/server/mod.rs
@@ -32,6 +32,8 @@ use crate::core::ServerResponseStreamItem;
 use crate::core::Trailers;
 use tokio::sync::oneshot;
 
+pub mod stream_util;
+
 pub struct Server {
     handler: Option<Arc<dyn DynHandle>>,
 }

--- a/grpc/src/server/mod.rs
+++ b/grpc/src/server/mod.rs
@@ -29,6 +29,8 @@ use crate::client::CallOptions;
 use crate::core::RecvMessage;
 use crate::core::RequestHeaders;
 use crate::core::ServerResponseStreamItem;
+use crate::core::Trailers;
+use tokio::sync::oneshot;
 
 pub struct Server {
     handler: Option<Arc<dyn DynHandle>>,
@@ -38,6 +40,7 @@ pub struct Call<SS, RS> {
     pub headers: RequestHeaders,
     pub send: SS,
     pub recv: RS,
+    pub trailers_tx: oneshot::Sender<Trailers>,
 }
 
 #[trait_variant::make(Send)]
@@ -64,11 +67,13 @@ impl Server {
             let mut send: Box<dyn DynSendStream> = Box::new(call.send);
             let recv = BoxedRecvStream(Box::new(call.recv));
             let options = CallOptions::default();
-            self.handler
+            let trailers_tx = call.trailers_tx;
+            let trailers = self.handler
                 .as_ref()
                 .unwrap()
                 .dyn_handle(call.headers, options, &mut *send, recv)
                 .await;
+            let _ = trailers_tx.send(trailers);
         }
     }
 }
@@ -92,7 +97,7 @@ pub trait Handle: Send + Sync {
         options: CallOptions,
         tx: &mut impl SendStream,
         rx: impl RecvStream + 'static,
-    );
+    ) -> Trailers;
 }
 
 #[async_trait]
@@ -103,7 +108,7 @@ trait DynHandle: Send + Sync {
         options: CallOptions,
         tx: &mut dyn DynSendStream,
         rx: BoxedRecvStream,
-    );
+    ) -> Trailers;
 }
 
 #[async_trait]
@@ -114,7 +119,7 @@ impl<T: Handle> DynHandle for T {
         options: CallOptions,
         mut tx: &mut dyn DynSendStream,
         rx: BoxedRecvStream,
-    ) {
+    ) -> Trailers {
         self.handle(headers, options, &mut tx, rx).await
     }
 }
@@ -146,10 +151,9 @@ impl RecvStream for BoxedRecvStream {
 pub trait SendStream {
     /// Sends the next item on the stream. Returns `Ok(())` on success, or
     /// `Err(())` on failure. `Err(())` is a terminal state.
-    /// Sending is also considered complete after successfully sending
-    /// `ServerResponseStreamItem::Trailers`.
-    /// Calling this method after an error or after sending trailers should be
-    /// avoided and is unspecified.
+    /// Sending is considered complete when the `handle` method returns
+    /// `Trailers`.
+    /// Calling this method after an error should be avoided and is unspecified.
     ///
     /// # Cancel safety
     ///

--- a/grpc/src/server/stream_util.rs
+++ b/grpc/src/server/stream_util.rs
@@ -1,0 +1,384 @@
+/*
+ *
+ * Copyright 2026 gRPC authors.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to
+ * deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ *
+ */
+
+use crate::core::RecvMessage;
+use crate::core::ServerResponseStreamItem;
+use crate::server::RecvStream;
+use crate::server::SendOptions;
+use crate::server::SendStream;
+
+/// Enforces proper gRPC semantics on the server sending stream.
+pub struct ServerSendStreamValidator<S> {
+    inner: S,
+    state: SendStreamState,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum SendStreamState {
+    Init,
+    HeadersSent,
+    MessagesSent,
+    Done,
+}
+
+impl<S> ServerSendStreamValidator<S>
+where
+    S: SendStream,
+{
+    /// Constructs a new `ServerSendStreamValidator`.
+    pub fn new(inner: S) -> Self {
+        Self {
+            inner,
+            state: SendStreamState::Init,
+        }
+    }
+}
+
+impl<S> SendStream for ServerSendStreamValidator<S>
+where
+    S: SendStream,
+{
+    async fn send<'a>(
+        &mut self,
+        item: ServerResponseStreamItem<'a>,
+        options: SendOptions,
+    ) -> Result<(), ()> {
+        match self.state {
+            SendStreamState::Done => {
+                return Err(());
+            }
+            _ => {}
+        }
+
+        let next_state = match &item {
+            ServerResponseStreamItem::Headers(_) => match self.state {
+                SendStreamState::Init => SendStreamState::HeadersSent,
+                _ => {
+                    self.state = SendStreamState::Done;
+                    return Err(());
+                }
+            },
+            ServerResponseStreamItem::Message(_) => match self.state {
+                SendStreamState::HeadersSent | SendStreamState::MessagesSent => {
+                    SendStreamState::MessagesSent
+                }
+                _ => {
+                    self.state = SendStreamState::Done;
+                    return Err(());
+                }
+            },
+        };
+
+        let res = self.inner.send(item, options).await;
+        match res {
+            Ok(()) => self.state = next_state,
+            Err(_) => self.state = SendStreamState::Done,
+        }
+        res
+    }
+}
+
+/// Enforces proper gRPC semantics on the server receiving stream.
+pub struct ServerRecvStreamValidator<R> {
+    inner: R,
+    state: RecvStreamState,
+}
+
+#[derive(Debug, Clone)]
+enum RecvStreamState {
+    Init,
+    Done,
+}
+
+impl<R> ServerRecvStreamValidator<R>
+where
+    R: RecvStream,
+{
+    /// Constructs a new `ServerRecvStreamValidator`.
+    pub fn new(inner: R) -> Self {
+        Self {
+            inner,
+            state: RecvStreamState::Init,
+        }
+    }
+}
+
+impl<R> RecvStream for ServerRecvStreamValidator<R>
+where
+    R: RecvStream,
+{
+    async fn next(&mut self, msg: &mut dyn RecvMessage) -> Option<Result<(), ()>> {
+        match &self.state {
+            RecvStreamState::Done => return Some(Err(())),
+            _ => {}
+        }
+
+        let res = self.inner.next(msg).await;
+
+        match res {
+            Some(Ok(())) => Some(Ok(())),
+            None => {
+                self.state = RecvStreamState::Done;
+                None
+            }
+            Some(Err(())) => {
+                self.state = RecvStreamState::Done;
+                Some(Err(()))
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::Status;
+    use crate::StatusCode;
+    use crate::core::ResponseHeaders;
+    use crate::core::SendMessage;
+    use crate::core::Trailers;
+    use bytes::Buf;
+    use bytes::Bytes;
+
+    impl SendMessage for () {
+        fn encode(&self) -> Result<Box<dyn Buf + Send + Sync>, String> {
+            Ok(Box::new(Bytes::new()))
+        }
+    }
+
+    #[derive(Debug, PartialEq, Eq)]
+    enum SendEvent {
+        Headers,
+        Message,
+    }
+
+    struct MockSendStream {
+        events: Vec<SendEvent>,
+    }
+
+    impl MockSendStream {
+        fn new() -> Self {
+            Self { events: Vec::new() }
+        }
+    }
+
+    impl SendStream for MockSendStream {
+        async fn send<'a>(
+            &mut self,
+            item: ServerResponseStreamItem<'a>,
+            _options: SendOptions,
+        ) -> Result<(), ()> {
+            match item {
+                ServerResponseStreamItem::Headers(_) => self.events.push(SendEvent::Headers),
+                ServerResponseStreamItem::Message(_) => self.events.push(SendEvent::Message),
+            }
+            Ok(())
+        }
+    }
+
+    #[tokio::test]
+    async fn test_send_validator_valid_full_stream() {
+        let mock = MockSendStream::new();
+        let mut validator = ServerSendStreamValidator::new(mock);
+
+        assert!(
+            validator
+                .send(
+                    ServerResponseStreamItem::Headers(ResponseHeaders::default()),
+                    SendOptions::default()
+                )
+                .await
+                .is_ok()
+        );
+        assert!(
+            validator
+                .send(
+                    ServerResponseStreamItem::Message(&()),
+                    SendOptions::default()
+                )
+                .await
+                .is_ok()
+        );
+
+        assert_eq!(
+            validator.inner.events,
+            vec![SendEvent::Headers, SendEvent::Message]
+        );
+    }
+
+
+
+    struct FailingMockSendStream;
+
+    impl SendStream for FailingMockSendStream {
+        async fn send<'a>(
+            &mut self,
+            _item: ServerResponseStreamItem<'a>,
+            _options: SendOptions,
+        ) -> Result<(), ()> {
+            Err(())
+        }
+    }
+
+    #[tokio::test]
+    async fn test_send_validator_invalid_message_before_headers() {
+        let mock = MockSendStream::new();
+        let mut validator = ServerSendStreamValidator::new(mock);
+
+        assert!(
+            validator
+                .send(
+                    ServerResponseStreamItem::Message(&()),
+                    SendOptions::default()
+                )
+                .await
+                .is_err()
+        );
+        assert_eq!(validator.state, SendStreamState::Done);
+    }
+
+    #[tokio::test]
+    async fn test_send_validator_invalid_headers_twice() {
+        let mock = MockSendStream::new();
+        let mut validator = ServerSendStreamValidator::new(mock);
+
+        assert!(
+            validator
+                .send(
+                    ServerResponseStreamItem::Headers(ResponseHeaders::default()),
+                    SendOptions::default()
+                )
+                .await
+                .is_ok()
+        );
+        assert!(
+            validator
+                .send(
+                    ServerResponseStreamItem::Headers(ResponseHeaders::default()),
+                    SendOptions::default()
+                )
+                .await
+                .is_err()
+        );
+    }
+
+    #[tokio::test]
+    async fn test_send_validator_state_transitions_to_done_on_error() {
+        let mock = FailingMockSendStream;
+        let mut validator = ServerSendStreamValidator::new(mock);
+
+        assert!(
+            validator
+                .send(
+                    ServerResponseStreamItem::Headers(ResponseHeaders::default()),
+                    SendOptions::default()
+                )
+                .await
+                .is_err()
+        );
+        assert_eq!(validator.state, SendStreamState::Done);
+    }
+
+    struct MockRecvStream {
+        items: Vec<Option<Result<(), ()>>>,
+        index: usize,
+    }
+
+    impl MockRecvStream {
+        fn new(items: Vec<Option<Result<(), ()>>>) -> Self {
+            Self { items, index: 0 }
+        }
+    }
+
+    impl RecvStream for MockRecvStream {
+        async fn next(&mut self, _msg: &mut dyn RecvMessage) -> Option<Result<(), ()>> {
+            if self.index < self.items.len() {
+                let res = self.items[self.index].clone();
+                self.index += 1;
+                res
+            } else {
+                None
+            }
+        }
+    }
+
+    struct NopRecvMessage;
+    impl RecvMessage for NopRecvMessage {
+        fn decode(&mut self, _data: &mut dyn bytes::Buf) -> Result<(), String> {
+            Ok(())
+        }
+    }
+
+    #[tokio::test]
+    async fn test_recv_validator_valid_unary() {
+        let mock = MockRecvStream::new(vec![Some(Ok(())), None]);
+        let mut validator = ServerRecvStreamValidator::new(mock);
+        let mut msg = NopRecvMessage;
+
+        assert!(matches!(validator.next(&mut msg).await, Some(Ok(()))));
+        assert!(matches!(validator.next(&mut msg).await, None));
+    }
+
+    #[tokio::test]
+    async fn test_recv_validator_empty_stream() {
+        let mock = MockRecvStream::new(vec![None]);
+        let mut validator = ServerRecvStreamValidator::new(mock);
+        let mut msg = NopRecvMessage;
+
+        assert!(matches!(validator.next(&mut msg).await, None));
+    }
+
+    #[tokio::test]
+    async fn test_recv_validator_error_after_done() {
+        let mock = MockRecvStream::new(vec![None]);
+        let mut validator = ServerRecvStreamValidator::new(mock);
+        let mut msg = NopRecvMessage;
+
+        assert!(matches!(validator.next(&mut msg).await, None));
+        assert!(matches!(validator.next(&mut msg).await, Some(Err(()))));
+    }
+
+    #[tokio::test]
+    async fn test_recv_validator_valid_streaming() {
+        let mock = MockRecvStream::new(vec![Some(Ok(())), Some(Ok(())), None]);
+        let mut validator = ServerRecvStreamValidator::new(mock);
+        let mut msg = NopRecvMessage;
+
+        assert!(matches!(validator.next(&mut msg).await, Some(Ok(()))));
+        assert!(matches!(validator.next(&mut msg).await, Some(Ok(()))));
+        assert!(matches!(validator.next(&mut msg).await, None));
+    }
+
+    #[tokio::test]
+    async fn test_recv_validator_terminal_error() {
+        let mock = MockRecvStream::new(vec![Some(Err(()))]);
+        let mut validator = ServerRecvStreamValidator::new(mock);
+        let mut msg = NopRecvMessage;
+
+        assert!(matches!(validator.next(&mut msg).await, Some(Err(()))));
+
+        // Further calls should return the same error
+        assert!(matches!(validator.next(&mut msg).await, Some(Err(()))));
+    }
+}


### PR DESCRIPTION
Introduces `ServerSendStreamValidator` and `ServerRecvStreamValidator` to enforce strict gRPC semantics on server streams. These are intended to wrap raw transport streams before passing them to application-level handlers, ensuring that user-provided service logic cannot violate protocol rules.

- `ServerSendStreamValidator` ensures proper response sequencing (Headers -> Messages -> Trailers) and prevents invalid state transitions, while fully supporting trailers-only responses.
- `ServerRecvStreamValidator` safely manages terminal states, ensuring that any subsequent polls after stream completion consistently return an error to prevent undefined behavior.
- Adds comprehensive unit tests to verify state machine correctness and protocol compliance.