### PR TITLE
tonic-reflection: fix panic when client drops connection early

### DIFF
--- a/tonic-reflection/src/server/v1.rs
+++ b/tonic-reflection/src/server/v1.rs
@@ -82,10 +82,12 @@ impl ServerReflection for ReflectionService {
                             original_request: Some(req.clone()),
                             message_response: Some(resp_msg),
                         };
-                        resp_tx.send(Ok(resp)).await.expect("send");
+                        if resp_tx.send(Ok(resp)).await.is_err() {
+                            return;
+                        }
                     }
                     Err(status) => {
-                        resp_tx.send(Err(status)).await.expect("send");
+                        let _ = resp_tx.send(Err(status)).await;
                         return;
                     }
                 }

--- a/tonic-reflection/src/server/v1alpha.rs
+++ b/tonic-reflection/src/server/v1alpha.rs
@@ -82,10 +82,12 @@ impl ServerReflection for ReflectionService {
                             original_request: Some(req.clone()),
                             message_response: Some(resp_msg),
                         };
-                        resp_tx.send(Ok(resp)).await.expect("send");
+                        if resp_tx.send(Ok(resp)).await.is_err() {
+                            return;
+                        }
                     }
                     Err(status) => {
-                        resp_tx.send(Err(status)).await.expect("send");
+                        let _ = resp_tx.send(Err(status)).await;
                         return;
                     }
                 }


### PR DESCRIPTION
## Motivation

This patch fixes a panic due to an `expect` call when sending on a channel. It is possible for the client to close half of the bidi streaming request early leading to the response stream being closed and dropped before the request stream is terminated.

## Solution

This patch addresses this by not panicking if the recieving side of the channel has been close and instead gracefully ends the task.