### PR TITLE
feat(transport/channel): expose ServerCertVerifier hook on ClientTlsConfig

### DIFF
--- a/tonic/Cargo.toml
+++ b/tonic/Cargo.toml
@@ -128,6 +128,7 @@ allowed_external_types = [
   "axum::routing::Router",
   "futures_core::stream::Stream",
   "h2::error::Error",
+  "rustls::client::danger::ServerCertVerifier",
   "tower_service::Service",
   "tower_layer::Layer",
   "tower_layer::stack::Stack",

--- a/tonic/Cargo.toml
+++ b/tonic/Cargo.toml
@@ -128,7 +128,7 @@ allowed_external_types = [
   "axum::routing::Router",
   "futures_core::stream::Stream",
   "h2::error::Error",
-  "rustls::client::danger::ServerCertVerifier",
+  "rustls::verify::ServerCertVerifier",
   "tower_service::Service",
   "tower_layer::Layer",
   "tower_layer::stack::Stack",

--- a/tonic/src/transport/channel/service/tls.rs
+++ b/tonic/src/transport/channel/service/tls.rs
@@ -7,7 +7,9 @@ use tokio::time;
 use tokio_rustls::{
     TlsConnector as RustlsConnector,
     rustls::{
-        ClientConfig, ConfigBuilder, RootCertStore, WantsVerifier, crypto,
+        ClientConfig, ConfigBuilder, RootCertStore, WantsVerifier,
+        client::danger::ServerCertVerifier,
+        crypto,
         pki_types::{ServerName, TrustAnchor},
     },
 };
@@ -32,6 +34,7 @@ impl TlsConnector {
         ca_certs: Vec<Certificate>,
         trust_anchors: Vec<TrustAnchor<'static>>,
         identity: Option<Identity>,
+        server_cert_verifier: Option<Arc<dyn ServerCertVerifier>>,
         domain: &str,
         assume_http2: bool,
         use_key_log: bool,
@@ -58,31 +61,61 @@ impl TlsConnector {
             _ => ClientConfig::builder(),
         };
 
-        let mut roots = RootCertStore::from_iter(trust_anchors);
+        let builder = match server_cert_verifier {
+            Some(verifier) => {
+                // A custom verifier replaces the default WebPKI verifier and
+                // its root-store config — the two are mutually exclusive.
+                #[cfg(feature = "tls-native-roots")]
+                let conflicts_native_roots = with_native_roots;
+                #[cfg(not(feature = "tls-native-roots"))]
+                let conflicts_native_roots = false;
 
-        #[cfg(feature = "tls-native-roots")]
-        if with_native_roots {
-            let rustls_native_certs::CertificateResult { certs, errors, .. } =
-                rustls_native_certs::load_native_certs();
-            if !errors.is_empty() {
-                tracing::debug!("errors occurred when loading native certs: {errors:?}");
+                #[cfg(feature = "tls-webpki-roots")]
+                let conflicts_webpki_roots = with_webpki_roots;
+                #[cfg(not(feature = "tls-webpki-roots"))]
+                let conflicts_webpki_roots = false;
+
+                if !ca_certs.is_empty()
+                    || !trust_anchors.is_empty()
+                    || conflicts_native_roots
+                    || conflicts_webpki_roots
+                {
+                    return Err(TlsError::VerifierConflict.into());
+                }
+
+                builder
+                    .dangerous()
+                    .with_custom_certificate_verifier(verifier)
             }
-            if certs.is_empty() {
-                return Err(TlsError::NativeCertsNotFound.into());
+            None => {
+                let mut roots = RootCertStore::from_iter(trust_anchors);
+
+                #[cfg(feature = "tls-native-roots")]
+                if with_native_roots {
+                    let rustls_native_certs::CertificateResult { certs, errors, .. } =
+                        rustls_native_certs::load_native_certs();
+                    if !errors.is_empty() {
+                        tracing::debug!("errors occurred when loading native certs: {errors:?}");
+                    }
+                    if certs.is_empty() {
+                        return Err(TlsError::NativeCertsNotFound.into());
+                    }
+                    roots.add_parsable_certificates(certs);
+                }
+
+                #[cfg(feature = "tls-webpki-roots")]
+                if with_webpki_roots {
+                    roots.extend(webpki_roots::TLS_SERVER_ROOTS.iter().cloned());
+                }
+
+                for cert in ca_certs {
+                    roots.add_parsable_certificates(convert_certificate_to_pki_types(&cert)?);
+                }
+
+                builder.with_root_certificates(roots)
             }
-            roots.add_parsable_certificates(certs);
-        }
+        };
 
-        #[cfg(feature = "tls-webpki-roots")]
-        if with_webpki_roots {
-            roots.extend(webpki_roots::TLS_SERVER_ROOTS.iter().cloned());
-        }
-
-        for cert in ca_certs {
-            roots.add_parsable_certificates(convert_certificate_to_pki_types(&cert)?);
-        }
-
-        let builder = builder.with_root_certificates(roots);
         let mut config = match identity {
             Some(identity) => {
                 let (client_cert, client_key) = convert_identity_to_pki_types(&identity)?;

--- a/tonic/src/transport/channel/tls.rs
+++ b/tonic/src/transport/channel/tls.rs
@@ -4,7 +4,9 @@ use crate::transport::{
     tls::{Certificate, Identity},
 };
 use http::Uri;
+use std::sync::Arc;
 use std::time::Duration;
+use tokio_rustls::rustls::client::danger::ServerCertVerifier;
 use tokio_rustls::rustls::pki_types::TrustAnchor;
 
 /// Configures TLS settings for endpoints.
@@ -21,6 +23,7 @@ pub struct ClientTlsConfig {
     with_webpki_roots: bool,
     use_key_log: bool,
     timeout: Option<Duration>,
+    server_cert_verifier: Option<Arc<dyn ServerCertVerifier>>,
 }
 
 impl ClientTlsConfig {
@@ -133,6 +136,32 @@ impl ClientTlsConfig {
         }
     }
 
+    /// Replaces the default WebPKI server certificate verifier with a custom
+    /// implementation.
+    ///
+    /// **Warning:** A misconfigured verifier can silently disable peer
+    /// validation. Only use this if you understand rustls' verifier contract.
+    ///
+    /// Cannot be combined with [`ca_certificate`](Self::ca_certificate),
+    /// [`ca_certificates`](Self::ca_certificates),
+    /// [`trust_anchor`](Self::trust_anchor),
+    /// [`trust_anchors`](Self::trust_anchors),
+    /// `with_native_roots`, `with_webpki_roots`, or
+    /// [`with_enabled_roots`](Self::with_enabled_roots) — those configure the
+    /// default verifier, which is replaced when a custom one is set. Mixing
+    /// produces an error at connector-construction time.
+    ///
+    /// SNI ([`domain_name`](Self::domain_name)), client identity
+    /// ([`identity`](Self::identity)), [`timeout`](Self::timeout),
+    /// [`use_key_log`](Self::use_key_log), and
+    /// [`assume_http2`](Self::assume_http2) continue to apply.
+    pub fn server_cert_verifier(self, verifier: Arc<dyn ServerCertVerifier>) -> Self {
+        ClientTlsConfig {
+            server_cert_verifier: Some(verifier),
+            ..self
+        }
+    }
+
     pub(crate) fn into_tls_connector(self, uri: &Uri) -> Result<TlsConnector, crate::BoxError> {
         let domain = match &self.domain {
             Some(domain) => domain,
@@ -142,6 +171,7 @@ impl ClientTlsConfig {
             self.certs,
             self.trust_anchors,
             self.identity,
+            self.server_cert_verifier,
             domain,
             self.assume_http2,
             self.use_key_log,

--- a/tonic/src/transport/service/tls.rs
+++ b/tonic/src/transport/service/tls.rs
@@ -16,6 +16,8 @@ pub(crate) enum TlsError {
     CertificateParseError,
     PrivateKeyParseError,
     HandshakeTimeout,
+    #[cfg(feature = "channel")]
+    VerifierConflict,
 }
 
 impl fmt::Display for TlsError {
@@ -31,6 +33,13 @@ impl fmt::Display for TlsError {
                 "Error parsing TLS private key - no RSA or PKCS8-encoded keys found."
             ),
             TlsError::HandshakeTimeout => write!(f, "TLS handshake timeout."),
+            #[cfg(feature = "channel")]
+            TlsError::VerifierConflict => write!(
+                f,
+                "ClientTlsConfig::server_cert_verifier cannot be combined with \
+                 ca_certificate(s), trust_anchor(s), or with_*_roots methods — those \
+                 configure the default verifier, which is replaced by the custom one."
+            ),
         }
     }
 }


### PR DESCRIPTION
## Motivation

Ref: #2444

`tonic::transport::ClientTlsConfig` currently builds the `rustls::ClientConfig` internally with the default `WebPkiServerVerifier`. There's no way to inject a custom `ServerCertVerifier` without abandoning `ClientTlsConfig` and going through `Endpoint::connect_with_connector_lazy`, which means reimplementing TCP + TLS handshake + ALPN enforcement + timeout handling that tonic already provides correctly.

This blocks gRFC A29 (xDS-Based TLS Security) SAN matching feature which we are adding to `tonic-xds`.

## Solution

Adds `ClientTlsConfig::server_cert_verifier(Arc<dyn ServerCertVerifier>)`. When set, `TlsConnector::new` builds the `ClientConfig` via `.dangerous().with_custom_certificate_verifier(...)` instead of the default root-store path. SNI, ALPN, timeout, identity, and key-log continue to apply.

### Design Highlight

Conflict detection: combining a custom verifier with `ca_certificate`, `ca_certificates`, `trust_anchor`, `trust_anchors`, `with_*_roots` returns `TlsError::VerifierConflict` at connector-construction time. A custom verifier replaces the entire default-verifier path including its trust roots, so the CA-configuration methods would be silently ignored. We chose to emit an explicit error to help prevent such footguns. Users who want both standard WebPKI behavior and additional checks can compose `WebPkiServerVerifier` inside their custom verifier with their own root store (as is planned for `tonic-xds` A29 implementation)