### PR TITLE
feat(grpc): Rename Rustls credentials

### DIFF
--- a/grpc/src/client/transport/tonic/test.rs
+++ b/grpc/src/client/transport/tonic/test.rs
@@ -75,7 +75,7 @@ use crate::credentials::common::Authority;
 use crate::credentials::rustls::RootCertificates;
 use crate::credentials::rustls::StaticProvider;
 use crate::credentials::rustls::client::ClientTlsConfig;
-use crate::credentials::rustls::client::RustlsClientTlsCredendials;
+use crate::credentials::rustls::client::RustlsChannelCredendials;
 use crate::echo_pb::EchoRequest;
 use crate::echo_pb::EchoResponse;
 use crate::echo_pb::echo_server::Echo;
@@ -437,7 +437,7 @@ async fn grpc_invoke_tonic_unary_tls() {
     let root_certs = RootCertificates::from_pem(ca_cert);
     let root_provider = StaticProvider::new(root_certs);
     let config = ClientTlsConfig::new().with_root_certificates_provider(root_provider);
-    let creds = RustlsClientTlsCredendials::new(config).unwrap();
+    let creds = RustlsChannelCredendials::new(config).unwrap();
     let call_creds = Arc::new(MockCallCredentials {
         metadata: vec![("x-test-metadata", "test-value")],
         min_security_level: SecurityLevel::PrivacyAndIntegrity,

--- a/grpc/src/credentials/rustls/client/mod.rs
+++ b/grpc/src/credentials/rustls/client/mod.rs
@@ -121,15 +121,16 @@ impl Default for ClientTlsConfig {
     }
 }
 
+/// TLS channel credentials based on Rustls.
 #[derive(Clone)]
-pub struct RustlsClientTlsCredendials {
+pub struct RustlsChannelCredendials {
     connector: TlsConnector,
 }
 
-impl RustlsClientTlsCredendials {
+impl RustlsChannelCredendials {
     /// Constructs a new `ClientTlsCredendials` instance from the provided
     /// configuration.
-    pub fn new(config: ClientTlsConfig) -> Result<RustlsClientTlsCredendials, String> {
+    pub fn new(config: ClientTlsConfig) -> Result<RustlsChannelCredendials, String> {
         let provider = if let Some(p) = CryptoProvider::get_default() {
             p.as_ref().clone()
         } else {
@@ -145,7 +146,7 @@ impl RustlsClientTlsCredendials {
     fn new_impl(
         mut config: ClientTlsConfig,
         provider: CryptoProvider,
-    ) -> Result<RustlsClientTlsCredendials, String> {
+    ) -> Result<RustlsChannelCredendials, String> {
         let provider = sanitize_crypto_provider(provider)?;
         let builder = rustls::ClientConfig::builder_with_provider(Arc::new(provider))
             .with_protocol_versions(&[&rustls::version::TLS13, &rustls::version::TLS12])
@@ -184,7 +185,7 @@ impl RustlsClientTlsCredendials {
             client_config.key_log = Arc::new(KeyLogFile::new(&path))
         }
 
-        Ok(RustlsClientTlsCredendials {
+        Ok(RustlsChannelCredendials {
             connector: TlsConnector::from(Arc::new(client_config)),
         })
     }
@@ -215,7 +216,7 @@ impl ClientConnectionSecurityContext for ClientTlsSecContext {
     }
 }
 
-impl ChannelCredentials for RustlsClientTlsCredendials {
+impl ChannelCredentials for RustlsChannelCredendials {
     type ContextType = ClientTlsSecContext;
     type Output<I> = TlsStream<I>;
 

--- a/grpc/src/credentials/rustls/client/test.rs
+++ b/grpc/src/credentials/rustls/client/test.rs
@@ -48,7 +48,7 @@ use crate::credentials::rustls::Identity;
 use crate::credentials::rustls::RootCertificates;
 use crate::credentials::rustls::StaticProvider;
 use crate::credentials::rustls::client::ClientTlsConfig;
-use crate::credentials::rustls::client::RustlsClientTlsCredendials;
+use crate::credentials::rustls::client::RustlsChannelCredendials;
 use crate::private;
 use crate::rt;
 use crate::rt::AsyncIoAdapter;
@@ -102,7 +102,7 @@ async fn test_tls_cipher_suites_secure() {
         .clone();
 
     // This should succeed as default provider usually has secure suites.
-    let creds = RustlsClientTlsCredendials::new_impl(config, provider);
+    let creds = RustlsChannelCredendials::new_impl(config, provider);
     assert!(
         creds.is_ok(),
         "Failed to create creds with secure provider: {:?}",
@@ -140,7 +140,7 @@ async fn test_tls_cipher_suites_insecure() {
     // Remove all cipher suites that are considered secure by our policy
     provider.cipher_suites.retain(|suite| !is_secure(suite));
 
-    let creds = RustlsClientTlsCredendials::new_impl(config, provider);
+    let creds = RustlsChannelCredendials::new_impl(config, provider);
     assert!(creds.err().unwrap().contains("no cipher suites matching"));
 }
 
@@ -161,7 +161,7 @@ async fn test_tls_key_log() {
         .with_root_certificates_provider(root_provider)
         .insecure_with_key_log_path(key_log_file.path());
 
-    let creds = RustlsClientTlsCredendials::new(config).unwrap();
+    let creds = RustlsChannelCredendials::new(config).unwrap();
 
     let runtime = rt::default_runtime();
     let endpoint = runtime
@@ -211,7 +211,7 @@ async fn test_tls_handshake_wrong_server_name() {
     let root_provider = StaticProvider::new(root_certs);
     let config = ClientTlsConfig::new().with_root_certificates_provider(root_provider);
 
-    let creds = RustlsClientTlsCredendials::new(config).unwrap();
+    let creds = RustlsChannelCredendials::new(config).unwrap();
 
     let runtime = rt::default_runtime();
     let endpoint = runtime
@@ -268,7 +268,7 @@ async fn test_tls_validate_authority() {
     let root_provider = StaticProvider::new(root_certs);
     let config = ClientTlsConfig::new().with_root_certificates_provider(root_provider);
 
-    let creds = RustlsClientTlsCredendials::new(config).unwrap();
+    let creds = RustlsChannelCredendials::new(config).unwrap();
 
     let runtime = rt::default_runtime();
     let endpoint = runtime
@@ -312,7 +312,7 @@ async fn test_mtls_handshake_no_identity() {
     let config = ClientTlsConfig::new()
         .with_root_certificates_provider(StaticProvider::new(load_root_certs("ca.pem")));
 
-    let creds = RustlsClientTlsCredendials::new(config).unwrap();
+    let creds = RustlsChannelCredendials::new(config).unwrap();
     let runtime = rt::default_runtime();
     let endpoint = runtime
         .tcp_stream(addr, TcpOptions::default())
@@ -367,7 +367,7 @@ async fn test_mtls_handshake_with_identitiy() {
         .with_root_certificates_provider(root_provider)
         .with_identity_provider(identity_provider);
 
-    let creds = RustlsClientTlsCredendials::new(config).unwrap();
+    let creds = RustlsChannelCredendials::new(config).unwrap();
     let runtime = rt::default_runtime();
     let endpoint = runtime
         .tcp_stream(addr, TcpOptions::default())
@@ -422,7 +422,7 @@ async fn check_client_resumption_disabled(
     let root_provider = StaticProvider::new(root_certs);
     let config = ClientTlsConfig::new().with_root_certificates_provider(root_provider);
 
-    let creds = RustlsClientTlsCredendials::new(config).unwrap();
+    let creds = RustlsChannelCredendials::new(config).unwrap();
 
     for i in 0..2 {
         let runtime = rt::default_runtime();
@@ -597,7 +597,7 @@ async fn run_handshake_test(server_alpn: Vec<Vec<u8>>, expect_success: bool) {
 
     let config = ClientTlsConfig::new().with_root_certificates_provider(root_provider);
 
-    let creds = RustlsClientTlsCredendials::new(config).unwrap();
+    let creds = RustlsChannelCredendials::new(config).unwrap();
 
     let runtime = rt::default_runtime();
     let endpoint = runtime

--- a/grpc/src/credentials/rustls/server/mod.rs
+++ b/grpc/src/credentials/rustls/server/mod.rs
@@ -161,7 +161,7 @@ impl From<TlsClientCertificateRequestType> for InnerClientCertificateRequestType
 }
 
 #[derive(Clone)]
-pub struct RustlsServerTlsCredendials {
+pub struct RustlsServerCredendials {
     acceptor: TlsAcceptor,
 }
 
@@ -205,8 +205,8 @@ impl ServerTlsConfig {
     }
 }
 
-impl RustlsServerTlsCredendials {
-    pub fn new(config: ServerTlsConfig) -> Result<RustlsServerTlsCredendials, String> {
+impl RustlsServerCredendials {
+    pub fn new(config: ServerTlsConfig) -> Result<RustlsServerCredendials, String> {
         let provider = if let Some(p) = CryptoProvider::get_default() {
             p.as_ref().clone()
         } else {
@@ -222,7 +222,7 @@ impl RustlsServerTlsCredendials {
     fn new_impl(
         mut config: ServerTlsConfig,
         provider: CryptoProvider,
-    ) -> Result<RustlsServerTlsCredendials, String> {
+    ) -> Result<RustlsServerCredendials, String> {
         let provider = sanitize_crypto_provider(provider)?;
         let id_list = config.identities_provider.borrow_and_update().clone();
         if id_list.is_empty() {
@@ -295,7 +295,7 @@ impl RustlsServerTlsCredendials {
         // Install a dummy ticketer that refuses to issue tickets.
         server_config.ticketer = Arc::new(NoTicketer);
 
-        Ok(RustlsServerTlsCredendials {
+        Ok(RustlsServerCredendials {
             acceptor: TlsAcceptor::from(Arc::new(server_config)),
         })
     }
@@ -320,7 +320,7 @@ impl ProducesTickets for NoTicketer {
     }
 }
 
-impl ServerCredentials for RustlsServerTlsCredendials {
+impl ServerCredentials for RustlsServerCredendials {
     type Output<Input> = TlsStream<Input>;
 
     async fn accept<Input: GrpcEndpoint>(

--- a/grpc/src/credentials/rustls/server/test.rs
+++ b/grpc/src/credentials/rustls/server/test.rs
@@ -41,7 +41,7 @@ use crate::credentials::rustls::ALPN_PROTO_STR_H2;
 use crate::credentials::rustls::Identity;
 use crate::credentials::rustls::RootCertificates;
 use crate::credentials::rustls::StaticProvider;
-use crate::credentials::rustls::server::RustlsServerTlsCredendials;
+use crate::credentials::rustls::server::RustlsServerCredendials;
 use crate::credentials::rustls::server::ServerTlsConfig;
 use crate::credentials::rustls::server::TlsClientCertificateRequestType;
 use crate::private;
@@ -65,7 +65,7 @@ async fn test_tls_server_handshake() {
     let identity = load_identity("server.pem", "server.key");
     let identity_provider = StaticProvider::new(vec![identity]);
     let config = ServerTlsConfig::new(identity_provider);
-    let creds = RustlsServerTlsCredendials::new(config).unwrap();
+    let creds = RustlsServerCredendials::new(config).unwrap();
 
     let runtime = rt::default_runtime();
     let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
@@ -121,7 +121,7 @@ async fn test_tls_server_handshake_no_alpn() {
     let identity = load_identity("server.pem", "server.key");
     let identity_provider = StaticProvider::new(vec![identity]);
     let config = ServerTlsConfig::new(identity_provider);
-    let creds = RustlsServerTlsCredendials::new(config).unwrap();
+    let creds = RustlsServerCredendials::new(config).unwrap();
 
     let runtime = rt::default_runtime();
     let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
@@ -164,7 +164,7 @@ async fn test_tls_server_handshake_bad_alpn() {
     let identity = load_identity("server.pem", "server.key");
     let identity_provider = StaticProvider::new(vec![identity]);
     let config = ServerTlsConfig::new(identity_provider);
-    let creds = RustlsServerTlsCredendials::new(config).unwrap();
+    let creds = RustlsServerCredendials::new(config).unwrap();
 
     let runtime = rt::default_runtime();
     let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
@@ -201,7 +201,7 @@ async fn test_tls_handshake_alpn_h1_and_h2() {
     let identity = load_identity("server.pem", "server.key");
     let identity_provider = StaticProvider::new(vec![identity]);
     let config = ServerTlsConfig::new(identity_provider);
-    let creds = RustlsServerTlsCredendials::new(config).unwrap();
+    let creds = RustlsServerCredendials::new(config).unwrap();
 
     let runtime = rt::default_runtime();
     let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
@@ -248,7 +248,7 @@ async fn test_tls_server_mtls_require_fail() {
         },
     );
 
-    let creds = RustlsServerTlsCredendials::new(config).unwrap();
+    let creds = RustlsServerCredendials::new(config).unwrap();
 
     let runtime = rt::default_runtime();
     let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
@@ -299,7 +299,7 @@ async fn test_tls_server_mtls_success() {
         },
     );
 
-    let creds = RustlsServerTlsCredendials::new(config).unwrap();
+    let creds = RustlsServerCredendials::new(config).unwrap();
 
     let runtime = rt::default_runtime();
     let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
@@ -359,7 +359,7 @@ async fn test_tls_server_mtls_optional() {
         },
     );
 
-    let creds = RustlsServerTlsCredendials::new(config).unwrap();
+    let creds = RustlsServerCredendials::new(config).unwrap();
 
     let runtime = rt::default_runtime();
     let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
@@ -409,7 +409,7 @@ async fn test_tls_server_key_log() {
     let config =
         ServerTlsConfig::new(identity_provider).insecure_with_key_log_path(key_log_file.path());
 
-    let creds = RustlsServerTlsCredendials::new(config).unwrap();
+    let creds = RustlsServerCredendials::new(config).unwrap();
 
     let runtime = rt::default_runtime();
     let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
@@ -462,7 +462,7 @@ async fn check_resumption_disabled(versions: Vec<&'static rustls::SupportedProto
     let identity = load_identity("server.pem", "server.key");
     let identity_provider = StaticProvider::new(vec![identity]);
     let config = ServerTlsConfig::new(identity_provider);
-    let creds = RustlsServerTlsCredendials::new(config).unwrap();
+    let creds = RustlsServerCredendials::new(config).unwrap();
 
     let runtime = rt::default_runtime();
     let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
@@ -538,7 +538,7 @@ async fn test_tls_server_sni() {
     // identity2 has *.test.com
     let identity_provider = StaticProvider::new(vec![identity1, identity2]);
     let config = ServerTlsConfig::new(identity_provider);
-    let creds = RustlsServerTlsCredendials::new(config).unwrap();
+    let creds = RustlsServerCredendials::new(config).unwrap();
 
     let runtime = rt::default_runtime();
     let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
@@ -651,7 +651,7 @@ async fn test_tls_server_cipher_suites_insecure() {
     // Remove all cipher suites that are considered secure by gRPC.
     provider.cipher_suites.retain(|suite| !is_secure(suite));
 
-    let creds = RustlsServerTlsCredendials::new_impl(config, provider);
+    let creds = RustlsServerCredendials::new_impl(config, provider);
     assert!(creds.err().unwrap().contains("no cipher suites matching"));
 }
 

--- a/interop/src/bin/client.rs
+++ b/interop/src/bin/client.rs
@@ -7,7 +7,7 @@ use grpc::credentials::LocalChannelCredentials;
 use grpc::credentials::rustls::RootCertificates;
 use grpc::credentials::rustls::StaticProvider;
 use grpc::credentials::rustls::client::ClientTlsConfig as GrpcClientTlsConfig;
-use grpc::credentials::rustls::client::RustlsClientTlsCredendials;
+use grpc::credentials::rustls::client::RustlsChannelCredendials;
 use interop::client::InteropTest;
 use interop::client::InteropTestUnimplemented;
 use interop::client_prost;
@@ -95,7 +95,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
                 let pem = std::fs::read_to_string("interop/data/ca.pem")?;
                 let root_certs = RootCertificates::from_pem(pem);
-                let creds = RustlsClientTlsCredendials::new(
+                let creds = RustlsChannelCredendials::new(
                     GrpcClientTlsConfig::new()
                         .with_root_certificates_provider(StaticProvider::new(root_certs)),
                 )?;


### PR DESCRIPTION
This PR updates the following symbols to remove the redundant "TLS" from their names:
* `RustlsClientTlsCredentials` -> `RustlsChannelCredentials`
* `RustlsServerTlsCredentials` -> `RustlsServerCredentials`

Additionally, it replaces `ClientCredentials` with `ChannelCredentials` to properly align with the channel credentials trait name.