### PR TITLE
[tonic-xds] Add the loadbalancer tower service

### DIFF
--- a/tonic-xds/Cargo.toml
+++ b/tonic-xds/Cargo.toml
@@ -43,6 +43,8 @@ tokio = { version = "1", features = ["sync", "time"] }
 # Used for weighted cluster selection and fractional route matching — does not need
 # cryptographic security, only statistical uniformity for traffic distribution.
 fastrand = "2"
+indexmap = "2"
+tracing = "0.1"
 tokio-stream = "0.1"
 tokio-util = "0.7"
 backoff = "0.4"

--- a/tonic-xds/src/client/endpoint.rs
+++ b/tonic-xds/src/client/endpoint.rs
@@ -170,3 +170,21 @@ pub(crate) trait Connector {
         addr: &EndpointAddress,
     ) -> crate::common::async_util::BoxFuture<Self::Service>;
 }
+
+/// Factory for creating per-cluster [`Connector`]s.
+///
+/// The implementation can use the cluster name to look up cluster-specific
+/// config (e.g., TLS settings from xDS CDS, cert providers from A29).
+///
+/// Both `Service` and `Connector` are exposed as associated types so callers
+/// can reference `MC::Service` directly without chaining through
+/// `<MC::Connector as Connector>::Service`.
+pub(crate) trait MakeConnector: Send + Sync + 'static {
+    /// The service type produced by the connector.
+    type Service;
+    /// The connector type produced for each cluster.
+    type Connector: Connector<Service = Self::Service>;
+
+    /// Create a connector for the given cluster.
+    fn make_connector(&self, cluster_name: &str) -> std::sync::Arc<Self::Connector>;
+}

--- a/tonic-xds/src/client/endpoint.rs
+++ b/tonic-xds/src/client/endpoint.rs
@@ -179,6 +179,7 @@ pub(crate) trait Connector {
 /// Both `Service` and `Connector` are exposed as associated types so callers
 /// can reference `MC::Service` directly without chaining through
 /// `<MC::Connector as Connector>::Service`.
+#[allow(dead_code)]
 pub(crate) trait MakeConnector: Send + Sync + 'static {
     /// The service type produced by the connector.
     type Service;

--- a/tonic-xds/src/client/loadbalance/channel_state.rs
+++ b/tonic-xds/src/client/loadbalance/channel_state.rs
@@ -31,6 +31,7 @@ use std::time::Duration;
 
 use pin_project_lite::pin_project;
 use tower::Service;
+use tower::load::Load;
 
 use crate::client::endpoint::{Connector, EndpointAddress};
 use crate::common::async_util::BoxFuture;
@@ -167,6 +168,14 @@ where
 
     fn call(&mut self, req: Req) -> Self::Future {
         self.inner.call(req)
+    }
+}
+
+impl<S: Load> Load for ReadyChannel<S> {
+    type Metric = S::Metric;
+
+    fn load(&self) -> Self::Metric {
+        self.inner.load()
     }
 }
 

--- a/tonic-xds/src/client/loadbalance/errors.rs
+++ b/tonic-xds/src/client/loadbalance/errors.rs
@@ -28,11 +28,9 @@ impl From<LbError> for tonic::Status {
     fn from(err: LbError) -> Self {
         match err {
             LbError::Unavailable => tonic::Status::unavailable("no ready endpoints available"),
-            LbError::LbChannelPollReadyError(inner) => {
-                tonic::Status::unavailable(format!(
-                    "error when polling readiness of lb channel: {inner}"
-                ))
-            }
+            LbError::LbChannelPollReadyError(inner) => tonic::Status::unavailable(format!(
+                "error when polling readiness of lb channel: {inner}"
+            )),
             LbError::Discover(source) => {
                 tonic::Status::unavailable(format!("discovery error: {source}"))
             }

--- a/tonic-xds/src/client/loadbalance/errors.rs
+++ b/tonic-xds/src/client/loadbalance/errors.rs
@@ -1,0 +1,46 @@
+//! Errors for the load balancer.
+
+/// Errors produced by the load balancer.
+#[derive(Debug, thiserror::Error)]
+pub(crate) enum LbError {
+    /// No ready endpoints available to serve the request.
+    #[error("no ready endpoints available")]
+    Unavailable,
+
+    /// The selected lb channel was not ready.
+    #[error("lb channel not ready: {0}")]
+    LbChannelPollReadyError(tower::BoxError),
+
+    /// The selected lb channel returned an error.
+    #[error("lb channel error: {0}")]
+    LbChannelCallError(tower::BoxError),
+
+    /// Discovery stream produced an error.
+    #[error("discovery error: {0}")]
+    Discover(tower::BoxError),
+
+    /// Internal precondition violation (bug).
+    #[error("failed precondition: {0}")]
+    FailedPrecondition(&'static str),
+}
+
+impl From<LbError> for tonic::Status {
+    fn from(err: LbError) -> Self {
+        match err {
+            LbError::Unavailable => tonic::Status::unavailable("no ready endpoints available"),
+            LbError::LbChannelPollReadyError(inner) => {
+                tonic::Status::unavailable(format!(
+                    "error when polling readiness of lb channel: {inner}"
+                ))
+            }
+            LbError::Discover(source) => {
+                tonic::Status::unavailable(format!("discovery error: {source}"))
+            }
+            LbError::FailedPrecondition(msg) => tonic::Status::failed_precondition(msg),
+            LbError::LbChannelCallError(source) => match source.downcast::<tonic::Status>() {
+                Ok(status) => *status,
+                Err(source) => tonic::Status::unknown(format!("lb channel error: {source}")),
+            },
+        }
+    }
+}

--- a/tonic-xds/src/client/loadbalance/errors.rs
+++ b/tonic-xds/src/client/loadbalance/errors.rs
@@ -17,11 +17,20 @@ pub(crate) enum LbError {
 
     /// Discovery stream produced an error.
     #[error("discovery error: {0}")]
-    Discover(tower::BoxError),
+    DiscoverError(tower::BoxError),
+
+    /// Discovery stream is closed (returned None).
+    #[error("discovery stream is closed")]
+    DiscoverClosed,
 
     /// Internal precondition violation (bug).
     #[error("failed precondition: {0}")]
     FailedPrecondition(&'static str),
+
+    /// Discovery is closed and no endpoints are connecting or ready —
+    /// no progress is possible, fail fast instead of hanging.
+    #[error("load balancer is stagnant: discovery is closed and no endpoints are available")]
+    Stagnation,
 }
 
 impl From<LbError> for tonic::Status {
@@ -31,10 +40,14 @@ impl From<LbError> for tonic::Status {
             LbError::LbChannelPollReadyError(inner) => tonic::Status::unavailable(format!(
                 "error when polling readiness of lb channel: {inner}"
             )),
-            LbError::Discover(source) => {
+            LbError::DiscoverError(source) => {
                 tonic::Status::unavailable(format!("discovery error: {source}"))
             }
+            LbError::DiscoverClosed => tonic::Status::unavailable("discovery stream is closed"),
             LbError::FailedPrecondition(msg) => tonic::Status::failed_precondition(msg),
+            LbError::Stagnation => tonic::Status::unavailable(
+                "load balancer is stagnant: discovery is closed and no endpoints are available",
+            ),
             LbError::LbChannelCallError(source) => match source.downcast::<tonic::Status>() {
                 Ok(status) => *status,
                 Err(source) => tonic::Status::unknown(format!("lb channel error: {source}")),

--- a/tonic-xds/src/client/loadbalance/loadbalancer.rs
+++ b/tonic-xds/src/client/loadbalance/loadbalancer.rs
@@ -514,14 +514,15 @@ mod tests {
         assert_eq!(lb.connecting.len(), 1);
         assert_eq!(lb.ready.len(), 0);
 
-        // Resolve the connection — the connecting waker fires and wakes poll_ready.
-        let c = connector.clone();
-        tokio::spawn(async move { c.resolve_all() });
+        // Resolve the connection synchronously.
+        connector.resolve_all();
 
         // Now ready.len() > 0 → poll_ready returns Ready(Ok(())).
-        futures_util::future::poll_fn(|cx| lb.poll_ready(cx))
-            .await
-            .unwrap();
+        let result = poll_ready_now(&mut lb);
+        assert!(
+            matches!(result, Some(Ok(()))),
+            "expected Ready(Ok(())), got {result:?}"
+        );
         assert_eq!(lb.ready.len(), 1);
     }
 

--- a/tonic-xds/src/client/loadbalance/loadbalancer.rs
+++ b/tonic-xds/src/client/loadbalance/loadbalancer.rs
@@ -7,11 +7,11 @@
 use std::future::Future;
 use std::pin::Pin;
 use std::sync::Arc;
-use std::task::{ready, Context, Poll};
+use std::task::{Context, Poll, ready};
 
 use indexmap::IndexMap;
-use tower::discover::{Change, Discover};
 use tower::Service;
+use tower::discover::{Change, Discover};
 
 use crate::client::endpoint::{Connector, EndpointAddress};
 use crate::client::loadbalance::channel_state::{IdleChannel, ReadyChannel};
@@ -320,9 +320,8 @@ mod tests {
         Arc<MockConnector>,
     ) {
         let connector = Arc::new(MockConnector::new());
-        let picker: Arc<
-            dyn ChannelPicker<ReadyChannel<MockService>, &'static str> + Send + Sync,
-        > = Arc::new(P2cPicker);
+        let picker: Arc<dyn ChannelPicker<ReadyChannel<MockService>, &'static str> + Send + Sync> =
+            Arc::new(P2cPicker);
         let lb = LoadBalancer::new(discover, connector.clone(), picker);
         (lb, connector)
     }

--- a/tonic-xds/src/client/loadbalance/loadbalancer.rs
+++ b/tonic-xds/src/client/loadbalance/loadbalancer.rs
@@ -380,7 +380,7 @@ mod tests {
     #[tokio::test]
     async fn test_discover_remove_cancels_connecting() {
         let (tx, discover) = new_discover();
-        let (mut lb, connector) = make_lb(discover);
+        let (mut lb, _connector) = make_lb(discover);
 
         tx.send(Ok(Change::Insert(addr(8080), IdleChannel::new(addr(8080)))))
             .await

--- a/tonic-xds/src/client/loadbalance/loadbalancer.rs
+++ b/tonic-xds/src/client/loadbalance/loadbalancer.rs
@@ -87,29 +87,28 @@ where
         }
     }
 
-    /// Poll the discovery stream for endpoint changes.
-    /// Returns `Err(LbError::DiscoverClosed)` when the stream is closed (None),
-    /// or `Err(LbError::DiscoverError)` on a discovery error.
-    fn poll_discover(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), LbError>> {
+    /// Drain pending discovery events. Either resolves to an error
+    /// ([`LbError::DiscoverClosed`] or [`LbError::DiscoverError`]) or stays
+    /// pending — there is no success outcome since the loop only exits on
+    /// pending or error.
+    fn poll_discover(&mut self, cx: &mut Context<'_>) -> Poll<LbError> {
         loop {
-            match ready!(Pin::new(&mut self.discovery).poll_discover(cx))
-                .transpose()
-                .map_err(|e| LbError::DiscoverError(e.into()))?
-            {
+            match ready!(Pin::new(&mut self.discovery).poll_discover(cx)) {
                 None => {
                     // tower::discover::Discover::poll_discover() returns Ready(None) when the
                     // discover object is closed, as indicated by Stream trait.
                     tracing::error!("discover object is closed");
-                    return Poll::Ready(Err(LbError::DiscoverClosed));
+                    return Poll::Ready(LbError::DiscoverClosed);
                 }
-                Some(Change::Insert(addr, idle)) => {
+                Some(Err(e)) => return Poll::Ready(LbError::DiscoverError(e.into())),
+                Some(Ok(Change::Insert(addr, idle))) => {
                     tracing::trace!("discovery: insert {addr}");
                     let _ = self.connecting.cancel(&addr);
                     self.ready.swap_remove(&addr);
                     let connecting = idle.connect(self.connector.clone());
                     let _ = self.connecting.add(addr, connecting);
                 }
-                Some(Change::Remove(addr)) => {
+                Some(Ok(Change::Remove(addr))) => {
                     tracing::trace!("discovery: remove {addr}");
                     let _ = self.connecting.cancel(&addr);
                     self.ready.swap_remove(&addr);
@@ -151,17 +150,17 @@ where
 
         // No ready endpoints. Check if we should fail fast.
         match discover_result {
-            Poll::Ready(Err(LbError::DiscoverClosed)) if self.connecting.len() == 0 => {
+            Poll::Ready(LbError::DiscoverClosed) if self.connecting.len() == 0 => {
                 // Discovery is closed and nothing is connecting — no progress is possible.
                 Poll::Ready(Err(LbError::Stagnation))
             }
-            Poll::Ready(Err(e)) => {
+            Poll::Ready(e) => {
                 // Other discovery errors (or DiscoverClosed with connecting in flight)
                 // are non-fatal — log and stay pending.
                 tracing::warn!("discovery yielded error: {e}");
                 Poll::Pending
             }
-            _ => {
+            Poll::Pending => {
                 tracing::trace!(
                     "waiting for connections, inflight={}",
                     self.connecting.len()

--- a/tonic-xds/src/client/loadbalance/loadbalancer.rs
+++ b/tonic-xds/src/client/loadbalance/loadbalancer.rs
@@ -88,13 +88,20 @@ where
     }
 
     /// Poll the discovery stream for endpoint changes.
+    /// Returns `Err(LbError::DiscoverClosed)` when the stream is closed (None),
+    /// or `Err(LbError::DiscoverError)` on a discovery error.
     fn poll_discover(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), LbError>> {
         loop {
             match ready!(Pin::new(&mut self.discovery).poll_discover(cx))
                 .transpose()
-                .map_err(|e| LbError::Discover(e.into()))?
+                .map_err(|e| LbError::DiscoverError(e.into()))?
             {
-                None => return Poll::Ready(Ok(())),
+                None => {
+                    // tower::discover::Discover::poll_discover() returns Ready(None) when the
+                    // discover object is closed, as indicated by Stream trait.
+                    tracing::error!("discover object is closed");
+                    return Poll::Ready(Err(LbError::DiscoverClosed));
+                }
                 Some(Change::Insert(addr, idle)) => {
                     tracing::trace!("discovery: insert {addr}");
                     let _ = self.connecting.cancel(&addr);
@@ -135,19 +142,33 @@ where
     type Future = LbFuture<Self::Response>;
 
     fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
-        // Discovery errors are logged but don't make the LB unready —
-        // we can still serve from already-connected endpoints.
-        if let Poll::Ready(Err(e)) = self.poll_discover(cx) {
-            tracing::warn!("{e}");
-        }
+        let discover_result = self.poll_discover(cx);
         self.poll_connecting(cx);
 
-        if self.ready.is_empty() {
-            // No ready endpoints yet — stay pending until a connection completes.
-            // The waker is already registered by poll_discover / poll_connecting.
-            return Poll::Pending;
+        if !self.ready.is_empty() {
+            return Poll::Ready(Ok(()));
         }
-        Poll::Ready(Ok(()))
+
+        // No ready endpoints. Check if we should fail fast.
+        match discover_result {
+            Poll::Ready(Err(LbError::DiscoverClosed)) if self.connecting.len() == 0 => {
+                // Discovery is closed and nothing is connecting — no progress is possible.
+                Poll::Ready(Err(LbError::Stagnation))
+            }
+            Poll::Ready(Err(e)) => {
+                // Other discovery errors (or DiscoverClosed with connecting in flight)
+                // are non-fatal — log and stay pending.
+                tracing::warn!("discovery yielded error: {e}");
+                Poll::Pending
+            }
+            _ => {
+                tracing::trace!(
+                    "waiting for connections, inflight={}",
+                    self.connecting.len()
+                );
+                Poll::Pending
+            }
+        }
     }
 
     fn call(&mut self, req: Req) -> Self::Future {
@@ -330,7 +351,9 @@ mod tests {
 
     /// Poll poll_ready once synchronously. Returns `Some(Ok(()))` if ready,
     /// `Some(Err(_))` on error, `None` if pending.
-    fn poll_ready_now(lb: &mut Lb) -> Option<Result<(), LbError>> {
+    fn poll_ready_now<L: Service<&'static str, Error = LbError>>(
+        lb: &mut L,
+    ) -> Option<Result<(), LbError>> {
         futures_util::future::poll_fn(|cx| lb.poll_ready(cx)).now_or_never()
     }
 
@@ -469,6 +492,59 @@ mod tests {
         poll_ready_now(&mut lb).unwrap().unwrap();
         assert_eq!(lb.ready.len(), 1);
         assert!(lb.ready.contains_key(&addr(8080)));
+    }
+
+    /// When discovery is closed, poll_ready behaves based on connecting/ready state:
+    /// - ready.len() > 0 → Ready(Ok(()))
+    /// - ready.len() == 0 && connecting.len() == 0 → Pending forever
+    /// - ready.len() == 0 && connecting.len() > 0 → Pending, but wakes when connecting resolves
+    #[tokio::test]
+    async fn test_poll_ready_with_closed_discovery() {
+        let (tx, discover) = new_discover();
+        let (mut lb, connector) = make_lb(discover);
+
+        // Send an Insert and close the discovery stream.
+        tx.send(Ok(Change::Insert(addr(8080), IdleChannel::new(addr(8080)))))
+            .await
+            .unwrap();
+        drop(tx);
+
+        // poll_discover drains the Insert, then sees Ready(None) (closed) → returns Ready(Ok(())).
+        // ready=0, connecting=1 → Pending. Connecting waker is registered.
+        assert!(poll_ready_now(&mut lb).is_none());
+        assert_eq!(lb.connecting.len(), 1);
+        assert_eq!(lb.ready.len(), 0);
+
+        // Resolve the connection — the connecting waker fires and wakes poll_ready.
+        let c = connector.clone();
+        tokio::spawn(async move { c.resolve_all() });
+
+        // Now ready.len() > 0 → poll_ready returns Ready(Ok(())).
+        futures_util::future::poll_fn(|cx| lb.poll_ready(cx))
+            .await
+            .unwrap();
+        assert_eq!(lb.ready.len(), 1);
+    }
+
+    /// When discovery is closed and there are no connecting futures or ready
+    /// endpoints, poll_ready fails fast with Stagnation rather than hanging.
+    #[tokio::test]
+    async fn test_poll_ready_stagnation_when_closed_and_empty() {
+        let (tx, discover) = new_discover();
+        let (mut lb, _connector) = make_lb(discover);
+
+        // Close discovery without sending any Insert.
+        drop(tx);
+
+        // poll_discover returns Err(DiscoverClosed); ready=0 and connecting=0
+        // → poll_ready fails fast with Stagnation.
+        let result = poll_ready_now(&mut lb).unwrap();
+        assert!(
+            matches!(result, Err(LbError::Stagnation)),
+            "expected Stagnation, got {result:?}"
+        );
+        assert_eq!(lb.connecting.len(), 0);
+        assert_eq!(lb.ready.len(), 0);
     }
 
     // -- call() tests --

--- a/tonic-xds/src/client/loadbalance/loadbalancer.rs
+++ b/tonic-xds/src/client/loadbalance/loadbalancer.rs
@@ -1,0 +1,592 @@
+//! Load balancer tower service.
+//!
+//! Receives endpoint updates via [`tower::discover::Discover`] (yielding
+//! [`IdleChannel`]s), manages the connection lifecycle via the channel state
+//! machine, and routes requests to ready endpoints via a [`ChannelPicker`].
+
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::Arc;
+use std::task::{ready, Context, Poll};
+
+use indexmap::IndexMap;
+use tower::discover::{Change, Discover};
+use tower::Service;
+
+use crate::client::endpoint::{Connector, EndpointAddress};
+use crate::client::loadbalance::channel_state::{IdleChannel, ReadyChannel};
+use crate::client::loadbalance::errors::LbError;
+use crate::client::loadbalance::keyed_futures::KeyedFutures;
+use crate::client::loadbalance::pickers::ChannelPicker;
+
+/// Future returned by [`LoadBalancer::call`].
+///
+/// Either resolves immediately with an [`LbError`], or drives `poll_ready` +
+/// `call` on the selected channel asynchronously.
+pub(crate) enum LbFuture<Resp> {
+    Error(Option<LbError>),
+    Pending(Pin<Box<dyn Future<Output = Result<Resp, LbError>> + Send>>),
+}
+
+impl<Resp> Future for LbFuture<Resp> {
+    type Output = Result<Resp, LbError>;
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        match self.get_mut() {
+            LbFuture::Error(error) => match error.take() {
+                Some(e) => Poll::Ready(Err(e)),
+                None => Poll::Ready(Err(LbError::FailedPrecondition(
+                    "LbFuture::Error polled twice",
+                ))),
+            },
+            LbFuture::Pending(fut) => fut.as_mut().poll(cx),
+        }
+    }
+}
+
+/// A load-balancing tower [`Service`] that manages endpoint lifecycle and
+/// distributes requests across ready endpoints.
+///
+/// Type parameters:
+/// - `D`: Discovery stream yielding `Change<EndpointAddress, IdleChannel>`
+/// - `C`: Connector that produces services from endpoint addresses.
+///   `C::Service` is the underlying service type held in ready channels.
+/// - `Req`: The request type.
+pub(crate) struct LoadBalancer<D, C: Connector, Req> {
+    /// Discovery stream providing endpoint additions/removals.
+    discovery: D,
+    /// Connector for creating connections from idle channels.
+    connector: Arc<C>,
+    /// In-flight connection attempts, keyed by endpoint address.
+    connecting: KeyedFutures<EndpointAddress, ReadyChannel<C::Service>>,
+    /// Ready-to-serve channels, keyed by endpoint address.
+    ready: IndexMap<EndpointAddress, ReadyChannel<C::Service>>,
+    /// Channel picker for load balancing.
+    picker: Arc<dyn ChannelPicker<ReadyChannel<C::Service>, Req> + Send + Sync>,
+}
+
+impl<D, C, Req> LoadBalancer<D, C, Req>
+where
+    D: Discover<Key = EndpointAddress, Service = IdleChannel> + Unpin,
+    D::Error: Into<tower::BoxError>,
+    C: Connector + Send + Sync + 'static,
+    C::Service: Send + 'static,
+{
+    /// Create a new load balancer with the given picker.
+    pub(crate) fn new(
+        discovery: D,
+        connector: Arc<C>,
+        picker: Arc<dyn ChannelPicker<ReadyChannel<C::Service>, Req> + Send + Sync>,
+    ) -> Self {
+        Self {
+            discovery,
+            connector,
+            connecting: KeyedFutures::new(),
+            ready: IndexMap::new(),
+            picker,
+        }
+    }
+
+    /// Poll the discovery stream for endpoint changes.
+    fn poll_discover(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), LbError>> {
+        loop {
+            match ready!(Pin::new(&mut self.discovery).poll_discover(cx))
+                .transpose()
+                .map_err(|e| LbError::Discover(e.into()))?
+            {
+                None => return Poll::Ready(Ok(())),
+                Some(Change::Insert(addr, idle)) => {
+                    tracing::trace!("discovery: insert {addr}");
+                    let _ = self.connecting.cancel(&addr);
+                    self.ready.swap_remove(&addr);
+                    let connecting = idle.connect(self.connector.clone());
+                    let _ = self.connecting.add(addr, connecting);
+                }
+                Some(Change::Remove(addr)) => {
+                    tracing::trace!("discovery: remove {addr}");
+                    let _ = self.connecting.cancel(&addr);
+                    self.ready.swap_remove(&addr);
+                }
+            }
+        }
+    }
+
+    /// Drain completed connection futures into the ready set.
+    fn poll_connecting(&mut self, cx: &mut Context<'_>) {
+        while let Poll::Ready(Some((addr, ready))) = self.connecting.poll_next(cx) {
+            self.ready.insert(addr, ready);
+        }
+    }
+}
+
+impl<D, C, Req> Service<Req> for LoadBalancer<D, C, Req>
+where
+    D: Discover<Key = EndpointAddress, Service = IdleChannel> + Unpin,
+    D::Error: Into<tower::BoxError>,
+    C: Connector + Send + Sync + 'static,
+    C::Service: Service<Req> + Clone + Send + 'static,
+    <C::Service as Service<Req>>::Response: Send + 'static,
+    <C::Service as Service<Req>>::Error: Into<tower::BoxError>,
+    <C::Service as Service<Req>>::Future: Send + 'static,
+    Req: Send + 'static,
+{
+    type Response = <C::Service as Service<Req>>::Response;
+    type Error = LbError;
+    type Future = LbFuture<Self::Response>;
+
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        // Discovery errors are logged but don't make the LB unready —
+        // we can still serve from already-connected endpoints.
+        if let Poll::Ready(Err(e)) = self.poll_discover(cx) {
+            tracing::warn!("{e}");
+        }
+        self.poll_connecting(cx);
+
+        if self.ready.is_empty() {
+            // No ready endpoints yet — stay pending until a connection completes.
+            // The waker is already registered by poll_discover / poll_connecting.
+            return Poll::Pending;
+        }
+        Poll::Ready(Ok(()))
+    }
+
+    fn call(&mut self, req: Req) -> Self::Future {
+        // Tower contract: poll_ready must return Ready(Ok(())) before call().
+        // If ready is empty, the caller violated the contract.
+        let Some(idx) = self.picker.pick(&req, &self.ready) else {
+            return LbFuture::Error(Some(LbError::FailedPrecondition(
+                "call() invoked without ready endpoints (poll_ready not called?)",
+            )));
+        };
+        let Some((_, svc)) = self.ready.get_index_mut(idx) else {
+            return LbFuture::Error(Some(LbError::FailedPrecondition(
+                "picker returned invalid index",
+            )));
+        };
+        let mut svc = svc.clone();
+        LbFuture::Pending(Box::pin(async move {
+            tower::ServiceExt::ready(&mut svc)
+                .await
+                .map_err(|e| LbError::LbChannelPollReadyError(e.into()))?;
+            svc.call(req)
+                .await
+                .map_err(|e| LbError::LbChannelCallError(e.into()))
+        }))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::client::endpoint::Connector;
+    use crate::client::loadbalance::pickers::p2c::P2cPicker;
+    use crate::common::async_util::BoxFuture;
+    use futures_util::FutureExt;
+    use std::future;
+    use std::sync::atomic::{AtomicU64, Ordering};
+    use tokio::sync::mpsc;
+    use tower::load::Load;
+
+    // -- Mock service --
+
+    use std::sync::atomic::AtomicBool;
+
+    #[derive(Clone)]
+    struct MockService {
+        load: Arc<AtomicU64>,
+        /// When true, poll_ready returns an error.
+        fail_poll_ready: Arc<AtomicBool>,
+        /// When true, call returns an error.
+        fail_call: Arc<AtomicBool>,
+        /// Tracks how many times call() was invoked.
+        call_count: Arc<AtomicU64>,
+    }
+
+    impl MockService {
+        fn new() -> Self {
+            Self {
+                load: Arc::new(AtomicU64::new(0)),
+                fail_poll_ready: Arc::new(AtomicBool::new(false)),
+                fail_call: Arc::new(AtomicBool::new(false)),
+                call_count: Arc::new(AtomicU64::new(0)),
+            }
+        }
+    }
+
+    impl Service<&'static str> for MockService {
+        type Response = &'static str;
+        type Error = tower::BoxError;
+        type Future = future::Ready<Result<&'static str, tower::BoxError>>;
+
+        fn poll_ready(&mut self, _cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+            if self.fail_poll_ready.load(Ordering::Relaxed) {
+                Poll::Ready(Err("injected poll_ready error".into()))
+            } else {
+                Poll::Ready(Ok(()))
+            }
+        }
+
+        fn call(&mut self, _req: &'static str) -> Self::Future {
+            self.call_count.fetch_add(1, Ordering::Relaxed);
+            if self.fail_call.load(Ordering::Relaxed) {
+                future::ready(Err("injected call error".into()))
+            } else {
+                future::ready(Ok("ok"))
+            }
+        }
+    }
+
+    impl Load for MockService {
+        type Metric = u64;
+        fn load(&self) -> Self::Metric {
+            self.load.load(Ordering::Relaxed)
+        }
+    }
+
+    // -- Mock connector --
+
+    /// A connector that returns a pending future until signaled via oneshot.
+    /// Each `connect()` call stores the sender so tests can control when
+    /// connections complete.
+    use std::collections::HashMap;
+
+    struct MockConnector {
+        senders:
+            std::sync::Mutex<HashMap<EndpointAddress, tokio::sync::oneshot::Sender<MockService>>>,
+        /// Services created by resolve_all, keyed by endpoint address.
+        services: std::sync::Mutex<HashMap<EndpointAddress, MockService>>,
+    }
+
+    impl MockConnector {
+        fn new() -> Self {
+            Self {
+                senders: std::sync::Mutex::new(HashMap::new()),
+                services: std::sync::Mutex::new(HashMap::new()),
+            }
+        }
+
+        /// Complete all pending connections.
+        fn resolve_all(&self) {
+            let senders: HashMap<_, _> = self.senders.lock().unwrap().drain().collect();
+            for (addr, tx) in senders {
+                let svc = MockService::new();
+                self.services.lock().unwrap().insert(addr, svc.clone());
+                let _ = tx.send(svc);
+            }
+        }
+
+        /// Get the service for the given address (created by resolve_all).
+        fn service(&self, addr: &EndpointAddress) -> MockService {
+            self.services.lock().unwrap()[addr].clone()
+        }
+
+        /// Number of pending (unresolved) connections.
+        fn pending_count(&self) -> usize {
+            self.senders.lock().unwrap().len()
+        }
+    }
+
+    impl Connector for MockConnector {
+        type Service = MockService;
+
+        fn connect(&self, addr: &EndpointAddress) -> BoxFuture<Self::Service> {
+            let (tx, rx) = tokio::sync::oneshot::channel();
+            self.senders.lock().unwrap().insert(addr.clone(), tx);
+            Box::pin(async move { rx.await.unwrap() })
+        }
+    }
+
+    // -- Discovery helper --
+
+    type DiscoverItem = Result<Change<EndpointAddress, IdleChannel>, tower::BoxError>;
+
+    /// Tower's `Discover` is sealed, but has a blanket impl for any
+    /// `Stream<Item = Result<Change<K, S>, E>>`. We use `ReceiverStream` directly.
+    type MockDiscover = tokio_stream::wrappers::ReceiverStream<DiscoverItem>;
+
+    fn addr(port: u16) -> EndpointAddress {
+        EndpointAddress::new("127.0.0.1", port)
+    }
+
+    fn new_discover() -> (mpsc::Sender<DiscoverItem>, MockDiscover) {
+        let (tx, rx) = mpsc::channel(16);
+        (tx, tokio_stream::wrappers::ReceiverStream::new(rx))
+    }
+
+    fn make_lb(
+        discover: MockDiscover,
+    ) -> (
+        LoadBalancer<MockDiscover, MockConnector, &'static str>,
+        Arc<MockConnector>,
+    ) {
+        let connector = Arc::new(MockConnector::new());
+        let picker: Arc<
+            dyn ChannelPicker<ReadyChannel<MockService>, &'static str> + Send + Sync,
+        > = Arc::new(P2cPicker);
+        let lb = LoadBalancer::new(discover, connector.clone(), picker);
+        (lb, connector)
+    }
+
+    type Lb = LoadBalancer<MockDiscover, MockConnector, &'static str>;
+
+    /// Poll poll_ready once synchronously. Returns `Some(Ok(()))` if ready,
+    /// `Some(Err(_))` on error, `None` if pending.
+    fn poll_ready_now(lb: &mut Lb) -> Option<Result<(), LbError>> {
+        futures_util::future::poll_fn(|cx| lb.poll_ready(cx)).now_or_never()
+    }
+
+    /// Drive poll_ready until the LB has ready endpoints.
+    async fn drive_to_ready(lb: &mut Lb, connector: &Arc<MockConnector>) {
+        let c = connector.clone();
+        tokio::spawn(async move { c.resolve_all() });
+        futures_util::future::poll_fn(|cx| lb.poll_ready(cx))
+            .await
+            .unwrap();
+    }
+
+    // -- poll_discover tests --
+
+    #[tokio::test]
+    async fn test_discover_insert_starts_connecting() {
+        let (tx, discover) = new_discover();
+        let (mut lb, connector) = make_lb(discover);
+
+        tx.send(Ok(Change::Insert(addr(8080), IdleChannel::new(addr(8080)))))
+            .await
+            .unwrap();
+
+        // Discovers insert, starts connecting, returns Pending (no ready yet).
+        assert!(poll_ready_now(&mut lb).is_none());
+        assert_eq!(connector.pending_count(), 1);
+        assert_eq!(lb.ready.len(), 0);
+    }
+
+    #[tokio::test]
+    async fn test_discover_insert_then_resolves_to_ready() {
+        let (tx, discover) = new_discover();
+        let (mut lb, connector) = make_lb(discover);
+
+        tx.send(Ok(Change::Insert(addr(8080), IdleChannel::new(addr(8080)))))
+            .await
+            .unwrap();
+
+        assert!(poll_ready_now(&mut lb).is_none());
+        assert_eq!(connector.pending_count(), 1);
+
+        drive_to_ready(&mut lb, &connector).await;
+        assert_eq!(lb.ready.len(), 1);
+        assert!(lb.ready.contains_key(&addr(8080)));
+    }
+
+    #[tokio::test]
+    async fn test_discover_remove_cancels_connecting() {
+        let (tx, discover) = new_discover();
+        let (mut lb, connector) = make_lb(discover);
+
+        tx.send(Ok(Change::Insert(addr(8080), IdleChannel::new(addr(8080)))))
+            .await
+            .unwrap();
+        tx.send(Ok(Change::Remove(addr(8080)))).await.unwrap();
+
+        // Both processed in one poll — insert then remove cancels the connecting.
+        assert!(poll_ready_now(&mut lb).is_none());
+        assert_eq!(lb.ready.len(), 0);
+        assert_eq!(lb.connecting.len(), 0);
+    }
+
+    #[tokio::test]
+    async fn test_discover_remove_evicts_ready() {
+        let (tx, discover) = new_discover();
+        let (mut lb, connector) = make_lb(discover);
+
+        tx.send(Ok(Change::Insert(addr(8080), IdleChannel::new(addr(8080)))))
+            .await
+            .unwrap();
+        drive_to_ready(&mut lb, &connector).await;
+        assert_eq!(lb.ready.len(), 1);
+
+        tx.send(Ok(Change::Remove(addr(8080)))).await.unwrap();
+        // After remove, ready is empty → Pending.
+        assert!(poll_ready_now(&mut lb).is_none());
+        assert_eq!(lb.ready.len(), 0);
+    }
+
+    #[tokio::test]
+    async fn test_discover_replace_endpoint() {
+        let (tx, discover) = new_discover();
+        let (mut lb, connector) = make_lb(discover);
+
+        tx.send(Ok(Change::Insert(addr(8080), IdleChannel::new(addr(8080)))))
+            .await
+            .unwrap();
+        drive_to_ready(&mut lb, &connector).await;
+        assert_eq!(lb.ready.len(), 1);
+
+        // Re-insert same address — old ready evicted, new one connecting.
+        tx.send(Ok(Change::Insert(addr(8080), IdleChannel::new(addr(8080)))))
+            .await
+            .unwrap();
+        assert!(poll_ready_now(&mut lb).is_none());
+        assert_eq!(lb.ready.len(), 0);
+        assert_eq!(connector.pending_count(), 1);
+
+        drive_to_ready(&mut lb, &connector).await;
+        assert_eq!(lb.ready.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn test_discover_multiple_endpoints() {
+        let (tx, discover) = new_discover();
+        let (mut lb, connector) = make_lb(discover);
+
+        for port in 8080..8083 {
+            tx.send(Ok(Change::Insert(addr(port), IdleChannel::new(addr(port)))))
+                .await
+                .unwrap();
+        }
+
+        assert!(poll_ready_now(&mut lb).is_none());
+        assert_eq!(connector.pending_count(), 3);
+        assert_eq!(lb.ready.len(), 0);
+
+        drive_to_ready(&mut lb, &connector).await;
+        assert_eq!(lb.ready.len(), 3);
+    }
+
+    #[tokio::test]
+    async fn test_discover_remove_nonexistent_is_defensive() {
+        let (tx, discover) = new_discover();
+        let (mut lb, connector) = make_lb(discover);
+
+        tx.send(Ok(Change::Insert(addr(8080), IdleChannel::new(addr(8080)))))
+            .await
+            .unwrap();
+        drive_to_ready(&mut lb, &connector).await;
+        assert_eq!(lb.ready.len(), 1);
+
+        // Remove an address that was never added — should not crash or affect existing.
+        tx.send(Ok(Change::Remove(addr(9999)))).await.unwrap();
+        // Still has one ready endpoint → Ready.
+        poll_ready_now(&mut lb).unwrap().unwrap();
+        assert_eq!(lb.ready.len(), 1);
+        assert!(lb.ready.contains_key(&addr(8080)));
+    }
+
+    // -- call() tests --
+
+    #[tokio::test]
+    async fn test_call_no_endpoints_returns_failed_precondition() {
+        let (_tx, discover) = new_discover();
+        let (mut lb, _connector) = make_lb(discover);
+
+        // poll_ready returns Pending — calling anyway violates tower contract.
+        assert!(poll_ready_now(&mut lb).is_none());
+
+        let result = lb.call("hello").await;
+        assert!(
+            matches!(result, Err(LbError::FailedPrecondition(_))),
+            "expected FailedPrecondition, got {result:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_call_success() {
+        let (tx, discover) = new_discover();
+        let (mut lb, connector) = make_lb(discover);
+
+        tx.send(Ok(Change::Insert(addr(8080), IdleChannel::new(addr(8080)))))
+            .await
+            .unwrap();
+        drive_to_ready(&mut lb, &connector).await;
+
+        let result = lb.call("hello").await;
+        assert_eq!(result.unwrap(), "ok");
+    }
+
+    #[tokio::test]
+    async fn test_call_distributes_across_endpoints() {
+        let (tx, discover) = new_discover();
+        let (mut lb, connector) = make_lb(discover);
+
+        let ports: Vec<u16> = (8080..8085).collect();
+        for &port in &ports {
+            tx.send(Ok(Change::Insert(addr(port), IdleChannel::new(addr(port)))))
+                .await
+                .unwrap();
+        }
+        drive_to_ready(&mut lb, &connector).await;
+        assert_eq!(lb.ready.len(), 5);
+
+        let num_requests = 1000;
+        for _ in 0..num_requests {
+            assert_eq!(lb.call("hello").await.unwrap(), "ok");
+        }
+
+        // Check all endpoints were called.
+        let mut total = 0u64;
+        for &port in &ports {
+            let svc = connector.service(&addr(port));
+            let count = svc.call_count.load(Ordering::Relaxed);
+            assert!(count > 0, "endpoint {port} was never called");
+            total += count;
+        }
+        assert_eq!(total, num_requests);
+
+        // Check distribution is reasonably balanced (within 3x of uniform).
+        let expected = num_requests / ports.len() as u64;
+        for &port in &ports {
+            let svc = connector.service(&addr(port));
+            let count = svc.call_count.load(Ordering::Relaxed);
+            assert!(
+                count >= expected / 3 && count <= expected * 3,
+                "endpoint {port} got {count} calls, expected ~{expected}"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn test_call_channel_poll_ready_error() {
+        let (tx, discover) = new_discover();
+        let (mut lb, connector) = make_lb(discover);
+
+        tx.send(Ok(Change::Insert(addr(8080), IdleChannel::new(addr(8080)))))
+            .await
+            .unwrap();
+        drive_to_ready(&mut lb, &connector).await;
+
+        // Inject poll_ready failure.
+        connector
+            .service(&addr(8080))
+            .fail_poll_ready
+            .store(true, Ordering::Relaxed);
+
+        let result = lb.call("hello").await;
+        assert!(
+            matches!(result, Err(LbError::LbChannelPollReadyError(_))),
+            "expected LbChannelPollReadyError, got {result:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_call_channel_call_error() {
+        let (tx, discover) = new_discover();
+        let (mut lb, connector) = make_lb(discover);
+
+        tx.send(Ok(Change::Insert(addr(8080), IdleChannel::new(addr(8080)))))
+            .await
+            .unwrap();
+        drive_to_ready(&mut lb, &connector).await;
+
+        // Inject call failure.
+        connector
+            .service(&addr(8080))
+            .fail_call
+            .store(true, Ordering::Relaxed);
+
+        let result = lb.call("hello").await;
+        assert!(
+            matches!(result, Err(LbError::LbChannelCallError(_))),
+            "expected LbChannelCallError, got {result:?}"
+        );
+    }
+}

--- a/tonic-xds/src/client/loadbalance/loadbalancer.rs
+++ b/tonic-xds/src/client/loadbalance/loadbalancer.rs
@@ -171,19 +171,12 @@ where
     }
 
     fn call(&mut self, req: Req) -> Self::Future {
-        // Tower contract: poll_ready must return Ready(Ok(())) before call().
-        // If ready is empty, the caller violated the contract.
-        let Some(idx) = self.picker.pick(&req, &self.ready) else {
-            return LbFuture::Error(Some(LbError::FailedPrecondition(
-                "call() invoked without ready endpoints (poll_ready not called?)",
-            )));
+        let Some(picked) = self.picker.pick(&req, &self.ready) else {
+            return LbFuture::Error(Some(LbError::Unavailable));
         };
-        let Some((_, svc)) = self.ready.get_index_mut(idx) else {
-            return LbFuture::Error(Some(LbError::FailedPrecondition(
-                "picker returned invalid index",
-            )));
-        };
-        let mut svc = svc.clone();
+        // `picked` is a read-only borrow into `self.ready`. Clone to get an
+        // owned service we can drive in the async block.
+        let mut svc = picked.clone();
         LbFuture::Pending(Box::pin(async move {
             tower::ServiceExt::ready(&mut svc)
                 .await
@@ -550,17 +543,18 @@ mod tests {
     // -- call() tests --
 
     #[tokio::test]
-    async fn test_call_no_endpoints_returns_failed_precondition() {
+    async fn test_call_no_endpoints_returns_unavailable() {
         let (_tx, discover) = new_discover();
         let (mut lb, _connector) = make_lb(discover);
 
-        // poll_ready returns Pending — calling anyway violates tower contract.
+        // poll_ready returns Pending — calling anyway violates tower contract,
+        // but the picker returns None so call returns Unavailable.
         assert!(poll_ready_now(&mut lb).is_none());
 
         let result = lb.call("hello").await;
         assert!(
-            matches!(result, Err(LbError::FailedPrecondition(_))),
-            "expected FailedPrecondition, got {result:?}"
+            matches!(result, Err(LbError::Unavailable)),
+            "expected Unavailable, got {result:?}"
         );
     }
 

--- a/tonic-xds/src/client/loadbalance/mod.rs
+++ b/tonic-xds/src/client/loadbalance/mod.rs
@@ -1,3 +1,6 @@
 pub(crate) mod channel;
 pub(crate) mod channel_state;
+pub(crate) mod errors;
 pub(crate) mod keyed_futures;
+pub(crate) mod loadbalancer;
+pub(crate) mod pickers;

--- a/tonic-xds/src/client/loadbalance/pickers/mod.rs
+++ b/tonic-xds/src/client/loadbalance/pickers/mod.rs
@@ -10,5 +10,5 @@ use crate::client::endpoint::EndpointAddress;
 /// The picker only needs to observe `S`'s load — it doesn't depend on any
 /// specific channel state type.
 pub(crate) trait ChannelPicker<S, Req> {
-    fn pick(&self, req: &Req, ready: &IndexMap<EndpointAddress, S>) -> Option<usize>;
+    fn pick<'a>(&self, req: &Req, ready: &'a IndexMap<EndpointAddress, S>) -> Option<&'a S>;
 }

--- a/tonic-xds/src/client/loadbalance/pickers/mod.rs
+++ b/tonic-xds/src/client/loadbalance/pickers/mod.rs
@@ -10,9 +10,5 @@ use crate::client::endpoint::EndpointAddress;
 /// The picker only needs to observe `S`'s load — it doesn't depend on any
 /// specific channel state type.
 pub(crate) trait ChannelPicker<S, Req> {
-    fn pick(
-        &self,
-        req: &Req,
-        ready: &IndexMap<EndpointAddress, S>,
-    ) -> Option<usize>;
+    fn pick(&self, req: &Req, ready: &IndexMap<EndpointAddress, S>) -> Option<usize>;
 }

--- a/tonic-xds/src/client/loadbalance/pickers/mod.rs
+++ b/tonic-xds/src/client/loadbalance/pickers/mod.rs
@@ -1,0 +1,18 @@
+pub(crate) mod p2c;
+
+use indexmap::IndexMap;
+
+use crate::client::endpoint::EndpointAddress;
+
+/// Trait for selecting a channel to handle a request.
+///
+/// Generic over `S` (the channel type in the ready set) and `Req` (the request).
+/// The picker only needs to observe `S`'s load — it doesn't depend on any
+/// specific channel state type.
+pub(crate) trait ChannelPicker<S, Req> {
+    fn pick(
+        &self,
+        req: &Req,
+        ready: &IndexMap<EndpointAddress, S>,
+    ) -> Option<usize>;
+}

--- a/tonic-xds/src/client/loadbalance/pickers/p2c.rs
+++ b/tonic-xds/src/client/loadbalance/pickers/p2c.rs
@@ -1,0 +1,139 @@
+//! Power-of-two-choices (P2C) channel picker.
+
+use indexmap::IndexMap;
+use tower::load::Load;
+
+use crate::client::endpoint::EndpointAddress;
+use crate::client::loadbalance::pickers::ChannelPicker;
+
+/// Pick two distinct random indices from `[0, length)` using Floyd's algorithm.
+fn sample_floyd2(length: usize) -> [usize; 2] {
+    debug_assert!(length >= 2);
+    let a = fastrand::usize(..length - 1);
+    let b = fastrand::usize(..length);
+    let a = if a == b { length - 1 } else { a };
+    [a, b]
+}
+
+/// Picks the least-loaded of two randomly chosen endpoints.
+pub(crate) struct P2cPicker;
+
+impl<S, Req> ChannelPicker<S, Req> for P2cPicker
+where
+    S: Load,
+    S::Metric: PartialOrd,
+{
+    fn pick(
+        &self,
+        _req: &Req,
+        ready: &IndexMap<EndpointAddress, S>,
+    ) -> Option<usize> {
+        let len = ready.len();
+        match len {
+            0 => None,
+            1 => Some(0),
+            _ => {
+                let [a, b] = sample_floyd2(len);
+                let (_, ch_a) = ready.get_index(a)?;
+                let (_, ch_b) = ready.get_index(b)?;
+                if ch_a.load() <= ch_b.load() {
+                    Some(a)
+                } else {
+                    Some(b)
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::{AtomicU64, Ordering};
+
+    /// A minimal Load impl for testing. Stores a fixed load value.
+    struct MockChannel {
+        load: AtomicU64,
+    }
+
+    impl MockChannel {
+        fn new(load: u64) -> Self {
+            Self {
+                load: AtomicU64::new(load),
+            }
+        }
+    }
+
+    impl Load for MockChannel {
+        type Metric = u64;
+        fn load(&self) -> Self::Metric {
+            self.load.load(Ordering::Relaxed)
+        }
+    }
+
+    fn addr(port: u16) -> EndpointAddress {
+        EndpointAddress::new("127.0.0.1", port)
+    }
+
+    #[test]
+    fn test_pick_empty_returns_none() {
+        let ready: IndexMap<EndpointAddress, MockChannel> = IndexMap::new();
+        assert_eq!(P2cPicker.pick(&(), &ready), None);
+    }
+
+    #[test]
+    fn test_pick_single_returns_zero() {
+        let mut ready = IndexMap::new();
+        ready.insert(addr(8080), MockChannel::new(0));
+        assert_eq!(P2cPicker.pick(&(), &ready), Some(0));
+    }
+
+    #[test]
+    fn test_pick_two_prefers_lower_load() {
+        let mut ready = IndexMap::new();
+        ready.insert(addr(8080), MockChannel::new(100));
+        ready.insert(addr(8081), MockChannel::new(0));
+
+        // With only 2 endpoints, P2C always compares both.
+        // The one with load=0 should always be picked.
+        for _ in 0..100 {
+            let idx = P2cPicker.pick(&(), &ready).unwrap();
+            let (_, ch) = ready.get_index(idx).unwrap();
+            assert_eq!(ch.load(), 0, "should always pick the lower-loaded endpoint");
+        }
+    }
+
+    #[test]
+    fn test_pick_equal_load_returns_valid_index() {
+        let mut ready = IndexMap::new();
+        ready.insert(addr(8080), MockChannel::new(5));
+        ready.insert(addr(8081), MockChannel::new(5));
+        ready.insert(addr(8082), MockChannel::new(5));
+
+        for _ in 0..100 {
+            let idx = P2cPicker.pick(&(), &ready).unwrap();
+            assert!(idx < ready.len());
+        }
+    }
+
+    #[test]
+    fn test_pick_many_endpoints_distributes() {
+        let mut ready = IndexMap::new();
+        for port in 8080..8090 {
+            ready.insert(addr(port), MockChannel::new(0));
+        }
+
+        let mut seen = std::collections::HashSet::new();
+        for _ in 0..1000 {
+            let idx = P2cPicker.pick(&(), &ready).unwrap();
+            assert!(idx < ready.len());
+            seen.insert(idx);
+        }
+        // With 10 endpoints and 1000 picks, we should hit most of them.
+        assert!(
+            seen.len() >= 8,
+            "expected to hit most endpoints, only hit {}",
+            seen.len()
+        );
+    }
+}

--- a/tonic-xds/src/client/loadbalance/pickers/p2c.rs
+++ b/tonic-xds/src/client/loadbalance/pickers/p2c.rs
@@ -23,11 +23,7 @@ where
     S: Load,
     S::Metric: PartialOrd,
 {
-    fn pick(
-        &self,
-        _req: &Req,
-        ready: &IndexMap<EndpointAddress, S>,
-    ) -> Option<usize> {
+    fn pick(&self, _req: &Req, ready: &IndexMap<EndpointAddress, S>) -> Option<usize> {
         let len = ready.len();
         match len {
             0 => None,

--- a/tonic-xds/src/client/loadbalance/pickers/p2c.rs
+++ b/tonic-xds/src/client/loadbalance/pickers/p2c.rs
@@ -23,19 +23,19 @@ where
     S: Load,
     S::Metric: PartialOrd,
 {
-    fn pick(&self, _req: &Req, ready: &IndexMap<EndpointAddress, S>) -> Option<usize> {
+    fn pick<'a>(&self, _req: &Req, ready: &'a IndexMap<EndpointAddress, S>) -> Option<&'a S> {
         let len = ready.len();
         match len {
             0 => None,
-            1 => Some(0),
+            1 => ready.get_index(0).map(|(_, s)| s),
             _ => {
                 let [a, b] = sample_floyd2(len);
                 let (_, ch_a) = ready.get_index(a)?;
                 let (_, ch_b) = ready.get_index(b)?;
                 if ch_a.load() <= ch_b.load() {
-                    Some(a)
+                    Some(ch_a)
                 } else {
-                    Some(b)
+                    Some(ch_b)
                 }
             }
         }
@@ -74,14 +74,16 @@ mod tests {
     #[test]
     fn test_pick_empty_returns_none() {
         let ready: IndexMap<EndpointAddress, MockChannel> = IndexMap::new();
-        assert_eq!(P2cPicker.pick(&(), &ready), None);
+        assert!(P2cPicker.pick(&(), &ready).is_none());
     }
 
     #[test]
-    fn test_pick_single_returns_zero() {
+    fn test_pick_single_returns_only_endpoint() {
         let mut ready = IndexMap::new();
-        ready.insert(addr(8080), MockChannel::new(0));
-        assert_eq!(P2cPicker.pick(&(), &ready), Some(0));
+        ready.insert(addr(8080), MockChannel::new(42));
+
+        let picked = P2cPicker.pick(&(), &ready).unwrap();
+        assert_eq!(picked.load(), 42);
     }
 
     #[test]
@@ -91,24 +93,26 @@ mod tests {
         ready.insert(addr(8081), MockChannel::new(0));
 
         // With only 2 endpoints, P2C always compares both.
-        // The one with load=0 should always be picked.
         for _ in 0..100 {
-            let idx = P2cPicker.pick(&(), &ready).unwrap();
-            let (_, ch) = ready.get_index(idx).unwrap();
-            assert_eq!(ch.load(), 0, "should always pick the lower-loaded endpoint");
+            let picked = P2cPicker.pick(&(), &ready).unwrap();
+            assert_eq!(
+                picked.load(),
+                0,
+                "should always pick the lower-loaded endpoint"
+            );
         }
     }
 
     #[test]
-    fn test_pick_equal_load_returns_valid_index() {
+    fn test_pick_equal_load_returns_some() {
         let mut ready = IndexMap::new();
         ready.insert(addr(8080), MockChannel::new(5));
         ready.insert(addr(8081), MockChannel::new(5));
         ready.insert(addr(8082), MockChannel::new(5));
 
         for _ in 0..100 {
-            let idx = P2cPicker.pick(&(), &ready).unwrap();
-            assert!(idx < ready.len());
+            let picked = P2cPicker.pick(&(), &ready).unwrap();
+            assert_eq!(picked.load(), 5);
         }
     }
 
@@ -116,14 +120,14 @@ mod tests {
     fn test_pick_many_endpoints_distributes() {
         let mut ready = IndexMap::new();
         for port in 8080..8090 {
-            ready.insert(addr(port), MockChannel::new(0));
+            // Encode the port in the load so we can identify which one was picked.
+            ready.insert(addr(port), MockChannel::new(port as u64));
         }
 
         let mut seen = std::collections::HashSet::new();
         for _ in 0..1000 {
-            let idx = P2cPicker.pick(&(), &ready).unwrap();
-            assert!(idx < ready.len());
-            seen.insert(idx);
+            let picked = P2cPicker.pick(&(), &ready).unwrap();
+            seen.insert(picked.load());
         }
         // With 10 endpoints and 1000 picks, we should hit most of them.
         assert!(


### PR DESCRIPTION
Add load balancer tower service that's extensive to support outlier detection and customized channel pickers.

Issue: https://github.com/hyperium/tonic/issues/2444

## Motivation
tonic-xds currently uses tower::balance, which is hard-coded to using P2C LB algorithm. For xDS, we need more flexibility and need full control over the underlying channels so that we can implement customized LB, outlier detection, etc.


## Solution
Leverage the channel states (Idle, Connecting and Ready for now), build a new LoadBalance tower service whose poll_ready() handles channel state transitions and call() handles load balance picking algorithm.

Also, added a simple ChannelPicker trait to abstract channel picking algorithm. In the future, customized LB can implement this trait and tonic-xds will provide a way to register customized LB and make it available for LoadBalance layer.

