### PR TITLE
grpc: add route_guide example and make minor tweaks to the generated code APIs

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -189,6 +189,7 @@ jobs:
 
   codegen:
     runs-on: ubuntu-latest
+    needs: build-protoc-plugin
     steps:
     - uses: actions/checkout@v6
     - uses: hecrj/setup-rust-action@v2

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -192,6 +192,32 @@ jobs:
     steps:
     - uses: actions/checkout@v6
     - uses: hecrj/setup-rust-action@v2
+    - name: Restore protoc and plugin from cache
+      id: cache-plugin
+      uses: actions/cache@v4
+      with:
+        path: ${{ runner.temp }}/protoc-plugin
+        key: ${{ runner.os }}-protoc-plugin-cmake-v4-${{ hashFiles('protoc-gen-rust-grpc/src/**', 'protoc-gen-rust-grpc/CMakeLists.txt', 'protoc-gen-rust-grpc/cmake/**') }}
+    - name: Add protoc and plugin to PATH
+      shell: bash
+      run: |
+        # Use forward slashes for all paths in bash, even on Windows
+        PROTOC_DIR="${{ runner.temp }}/protoc-plugin"
+        PROTOC_DIR="${PROTOC_DIR//\\/\/}"  # Convert backslashes to forward slashes
+
+        echo "${PROTOC_DIR}" >> $GITHUB_PATH
+
+        # Also set PROTOC for build scripts
+        if [ "${{ runner.os }}" = "Windows" ]; then
+          echo "PROTOC=${PROTOC_DIR}/protoc.exe" >> $GITHUB_ENV
+        else
+          echo "PROTOC=${PROTOC_DIR}/protoc" >> $GITHUB_ENV
+        fi
+
+        # Set the protoc include path only if it exists
+        if [ -d "${PROTOC_DIR}/include" ]; then
+          echo "PROTOC_INCLUDE=${PROTOC_DIR}/include" >> $GITHUB_ENV
+        fi
     - uses: Swatinem/rust-cache@v2
     - run: cargo run --package codegen
     - run: git diff --exit-code

--- a/codegen/Cargo.toml
+++ b/codegen/Cargo.toml
@@ -12,3 +12,4 @@ quote = "1"
 syn = "2"
 tempfile = "3.8.0"
 tonic-prost-build = {path = "../tonic-prost-build", default-features = false, features = ["cleanup-markdown"]}
+grpc-protobuf-build = { path = "../grpc-protobuf-build" }

--- a/codegen/src/main.rs
+++ b/codegen/src/main.rs
@@ -97,8 +97,8 @@ fn codegen_grpc_routeguide(root_dir: &Path) {
     let path = std::env::var("PATH").unwrap_or_default();
     unsafe {
         std::env::set_var("PATH", format!("{}:{}", path, grpc_protobuf_build::bin()));
-        // OUT_DIR must be set in CodeGen::new, so we set it correctly here
-        // instead of using `.output_dir()` on CodeGen.
+        // TODO: Once the codegen is updated to allow the `OUT_DIR` env var to
+        // be unset, change this to use `.output_dir` instead.
         std::env::set_var("OUT_DIR", root_dir.join("src/grpc-routeguide/generated"));
     }
 

--- a/codegen/src/main.rs
+++ b/codegen/src/main.rs
@@ -81,7 +81,35 @@ fn main() {
         true,
         true,
     );
+
+    // grpc-routeguide example
+    codegen_grpc_routeguide(
+        &PathBuf::from(std::env!("CARGO_MANIFEST_DIR"))
+            .parent()
+            .unwrap()
+            .join("examples"),
+    );
+
     println!("Codgen completed: {}ms", start.elapsed().as_millis());
+}
+
+fn codegen_grpc_routeguide(root_dir: &Path) {
+    let path = std::env::var("PATH").unwrap_or_default();
+    unsafe {
+        std::env::set_var("PATH", format!("{}:{}", path, grpc_protobuf_build::bin()));
+        // OUT_DIR must be set in CodeGen::new, so we set it correctly here
+        // instead of using `.output_dir()` on CodeGen.
+        std::env::set_var("OUT_DIR", root_dir.join("src/grpc-routeguide/generated"));
+    }
+
+    std::env::set_current_dir(root_dir).unwrap();
+
+    grpc_protobuf_build::CodeGen::new()
+        .include("proto/routeguide")
+        .inputs(["route_guide.proto"])
+        .client_only()
+        .compile()
+        .unwrap();
 }
 
 fn codegen(

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -254,12 +254,11 @@ path = "src/codec_buffers/client.rs"
 [[bin]]
 name = "grpc-routeguide-client"
 path = "src/grpc-routeguide/client.rs"
-required-features = ["grpc", "grpc-routeguide"]
+required-features = ["grpc-routeguide"]
 
 [features]
 gcp = ["dep:prost-types", "tonic/tls-ring"]
 routeguide = ["dep:async-stream", "dep:tokio-stream", "dep:rand", "dep:serde", "dep:serde_json"]
-grpc-routeguide = ["dep:rand"]
 reflection = ["dep:tonic-reflection"]
 autoreload = ["dep:tokio-stream", "tokio-stream?/net", "dep:listenfd"]
 health = ["dep:tonic-health"]
@@ -277,8 +276,8 @@ types = ["dep:tonic-types"]
 h2c = ["dep:hyper", "dep:tower", "dep:http", "dep:hyper-util"]
 cancellation = ["dep:tokio-util"]
 tower = ["dep:tower", "dep:http"]
-grpc = ["dep:grpc", "dep:grpc-protobuf", "dep:protobuf"]
-full = ["gcp", "routeguide", "reflection", "autoreload", "health", "grpc-web", "tracing", "uds", "streaming", "mock", "json-codec", "compression", "tls", "tls-rustls", "tls-client-auth", "types", "cancellation", "h2c", "grpc", "grpc-routeguide"]
+grpc-routeguide = ["dep:grpc", "dep:grpc-protobuf", "dep:protobuf", "dep:rand"]
+full = ["gcp", "routeguide", "reflection", "autoreload", "health", "grpc-web", "tracing", "uds", "streaming", "mock", "json-codec", "compression", "tls", "tls-rustls", "tls-client-auth", "types", "cancellation", "h2c", "grpc-routeguide"]
 default = ["full"]
 
 [dependencies]

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -254,11 +254,12 @@ path = "src/codec_buffers/client.rs"
 [[bin]]
 name = "grpc-routeguide-client"
 path = "src/grpc-routeguide/client.rs"
-required-features = ["grpc"]
+required-features = ["grpc", "grpc-routeguide"]
 
 [features]
 gcp = ["dep:prost-types", "tonic/tls-ring"]
 routeguide = ["dep:async-stream", "dep:tokio-stream", "dep:rand", "dep:serde", "dep:serde_json"]
+grpc-routeguide = ["dep:rand"]
 reflection = ["dep:tonic-reflection"]
 autoreload = ["dep:tokio-stream", "tokio-stream?/net", "dep:listenfd"]
 health = ["dep:tonic-health"]
@@ -277,7 +278,7 @@ h2c = ["dep:hyper", "dep:tower", "dep:http", "dep:hyper-util"]
 cancellation = ["dep:tokio-util"]
 tower = ["dep:tower", "dep:http"]
 grpc = ["dep:grpc", "dep:grpc-protobuf", "dep:protobuf"]
-full = ["gcp", "routeguide", "reflection", "autoreload", "health", "grpc-web", "tracing", "uds", "streaming", "mock", "json-codec", "compression", "tls", "tls-rustls", "tls-client-auth", "types", "cancellation", "h2c"]
+full = ["gcp", "routeguide", "reflection", "autoreload", "health", "grpc-web", "tracing", "uds", "streaming", "mock", "json-codec", "compression", "tls", "tls-rustls", "tls-client-auth", "types", "cancellation", "h2c", "grpc", "grpc-routeguide"]
 default = ["full"]
 
 [dependencies]

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -251,6 +251,10 @@ path = "src/codec_buffers/server.rs"
 name = "codec-buffers-client"
 path = "src/codec_buffers/client.rs"
 
+[[bin]]
+name = "grpc-routeguide-client"
+path = "src/grpc-routeguide/client.rs"
+required-features = ["grpc-routeguide"]
 
 [features]
 gcp = ["dep:prost-types", "tonic/tls-ring"]
@@ -271,6 +275,7 @@ tls-client-auth = ["tonic/tls-ring"]
 types = ["dep:tonic-types"]
 h2c = ["dep:hyper", "dep:tower", "dep:http", "dep:hyper-util"]
 cancellation = ["dep:tokio-util"]
+grpc-routeguide = ["dep:grpc", "dep:grpc-protobuf", "dep:protobuf"]
 
 full = ["gcp", "routeguide", "reflection", "autoreload", "health", "grpc-web", "tracing", "uds", "streaming", "mock", "json-codec", "compression", "tls", "tls-rustls", "tls-client-auth", "types", "cancellation", "h2c"]
 tower = ["dep:tower", "dep:http"]
@@ -306,6 +311,10 @@ h2 = { version = "0.4", optional = true }
 tokio-rustls = { version = "0.26.1", optional = true, features = ["ring", "tls12"], default-features = false }
 hyper-rustls = { version = "0.27.0", features = ["http2", "ring", "tls12"], optional = true, default-features = false }
 tower-http = { version = "0.6", optional = true }
+grpc-protobuf = { path = "../grpc-protobuf", optional = true }
+protobuf = { version = "4.34.0-release", optional = true }
+grpc = { path = "../grpc", optional = true }
 
 [build-dependencies]
 tonic-prost-build = { path = "../tonic-prost-build" }
+grpc-protobuf-build = { path = "../grpc-protobuf-build" }

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -254,7 +254,7 @@ path = "src/codec_buffers/client.rs"
 [[bin]]
 name = "grpc-routeguide-client"
 path = "src/grpc-routeguide/client.rs"
-required-features = ["grpc-routeguide"]
+required-features = ["grpc"]
 
 [features]
 gcp = ["dep:prost-types", "tonic/tls-ring"]
@@ -275,10 +275,9 @@ tls-client-auth = ["tonic/tls-ring"]
 types = ["dep:tonic-types"]
 h2c = ["dep:hyper", "dep:tower", "dep:http", "dep:hyper-util"]
 cancellation = ["dep:tokio-util"]
-grpc-routeguide = ["dep:grpc", "dep:grpc-protobuf", "dep:protobuf"]
-
-full = ["gcp", "routeguide", "reflection", "autoreload", "health", "grpc-web", "tracing", "uds", "streaming", "mock", "json-codec", "compression", "tls", "tls-rustls", "tls-client-auth", "types", "cancellation", "h2c"]
 tower = ["dep:tower", "dep:http"]
+grpc = ["dep:grpc", "dep:grpc-protobuf", "dep:protobuf"]
+full = ["gcp", "routeguide", "reflection", "autoreload", "health", "grpc-web", "tracing", "uds", "streaming", "mock", "json-codec", "compression", "tls", "tls-rustls", "tls-client-auth", "types", "cancellation", "h2c"]
 default = ["full"]
 
 [dependencies]
@@ -317,4 +316,3 @@ grpc = { path = "../grpc", optional = true }
 
 [build-dependencies]
 tonic-prost-build = { path = "../tonic-prost-build" }
-grpc-protobuf-build = { path = "../grpc-protobuf-build" }

--- a/examples/build.rs
+++ b/examples/build.rs
@@ -1,6 +1,8 @@
 use std::{env, path::PathBuf};
 
 fn main() {
+    build_grpc();
+
     tonic_prost_build::configure()
         .compile_protos(&["proto/routeguide/route_guide.proto"], &["proto"])
         .unwrap();
@@ -64,4 +66,25 @@ fn build_json_codec_service() {
         .build();
 
     tonic_prost_build::manual::Builder::new().compile(&[greeter_service]);
+}
+
+fn build_grpc() {
+    let proto = "proto/routeguide/route_guide.proto";
+
+    eprintln!("{}", grpc_protobuf_build::protoc());
+    let path = std::env::var("PATH").unwrap_or_default();
+    unsafe {
+        std::env::set_var("PATH", format!("{}:{}", path, grpc_protobuf_build::bin()));
+    }
+
+    grpc_protobuf_build::CodeGen::new()
+        .include("proto/routeguide")
+        .inputs(["route_guide.proto"])
+        .output_dir("src/grpc-routeguide/generated")
+        .client_only()
+        .compile()
+        .unwrap();
+
+    // prevent needing to rebuild if files (or deps) haven't changed
+    println!("cargo:rerun-if-changed={proto}");
 }

--- a/examples/build.rs
+++ b/examples/build.rs
@@ -1,8 +1,6 @@
 use std::{env, path::PathBuf};
 
 fn main() {
-    build_grpc();
-
     tonic_prost_build::configure()
         .compile_protos(&["proto/routeguide/route_guide.proto"], &["proto"])
         .unwrap();
@@ -66,25 +64,4 @@ fn build_json_codec_service() {
         .build();
 
     tonic_prost_build::manual::Builder::new().compile(&[greeter_service]);
-}
-
-fn build_grpc() {
-    let proto = "proto/routeguide/route_guide.proto";
-
-    eprintln!("{}", grpc_protobuf_build::protoc());
-    let path = std::env::var("PATH").unwrap_or_default();
-    unsafe {
-        std::env::set_var("PATH", format!("{}:{}", path, grpc_protobuf_build::bin()));
-    }
-
-    grpc_protobuf_build::CodeGen::new()
-        .include("proto/routeguide")
-        .inputs(["route_guide.proto"])
-        .output_dir("src/grpc-routeguide/generated")
-        .client_only()
-        .compile()
-        .unwrap();
-
-    // prevent needing to rebuild if files (or deps) haven't changed
-    println!("cargo:rerun-if-changed={proto}");
 }

--- a/examples/src/grpc-routeguide/client.rs
+++ b/examples/src/grpc-routeguide/client.rs
@@ -1,0 +1,186 @@
+use protobuf::proto;
+
+#[allow(unused)]
+mod generated {
+    pub mod routeguide {
+        include!("generated/generated.rs"); // Contains messages
+        include!("generated/route_guide_grpc.pb.rs"); // Contains grpc stubs
+    }
+}
+
+use std::sync::Arc;
+
+use grpc::client::Channel;
+use grpc::client::ChannelOptions;
+use grpc::client::Invoke;
+use grpc::credentials::LocalChannelCredentials;
+use tokio::task;
+
+use crate::generated::routeguide::Feature;
+use crate::generated::routeguide::Point;
+use crate::generated::routeguide::Rectangle;
+use crate::generated::routeguide::RouteNote;
+use crate::generated::routeguide::route_guide_client::RouteGuideClient;
+
+fn print_feature(feature: Feature) {
+    println!(
+        "Response = Name = \"{}\", Point: {{{}, {}}}",
+        feature.name(),
+        feature.location().latitude(),
+        feature.location().longitude()
+    );
+}
+
+async fn get_feature<T: Invoke>(client: &RouteGuideClient<T>, point: Point) {
+    let response = client.get_feature(point).await.expect("RPC failed");
+    print_feature(response);
+}
+
+async fn list_features<T: Invoke>(client: &RouteGuideClient<T>, rect: Rectangle) {
+    let mut response_stream = client.list_features(rect).start().await;
+    while let Some(feature) = response_stream.next().await {
+        print_feature(feature);
+    }
+    let status = response_stream.status().await;
+    assert_eq!(status.code(), grpc::StatusCode::Ok, "{:?}", status);
+}
+
+async fn record_route<T: Invoke>(client: &RouteGuideClient<T>) {
+    // Create a random number of random points.
+    let point_count = rand::random_range(2..=30); // Traverse at least two points
+    let mut points = Vec::with_capacity(point_count);
+    for _ in 0..point_count {
+        points.push(random_point());
+    }
+    println!("Traversing {point_count} points.");
+    let mut stream = client.record_route().await;
+    for point in points {
+        stream.send_message(&point).await.expect("RPC failed");
+    }
+    let response = stream.await.expect("RPC failed");
+    println!(
+        "Route summary: Point count: {}, Distance: {}",
+        response.point_count(),
+        response.distance()
+    );
+}
+
+async fn route_chat<T: Invoke>(client: &RouteGuideClient<T>) {
+    let notes = vec![
+        proto!(RouteNote {
+            location: Point {
+                latitude: 0,
+                longitude: 1,
+            },
+            message: format!("Message One"),
+        }),
+        proto!(RouteNote {
+            location: Point {
+                latitude: 0,
+                longitude: 2,
+            },
+            message: format!("Message Two"),
+        }),
+        proto!(RouteNote {
+            location: Point {
+                latitude: 0,
+                longitude: 3,
+            },
+            message: format!("Message Three"),
+        }),
+        proto!(RouteNote {
+            location: Point {
+                latitude: 0,
+                longitude: 1,
+            },
+            message: format!("Message Four"),
+        }),
+        proto!(RouteNote {
+            location: Point {
+                latitude: 0,
+                longitude: 1,
+            },
+            message: format!("Message Five"),
+        }),
+    ];
+    let (mut tx, mut rx) = client.route_chat().await;
+    let handle = task::spawn(async move {
+        while let Some(response) = rx.next().await {
+            println!(
+                "Got message {} at Point: {{{}, {}}}",
+                response.message(),
+                response.location().latitude(),
+                response.location().longitude()
+            );
+        }
+    });
+    for note in notes {
+        tx.send_message(note).await.expect("RPC errored");
+    }
+    // Dropping tx causes the client to send a "half close" to the server.
+    drop(tx);
+    // Await the async work where we read from the server.
+    handle.await.unwrap();
+}
+
+fn random_point() -> Point {
+    let latitude = (rand::random_range(0..180) - 90) * 10_000_000;
+    let longitude = (rand::random_range(0..360) - 180) * 10_000_000;
+    proto!(Point {
+        latitude,
+        longitude
+    })
+}
+
+#[tokio::main]
+async fn main() {
+    // Create a new gRPC channel:
+    let channel = Channel::new(
+        "dns:///localhost:50051",
+        Arc::new(LocalChannelCredentials::new()),
+        ChannelOptions::default(),
+    );
+    let client = RouteGuideClient::new(channel);
+
+    println!("*** SIMPLE RPC ***");
+    get_feature(
+        &client,
+        proto!(Point {
+            latitude: 409_146_138,
+            longitude: -746_188_906
+        }),
+    )
+    .await;
+
+    println!("*** MISSING FEATURE ***");
+    get_feature(
+        &client,
+        proto!(Point {
+            latitude: 0,
+            longitude: 0
+        }),
+    )
+    .await;
+
+    println!("*** FEATURES IN RANGE ***");
+    list_features(
+        &client,
+        proto!(Rectangle {
+            lo: Point {
+                latitude: 400000000,
+                longitude: -750000000
+            },
+            hi: Point {
+                latitude: 420000000,
+                longitude: -730000000
+            },
+        }),
+    )
+    .await;
+
+    println!("*** RECORD ROUTE ***");
+    record_route(&client).await;
+
+    println!("*** ROUTE CHAT ***");
+    route_chat(&client).await;
+}

--- a/examples/src/grpc-routeguide/client.rs
+++ b/examples/src/grpc-routeguide/client.rs
@@ -71,7 +71,7 @@ async fn record_route<T: Invoke>(client: &RouteGuideClient<T>) {
     }
 
     // Receive the response or status.
-    let response = stream.recv().await.expect("RPC failed");
+    let response = stream.close_and_recv().await.expect("RPC failed");
     println!(
         "Route summary: Point count: {}, Distance: {}",
         response.point_count(),
@@ -121,33 +121,37 @@ async fn route_chat<T: Invoke>(client: &RouteGuideClient<T>) {
     // Start the RPC.
     let (mut tx, mut rx) = client.route_chat().await;
 
-    // Spawn a task to receive the response messages asynchronously.
+    // Spawn a task to send the request messages asynchronously.
     let handle = task::spawn(async move {
-        while let Some(response) = rx.recv().await {
-            println!(
-                "Got message {} at Point: {{{}, {}}}",
-                response.message(),
-                response.location().latitude(),
-                response.location().longitude()
-            );
+        // Send the request messages.
+        for note in notes {
+            // Send errors (with a void error) if the stream encounters any
+            // problem, or if the server terminates the stream before the client
+            // is done sending.  We don't expect that in our RouteGuide
+            // protocol, so we can safely expect() no error.
+            tx.send(note).await.expect("RPC terminated early");
         }
-        // Return the status to the main task via our JoinHandle.
-        rx.status().await
+        // Send a "half close" signal to the server to indicate the client is
+        // done sending.  This triggers naturally if `tx` is dropped, which will
+        // happen automatically at the end of this task, but we call close()
+        // here just to be explicit.
+        tx.close();
     });
 
-    // Send the request messages.
-    for note in notes {
-        if tx.send(note).await.is_err() {
-            break;
-        }
+    while let Some(response) = rx.recv().await {
+        println!(
+            "Got message {} at Point: {{{}, {}}}",
+            response.message(),
+            response.location().latitude(),
+            response.location().longitude()
+        );
     }
 
-    // Drop tx, which causes the client to send a "half close" to the server.
-    drop(tx);
+    // Assert that spawned task did not encounter an error.
+    handle.await.expect("Sending notes failed");
 
-    // Await the async work where we read from the server and confirm the
-    // status.
-    let status = handle.await.unwrap();
+    // Confirm the status.
+    let status = rx.status().await;
     assert_eq!(status.code(), grpc::StatusCode::Ok, "{:?}", status);
 }
 

--- a/examples/src/grpc-routeguide/client.rs
+++ b/examples/src/grpc-routeguide/client.rs
@@ -32,15 +32,23 @@ fn print_feature(feature: Feature) {
 }
 
 async fn get_feature<T: Invoke>(client: &RouteGuideClient<T>, point: Point) {
+    // Perform the RPC.
     let response = client.get_feature(point).await.expect("RPC failed");
+
+    // Print its response.
     print_feature(response);
 }
 
 async fn list_features<T: Invoke>(client: &RouteGuideClient<T>, rect: Rectangle) {
-    let mut response_stream = client.list_features(rect).start().await;
-    while let Some(feature) = response_stream.next().await {
+    // Start the RPC.
+    let mut response_stream = client.list_features(rect).await;
+
+    // Receive the response messages.
+    while let Some(feature) = response_stream.recv().await {
         print_feature(feature);
     }
+
+    // Confirm the status.
     let status = response_stream.status().await;
     assert_eq!(status.code(), grpc::StatusCode::Ok, "{:?}", status);
 }
@@ -53,11 +61,17 @@ async fn record_route<T: Invoke>(client: &RouteGuideClient<T>) {
         points.push(random_point());
     }
     println!("Traversing {point_count} points.");
+
+    // Start the RPC.
     let mut stream = client.record_route().await;
+
+    // Send the request messages.
     for point in points {
-        stream.send_message(&point).await.expect("RPC failed");
+        stream.send(&point).await.expect("RPC failed");
     }
-    let response = stream.await.expect("RPC failed");
+
+    // Receive the response or status.
+    let response = stream.recv().await.expect("RPC failed");
     println!(
         "Route summary: Point count: {}, Distance: {}",
         response.point_count(),
@@ -103,9 +117,13 @@ async fn route_chat<T: Invoke>(client: &RouteGuideClient<T>) {
             message: format!("Message Five"),
         }),
     ];
+
+    // Start the RPC.
     let (mut tx, mut rx) = client.route_chat().await;
+
+    // Spawn a task to receive the response messages asynchronously.
     let handle = task::spawn(async move {
-        while let Some(response) = rx.next().await {
+        while let Some(response) = rx.recv().await {
             println!(
                 "Got message {} at Point: {{{}, {}}}",
                 response.message(),
@@ -113,23 +131,33 @@ async fn route_chat<T: Invoke>(client: &RouteGuideClient<T>) {
                 response.location().longitude()
             );
         }
+        // Return the status to the main task via our JoinHandle.
+        rx.status().await
     });
+
+    // Send the request messages.
     for note in notes {
-        tx.send_message(note).await.expect("RPC errored");
+        if tx.send(note).await.is_err() {
+            break;
+        }
     }
-    // Dropping tx causes the client to send a "half close" to the server.
+
+    // Drop tx, which causes the client to send a "half close" to the server.
     drop(tx);
-    // Await the async work where we read from the server.
-    handle.await.unwrap();
+
+    // Await the async work where we read from the server and confirm the
+    // status.
+    let status = handle.await.unwrap();
+    assert_eq!(status.code(), grpc::StatusCode::Ok, "{:?}", status);
 }
 
 fn random_point() -> Point {
     let latitude = (rand::random_range(0..180) - 90) * 10_000_000;
     let longitude = (rand::random_range(0..360) - 180) * 10_000_000;
-    proto!(Point {
+    return proto!(Point {
         latitude,
         longitude
-    })
+    });
 }
 
 #[tokio::main]

--- a/examples/src/grpc-routeguide/data/route_guide_db.json
+++ b/examples/src/grpc-routeguide/data/route_guide_db.json
@@ -1,0 +1,702 @@
+[
+    {
+        "location": {
+            "latitude": 407838351,
+            "longitude": -746143763
+        },
+        "name": "Patriots Path, Mendham, NJ 07945, USA"
+    },
+    {
+        "location": {
+            "latitude": 408122808,
+            "longitude": -743999179
+        },
+        "name": "101 New Jersey 10, Whippany, NJ 07981, USA"
+    },
+    {
+        "location": {
+            "latitude": 413628156,
+            "longitude": -749015468
+        },
+        "name": "U.S. 6, Shohola, PA 18458, USA"
+    },
+    {
+        "location": {
+            "latitude": 419999544,
+            "longitude": -740371136
+        },
+        "name": "5 Conners Road, Kingston, NY 12401, USA"
+    },
+    {
+        "location": {
+            "latitude": 414008389,
+            "longitude": -743951297
+        },
+        "name": "Mid Hudson Psychiatric Center, New Hampton, NY 10958, USA"
+    },
+    {
+        "location": {
+            "latitude": 419611318,
+            "longitude": -746524769
+        },
+        "name": "287 Flugertown Road, Livingston Manor, NY 12758, USA"
+    },
+    {
+        "location": {
+            "latitude": 406109563,
+            "longitude": -742186778
+        },
+        "name": "4001 Tremley Point Road, Linden, NJ 07036, USA"
+    },
+    {
+        "location": {
+            "latitude": 416802456,
+            "longitude": -742370183
+        },
+        "name": "352 South Mountain Road, Wallkill, NY 12589, USA"
+    },
+    {
+        "location": {
+            "latitude": 412950425,
+            "longitude": -741077389
+        },
+        "name": "Bailey Turn Road, Harriman, NY 10926, USA"
+    },
+    {
+        "location": {
+            "latitude": 412144655,
+            "longitude": -743949739
+        },
+        "name": "193-199 Wawayanda Road, Hewitt, NJ 07421, USA"
+    },
+    {
+        "location": {
+            "latitude": 415736605,
+            "longitude": -742847522
+        },
+        "name": "406-496 Ward Avenue, Pine Bush, NY 12566, USA"
+    },
+    {
+        "location": {
+            "latitude": 413843930,
+            "longitude": -740501726
+        },
+        "name": "162 Merrill Road, Highland Mills, NY 10930, USA"
+    },
+    {
+        "location": {
+            "latitude": 410873075,
+            "longitude": -744459023
+        },
+        "name": "Clinton Road, West Milford, NJ 07480, USA"
+    },
+    {
+        "location": {
+            "latitude": 412346009,
+            "longitude": -744026814
+        },
+        "name": "16 Old Brook Lane, Warwick, NY 10990, USA"
+    },
+    {
+        "location": {
+            "latitude": 402948455,
+            "longitude": -747903913
+        },
+        "name": "3 Drake Lane, Pennington, NJ 08534, USA"
+    },
+    {
+        "location": {
+            "latitude": 406337092,
+            "longitude": -740122226
+        },
+        "name": "6324 8th Avenue, Brooklyn, NY 11220, USA"
+    },
+    {
+        "location": {
+            "latitude": 406421967,
+            "longitude": -747727624
+        },
+        "name": "1 Merck Access Road, Whitehouse Station, NJ 08889, USA"
+    },
+    {
+        "location": {
+            "latitude": 416318082,
+            "longitude": -749677716
+        },
+        "name": "78-98 Schalck Road, Narrowsburg, NY 12764, USA"
+    },
+    {
+        "location": {
+            "latitude": 415301720,
+            "longitude": -748416257
+        },
+        "name": "282 Lakeview Drive Road, Highland Lake, NY 12743, USA"
+    },
+    {
+        "location": {
+            "latitude": 402647019,
+            "longitude": -747071791
+        },
+        "name": "330 Evelyn Avenue, Hamilton Township, NJ 08619, USA"
+    },
+    {
+        "location": {
+            "latitude": 412567807,
+            "longitude": -741058078
+        },
+        "name": "New York State Reference Route 987E, Southfields, NY 10975, USA"
+    },
+    {
+        "location": {
+            "latitude": 416855156,
+            "longitude": -744420597
+        },
+        "name": "103-271 Tempaloni Road, Ellenville, NY 12428, USA"
+    },
+    {
+        "location": {
+            "latitude": 404663628,
+            "longitude": -744820157
+        },
+        "name": "1300 Airport Road, North Brunswick Township, NJ 08902, USA"
+    },
+    {
+        "location": {
+            "latitude": 407113723,
+            "longitude": -749746483
+        },
+        "name": ""
+    },
+    {
+        "location": {
+            "latitude": 402133926,
+            "longitude": -743613249
+        },
+        "name": ""
+    },
+    {
+        "location": {
+            "latitude": 400273442,
+            "longitude": -741220915
+        },
+        "name": ""
+    },
+    {
+        "location": {
+            "latitude": 411236786,
+            "longitude": -744070769
+        },
+        "name": ""
+    },
+    {
+        "location": {
+            "latitude": 411633782,
+            "longitude": -746784970
+        },
+        "name": "211-225 Plains Road, Augusta, NJ 07822, USA"
+    },
+    {
+        "location": {
+            "latitude": 415830701,
+            "longitude": -742952812
+        },
+        "name": ""
+    },
+    {
+        "location": {
+            "latitude": 413447164,
+            "longitude": -748712898
+        },
+        "name": "165 Pedersen Ridge Road, Milford, PA 18337, USA"
+    },
+    {
+        "location": {
+            "latitude": 405047245,
+            "longitude": -749800722
+        },
+        "name": "100-122 Locktown Road, Frenchtown, NJ 08825, USA"
+    },
+    {
+        "location": {
+            "latitude": 418858923,
+            "longitude": -746156790
+        },
+        "name": ""
+    },
+    {
+        "location": {
+            "latitude": 417951888,
+            "longitude": -748484944
+        },
+        "name": "650-652 Willi Hill Road, Swan Lake, NY 12783, USA"
+    },
+    {
+        "location": {
+            "latitude": 407033786,
+            "longitude": -743977337
+        },
+        "name": "26 East 3rd Street, New Providence, NJ 07974, USA"
+    },
+    {
+        "location": {
+            "latitude": 417548014,
+            "longitude": -740075041
+        },
+        "name": ""
+    },
+    {
+        "location": {
+            "latitude": 410395868,
+            "longitude": -744972325
+        },
+        "name": ""
+    },
+    {
+        "location": {
+            "latitude": 404615353,
+            "longitude": -745129803
+        },
+        "name": ""
+    },
+    {
+        "location": {
+            "latitude": 406589790,
+            "longitude": -743560121
+        },
+        "name": "611 Lawrence Avenue, Westfield, NJ 07090, USA"
+    },
+    {
+        "location": {
+            "latitude": 414653148,
+            "longitude": -740477477
+        },
+        "name": "18 Lannis Avenue, New Windsor, NY 12553, USA"
+    },
+    {
+        "location": {
+            "latitude": 405957808,
+            "longitude": -743255336
+        },
+        "name": "82-104 Amherst Avenue, Colonia, NJ 07067, USA"
+    },
+    {
+        "location": {
+            "latitude": 411733589,
+            "longitude": -741648093
+        },
+        "name": "170 Seven Lakes Drive, Sloatsburg, NY 10974, USA"
+    },
+    {
+        "location": {
+            "latitude": 412676291,
+            "longitude": -742606606
+        },
+        "name": "1270 Lakes Road, Monroe, NY 10950, USA"
+    },
+    {
+        "location": {
+            "latitude": 409224445,
+            "longitude": -748286738
+        },
+        "name": "509-535 Alphano Road, Great Meadows, NJ 07838, USA"
+    },
+    {
+        "location": {
+            "latitude": 406523420,
+            "longitude": -742135517
+        },
+        "name": "652 Garden Street, Elizabeth, NJ 07202, USA"
+    },
+    {
+        "location": {
+            "latitude": 401827388,
+            "longitude": -740294537
+        },
+        "name": "349 Sea Spray Court, Neptune City, NJ 07753, USA"
+    },
+    {
+        "location": {
+            "latitude": 410564152,
+            "longitude": -743685054
+        },
+        "name": "13-17 Stanley Street, West Milford, NJ 07480, USA"
+    },
+    {
+        "location": {
+            "latitude": 408472324,
+            "longitude": -740726046
+        },
+        "name": "47 Industrial Avenue, Teterboro, NJ 07608, USA"
+    },
+    {
+        "location": {
+            "latitude": 412452168,
+            "longitude": -740214052
+        },
+        "name": "5 White Oak Lane, Stony Point, NY 10980, USA"
+    },
+    {
+        "location": {
+            "latitude": 409146138,
+            "longitude": -746188906
+        },
+        "name": "Berkshire Valley Management Area Trail, Jefferson, NJ, USA"
+    },
+    {
+        "location": {
+            "latitude": 404701380,
+            "longitude": -744781745
+        },
+        "name": "1007 Jersey Avenue, New Brunswick, NJ 08901, USA"
+    },
+    {
+        "location": {
+            "latitude": 409642566,
+            "longitude": -746017679
+        },
+        "name": "6 East Emerald Isle Drive, Lake Hopatcong, NJ 07849, USA"
+    },
+    {
+        "location": {
+            "latitude": 408031728,
+            "longitude": -748645385
+        },
+        "name": "1358-1474 New Jersey 57, Port Murray, NJ 07865, USA"
+    },
+    {
+        "location": {
+            "latitude": 413700272,
+            "longitude": -742135189
+        },
+        "name": "367 Prospect Road, Chester, NY 10918, USA"
+    },
+    {
+        "location": {
+            "latitude": 404310607,
+            "longitude": -740282632
+        },
+        "name": "10 Simon Lake Drive, Atlantic Highlands, NJ 07716, USA"
+    },
+    {
+        "location": {
+            "latitude": 409319800,
+            "longitude": -746201391
+        },
+        "name": "11 Ward Street, Mount Arlington, NJ 07856, USA"
+    },
+    {
+        "location": {
+            "latitude": 406685311,
+            "longitude": -742108603
+        },
+        "name": "300-398 Jefferson Avenue, Elizabeth, NJ 07201, USA"
+    },
+    {
+        "location": {
+            "latitude": 419018117,
+            "longitude": -749142781
+        },
+        "name": "43 Dreher Road, Roscoe, NY 12776, USA"
+    },
+    {
+        "location": {
+            "latitude": 412856162,
+            "longitude": -745148837
+        },
+        "name": "Swan Street, Pine Island, NY 10969, USA"
+    },
+    {
+        "location": {
+            "latitude": 416560744,
+            "longitude": -746721964
+        },
+        "name": "66 Pleasantview Avenue, Monticello, NY 12701, USA"
+    },
+    {
+        "location": {
+            "latitude": 405314270,
+            "longitude": -749836354
+        },
+        "name": ""
+    },
+    {
+        "location": {
+            "latitude": 414219548,
+            "longitude": -743327440
+        },
+        "name": ""
+    },
+    {
+        "location": {
+            "latitude": 415534177,
+            "longitude": -742900616
+        },
+        "name": "565 Winding Hills Road, Montgomery, NY 12549, USA"
+    },
+    {
+        "location": {
+            "latitude": 406898530,
+            "longitude": -749127080
+        },
+        "name": "231 Rocky Run Road, Glen Gardner, NJ 08826, USA"
+    },
+    {
+        "location": {
+            "latitude": 407586880,
+            "longitude": -741670168
+        },
+        "name": "100 Mount Pleasant Avenue, Newark, NJ 07104, USA"
+    },
+    {
+        "location": {
+            "latitude": 400106455,
+            "longitude": -742870190
+        },
+        "name": "517-521 Huntington Drive, Manchester Township, NJ 08759, USA"
+    },
+    {
+        "location": {
+            "latitude": 400066188,
+            "longitude": -746793294
+        },
+        "name": ""
+    },
+    {
+        "location": {
+            "latitude": 418803880,
+            "longitude": -744102673
+        },
+        "name": "40 Mountain Road, Napanoch, NY 12458, USA"
+    },
+    {
+        "location": {
+            "latitude": 414204288,
+            "longitude": -747895140
+        },
+        "name": ""
+    },
+    {
+        "location": {
+            "latitude": 414777405,
+            "longitude": -740615601
+        },
+        "name": ""
+    },
+    {
+        "location": {
+            "latitude": 415464475,
+            "longitude": -747175374
+        },
+        "name": "48 North Road, Forestburgh, NY 12777, USA"
+    },
+    {
+        "location": {
+            "latitude": 404062378,
+            "longitude": -746376177
+        },
+        "name": ""
+    },
+    {
+        "location": {
+            "latitude": 405688272,
+            "longitude": -749285130
+        },
+        "name": ""
+    },
+    {
+        "location": {
+            "latitude": 400342070,
+            "longitude": -748788996
+        },
+        "name": ""
+    },
+    {
+        "location": {
+            "latitude": 401809022,
+            "longitude": -744157964
+        },
+        "name": ""
+    },
+    {
+        "location": {
+            "latitude": 404226644,
+            "longitude": -740517141
+        },
+        "name": "9 Thompson Avenue, Leonardo, NJ 07737, USA"
+    },
+    {
+        "location": {
+            "latitude": 410322033,
+            "longitude": -747871659
+        },
+        "name": ""
+    },
+    {
+        "location": {
+            "latitude": 407100674,
+            "longitude": -747742727
+        },
+        "name": ""
+    },
+    {
+        "location": {
+            "latitude": 418811433,
+            "longitude": -741718005
+        },
+        "name": "213 Bush Road, Stone Ridge, NY 12484, USA"
+    },
+    {
+        "location": {
+            "latitude": 415034302,
+            "longitude": -743850945
+        },
+        "name": ""
+    },
+    {
+        "location": {
+            "latitude": 411349992,
+            "longitude": -743694161
+        },
+        "name": ""
+    },
+    {
+        "location": {
+            "latitude": 404839914,
+            "longitude": -744759616
+        },
+        "name": "1-17 Bergen Court, New Brunswick, NJ 08901, USA"
+    },
+    {
+        "location": {
+            "latitude": 414638017,
+            "longitude": -745957854
+        },
+        "name": "35 Oakland Valley Road, Cuddebackville, NY 12729, USA"
+    },
+    {
+        "location": {
+            "latitude": 412127800,
+            "longitude": -740173578
+        },
+        "name": ""
+    },
+    {
+        "location": {
+            "latitude": 401263460,
+            "longitude": -747964303
+        },
+        "name": ""
+    },
+    {
+        "location": {
+            "latitude": 412843391,
+            "longitude": -749086026
+        },
+        "name": ""
+    },
+    {
+        "location": {
+            "latitude": 418512773,
+            "longitude": -743067823
+        },
+        "name": ""
+    },
+    {
+        "location": {
+            "latitude": 404318328,
+            "longitude": -740835638
+        },
+        "name": "42-102 Main Street, Belford, NJ 07718, USA"
+    },
+    {
+        "location": {
+            "latitude": 419020746,
+            "longitude": -741172328
+        },
+        "name": ""
+    },
+    {
+        "location": {
+            "latitude": 404080723,
+            "longitude": -746119569
+        },
+        "name": ""
+    },
+    {
+        "location": {
+            "latitude": 401012643,
+            "longitude": -744035134
+        },
+        "name": ""
+    },
+    {
+        "location": {
+            "latitude": 404306372,
+            "longitude": -741079661
+        },
+        "name": ""
+    },
+    {
+        "location": {
+            "latitude": 403966326,
+            "longitude": -748519297
+        },
+        "name": ""
+    },
+    {
+        "location": {
+            "latitude": 405002031,
+            "longitude": -748407866
+        },
+        "name": ""
+    },
+    {
+        "location": {
+            "latitude": 409532885,
+            "longitude": -742200683
+        },
+        "name": ""
+    },
+    {
+        "location": {
+            "latitude": 416851321,
+            "longitude": -742674555
+        },
+        "name": ""
+    },
+    {
+        "location": {
+            "latitude": 406411633,
+            "longitude": -741722051
+        },
+        "name": "3387 Richmond Terrace, Staten Island, NY 10303, USA"
+    },
+    {
+        "location": {
+            "latitude": 413069058,
+            "longitude": -744597778
+        },
+        "name": "261 Van Sickle Road, Goshen, NY 10924, USA"
+    },
+    {
+        "location": {
+            "latitude": 418465462,
+            "longitude": -746859398
+        },
+        "name": ""
+    },
+    {
+        "location": {
+            "latitude": 411733222,
+            "longitude": -744228360
+        },
+        "name": ""
+    },
+    {
+        "location": {
+            "latitude": 410248224,
+            "longitude": -747127767
+        },
+        "name": "3 Hasta Way, Newton, NJ 07860, USA"
+    }
+]

--- a/examples/src/grpc-routeguide/generated/generated.rs
+++ b/examples/src/grpc-routeguide/generated/generated.rs
@@ -1,0 +1,11 @@
+#[path = "route_guide.u.pb.rs"]
+#[allow(nonstandard_style)]
+pub mod internal_do_not_use_route__guide;
+#[allow(unused_imports, nonstandard_style)]
+pub use internal_do_not_use_route__guide::*;
+pub mod __unstable {
+    pub static ROUTE_GUIDE_DESCRIPTOR_INFO: ::protobuf::__internal::runtime::__unstable::DescriptorInfo = ::protobuf::__internal::runtime::__unstable::DescriptorInfo {
+        descriptor: b"\n\x11route_guide.proto\x12\nrouteguide\",\n\x05Point\x12\x10\n\x08latitude\x18\x01 \x01(\x05\x12\x11\n\tlongitude\x18\x02 \x01(\x05\"I\n\tRectangle\x12\x1d\n\x02lo\x18\x01 \x01(\x0b\x32\x11.routeguide.Point\x12\x1d\n\x02hi\x18\x02 \x01(\x0b\x32\x11.routeguide.Point\"<\n\x07\x46\x65\x61ture\x12\x0c\n\x04name\x18\x01 \x01(\t\x12#\n\x08location\x18\x02 \x01(\x0b\x32\x11.routeguide.Point\"A\n\tRouteNote\x12#\n\x08location\x18\x01 \x01(\x0b\x32\x11.routeguide.Point\x12\x0f\n\x07message\x18\x02 \x01(\t\"b\n\x0cRouteSummary\x12\x13\n\x0bpoint_count\x18\x01 \x01(\x05\x12\x15\n\rfeature_count\x18\x02 \x01(\x05\x12\x10\n\x08\x64istance\x18\x03 \x01(\x05\x12\x14\n\x0c\x65lapsed_time\x18\x04 \x01(\x05\x32\x85\x02\n\nRouteGuide\x12\x36\n\nGetFeature\x12\x11.routeguide.Point\x1a\x13.routeguide.Feature\"\x00\x12>\n\x0cListFeatures\x12\x15.routeguide.Rectangle\x1a\x13.routeguide.Feature\"\x00\x30\x01\x12>\n\x0bRecordRoute\x12\x11.routeguide.Point\x1a\x18.routeguide.RouteSummary\"\x00(\x01\x12?\n\tRouteChat\x12\x15.routeguide.RouteNote\x1a\x15.routeguide.RouteNote\"\x00(\x01\x30\x01\x42\x30\n\x1bio.grpc.examples.routeguideB\x0fRouteGuideProtoP\x01\x62\x06proto3",
+        deps: &[],
+    };
+}

--- a/examples/src/grpc-routeguide/generated/route_guide.u.pb.rs
+++ b/examples/src/grpc-routeguide/generated/route_guide.u.pb.rs
@@ -1,0 +1,2115 @@
+const _: () = ::protobuf::__internal::assert_compatible_gencode_version(
+    "4.34.0-release",
+);
+pub(crate) static mut routeguide__Point_msg_init: ::protobuf::__internal::runtime::MiniTableInitPtr = ::protobuf::__internal::runtime::MiniTableInitPtr(
+    ::protobuf::__internal::runtime::MiniTablePtr::dangling(),
+);
+#[allow(non_camel_case_types)]
+pub struct Point {
+    inner: ::protobuf::__internal::runtime::OwnedMessageInner<Point>,
+}
+impl ::protobuf::Message for Point {}
+impl ::std::default::Default for Point {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+impl ::std::fmt::Debug for Point {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+        write!(f, "{}", ::protobuf::__internal::runtime::debug_string(self))
+    }
+}
+unsafe impl Sync for Point {}
+unsafe impl Send for Point {}
+impl ::protobuf::Proxied for Point {
+    type View<'msg> = PointView<'msg>;
+}
+impl ::protobuf::__internal::SealedInternal for Point {}
+impl ::protobuf::MutProxied for Point {
+    type Mut<'msg> = PointMut<'msg>;
+}
+#[derive(Copy, Clone)]
+#[allow(dead_code)]
+pub struct PointView<'msg> {
+    inner: ::protobuf::__internal::runtime::MessageViewInner<'msg, Point>,
+}
+impl<'msg> ::protobuf::__internal::SealedInternal for PointView<'msg> {}
+impl<'msg> ::protobuf::MessageView<'msg> for PointView<'msg> {
+    type Message = Point;
+}
+impl ::std::fmt::Debug for PointView<'_> {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+        write!(f, "{}", ::protobuf::__internal::runtime::debug_string(self))
+    }
+}
+impl ::std::default::Default for PointView<'_> {
+    fn default() -> PointView<'static> {
+        ::protobuf::__internal::runtime::MessageViewInner::default().into()
+    }
+}
+impl<'msg> From<::protobuf::__internal::runtime::MessageViewInner<'msg, Point>>
+for PointView<'msg> {
+    fn from(
+        inner: ::protobuf::__internal::runtime::MessageViewInner<'msg, Point>,
+    ) -> Self {
+        Self { inner }
+    }
+}
+#[allow(dead_code)]
+impl<'msg> PointView<'msg> {
+    pub fn to_owned(&self) -> Point {
+        ::protobuf::IntoProxied::into_proxied(*self, ::protobuf::__internal::Private)
+    }
+    pub fn latitude(self) -> i32 {
+        unsafe {
+            self.inner.ptr().get_i32_at_index(0, (0i32).into()).try_into().unwrap()
+        }
+    }
+    pub fn longitude(self) -> i32 {
+        unsafe {
+            self.inner.ptr().get_i32_at_index(1, (0i32).into()).try_into().unwrap()
+        }
+    }
+}
+unsafe impl Sync for PointView<'_> {}
+unsafe impl Send for PointView<'_> {}
+impl<'msg> ::protobuf::AsView for PointView<'msg> {
+    type Proxied = Point;
+    fn as_view(&self) -> ::protobuf::View<'msg, Point> {
+        *self
+    }
+}
+impl<'msg> ::protobuf::IntoView<'msg> for PointView<'msg> {
+    fn into_view<'shorter>(self) -> PointView<'shorter>
+    where
+        'msg: 'shorter,
+    {
+        self
+    }
+}
+impl<'msg> ::protobuf::IntoProxied<Point> for PointView<'msg> {
+    fn into_proxied(self, _private: ::protobuf::__internal::Private) -> Point {
+        let mut dst = Point::new();
+        assert!(
+            unsafe { dst.inner.ptr_mut().deep_copy(self.inner.ptr(), dst.inner.arena()) }
+        );
+        dst
+    }
+}
+impl<'msg> ::protobuf::IntoProxied<Point> for PointMut<'msg> {
+    fn into_proxied(self, _private: ::protobuf::__internal::Private) -> Point {
+        ::protobuf::IntoProxied::into_proxied(
+            ::protobuf::IntoView::into_view(self),
+            _private,
+        )
+    }
+}
+impl ::protobuf::__internal::runtime::EntityType for Point {
+    type Tag = ::protobuf::__internal::runtime::MessageTag;
+}
+impl<'msg> ::protobuf::__internal::runtime::EntityType for PointView<'msg> {
+    type Tag = ::protobuf::__internal::runtime::ViewProxyTag;
+}
+impl<'msg> ::protobuf::__internal::runtime::EntityType for PointMut<'msg> {
+    type Tag = ::protobuf::__internal::runtime::MutProxyTag;
+}
+#[allow(dead_code)]
+#[allow(non_camel_case_types)]
+pub struct PointMut<'msg> {
+    inner: ::protobuf::__internal::runtime::MessageMutInner<'msg, Point>,
+}
+impl<'msg> ::protobuf::__internal::SealedInternal for PointMut<'msg> {}
+impl<'msg> ::protobuf::MessageMut<'msg> for PointMut<'msg> {
+    type Message = Point;
+}
+impl ::std::fmt::Debug for PointMut<'_> {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+        write!(f, "{}", ::protobuf::__internal::runtime::debug_string(self))
+    }
+}
+impl<'msg> From<::protobuf::__internal::runtime::MessageMutInner<'msg, Point>>
+for PointMut<'msg> {
+    fn from(
+        inner: ::protobuf::__internal::runtime::MessageMutInner<'msg, Point>,
+    ) -> Self {
+        Self { inner }
+    }
+}
+#[allow(dead_code)]
+impl<'msg> PointMut<'msg> {
+    #[doc(hidden)]
+    pub fn as_message_mut_inner(
+        &mut self,
+        _private: ::protobuf::__internal::Private,
+    ) -> ::protobuf::__internal::runtime::MessageMutInner<'msg, Point> {
+        self.inner
+    }
+    pub fn to_owned(&self) -> Point {
+        ::protobuf::AsView::as_view(self).to_owned()
+    }
+    pub fn latitude(&self) -> i32 {
+        unsafe {
+            self.inner.ptr().get_i32_at_index(0, (0i32).into()).try_into().unwrap()
+        }
+    }
+    pub fn set_latitude(&mut self, val: i32) {
+        unsafe { self.inner.ptr_mut().set_base_field_i32_at_index(0, val.into()) }
+    }
+    pub fn longitude(&self) -> i32 {
+        unsafe {
+            self.inner.ptr().get_i32_at_index(1, (0i32).into()).try_into().unwrap()
+        }
+    }
+    pub fn set_longitude(&mut self, val: i32) {
+        unsafe { self.inner.ptr_mut().set_base_field_i32_at_index(1, val.into()) }
+    }
+}
+unsafe impl Send for PointMut<'_> {}
+unsafe impl Sync for PointMut<'_> {}
+impl<'msg> ::protobuf::AsView for PointMut<'msg> {
+    type Proxied = Point;
+    fn as_view(&self) -> ::protobuf::View<'_, Point> {
+        PointView {
+            inner: ::protobuf::__internal::runtime::MessageViewInner::view_of_mut(
+                self.inner,
+            ),
+        }
+    }
+}
+impl<'msg> ::protobuf::IntoView<'msg> for PointMut<'msg> {
+    fn into_view<'shorter>(self) -> ::protobuf::View<'shorter, Point>
+    where
+        'msg: 'shorter,
+    {
+        PointView {
+            inner: ::protobuf::__internal::runtime::MessageViewInner::view_of_mut(
+                self.inner,
+            ),
+        }
+    }
+}
+impl<'msg> ::protobuf::AsMut for PointMut<'msg> {
+    type MutProxied = Point;
+    fn as_mut(&mut self) -> PointMut<'msg> {
+        PointMut { inner: self.inner }
+    }
+}
+impl<'msg> ::protobuf::IntoMut<'msg> for PointMut<'msg> {
+    fn into_mut<'shorter>(self) -> PointMut<'shorter>
+    where
+        'msg: 'shorter,
+    {
+        self
+    }
+}
+#[allow(dead_code)]
+impl Point {
+    pub fn new() -> Self {
+        Self {
+            inner: ::protobuf::__internal::runtime::OwnedMessageInner::<Self>::new(),
+        }
+    }
+    #[doc(hidden)]
+    pub fn as_message_mut_inner(
+        &mut self,
+        _private: ::protobuf::__internal::Private,
+    ) -> ::protobuf::__internal::runtime::MessageMutInner<'_, Point> {
+        ::protobuf::__internal::runtime::MessageMutInner::mut_of_owned(&mut self.inner)
+    }
+    pub fn as_view(&self) -> PointView<'_> {
+        ::protobuf::__internal::runtime::MessageViewInner::view_of_owned(&self.inner)
+            .into()
+    }
+    pub fn as_mut(&mut self) -> PointMut<'_> {
+        ::protobuf::__internal::runtime::MessageMutInner::mut_of_owned(&mut self.inner)
+            .into()
+    }
+    pub fn latitude(&self) -> i32 {
+        unsafe {
+            self.inner.ptr().get_i32_at_index(0, (0i32).into()).try_into().unwrap()
+        }
+    }
+    pub fn set_latitude(&mut self, val: i32) {
+        unsafe { self.inner.ptr_mut().set_base_field_i32_at_index(0, val.into()) }
+    }
+    pub fn longitude(&self) -> i32 {
+        unsafe {
+            self.inner.ptr().get_i32_at_index(1, (0i32).into()).try_into().unwrap()
+        }
+    }
+    pub fn set_longitude(&mut self, val: i32) {
+        unsafe { self.inner.ptr_mut().set_base_field_i32_at_index(1, val.into()) }
+    }
+}
+impl ::std::ops::Drop for Point {
+    #[inline]
+    fn drop(&mut self) {}
+}
+impl ::std::clone::Clone for Point {
+    fn clone(&self) -> Self {
+        self.as_view().to_owned()
+    }
+}
+impl ::protobuf::AsView for Point {
+    type Proxied = Self;
+    fn as_view(&self) -> PointView<'_> {
+        self.as_view()
+    }
+}
+impl ::protobuf::AsMut for Point {
+    type MutProxied = Self;
+    fn as_mut(&mut self) -> PointMut<'_> {
+        self.as_mut()
+    }
+}
+unsafe impl ::protobuf::__internal::runtime::AssociatedMiniTable for Point {
+    fn mini_table() -> ::protobuf::__internal::runtime::MiniTablePtr {
+        static ONCE_LOCK: ::std::sync::OnceLock<
+            ::protobuf::__internal::runtime::MiniTableInitPtr,
+        > = ::std::sync::OnceLock::new();
+        unsafe {
+            ONCE_LOCK
+                .get_or_init(|| {
+                    super::routeguide__Point_msg_init.0 = ::protobuf::__internal::runtime::build_mini_table(
+                        "$(P(P",
+                    );
+                    ::protobuf::__internal::runtime::link_mini_table(
+                        super::routeguide__Point_msg_init.0,
+                        &[],
+                        &[],
+                    );
+                    ::protobuf::__internal::runtime::MiniTableInitPtr(
+                        super::routeguide__Point_msg_init.0,
+                    )
+                })
+                .0
+        }
+    }
+}
+unsafe impl ::protobuf::__internal::runtime::UpbGetArena for Point {
+    fn get_arena(
+        &mut self,
+        _private: ::protobuf::__internal::Private,
+    ) -> &::protobuf::__internal::runtime::Arena {
+        self.inner.arena()
+    }
+}
+unsafe impl ::protobuf::__internal::runtime::UpbGetMessagePtrMut for Point {
+    type Msg = Point;
+    fn get_ptr_mut(
+        &mut self,
+        _private: ::protobuf::__internal::Private,
+    ) -> ::protobuf::__internal::runtime::MessagePtr<Point> {
+        self.inner.ptr_mut()
+    }
+}
+unsafe impl ::protobuf::__internal::runtime::UpbGetMessagePtr for Point {
+    type Msg = Point;
+    fn get_ptr(
+        &self,
+        _private: ::protobuf::__internal::Private,
+    ) -> ::protobuf::__internal::runtime::MessagePtr<Point> {
+        self.inner.ptr()
+    }
+}
+unsafe impl ::protobuf::__internal::runtime::UpbGetMessagePtrMut for PointMut<'_> {
+    type Msg = Point;
+    fn get_ptr_mut(
+        &mut self,
+        _private: ::protobuf::__internal::Private,
+    ) -> ::protobuf::__internal::runtime::MessagePtr<Point> {
+        self.inner.ptr_mut()
+    }
+}
+unsafe impl ::protobuf::__internal::runtime::UpbGetMessagePtr for PointMut<'_> {
+    type Msg = Point;
+    fn get_ptr(
+        &self,
+        _private: ::protobuf::__internal::Private,
+    ) -> ::protobuf::__internal::runtime::MessagePtr<Point> {
+        self.inner.ptr()
+    }
+}
+unsafe impl ::protobuf::__internal::runtime::UpbGetMessagePtr for PointView<'_> {
+    type Msg = Point;
+    fn get_ptr(
+        &self,
+        _private: ::protobuf::__internal::Private,
+    ) -> ::protobuf::__internal::runtime::MessagePtr<Point> {
+        self.inner.ptr()
+    }
+}
+unsafe impl ::protobuf::__internal::runtime::UpbGetArena for PointMut<'_> {
+    fn get_arena(
+        &mut self,
+        _private: ::protobuf::__internal::Private,
+    ) -> &::protobuf::__internal::runtime::Arena {
+        self.inner.arena()
+    }
+}
+pub(crate) static mut routeguide__Rectangle_msg_init: ::protobuf::__internal::runtime::MiniTableInitPtr = ::protobuf::__internal::runtime::MiniTableInitPtr(
+    ::protobuf::__internal::runtime::MiniTablePtr::dangling(),
+);
+#[allow(non_camel_case_types)]
+pub struct Rectangle {
+    inner: ::protobuf::__internal::runtime::OwnedMessageInner<Rectangle>,
+}
+impl ::protobuf::Message for Rectangle {}
+impl ::std::default::Default for Rectangle {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+impl ::std::fmt::Debug for Rectangle {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+        write!(f, "{}", ::protobuf::__internal::runtime::debug_string(self))
+    }
+}
+unsafe impl Sync for Rectangle {}
+unsafe impl Send for Rectangle {}
+impl ::protobuf::Proxied for Rectangle {
+    type View<'msg> = RectangleView<'msg>;
+}
+impl ::protobuf::__internal::SealedInternal for Rectangle {}
+impl ::protobuf::MutProxied for Rectangle {
+    type Mut<'msg> = RectangleMut<'msg>;
+}
+#[derive(Copy, Clone)]
+#[allow(dead_code)]
+pub struct RectangleView<'msg> {
+    inner: ::protobuf::__internal::runtime::MessageViewInner<'msg, Rectangle>,
+}
+impl<'msg> ::protobuf::__internal::SealedInternal for RectangleView<'msg> {}
+impl<'msg> ::protobuf::MessageView<'msg> for RectangleView<'msg> {
+    type Message = Rectangle;
+}
+impl ::std::fmt::Debug for RectangleView<'_> {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+        write!(f, "{}", ::protobuf::__internal::runtime::debug_string(self))
+    }
+}
+impl ::std::default::Default for RectangleView<'_> {
+    fn default() -> RectangleView<'static> {
+        ::protobuf::__internal::runtime::MessageViewInner::default().into()
+    }
+}
+impl<'msg> From<::protobuf::__internal::runtime::MessageViewInner<'msg, Rectangle>>
+for RectangleView<'msg> {
+    fn from(
+        inner: ::protobuf::__internal::runtime::MessageViewInner<'msg, Rectangle>,
+    ) -> Self {
+        Self { inner }
+    }
+}
+#[allow(dead_code)]
+impl<'msg> RectangleView<'msg> {
+    pub fn to_owned(&self) -> Rectangle {
+        ::protobuf::IntoProxied::into_proxied(*self, ::protobuf::__internal::Private)
+    }
+    pub fn has_lo(self) -> bool {
+        unsafe { self.inner.ptr().has_field_at_index(0) }
+    }
+    pub fn lo_opt(self) -> ::protobuf::Optional<super::PointView<'msg>> {
+        ::protobuf::Optional::new(self.lo(), self.has_lo())
+    }
+    pub fn lo(self) -> super::PointView<'msg> {
+        let submsg = unsafe { self.inner.ptr().get_message_at_index(0) };
+        submsg
+            .map(|ptr| unsafe {
+                ::protobuf::__internal::runtime::MessageViewInner::wrap(ptr).into()
+            })
+            .unwrap_or(super::PointView::default())
+    }
+    pub fn has_hi(self) -> bool {
+        unsafe { self.inner.ptr().has_field_at_index(1) }
+    }
+    pub fn hi_opt(self) -> ::protobuf::Optional<super::PointView<'msg>> {
+        ::protobuf::Optional::new(self.hi(), self.has_hi())
+    }
+    pub fn hi(self) -> super::PointView<'msg> {
+        let submsg = unsafe { self.inner.ptr().get_message_at_index(1) };
+        submsg
+            .map(|ptr| unsafe {
+                ::protobuf::__internal::runtime::MessageViewInner::wrap(ptr).into()
+            })
+            .unwrap_or(super::PointView::default())
+    }
+}
+unsafe impl Sync for RectangleView<'_> {}
+unsafe impl Send for RectangleView<'_> {}
+impl<'msg> ::protobuf::AsView for RectangleView<'msg> {
+    type Proxied = Rectangle;
+    fn as_view(&self) -> ::protobuf::View<'msg, Rectangle> {
+        *self
+    }
+}
+impl<'msg> ::protobuf::IntoView<'msg> for RectangleView<'msg> {
+    fn into_view<'shorter>(self) -> RectangleView<'shorter>
+    where
+        'msg: 'shorter,
+    {
+        self
+    }
+}
+impl<'msg> ::protobuf::IntoProxied<Rectangle> for RectangleView<'msg> {
+    fn into_proxied(self, _private: ::protobuf::__internal::Private) -> Rectangle {
+        let mut dst = Rectangle::new();
+        assert!(
+            unsafe { dst.inner.ptr_mut().deep_copy(self.inner.ptr(), dst.inner.arena()) }
+        );
+        dst
+    }
+}
+impl<'msg> ::protobuf::IntoProxied<Rectangle> for RectangleMut<'msg> {
+    fn into_proxied(self, _private: ::protobuf::__internal::Private) -> Rectangle {
+        ::protobuf::IntoProxied::into_proxied(
+            ::protobuf::IntoView::into_view(self),
+            _private,
+        )
+    }
+}
+impl ::protobuf::__internal::runtime::EntityType for Rectangle {
+    type Tag = ::protobuf::__internal::runtime::MessageTag;
+}
+impl<'msg> ::protobuf::__internal::runtime::EntityType for RectangleView<'msg> {
+    type Tag = ::protobuf::__internal::runtime::ViewProxyTag;
+}
+impl<'msg> ::protobuf::__internal::runtime::EntityType for RectangleMut<'msg> {
+    type Tag = ::protobuf::__internal::runtime::MutProxyTag;
+}
+#[allow(dead_code)]
+#[allow(non_camel_case_types)]
+pub struct RectangleMut<'msg> {
+    inner: ::protobuf::__internal::runtime::MessageMutInner<'msg, Rectangle>,
+}
+impl<'msg> ::protobuf::__internal::SealedInternal for RectangleMut<'msg> {}
+impl<'msg> ::protobuf::MessageMut<'msg> for RectangleMut<'msg> {
+    type Message = Rectangle;
+}
+impl ::std::fmt::Debug for RectangleMut<'_> {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+        write!(f, "{}", ::protobuf::__internal::runtime::debug_string(self))
+    }
+}
+impl<'msg> From<::protobuf::__internal::runtime::MessageMutInner<'msg, Rectangle>>
+for RectangleMut<'msg> {
+    fn from(
+        inner: ::protobuf::__internal::runtime::MessageMutInner<'msg, Rectangle>,
+    ) -> Self {
+        Self { inner }
+    }
+}
+#[allow(dead_code)]
+impl<'msg> RectangleMut<'msg> {
+    #[doc(hidden)]
+    pub fn as_message_mut_inner(
+        &mut self,
+        _private: ::protobuf::__internal::Private,
+    ) -> ::protobuf::__internal::runtime::MessageMutInner<'msg, Rectangle> {
+        self.inner
+    }
+    pub fn to_owned(&self) -> Rectangle {
+        ::protobuf::AsView::as_view(self).to_owned()
+    }
+    pub fn has_lo(&self) -> bool {
+        unsafe { self.inner.ptr().has_field_at_index(0) }
+    }
+    pub fn clear_lo(&mut self) {
+        unsafe {
+            self.inner.ptr().clear_field_at_index(0);
+        }
+    }
+    pub fn lo_opt(&self) -> ::protobuf::Optional<super::PointView<'_>> {
+        ::protobuf::Optional::new(self.lo(), self.has_lo())
+    }
+    pub fn lo(&self) -> super::PointView<'_> {
+        let submsg = unsafe { self.inner.ptr().get_message_at_index(0) };
+        submsg
+            .map(|ptr| unsafe {
+                ::protobuf::__internal::runtime::MessageViewInner::wrap(ptr).into()
+            })
+            .unwrap_or(super::PointView::default())
+    }
+    pub fn lo_mut(&mut self) -> super::PointMut<'_> {
+        let ptr = unsafe {
+            self.inner
+                .ptr_mut()
+                .get_or_create_mutable_message_at_index(0, self.inner.arena())
+                .unwrap()
+        };
+        ::protobuf::__internal::runtime::MessageMutInner::from_parent(
+                self.as_message_mut_inner(::protobuf::__internal::Private),
+                ptr,
+            )
+            .into()
+    }
+    pub fn set_lo(&mut self, val: impl ::protobuf::IntoProxied<super::Point>) {
+        unsafe {
+            ::protobuf::__internal::runtime::message_set_sub_message(
+                ::protobuf::AsMut::as_mut(self).inner,
+                0,
+                val,
+            );
+        }
+    }
+    pub fn has_hi(&self) -> bool {
+        unsafe { self.inner.ptr().has_field_at_index(1) }
+    }
+    pub fn clear_hi(&mut self) {
+        unsafe {
+            self.inner.ptr().clear_field_at_index(1);
+        }
+    }
+    pub fn hi_opt(&self) -> ::protobuf::Optional<super::PointView<'_>> {
+        ::protobuf::Optional::new(self.hi(), self.has_hi())
+    }
+    pub fn hi(&self) -> super::PointView<'_> {
+        let submsg = unsafe { self.inner.ptr().get_message_at_index(1) };
+        submsg
+            .map(|ptr| unsafe {
+                ::protobuf::__internal::runtime::MessageViewInner::wrap(ptr).into()
+            })
+            .unwrap_or(super::PointView::default())
+    }
+    pub fn hi_mut(&mut self) -> super::PointMut<'_> {
+        let ptr = unsafe {
+            self.inner
+                .ptr_mut()
+                .get_or_create_mutable_message_at_index(1, self.inner.arena())
+                .unwrap()
+        };
+        ::protobuf::__internal::runtime::MessageMutInner::from_parent(
+                self.as_message_mut_inner(::protobuf::__internal::Private),
+                ptr,
+            )
+            .into()
+    }
+    pub fn set_hi(&mut self, val: impl ::protobuf::IntoProxied<super::Point>) {
+        unsafe {
+            ::protobuf::__internal::runtime::message_set_sub_message(
+                ::protobuf::AsMut::as_mut(self).inner,
+                1,
+                val,
+            );
+        }
+    }
+}
+unsafe impl Send for RectangleMut<'_> {}
+unsafe impl Sync for RectangleMut<'_> {}
+impl<'msg> ::protobuf::AsView for RectangleMut<'msg> {
+    type Proxied = Rectangle;
+    fn as_view(&self) -> ::protobuf::View<'_, Rectangle> {
+        RectangleView {
+            inner: ::protobuf::__internal::runtime::MessageViewInner::view_of_mut(
+                self.inner,
+            ),
+        }
+    }
+}
+impl<'msg> ::protobuf::IntoView<'msg> for RectangleMut<'msg> {
+    fn into_view<'shorter>(self) -> ::protobuf::View<'shorter, Rectangle>
+    where
+        'msg: 'shorter,
+    {
+        RectangleView {
+            inner: ::protobuf::__internal::runtime::MessageViewInner::view_of_mut(
+                self.inner,
+            ),
+        }
+    }
+}
+impl<'msg> ::protobuf::AsMut for RectangleMut<'msg> {
+    type MutProxied = Rectangle;
+    fn as_mut(&mut self) -> RectangleMut<'msg> {
+        RectangleMut { inner: self.inner }
+    }
+}
+impl<'msg> ::protobuf::IntoMut<'msg> for RectangleMut<'msg> {
+    fn into_mut<'shorter>(self) -> RectangleMut<'shorter>
+    where
+        'msg: 'shorter,
+    {
+        self
+    }
+}
+#[allow(dead_code)]
+impl Rectangle {
+    pub fn new() -> Self {
+        Self {
+            inner: ::protobuf::__internal::runtime::OwnedMessageInner::<Self>::new(),
+        }
+    }
+    #[doc(hidden)]
+    pub fn as_message_mut_inner(
+        &mut self,
+        _private: ::protobuf::__internal::Private,
+    ) -> ::protobuf::__internal::runtime::MessageMutInner<'_, Rectangle> {
+        ::protobuf::__internal::runtime::MessageMutInner::mut_of_owned(&mut self.inner)
+    }
+    pub fn as_view(&self) -> RectangleView<'_> {
+        ::protobuf::__internal::runtime::MessageViewInner::view_of_owned(&self.inner)
+            .into()
+    }
+    pub fn as_mut(&mut self) -> RectangleMut<'_> {
+        ::protobuf::__internal::runtime::MessageMutInner::mut_of_owned(&mut self.inner)
+            .into()
+    }
+    pub fn has_lo(&self) -> bool {
+        unsafe { self.inner.ptr().has_field_at_index(0) }
+    }
+    pub fn clear_lo(&mut self) {
+        unsafe {
+            self.inner.ptr().clear_field_at_index(0);
+        }
+    }
+    pub fn lo_opt(&self) -> ::protobuf::Optional<super::PointView<'_>> {
+        ::protobuf::Optional::new(self.lo(), self.has_lo())
+    }
+    pub fn lo(&self) -> super::PointView<'_> {
+        let submsg = unsafe { self.inner.ptr().get_message_at_index(0) };
+        submsg
+            .map(|ptr| unsafe {
+                ::protobuf::__internal::runtime::MessageViewInner::wrap(ptr).into()
+            })
+            .unwrap_or(super::PointView::default())
+    }
+    pub fn lo_mut(&mut self) -> super::PointMut<'_> {
+        let ptr = unsafe {
+            self.inner
+                .ptr_mut()
+                .get_or_create_mutable_message_at_index(0, self.inner.arena())
+                .unwrap()
+        };
+        ::protobuf::__internal::runtime::MessageMutInner::from_parent(
+                self.as_message_mut_inner(::protobuf::__internal::Private),
+                ptr,
+            )
+            .into()
+    }
+    pub fn set_lo(&mut self, val: impl ::protobuf::IntoProxied<super::Point>) {
+        unsafe {
+            ::protobuf::__internal::runtime::message_set_sub_message(
+                ::protobuf::AsMut::as_mut(self).inner,
+                0,
+                val,
+            );
+        }
+    }
+    pub fn has_hi(&self) -> bool {
+        unsafe { self.inner.ptr().has_field_at_index(1) }
+    }
+    pub fn clear_hi(&mut self) {
+        unsafe {
+            self.inner.ptr().clear_field_at_index(1);
+        }
+    }
+    pub fn hi_opt(&self) -> ::protobuf::Optional<super::PointView<'_>> {
+        ::protobuf::Optional::new(self.hi(), self.has_hi())
+    }
+    pub fn hi(&self) -> super::PointView<'_> {
+        let submsg = unsafe { self.inner.ptr().get_message_at_index(1) };
+        submsg
+            .map(|ptr| unsafe {
+                ::protobuf::__internal::runtime::MessageViewInner::wrap(ptr).into()
+            })
+            .unwrap_or(super::PointView::default())
+    }
+    pub fn hi_mut(&mut self) -> super::PointMut<'_> {
+        let ptr = unsafe {
+            self.inner
+                .ptr_mut()
+                .get_or_create_mutable_message_at_index(1, self.inner.arena())
+                .unwrap()
+        };
+        ::protobuf::__internal::runtime::MessageMutInner::from_parent(
+                self.as_message_mut_inner(::protobuf::__internal::Private),
+                ptr,
+            )
+            .into()
+    }
+    pub fn set_hi(&mut self, val: impl ::protobuf::IntoProxied<super::Point>) {
+        unsafe {
+            ::protobuf::__internal::runtime::message_set_sub_message(
+                ::protobuf::AsMut::as_mut(self).inner,
+                1,
+                val,
+            );
+        }
+    }
+}
+impl ::std::ops::Drop for Rectangle {
+    #[inline]
+    fn drop(&mut self) {}
+}
+impl ::std::clone::Clone for Rectangle {
+    fn clone(&self) -> Self {
+        self.as_view().to_owned()
+    }
+}
+impl ::protobuf::AsView for Rectangle {
+    type Proxied = Self;
+    fn as_view(&self) -> RectangleView<'_> {
+        self.as_view()
+    }
+}
+impl ::protobuf::AsMut for Rectangle {
+    type MutProxied = Self;
+    fn as_mut(&mut self) -> RectangleMut<'_> {
+        self.as_mut()
+    }
+}
+unsafe impl ::protobuf::__internal::runtime::AssociatedMiniTable for Rectangle {
+    fn mini_table() -> ::protobuf::__internal::runtime::MiniTablePtr {
+        static ONCE_LOCK: ::std::sync::OnceLock<
+            ::protobuf::__internal::runtime::MiniTableInitPtr,
+        > = ::std::sync::OnceLock::new();
+        unsafe {
+            ONCE_LOCK
+                .get_or_init(|| {
+                    super::routeguide__Rectangle_msg_init.0 = ::protobuf::__internal::runtime::build_mini_table(
+                        "$33",
+                    );
+                    ::protobuf::__internal::runtime::link_mini_table(
+                        super::routeguide__Rectangle_msg_init.0,
+                        &[
+                            <super::Point as ::protobuf::__internal::runtime::AssociatedMiniTable>::mini_table(),
+                            <super::Point as ::protobuf::__internal::runtime::AssociatedMiniTable>::mini_table(),
+                        ],
+                        &[],
+                    );
+                    ::protobuf::__internal::runtime::MiniTableInitPtr(
+                        super::routeguide__Rectangle_msg_init.0,
+                    )
+                })
+                .0
+        }
+    }
+}
+unsafe impl ::protobuf::__internal::runtime::UpbGetArena for Rectangle {
+    fn get_arena(
+        &mut self,
+        _private: ::protobuf::__internal::Private,
+    ) -> &::protobuf::__internal::runtime::Arena {
+        self.inner.arena()
+    }
+}
+unsafe impl ::protobuf::__internal::runtime::UpbGetMessagePtrMut for Rectangle {
+    type Msg = Rectangle;
+    fn get_ptr_mut(
+        &mut self,
+        _private: ::protobuf::__internal::Private,
+    ) -> ::protobuf::__internal::runtime::MessagePtr<Rectangle> {
+        self.inner.ptr_mut()
+    }
+}
+unsafe impl ::protobuf::__internal::runtime::UpbGetMessagePtr for Rectangle {
+    type Msg = Rectangle;
+    fn get_ptr(
+        &self,
+        _private: ::protobuf::__internal::Private,
+    ) -> ::protobuf::__internal::runtime::MessagePtr<Rectangle> {
+        self.inner.ptr()
+    }
+}
+unsafe impl ::protobuf::__internal::runtime::UpbGetMessagePtrMut for RectangleMut<'_> {
+    type Msg = Rectangle;
+    fn get_ptr_mut(
+        &mut self,
+        _private: ::protobuf::__internal::Private,
+    ) -> ::protobuf::__internal::runtime::MessagePtr<Rectangle> {
+        self.inner.ptr_mut()
+    }
+}
+unsafe impl ::protobuf::__internal::runtime::UpbGetMessagePtr for RectangleMut<'_> {
+    type Msg = Rectangle;
+    fn get_ptr(
+        &self,
+        _private: ::protobuf::__internal::Private,
+    ) -> ::protobuf::__internal::runtime::MessagePtr<Rectangle> {
+        self.inner.ptr()
+    }
+}
+unsafe impl ::protobuf::__internal::runtime::UpbGetMessagePtr for RectangleView<'_> {
+    type Msg = Rectangle;
+    fn get_ptr(
+        &self,
+        _private: ::protobuf::__internal::Private,
+    ) -> ::protobuf::__internal::runtime::MessagePtr<Rectangle> {
+        self.inner.ptr()
+    }
+}
+unsafe impl ::protobuf::__internal::runtime::UpbGetArena for RectangleMut<'_> {
+    fn get_arena(
+        &mut self,
+        _private: ::protobuf::__internal::Private,
+    ) -> &::protobuf::__internal::runtime::Arena {
+        self.inner.arena()
+    }
+}
+pub(crate) static mut routeguide__Feature_msg_init: ::protobuf::__internal::runtime::MiniTableInitPtr = ::protobuf::__internal::runtime::MiniTableInitPtr(
+    ::protobuf::__internal::runtime::MiniTablePtr::dangling(),
+);
+#[allow(non_camel_case_types)]
+pub struct Feature {
+    inner: ::protobuf::__internal::runtime::OwnedMessageInner<Feature>,
+}
+impl ::protobuf::Message for Feature {}
+impl ::std::default::Default for Feature {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+impl ::std::fmt::Debug for Feature {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+        write!(f, "{}", ::protobuf::__internal::runtime::debug_string(self))
+    }
+}
+unsafe impl Sync for Feature {}
+unsafe impl Send for Feature {}
+impl ::protobuf::Proxied for Feature {
+    type View<'msg> = FeatureView<'msg>;
+}
+impl ::protobuf::__internal::SealedInternal for Feature {}
+impl ::protobuf::MutProxied for Feature {
+    type Mut<'msg> = FeatureMut<'msg>;
+}
+#[derive(Copy, Clone)]
+#[allow(dead_code)]
+pub struct FeatureView<'msg> {
+    inner: ::protobuf::__internal::runtime::MessageViewInner<'msg, Feature>,
+}
+impl<'msg> ::protobuf::__internal::SealedInternal for FeatureView<'msg> {}
+impl<'msg> ::protobuf::MessageView<'msg> for FeatureView<'msg> {
+    type Message = Feature;
+}
+impl ::std::fmt::Debug for FeatureView<'_> {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+        write!(f, "{}", ::protobuf::__internal::runtime::debug_string(self))
+    }
+}
+impl ::std::default::Default for FeatureView<'_> {
+    fn default() -> FeatureView<'static> {
+        ::protobuf::__internal::runtime::MessageViewInner::default().into()
+    }
+}
+impl<'msg> From<::protobuf::__internal::runtime::MessageViewInner<'msg, Feature>>
+for FeatureView<'msg> {
+    fn from(
+        inner: ::protobuf::__internal::runtime::MessageViewInner<'msg, Feature>,
+    ) -> Self {
+        Self { inner }
+    }
+}
+#[allow(dead_code)]
+impl<'msg> FeatureView<'msg> {
+    pub fn to_owned(&self) -> Feature {
+        ::protobuf::IntoProxied::into_proxied(*self, ::protobuf::__internal::Private)
+    }
+    pub fn name(self) -> ::protobuf::View<'msg, ::protobuf::ProtoString> {
+        let str_view = unsafe { self.inner.ptr().get_string_at_index(0, (b"").into()) };
+        unsafe { ::protobuf::ProtoStr::from_utf8_unchecked(str_view.as_ref()) }
+    }
+    pub fn has_location(self) -> bool {
+        unsafe { self.inner.ptr().has_field_at_index(1) }
+    }
+    pub fn location_opt(self) -> ::protobuf::Optional<super::PointView<'msg>> {
+        ::protobuf::Optional::new(self.location(), self.has_location())
+    }
+    pub fn location(self) -> super::PointView<'msg> {
+        let submsg = unsafe { self.inner.ptr().get_message_at_index(1) };
+        submsg
+            .map(|ptr| unsafe {
+                ::protobuf::__internal::runtime::MessageViewInner::wrap(ptr).into()
+            })
+            .unwrap_or(super::PointView::default())
+    }
+}
+unsafe impl Sync for FeatureView<'_> {}
+unsafe impl Send for FeatureView<'_> {}
+impl<'msg> ::protobuf::AsView for FeatureView<'msg> {
+    type Proxied = Feature;
+    fn as_view(&self) -> ::protobuf::View<'msg, Feature> {
+        *self
+    }
+}
+impl<'msg> ::protobuf::IntoView<'msg> for FeatureView<'msg> {
+    fn into_view<'shorter>(self) -> FeatureView<'shorter>
+    where
+        'msg: 'shorter,
+    {
+        self
+    }
+}
+impl<'msg> ::protobuf::IntoProxied<Feature> for FeatureView<'msg> {
+    fn into_proxied(self, _private: ::protobuf::__internal::Private) -> Feature {
+        let mut dst = Feature::new();
+        assert!(
+            unsafe { dst.inner.ptr_mut().deep_copy(self.inner.ptr(), dst.inner.arena()) }
+        );
+        dst
+    }
+}
+impl<'msg> ::protobuf::IntoProxied<Feature> for FeatureMut<'msg> {
+    fn into_proxied(self, _private: ::protobuf::__internal::Private) -> Feature {
+        ::protobuf::IntoProxied::into_proxied(
+            ::protobuf::IntoView::into_view(self),
+            _private,
+        )
+    }
+}
+impl ::protobuf::__internal::runtime::EntityType for Feature {
+    type Tag = ::protobuf::__internal::runtime::MessageTag;
+}
+impl<'msg> ::protobuf::__internal::runtime::EntityType for FeatureView<'msg> {
+    type Tag = ::protobuf::__internal::runtime::ViewProxyTag;
+}
+impl<'msg> ::protobuf::__internal::runtime::EntityType for FeatureMut<'msg> {
+    type Tag = ::protobuf::__internal::runtime::MutProxyTag;
+}
+#[allow(dead_code)]
+#[allow(non_camel_case_types)]
+pub struct FeatureMut<'msg> {
+    inner: ::protobuf::__internal::runtime::MessageMutInner<'msg, Feature>,
+}
+impl<'msg> ::protobuf::__internal::SealedInternal for FeatureMut<'msg> {}
+impl<'msg> ::protobuf::MessageMut<'msg> for FeatureMut<'msg> {
+    type Message = Feature;
+}
+impl ::std::fmt::Debug for FeatureMut<'_> {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+        write!(f, "{}", ::protobuf::__internal::runtime::debug_string(self))
+    }
+}
+impl<'msg> From<::protobuf::__internal::runtime::MessageMutInner<'msg, Feature>>
+for FeatureMut<'msg> {
+    fn from(
+        inner: ::protobuf::__internal::runtime::MessageMutInner<'msg, Feature>,
+    ) -> Self {
+        Self { inner }
+    }
+}
+#[allow(dead_code)]
+impl<'msg> FeatureMut<'msg> {
+    #[doc(hidden)]
+    pub fn as_message_mut_inner(
+        &mut self,
+        _private: ::protobuf::__internal::Private,
+    ) -> ::protobuf::__internal::runtime::MessageMutInner<'msg, Feature> {
+        self.inner
+    }
+    pub fn to_owned(&self) -> Feature {
+        ::protobuf::AsView::as_view(self).to_owned()
+    }
+    pub fn name(&self) -> ::protobuf::View<'_, ::protobuf::ProtoString> {
+        let str_view = unsafe { self.inner.ptr().get_string_at_index(0, (b"").into()) };
+        unsafe { ::protobuf::ProtoStr::from_utf8_unchecked(str_view.as_ref()) }
+    }
+    pub fn set_name(
+        &mut self,
+        val: impl ::protobuf::IntoProxied<::protobuf::ProtoString>,
+    ) {
+        unsafe {
+            ::protobuf::__internal::runtime::message_set_string_field(
+                ::protobuf::AsMut::as_mut(self).inner,
+                0,
+                val,
+            );
+        }
+    }
+    pub fn has_location(&self) -> bool {
+        unsafe { self.inner.ptr().has_field_at_index(1) }
+    }
+    pub fn clear_location(&mut self) {
+        unsafe {
+            self.inner.ptr().clear_field_at_index(1);
+        }
+    }
+    pub fn location_opt(&self) -> ::protobuf::Optional<super::PointView<'_>> {
+        ::protobuf::Optional::new(self.location(), self.has_location())
+    }
+    pub fn location(&self) -> super::PointView<'_> {
+        let submsg = unsafe { self.inner.ptr().get_message_at_index(1) };
+        submsg
+            .map(|ptr| unsafe {
+                ::protobuf::__internal::runtime::MessageViewInner::wrap(ptr).into()
+            })
+            .unwrap_or(super::PointView::default())
+    }
+    pub fn location_mut(&mut self) -> super::PointMut<'_> {
+        let ptr = unsafe {
+            self.inner
+                .ptr_mut()
+                .get_or_create_mutable_message_at_index(1, self.inner.arena())
+                .unwrap()
+        };
+        ::protobuf::__internal::runtime::MessageMutInner::from_parent(
+                self.as_message_mut_inner(::protobuf::__internal::Private),
+                ptr,
+            )
+            .into()
+    }
+    pub fn set_location(&mut self, val: impl ::protobuf::IntoProxied<super::Point>) {
+        unsafe {
+            ::protobuf::__internal::runtime::message_set_sub_message(
+                ::protobuf::AsMut::as_mut(self).inner,
+                1,
+                val,
+            );
+        }
+    }
+}
+unsafe impl Send for FeatureMut<'_> {}
+unsafe impl Sync for FeatureMut<'_> {}
+impl<'msg> ::protobuf::AsView for FeatureMut<'msg> {
+    type Proxied = Feature;
+    fn as_view(&self) -> ::protobuf::View<'_, Feature> {
+        FeatureView {
+            inner: ::protobuf::__internal::runtime::MessageViewInner::view_of_mut(
+                self.inner,
+            ),
+        }
+    }
+}
+impl<'msg> ::protobuf::IntoView<'msg> for FeatureMut<'msg> {
+    fn into_view<'shorter>(self) -> ::protobuf::View<'shorter, Feature>
+    where
+        'msg: 'shorter,
+    {
+        FeatureView {
+            inner: ::protobuf::__internal::runtime::MessageViewInner::view_of_mut(
+                self.inner,
+            ),
+        }
+    }
+}
+impl<'msg> ::protobuf::AsMut for FeatureMut<'msg> {
+    type MutProxied = Feature;
+    fn as_mut(&mut self) -> FeatureMut<'msg> {
+        FeatureMut { inner: self.inner }
+    }
+}
+impl<'msg> ::protobuf::IntoMut<'msg> for FeatureMut<'msg> {
+    fn into_mut<'shorter>(self) -> FeatureMut<'shorter>
+    where
+        'msg: 'shorter,
+    {
+        self
+    }
+}
+#[allow(dead_code)]
+impl Feature {
+    pub fn new() -> Self {
+        Self {
+            inner: ::protobuf::__internal::runtime::OwnedMessageInner::<Self>::new(),
+        }
+    }
+    #[doc(hidden)]
+    pub fn as_message_mut_inner(
+        &mut self,
+        _private: ::protobuf::__internal::Private,
+    ) -> ::protobuf::__internal::runtime::MessageMutInner<'_, Feature> {
+        ::protobuf::__internal::runtime::MessageMutInner::mut_of_owned(&mut self.inner)
+    }
+    pub fn as_view(&self) -> FeatureView<'_> {
+        ::protobuf::__internal::runtime::MessageViewInner::view_of_owned(&self.inner)
+            .into()
+    }
+    pub fn as_mut(&mut self) -> FeatureMut<'_> {
+        ::protobuf::__internal::runtime::MessageMutInner::mut_of_owned(&mut self.inner)
+            .into()
+    }
+    pub fn name(&self) -> ::protobuf::View<'_, ::protobuf::ProtoString> {
+        let str_view = unsafe { self.inner.ptr().get_string_at_index(0, (b"").into()) };
+        unsafe { ::protobuf::ProtoStr::from_utf8_unchecked(str_view.as_ref()) }
+    }
+    pub fn set_name(
+        &mut self,
+        val: impl ::protobuf::IntoProxied<::protobuf::ProtoString>,
+    ) {
+        unsafe {
+            ::protobuf::__internal::runtime::message_set_string_field(
+                ::protobuf::AsMut::as_mut(self).inner,
+                0,
+                val,
+            );
+        }
+    }
+    pub fn has_location(&self) -> bool {
+        unsafe { self.inner.ptr().has_field_at_index(1) }
+    }
+    pub fn clear_location(&mut self) {
+        unsafe {
+            self.inner.ptr().clear_field_at_index(1);
+        }
+    }
+    pub fn location_opt(&self) -> ::protobuf::Optional<super::PointView<'_>> {
+        ::protobuf::Optional::new(self.location(), self.has_location())
+    }
+    pub fn location(&self) -> super::PointView<'_> {
+        let submsg = unsafe { self.inner.ptr().get_message_at_index(1) };
+        submsg
+            .map(|ptr| unsafe {
+                ::protobuf::__internal::runtime::MessageViewInner::wrap(ptr).into()
+            })
+            .unwrap_or(super::PointView::default())
+    }
+    pub fn location_mut(&mut self) -> super::PointMut<'_> {
+        let ptr = unsafe {
+            self.inner
+                .ptr_mut()
+                .get_or_create_mutable_message_at_index(1, self.inner.arena())
+                .unwrap()
+        };
+        ::protobuf::__internal::runtime::MessageMutInner::from_parent(
+                self.as_message_mut_inner(::protobuf::__internal::Private),
+                ptr,
+            )
+            .into()
+    }
+    pub fn set_location(&mut self, val: impl ::protobuf::IntoProxied<super::Point>) {
+        unsafe {
+            ::protobuf::__internal::runtime::message_set_sub_message(
+                ::protobuf::AsMut::as_mut(self).inner,
+                1,
+                val,
+            );
+        }
+    }
+}
+impl ::std::ops::Drop for Feature {
+    #[inline]
+    fn drop(&mut self) {}
+}
+impl ::std::clone::Clone for Feature {
+    fn clone(&self) -> Self {
+        self.as_view().to_owned()
+    }
+}
+impl ::protobuf::AsView for Feature {
+    type Proxied = Self;
+    fn as_view(&self) -> FeatureView<'_> {
+        self.as_view()
+    }
+}
+impl ::protobuf::AsMut for Feature {
+    type MutProxied = Self;
+    fn as_mut(&mut self) -> FeatureMut<'_> {
+        self.as_mut()
+    }
+}
+unsafe impl ::protobuf::__internal::runtime::AssociatedMiniTable for Feature {
+    fn mini_table() -> ::protobuf::__internal::runtime::MiniTablePtr {
+        static ONCE_LOCK: ::std::sync::OnceLock<
+            ::protobuf::__internal::runtime::MiniTableInitPtr,
+        > = ::std::sync::OnceLock::new();
+        unsafe {
+            ONCE_LOCK
+                .get_or_init(|| {
+                    super::routeguide__Feature_msg_init.0 = ::protobuf::__internal::runtime::build_mini_table(
+                        "$1X3",
+                    );
+                    ::protobuf::__internal::runtime::link_mini_table(
+                        super::routeguide__Feature_msg_init.0,
+                        &[
+                            <super::Point as ::protobuf::__internal::runtime::AssociatedMiniTable>::mini_table(),
+                        ],
+                        &[],
+                    );
+                    ::protobuf::__internal::runtime::MiniTableInitPtr(
+                        super::routeguide__Feature_msg_init.0,
+                    )
+                })
+                .0
+        }
+    }
+}
+unsafe impl ::protobuf::__internal::runtime::UpbGetArena for Feature {
+    fn get_arena(
+        &mut self,
+        _private: ::protobuf::__internal::Private,
+    ) -> &::protobuf::__internal::runtime::Arena {
+        self.inner.arena()
+    }
+}
+unsafe impl ::protobuf::__internal::runtime::UpbGetMessagePtrMut for Feature {
+    type Msg = Feature;
+    fn get_ptr_mut(
+        &mut self,
+        _private: ::protobuf::__internal::Private,
+    ) -> ::protobuf::__internal::runtime::MessagePtr<Feature> {
+        self.inner.ptr_mut()
+    }
+}
+unsafe impl ::protobuf::__internal::runtime::UpbGetMessagePtr for Feature {
+    type Msg = Feature;
+    fn get_ptr(
+        &self,
+        _private: ::protobuf::__internal::Private,
+    ) -> ::protobuf::__internal::runtime::MessagePtr<Feature> {
+        self.inner.ptr()
+    }
+}
+unsafe impl ::protobuf::__internal::runtime::UpbGetMessagePtrMut for FeatureMut<'_> {
+    type Msg = Feature;
+    fn get_ptr_mut(
+        &mut self,
+        _private: ::protobuf::__internal::Private,
+    ) -> ::protobuf::__internal::runtime::MessagePtr<Feature> {
+        self.inner.ptr_mut()
+    }
+}
+unsafe impl ::protobuf::__internal::runtime::UpbGetMessagePtr for FeatureMut<'_> {
+    type Msg = Feature;
+    fn get_ptr(
+        &self,
+        _private: ::protobuf::__internal::Private,
+    ) -> ::protobuf::__internal::runtime::MessagePtr<Feature> {
+        self.inner.ptr()
+    }
+}
+unsafe impl ::protobuf::__internal::runtime::UpbGetMessagePtr for FeatureView<'_> {
+    type Msg = Feature;
+    fn get_ptr(
+        &self,
+        _private: ::protobuf::__internal::Private,
+    ) -> ::protobuf::__internal::runtime::MessagePtr<Feature> {
+        self.inner.ptr()
+    }
+}
+unsafe impl ::protobuf::__internal::runtime::UpbGetArena for FeatureMut<'_> {
+    fn get_arena(
+        &mut self,
+        _private: ::protobuf::__internal::Private,
+    ) -> &::protobuf::__internal::runtime::Arena {
+        self.inner.arena()
+    }
+}
+pub(crate) static mut routeguide__RouteNote_msg_init: ::protobuf::__internal::runtime::MiniTableInitPtr = ::protobuf::__internal::runtime::MiniTableInitPtr(
+    ::protobuf::__internal::runtime::MiniTablePtr::dangling(),
+);
+#[allow(non_camel_case_types)]
+pub struct RouteNote {
+    inner: ::protobuf::__internal::runtime::OwnedMessageInner<RouteNote>,
+}
+impl ::protobuf::Message for RouteNote {}
+impl ::std::default::Default for RouteNote {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+impl ::std::fmt::Debug for RouteNote {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+        write!(f, "{}", ::protobuf::__internal::runtime::debug_string(self))
+    }
+}
+unsafe impl Sync for RouteNote {}
+unsafe impl Send for RouteNote {}
+impl ::protobuf::Proxied for RouteNote {
+    type View<'msg> = RouteNoteView<'msg>;
+}
+impl ::protobuf::__internal::SealedInternal for RouteNote {}
+impl ::protobuf::MutProxied for RouteNote {
+    type Mut<'msg> = RouteNoteMut<'msg>;
+}
+#[derive(Copy, Clone)]
+#[allow(dead_code)]
+pub struct RouteNoteView<'msg> {
+    inner: ::protobuf::__internal::runtime::MessageViewInner<'msg, RouteNote>,
+}
+impl<'msg> ::protobuf::__internal::SealedInternal for RouteNoteView<'msg> {}
+impl<'msg> ::protobuf::MessageView<'msg> for RouteNoteView<'msg> {
+    type Message = RouteNote;
+}
+impl ::std::fmt::Debug for RouteNoteView<'_> {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+        write!(f, "{}", ::protobuf::__internal::runtime::debug_string(self))
+    }
+}
+impl ::std::default::Default for RouteNoteView<'_> {
+    fn default() -> RouteNoteView<'static> {
+        ::protobuf::__internal::runtime::MessageViewInner::default().into()
+    }
+}
+impl<'msg> From<::protobuf::__internal::runtime::MessageViewInner<'msg, RouteNote>>
+for RouteNoteView<'msg> {
+    fn from(
+        inner: ::protobuf::__internal::runtime::MessageViewInner<'msg, RouteNote>,
+    ) -> Self {
+        Self { inner }
+    }
+}
+#[allow(dead_code)]
+impl<'msg> RouteNoteView<'msg> {
+    pub fn to_owned(&self) -> RouteNote {
+        ::protobuf::IntoProxied::into_proxied(*self, ::protobuf::__internal::Private)
+    }
+    pub fn has_location(self) -> bool {
+        unsafe { self.inner.ptr().has_field_at_index(0) }
+    }
+    pub fn location_opt(self) -> ::protobuf::Optional<super::PointView<'msg>> {
+        ::protobuf::Optional::new(self.location(), self.has_location())
+    }
+    pub fn location(self) -> super::PointView<'msg> {
+        let submsg = unsafe { self.inner.ptr().get_message_at_index(0) };
+        submsg
+            .map(|ptr| unsafe {
+                ::protobuf::__internal::runtime::MessageViewInner::wrap(ptr).into()
+            })
+            .unwrap_or(super::PointView::default())
+    }
+    pub fn message(self) -> ::protobuf::View<'msg, ::protobuf::ProtoString> {
+        let str_view = unsafe { self.inner.ptr().get_string_at_index(1, (b"").into()) };
+        unsafe { ::protobuf::ProtoStr::from_utf8_unchecked(str_view.as_ref()) }
+    }
+}
+unsafe impl Sync for RouteNoteView<'_> {}
+unsafe impl Send for RouteNoteView<'_> {}
+impl<'msg> ::protobuf::AsView for RouteNoteView<'msg> {
+    type Proxied = RouteNote;
+    fn as_view(&self) -> ::protobuf::View<'msg, RouteNote> {
+        *self
+    }
+}
+impl<'msg> ::protobuf::IntoView<'msg> for RouteNoteView<'msg> {
+    fn into_view<'shorter>(self) -> RouteNoteView<'shorter>
+    where
+        'msg: 'shorter,
+    {
+        self
+    }
+}
+impl<'msg> ::protobuf::IntoProxied<RouteNote> for RouteNoteView<'msg> {
+    fn into_proxied(self, _private: ::protobuf::__internal::Private) -> RouteNote {
+        let mut dst = RouteNote::new();
+        assert!(
+            unsafe { dst.inner.ptr_mut().deep_copy(self.inner.ptr(), dst.inner.arena()) }
+        );
+        dst
+    }
+}
+impl<'msg> ::protobuf::IntoProxied<RouteNote> for RouteNoteMut<'msg> {
+    fn into_proxied(self, _private: ::protobuf::__internal::Private) -> RouteNote {
+        ::protobuf::IntoProxied::into_proxied(
+            ::protobuf::IntoView::into_view(self),
+            _private,
+        )
+    }
+}
+impl ::protobuf::__internal::runtime::EntityType for RouteNote {
+    type Tag = ::protobuf::__internal::runtime::MessageTag;
+}
+impl<'msg> ::protobuf::__internal::runtime::EntityType for RouteNoteView<'msg> {
+    type Tag = ::protobuf::__internal::runtime::ViewProxyTag;
+}
+impl<'msg> ::protobuf::__internal::runtime::EntityType for RouteNoteMut<'msg> {
+    type Tag = ::protobuf::__internal::runtime::MutProxyTag;
+}
+#[allow(dead_code)]
+#[allow(non_camel_case_types)]
+pub struct RouteNoteMut<'msg> {
+    inner: ::protobuf::__internal::runtime::MessageMutInner<'msg, RouteNote>,
+}
+impl<'msg> ::protobuf::__internal::SealedInternal for RouteNoteMut<'msg> {}
+impl<'msg> ::protobuf::MessageMut<'msg> for RouteNoteMut<'msg> {
+    type Message = RouteNote;
+}
+impl ::std::fmt::Debug for RouteNoteMut<'_> {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+        write!(f, "{}", ::protobuf::__internal::runtime::debug_string(self))
+    }
+}
+impl<'msg> From<::protobuf::__internal::runtime::MessageMutInner<'msg, RouteNote>>
+for RouteNoteMut<'msg> {
+    fn from(
+        inner: ::protobuf::__internal::runtime::MessageMutInner<'msg, RouteNote>,
+    ) -> Self {
+        Self { inner }
+    }
+}
+#[allow(dead_code)]
+impl<'msg> RouteNoteMut<'msg> {
+    #[doc(hidden)]
+    pub fn as_message_mut_inner(
+        &mut self,
+        _private: ::protobuf::__internal::Private,
+    ) -> ::protobuf::__internal::runtime::MessageMutInner<'msg, RouteNote> {
+        self.inner
+    }
+    pub fn to_owned(&self) -> RouteNote {
+        ::protobuf::AsView::as_view(self).to_owned()
+    }
+    pub fn has_location(&self) -> bool {
+        unsafe { self.inner.ptr().has_field_at_index(0) }
+    }
+    pub fn clear_location(&mut self) {
+        unsafe {
+            self.inner.ptr().clear_field_at_index(0);
+        }
+    }
+    pub fn location_opt(&self) -> ::protobuf::Optional<super::PointView<'_>> {
+        ::protobuf::Optional::new(self.location(), self.has_location())
+    }
+    pub fn location(&self) -> super::PointView<'_> {
+        let submsg = unsafe { self.inner.ptr().get_message_at_index(0) };
+        submsg
+            .map(|ptr| unsafe {
+                ::protobuf::__internal::runtime::MessageViewInner::wrap(ptr).into()
+            })
+            .unwrap_or(super::PointView::default())
+    }
+    pub fn location_mut(&mut self) -> super::PointMut<'_> {
+        let ptr = unsafe {
+            self.inner
+                .ptr_mut()
+                .get_or_create_mutable_message_at_index(0, self.inner.arena())
+                .unwrap()
+        };
+        ::protobuf::__internal::runtime::MessageMutInner::from_parent(
+                self.as_message_mut_inner(::protobuf::__internal::Private),
+                ptr,
+            )
+            .into()
+    }
+    pub fn set_location(&mut self, val: impl ::protobuf::IntoProxied<super::Point>) {
+        unsafe {
+            ::protobuf::__internal::runtime::message_set_sub_message(
+                ::protobuf::AsMut::as_mut(self).inner,
+                0,
+                val,
+            );
+        }
+    }
+    pub fn message(&self) -> ::protobuf::View<'_, ::protobuf::ProtoString> {
+        let str_view = unsafe { self.inner.ptr().get_string_at_index(1, (b"").into()) };
+        unsafe { ::protobuf::ProtoStr::from_utf8_unchecked(str_view.as_ref()) }
+    }
+    pub fn set_message(
+        &mut self,
+        val: impl ::protobuf::IntoProxied<::protobuf::ProtoString>,
+    ) {
+        unsafe {
+            ::protobuf::__internal::runtime::message_set_string_field(
+                ::protobuf::AsMut::as_mut(self).inner,
+                1,
+                val,
+            );
+        }
+    }
+}
+unsafe impl Send for RouteNoteMut<'_> {}
+unsafe impl Sync for RouteNoteMut<'_> {}
+impl<'msg> ::protobuf::AsView for RouteNoteMut<'msg> {
+    type Proxied = RouteNote;
+    fn as_view(&self) -> ::protobuf::View<'_, RouteNote> {
+        RouteNoteView {
+            inner: ::protobuf::__internal::runtime::MessageViewInner::view_of_mut(
+                self.inner,
+            ),
+        }
+    }
+}
+impl<'msg> ::protobuf::IntoView<'msg> for RouteNoteMut<'msg> {
+    fn into_view<'shorter>(self) -> ::protobuf::View<'shorter, RouteNote>
+    where
+        'msg: 'shorter,
+    {
+        RouteNoteView {
+            inner: ::protobuf::__internal::runtime::MessageViewInner::view_of_mut(
+                self.inner,
+            ),
+        }
+    }
+}
+impl<'msg> ::protobuf::AsMut for RouteNoteMut<'msg> {
+    type MutProxied = RouteNote;
+    fn as_mut(&mut self) -> RouteNoteMut<'msg> {
+        RouteNoteMut { inner: self.inner }
+    }
+}
+impl<'msg> ::protobuf::IntoMut<'msg> for RouteNoteMut<'msg> {
+    fn into_mut<'shorter>(self) -> RouteNoteMut<'shorter>
+    where
+        'msg: 'shorter,
+    {
+        self
+    }
+}
+#[allow(dead_code)]
+impl RouteNote {
+    pub fn new() -> Self {
+        Self {
+            inner: ::protobuf::__internal::runtime::OwnedMessageInner::<Self>::new(),
+        }
+    }
+    #[doc(hidden)]
+    pub fn as_message_mut_inner(
+        &mut self,
+        _private: ::protobuf::__internal::Private,
+    ) -> ::protobuf::__internal::runtime::MessageMutInner<'_, RouteNote> {
+        ::protobuf::__internal::runtime::MessageMutInner::mut_of_owned(&mut self.inner)
+    }
+    pub fn as_view(&self) -> RouteNoteView<'_> {
+        ::protobuf::__internal::runtime::MessageViewInner::view_of_owned(&self.inner)
+            .into()
+    }
+    pub fn as_mut(&mut self) -> RouteNoteMut<'_> {
+        ::protobuf::__internal::runtime::MessageMutInner::mut_of_owned(&mut self.inner)
+            .into()
+    }
+    pub fn has_location(&self) -> bool {
+        unsafe { self.inner.ptr().has_field_at_index(0) }
+    }
+    pub fn clear_location(&mut self) {
+        unsafe {
+            self.inner.ptr().clear_field_at_index(0);
+        }
+    }
+    pub fn location_opt(&self) -> ::protobuf::Optional<super::PointView<'_>> {
+        ::protobuf::Optional::new(self.location(), self.has_location())
+    }
+    pub fn location(&self) -> super::PointView<'_> {
+        let submsg = unsafe { self.inner.ptr().get_message_at_index(0) };
+        submsg
+            .map(|ptr| unsafe {
+                ::protobuf::__internal::runtime::MessageViewInner::wrap(ptr).into()
+            })
+            .unwrap_or(super::PointView::default())
+    }
+    pub fn location_mut(&mut self) -> super::PointMut<'_> {
+        let ptr = unsafe {
+            self.inner
+                .ptr_mut()
+                .get_or_create_mutable_message_at_index(0, self.inner.arena())
+                .unwrap()
+        };
+        ::protobuf::__internal::runtime::MessageMutInner::from_parent(
+                self.as_message_mut_inner(::protobuf::__internal::Private),
+                ptr,
+            )
+            .into()
+    }
+    pub fn set_location(&mut self, val: impl ::protobuf::IntoProxied<super::Point>) {
+        unsafe {
+            ::protobuf::__internal::runtime::message_set_sub_message(
+                ::protobuf::AsMut::as_mut(self).inner,
+                0,
+                val,
+            );
+        }
+    }
+    pub fn message(&self) -> ::protobuf::View<'_, ::protobuf::ProtoString> {
+        let str_view = unsafe { self.inner.ptr().get_string_at_index(1, (b"").into()) };
+        unsafe { ::protobuf::ProtoStr::from_utf8_unchecked(str_view.as_ref()) }
+    }
+    pub fn set_message(
+        &mut self,
+        val: impl ::protobuf::IntoProxied<::protobuf::ProtoString>,
+    ) {
+        unsafe {
+            ::protobuf::__internal::runtime::message_set_string_field(
+                ::protobuf::AsMut::as_mut(self).inner,
+                1,
+                val,
+            );
+        }
+    }
+}
+impl ::std::ops::Drop for RouteNote {
+    #[inline]
+    fn drop(&mut self) {}
+}
+impl ::std::clone::Clone for RouteNote {
+    fn clone(&self) -> Self {
+        self.as_view().to_owned()
+    }
+}
+impl ::protobuf::AsView for RouteNote {
+    type Proxied = Self;
+    fn as_view(&self) -> RouteNoteView<'_> {
+        self.as_view()
+    }
+}
+impl ::protobuf::AsMut for RouteNote {
+    type MutProxied = Self;
+    fn as_mut(&mut self) -> RouteNoteMut<'_> {
+        self.as_mut()
+    }
+}
+unsafe impl ::protobuf::__internal::runtime::AssociatedMiniTable for RouteNote {
+    fn mini_table() -> ::protobuf::__internal::runtime::MiniTablePtr {
+        static ONCE_LOCK: ::std::sync::OnceLock<
+            ::protobuf::__internal::runtime::MiniTableInitPtr,
+        > = ::std::sync::OnceLock::new();
+        unsafe {
+            ONCE_LOCK
+                .get_or_init(|| {
+                    super::routeguide__RouteNote_msg_init.0 = ::protobuf::__internal::runtime::build_mini_table(
+                        "$31X",
+                    );
+                    ::protobuf::__internal::runtime::link_mini_table(
+                        super::routeguide__RouteNote_msg_init.0,
+                        &[
+                            <super::Point as ::protobuf::__internal::runtime::AssociatedMiniTable>::mini_table(),
+                        ],
+                        &[],
+                    );
+                    ::protobuf::__internal::runtime::MiniTableInitPtr(
+                        super::routeguide__RouteNote_msg_init.0,
+                    )
+                })
+                .0
+        }
+    }
+}
+unsafe impl ::protobuf::__internal::runtime::UpbGetArena for RouteNote {
+    fn get_arena(
+        &mut self,
+        _private: ::protobuf::__internal::Private,
+    ) -> &::protobuf::__internal::runtime::Arena {
+        self.inner.arena()
+    }
+}
+unsafe impl ::protobuf::__internal::runtime::UpbGetMessagePtrMut for RouteNote {
+    type Msg = RouteNote;
+    fn get_ptr_mut(
+        &mut self,
+        _private: ::protobuf::__internal::Private,
+    ) -> ::protobuf::__internal::runtime::MessagePtr<RouteNote> {
+        self.inner.ptr_mut()
+    }
+}
+unsafe impl ::protobuf::__internal::runtime::UpbGetMessagePtr for RouteNote {
+    type Msg = RouteNote;
+    fn get_ptr(
+        &self,
+        _private: ::protobuf::__internal::Private,
+    ) -> ::protobuf::__internal::runtime::MessagePtr<RouteNote> {
+        self.inner.ptr()
+    }
+}
+unsafe impl ::protobuf::__internal::runtime::UpbGetMessagePtrMut for RouteNoteMut<'_> {
+    type Msg = RouteNote;
+    fn get_ptr_mut(
+        &mut self,
+        _private: ::protobuf::__internal::Private,
+    ) -> ::protobuf::__internal::runtime::MessagePtr<RouteNote> {
+        self.inner.ptr_mut()
+    }
+}
+unsafe impl ::protobuf::__internal::runtime::UpbGetMessagePtr for RouteNoteMut<'_> {
+    type Msg = RouteNote;
+    fn get_ptr(
+        &self,
+        _private: ::protobuf::__internal::Private,
+    ) -> ::protobuf::__internal::runtime::MessagePtr<RouteNote> {
+        self.inner.ptr()
+    }
+}
+unsafe impl ::protobuf::__internal::runtime::UpbGetMessagePtr for RouteNoteView<'_> {
+    type Msg = RouteNote;
+    fn get_ptr(
+        &self,
+        _private: ::protobuf::__internal::Private,
+    ) -> ::protobuf::__internal::runtime::MessagePtr<RouteNote> {
+        self.inner.ptr()
+    }
+}
+unsafe impl ::protobuf::__internal::runtime::UpbGetArena for RouteNoteMut<'_> {
+    fn get_arena(
+        &mut self,
+        _private: ::protobuf::__internal::Private,
+    ) -> &::protobuf::__internal::runtime::Arena {
+        self.inner.arena()
+    }
+}
+pub(crate) static mut routeguide__RouteSummary_msg_init: ::protobuf::__internal::runtime::MiniTableInitPtr = ::protobuf::__internal::runtime::MiniTableInitPtr(
+    ::protobuf::__internal::runtime::MiniTablePtr::dangling(),
+);
+#[allow(non_camel_case_types)]
+pub struct RouteSummary {
+    inner: ::protobuf::__internal::runtime::OwnedMessageInner<RouteSummary>,
+}
+impl ::protobuf::Message for RouteSummary {}
+impl ::std::default::Default for RouteSummary {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+impl ::std::fmt::Debug for RouteSummary {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+        write!(f, "{}", ::protobuf::__internal::runtime::debug_string(self))
+    }
+}
+unsafe impl Sync for RouteSummary {}
+unsafe impl Send for RouteSummary {}
+impl ::protobuf::Proxied for RouteSummary {
+    type View<'msg> = RouteSummaryView<'msg>;
+}
+impl ::protobuf::__internal::SealedInternal for RouteSummary {}
+impl ::protobuf::MutProxied for RouteSummary {
+    type Mut<'msg> = RouteSummaryMut<'msg>;
+}
+#[derive(Copy, Clone)]
+#[allow(dead_code)]
+pub struct RouteSummaryView<'msg> {
+    inner: ::protobuf::__internal::runtime::MessageViewInner<'msg, RouteSummary>,
+}
+impl<'msg> ::protobuf::__internal::SealedInternal for RouteSummaryView<'msg> {}
+impl<'msg> ::protobuf::MessageView<'msg> for RouteSummaryView<'msg> {
+    type Message = RouteSummary;
+}
+impl ::std::fmt::Debug for RouteSummaryView<'_> {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+        write!(f, "{}", ::protobuf::__internal::runtime::debug_string(self))
+    }
+}
+impl ::std::default::Default for RouteSummaryView<'_> {
+    fn default() -> RouteSummaryView<'static> {
+        ::protobuf::__internal::runtime::MessageViewInner::default().into()
+    }
+}
+impl<'msg> From<::protobuf::__internal::runtime::MessageViewInner<'msg, RouteSummary>>
+for RouteSummaryView<'msg> {
+    fn from(
+        inner: ::protobuf::__internal::runtime::MessageViewInner<'msg, RouteSummary>,
+    ) -> Self {
+        Self { inner }
+    }
+}
+#[allow(dead_code)]
+impl<'msg> RouteSummaryView<'msg> {
+    pub fn to_owned(&self) -> RouteSummary {
+        ::protobuf::IntoProxied::into_proxied(*self, ::protobuf::__internal::Private)
+    }
+    pub fn point_count(self) -> i32 {
+        unsafe {
+            self.inner.ptr().get_i32_at_index(0, (0i32).into()).try_into().unwrap()
+        }
+    }
+    pub fn feature_count(self) -> i32 {
+        unsafe {
+            self.inner.ptr().get_i32_at_index(1, (0i32).into()).try_into().unwrap()
+        }
+    }
+    pub fn distance(self) -> i32 {
+        unsafe {
+            self.inner.ptr().get_i32_at_index(2, (0i32).into()).try_into().unwrap()
+        }
+    }
+    pub fn elapsed_time(self) -> i32 {
+        unsafe {
+            self.inner.ptr().get_i32_at_index(3, (0i32).into()).try_into().unwrap()
+        }
+    }
+}
+unsafe impl Sync for RouteSummaryView<'_> {}
+unsafe impl Send for RouteSummaryView<'_> {}
+impl<'msg> ::protobuf::AsView for RouteSummaryView<'msg> {
+    type Proxied = RouteSummary;
+    fn as_view(&self) -> ::protobuf::View<'msg, RouteSummary> {
+        *self
+    }
+}
+impl<'msg> ::protobuf::IntoView<'msg> for RouteSummaryView<'msg> {
+    fn into_view<'shorter>(self) -> RouteSummaryView<'shorter>
+    where
+        'msg: 'shorter,
+    {
+        self
+    }
+}
+impl<'msg> ::protobuf::IntoProxied<RouteSummary> for RouteSummaryView<'msg> {
+    fn into_proxied(self, _private: ::protobuf::__internal::Private) -> RouteSummary {
+        let mut dst = RouteSummary::new();
+        assert!(
+            unsafe { dst.inner.ptr_mut().deep_copy(self.inner.ptr(), dst.inner.arena()) }
+        );
+        dst
+    }
+}
+impl<'msg> ::protobuf::IntoProxied<RouteSummary> for RouteSummaryMut<'msg> {
+    fn into_proxied(self, _private: ::protobuf::__internal::Private) -> RouteSummary {
+        ::protobuf::IntoProxied::into_proxied(
+            ::protobuf::IntoView::into_view(self),
+            _private,
+        )
+    }
+}
+impl ::protobuf::__internal::runtime::EntityType for RouteSummary {
+    type Tag = ::protobuf::__internal::runtime::MessageTag;
+}
+impl<'msg> ::protobuf::__internal::runtime::EntityType for RouteSummaryView<'msg> {
+    type Tag = ::protobuf::__internal::runtime::ViewProxyTag;
+}
+impl<'msg> ::protobuf::__internal::runtime::EntityType for RouteSummaryMut<'msg> {
+    type Tag = ::protobuf::__internal::runtime::MutProxyTag;
+}
+#[allow(dead_code)]
+#[allow(non_camel_case_types)]
+pub struct RouteSummaryMut<'msg> {
+    inner: ::protobuf::__internal::runtime::MessageMutInner<'msg, RouteSummary>,
+}
+impl<'msg> ::protobuf::__internal::SealedInternal for RouteSummaryMut<'msg> {}
+impl<'msg> ::protobuf::MessageMut<'msg> for RouteSummaryMut<'msg> {
+    type Message = RouteSummary;
+}
+impl ::std::fmt::Debug for RouteSummaryMut<'_> {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+        write!(f, "{}", ::protobuf::__internal::runtime::debug_string(self))
+    }
+}
+impl<'msg> From<::protobuf::__internal::runtime::MessageMutInner<'msg, RouteSummary>>
+for RouteSummaryMut<'msg> {
+    fn from(
+        inner: ::protobuf::__internal::runtime::MessageMutInner<'msg, RouteSummary>,
+    ) -> Self {
+        Self { inner }
+    }
+}
+#[allow(dead_code)]
+impl<'msg> RouteSummaryMut<'msg> {
+    #[doc(hidden)]
+    pub fn as_message_mut_inner(
+        &mut self,
+        _private: ::protobuf::__internal::Private,
+    ) -> ::protobuf::__internal::runtime::MessageMutInner<'msg, RouteSummary> {
+        self.inner
+    }
+    pub fn to_owned(&self) -> RouteSummary {
+        ::protobuf::AsView::as_view(self).to_owned()
+    }
+    pub fn point_count(&self) -> i32 {
+        unsafe {
+            self.inner.ptr().get_i32_at_index(0, (0i32).into()).try_into().unwrap()
+        }
+    }
+    pub fn set_point_count(&mut self, val: i32) {
+        unsafe { self.inner.ptr_mut().set_base_field_i32_at_index(0, val.into()) }
+    }
+    pub fn feature_count(&self) -> i32 {
+        unsafe {
+            self.inner.ptr().get_i32_at_index(1, (0i32).into()).try_into().unwrap()
+        }
+    }
+    pub fn set_feature_count(&mut self, val: i32) {
+        unsafe { self.inner.ptr_mut().set_base_field_i32_at_index(1, val.into()) }
+    }
+    pub fn distance(&self) -> i32 {
+        unsafe {
+            self.inner.ptr().get_i32_at_index(2, (0i32).into()).try_into().unwrap()
+        }
+    }
+    pub fn set_distance(&mut self, val: i32) {
+        unsafe { self.inner.ptr_mut().set_base_field_i32_at_index(2, val.into()) }
+    }
+    pub fn elapsed_time(&self) -> i32 {
+        unsafe {
+            self.inner.ptr().get_i32_at_index(3, (0i32).into()).try_into().unwrap()
+        }
+    }
+    pub fn set_elapsed_time(&mut self, val: i32) {
+        unsafe { self.inner.ptr_mut().set_base_field_i32_at_index(3, val.into()) }
+    }
+}
+unsafe impl Send for RouteSummaryMut<'_> {}
+unsafe impl Sync for RouteSummaryMut<'_> {}
+impl<'msg> ::protobuf::AsView for RouteSummaryMut<'msg> {
+    type Proxied = RouteSummary;
+    fn as_view(&self) -> ::protobuf::View<'_, RouteSummary> {
+        RouteSummaryView {
+            inner: ::protobuf::__internal::runtime::MessageViewInner::view_of_mut(
+                self.inner,
+            ),
+        }
+    }
+}
+impl<'msg> ::protobuf::IntoView<'msg> for RouteSummaryMut<'msg> {
+    fn into_view<'shorter>(self) -> ::protobuf::View<'shorter, RouteSummary>
+    where
+        'msg: 'shorter,
+    {
+        RouteSummaryView {
+            inner: ::protobuf::__internal::runtime::MessageViewInner::view_of_mut(
+                self.inner,
+            ),
+        }
+    }
+}
+impl<'msg> ::protobuf::AsMut for RouteSummaryMut<'msg> {
+    type MutProxied = RouteSummary;
+    fn as_mut(&mut self) -> RouteSummaryMut<'msg> {
+        RouteSummaryMut {
+            inner: self.inner,
+        }
+    }
+}
+impl<'msg> ::protobuf::IntoMut<'msg> for RouteSummaryMut<'msg> {
+    fn into_mut<'shorter>(self) -> RouteSummaryMut<'shorter>
+    where
+        'msg: 'shorter,
+    {
+        self
+    }
+}
+#[allow(dead_code)]
+impl RouteSummary {
+    pub fn new() -> Self {
+        Self {
+            inner: ::protobuf::__internal::runtime::OwnedMessageInner::<Self>::new(),
+        }
+    }
+    #[doc(hidden)]
+    pub fn as_message_mut_inner(
+        &mut self,
+        _private: ::protobuf::__internal::Private,
+    ) -> ::protobuf::__internal::runtime::MessageMutInner<'_, RouteSummary> {
+        ::protobuf::__internal::runtime::MessageMutInner::mut_of_owned(&mut self.inner)
+    }
+    pub fn as_view(&self) -> RouteSummaryView<'_> {
+        ::protobuf::__internal::runtime::MessageViewInner::view_of_owned(&self.inner)
+            .into()
+    }
+    pub fn as_mut(&mut self) -> RouteSummaryMut<'_> {
+        ::protobuf::__internal::runtime::MessageMutInner::mut_of_owned(&mut self.inner)
+            .into()
+    }
+    pub fn point_count(&self) -> i32 {
+        unsafe {
+            self.inner.ptr().get_i32_at_index(0, (0i32).into()).try_into().unwrap()
+        }
+    }
+    pub fn set_point_count(&mut self, val: i32) {
+        unsafe { self.inner.ptr_mut().set_base_field_i32_at_index(0, val.into()) }
+    }
+    pub fn feature_count(&self) -> i32 {
+        unsafe {
+            self.inner.ptr().get_i32_at_index(1, (0i32).into()).try_into().unwrap()
+        }
+    }
+    pub fn set_feature_count(&mut self, val: i32) {
+        unsafe { self.inner.ptr_mut().set_base_field_i32_at_index(1, val.into()) }
+    }
+    pub fn distance(&self) -> i32 {
+        unsafe {
+            self.inner.ptr().get_i32_at_index(2, (0i32).into()).try_into().unwrap()
+        }
+    }
+    pub fn set_distance(&mut self, val: i32) {
+        unsafe { self.inner.ptr_mut().set_base_field_i32_at_index(2, val.into()) }
+    }
+    pub fn elapsed_time(&self) -> i32 {
+        unsafe {
+            self.inner.ptr().get_i32_at_index(3, (0i32).into()).try_into().unwrap()
+        }
+    }
+    pub fn set_elapsed_time(&mut self, val: i32) {
+        unsafe { self.inner.ptr_mut().set_base_field_i32_at_index(3, val.into()) }
+    }
+}
+impl ::std::ops::Drop for RouteSummary {
+    #[inline]
+    fn drop(&mut self) {}
+}
+impl ::std::clone::Clone for RouteSummary {
+    fn clone(&self) -> Self {
+        self.as_view().to_owned()
+    }
+}
+impl ::protobuf::AsView for RouteSummary {
+    type Proxied = Self;
+    fn as_view(&self) -> RouteSummaryView<'_> {
+        self.as_view()
+    }
+}
+impl ::protobuf::AsMut for RouteSummary {
+    type MutProxied = Self;
+    fn as_mut(&mut self) -> RouteSummaryMut<'_> {
+        self.as_mut()
+    }
+}
+unsafe impl ::protobuf::__internal::runtime::AssociatedMiniTable for RouteSummary {
+    fn mini_table() -> ::protobuf::__internal::runtime::MiniTablePtr {
+        static ONCE_LOCK: ::std::sync::OnceLock<
+            ::protobuf::__internal::runtime::MiniTableInitPtr,
+        > = ::std::sync::OnceLock::new();
+        unsafe {
+            ONCE_LOCK
+                .get_or_init(|| {
+                    super::routeguide__RouteSummary_msg_init.0 = ::protobuf::__internal::runtime::build_mini_table(
+                        "$(P(P(P(P",
+                    );
+                    ::protobuf::__internal::runtime::link_mini_table(
+                        super::routeguide__RouteSummary_msg_init.0,
+                        &[],
+                        &[],
+                    );
+                    ::protobuf::__internal::runtime::MiniTableInitPtr(
+                        super::routeguide__RouteSummary_msg_init.0,
+                    )
+                })
+                .0
+        }
+    }
+}
+unsafe impl ::protobuf::__internal::runtime::UpbGetArena for RouteSummary {
+    fn get_arena(
+        &mut self,
+        _private: ::protobuf::__internal::Private,
+    ) -> &::protobuf::__internal::runtime::Arena {
+        self.inner.arena()
+    }
+}
+unsafe impl ::protobuf::__internal::runtime::UpbGetMessagePtrMut for RouteSummary {
+    type Msg = RouteSummary;
+    fn get_ptr_mut(
+        &mut self,
+        _private: ::protobuf::__internal::Private,
+    ) -> ::protobuf::__internal::runtime::MessagePtr<RouteSummary> {
+        self.inner.ptr_mut()
+    }
+}
+unsafe impl ::protobuf::__internal::runtime::UpbGetMessagePtr for RouteSummary {
+    type Msg = RouteSummary;
+    fn get_ptr(
+        &self,
+        _private: ::protobuf::__internal::Private,
+    ) -> ::protobuf::__internal::runtime::MessagePtr<RouteSummary> {
+        self.inner.ptr()
+    }
+}
+unsafe impl ::protobuf::__internal::runtime::UpbGetMessagePtrMut
+for RouteSummaryMut<'_> {
+    type Msg = RouteSummary;
+    fn get_ptr_mut(
+        &mut self,
+        _private: ::protobuf::__internal::Private,
+    ) -> ::protobuf::__internal::runtime::MessagePtr<RouteSummary> {
+        self.inner.ptr_mut()
+    }
+}
+unsafe impl ::protobuf::__internal::runtime::UpbGetMessagePtr for RouteSummaryMut<'_> {
+    type Msg = RouteSummary;
+    fn get_ptr(
+        &self,
+        _private: ::protobuf::__internal::Private,
+    ) -> ::protobuf::__internal::runtime::MessagePtr<RouteSummary> {
+        self.inner.ptr()
+    }
+}
+unsafe impl ::protobuf::__internal::runtime::UpbGetMessagePtr for RouteSummaryView<'_> {
+    type Msg = RouteSummary;
+    fn get_ptr(
+        &self,
+        _private: ::protobuf::__internal::Private,
+    ) -> ::protobuf::__internal::runtime::MessagePtr<RouteSummary> {
+        self.inner.ptr()
+    }
+}
+unsafe impl ::protobuf::__internal::runtime::UpbGetArena for RouteSummaryMut<'_> {
+    fn get_arena(
+        &mut self,
+        _private: ::protobuf::__internal::Private,
+    ) -> &::protobuf::__internal::runtime::Arena {
+        self.inner.arena()
+    }
+}

--- a/examples/src/grpc-routeguide/generated/route_guide_grpc.pb.rs
+++ b/examples/src/grpc-routeguide/generated/route_guide_grpc.pb.rs
@@ -1,0 +1,77 @@
+/// Generated client implementations.
+pub mod route_guide_client {
+    use grpc::client::*;
+    use grpc_protobuf::*;
+    /// Interface exported by the server.
+    #[derive(Debug, Clone)]
+    pub struct RouteGuideClient<T> {
+        channel: T,
+    }
+    impl<T> RouteGuideClient<T>
+    where
+        T: grpc::client::Invoke,
+    {
+        pub fn new(channel: T) -> Self {
+            Self { channel }
+        }
+        /// A simple RPC.
+        ///
+        /// Obtains the feature at a given position.
+        ///
+        /// A feature with an empty name is returned if there's no feature at the given
+        /// position.
+        pub fn get_feature<ReqMsgView>(
+            &self,
+            request: ReqMsgView,
+        ) -> UnaryCallBuilder<'_, &T, ReqMsgView, super::Feature>
+        where
+            ReqMsgView: protobuf::AsView<Proxied = super::Point> + Send + Sync,
+        {
+            UnaryCallBuilder::new(
+                &self.channel,
+                "/routeguide.RouteGuide/GetFeature",
+                request,
+            )
+        }
+        /// A server-to-client streaming RPC.
+        ///
+        /// Obtains the Features available within the given Rectangle.  Results are
+        /// streamed rather than returned at once (e.g. in a response message with a
+        /// repeated field), as the rectangle may cover a large area and contain a
+        /// huge number of features.
+        pub fn list_features<ReqMsgView>(
+            &self,
+            request: ReqMsgView,
+        ) -> ServerStreamingCallBuilder<'_, &T, ReqMsgView, super::Feature>
+        where
+            ReqMsgView: protobuf::AsView<Proxied = super::Rectangle> + Send + Sync,
+        {
+            ServerStreamingCallBuilder::new(
+                &self.channel,
+                "/routeguide.RouteGuide/ListFeatures",
+                request,
+            )
+        }
+        /// A client-to-server streaming RPC.
+        ///
+        /// Accepts a stream of Points on a route being traversed, returning a
+        /// RouteSummary when traversal is completed.
+        pub fn record_route(
+            &self,
+        ) -> ClientStreamingCallBuilder<'_, &T, super::Point, super::RouteSummary> {
+            ClientStreamingCallBuilder::new(
+                &self.channel,
+                "/routeguide.RouteGuide/RecordRoute",
+            )
+        }
+        /// A Bidirectional streaming RPC.
+        ///
+        /// Accepts a stream of RouteNotes sent while a route is being traversed,
+        /// while receiving other RouteNotes (e.g. from other users).
+        pub fn route_chat(
+            &self,
+        ) -> BidiCallBuilder<'_, &T, super::RouteNote, super::RouteNote> {
+            BidiCallBuilder::new(&self.channel, "/routeguide.RouteGuide/RouteChat")
+        }
+    }
+}

--- a/grpc-protobuf-build/README.md
+++ b/grpc-protobuf-build/README.md
@@ -53,7 +53,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         .include("external")
         .message_module_path("super::proto")
         .dependencies(vec![dependency])
-        //.out_dir("src/generated")  // you can change the generated code's location
+        //.output_dir("src/generated")  // you can change the generated code's location
         .compile()?;
    Ok(())
 }

--- a/grpc-protobuf-build/src/lib.rs
+++ b/grpc-protobuf-build/src/lib.rs
@@ -130,6 +130,8 @@ impl CodeGen {
     pub fn new() -> Self {
         Self {
             inputs: Vec::new(),
+            // TODO: Delay this check until the field is read in order to allow
+            // it to be set via `output_dir()` if it isn't in the environment.
             output_dir: PathBuf::from(std::env::var("OUT_DIR").unwrap()),
             includes: Vec::new(),
             dependencies: Vec::new(),

--- a/grpc-protobuf-build/src/lib.rs
+++ b/grpc-protobuf-build/src/lib.rs
@@ -123,6 +123,7 @@ pub struct CodeGen {
     // Whether to generate message code, defaults to true.
     generate_message_code: bool,
     should_format_code: bool,
+    client_only: bool,
 }
 
 impl CodeGen {
@@ -135,7 +136,13 @@ impl CodeGen {
             message_module_path: None,
             generate_message_code: true,
             should_format_code: true,
+            client_only: false,
         }
+    }
+
+    pub fn client_only(&mut self) -> &mut Self {
+        self.client_only = true;
+        self
     }
 
     /// Sets whether to generate the message code. This can be disabled if the
@@ -223,6 +230,9 @@ impl CodeGen {
 
         // Generate the service code.
         let mut cmd = std::process::Command::new("protoc");
+        if self.client_only {
+            cmd.arg("--rust-grpc_opt=client_only=true");
+        }
         for input in &self.inputs {
             cmd.arg(input);
         }

--- a/grpc-protobuf/src/client/client_streaming.rs
+++ b/grpc-protobuf/src/client/client_streaming.rs
@@ -173,7 +173,7 @@ where
         }
     }
 
-    pub async fn recv(self) -> Result<Res, Status> {
+    pub async fn close_and_recv(self) -> Result<Res, Status> {
         let mut res = Res::default();
         let status = self.with_response_message(&mut res).await;
         if status.code() == StatusCode::Ok {

--- a/grpc-protobuf/src/client/client_streaming.rs
+++ b/grpc-protobuf/src/client/client_streaming.rs
@@ -154,7 +154,7 @@ where
     /// Note: success does *not* indicate successful transmission of the request
     /// or successful receipt of the request by the server.  Success only
     /// indicates that the stream has not yet terminated.
-    pub async fn send_message(&mut self, message: &impl AsView<Proxied = Req>) -> Result<(), ()> {
+    pub async fn send(&mut self, message: &impl AsView<Proxied = Req>) -> Result<(), ()> {
         let msg = ProtoSendMessage::from_view(message);
         self.tx.send(&msg, SendOptions::default()).await
     }
@@ -172,34 +172,14 @@ where
             }
         }
     }
-}
 
-impl<'a, C, Req, Res> IntoFuture for ClientStreamingCall<'a, C, Req, Res>
-where
-    C: InvokeOnce + 'a,
-    // Req is a proto message. (Ideally we could just require "Message" and
-    // protobuf would automatically include the rest.  For now we need the
-    // HRTBs.)
-    Req: Message,
-    for<'b> Req::View<'b>: MessageView<'b>,
-    // Res is a proto message. (Ideally we could just require "Message" and
-    // protobuf would automatically include the rest.  For now we need the
-    // HRTBs.)
-    Res: Message,
-    for<'b> Res::Mut<'b>: MessageMut<'b>,
-{
-    type Output = Result<Res, Status>;
-    type IntoFuture = Pin<Box<dyn Future<Output = Self::Output> + Send + 'a>>;
-
-    fn into_future(self) -> Self::IntoFuture {
-        Box::pin(async move {
-            let mut res = Res::default();
-            let status = self.with_response_message(&mut res).await;
-            if status.code() == StatusCode::Ok {
-                Ok(res)
-            } else {
-                Err(status)
-            }
-        })
+    pub async fn recv(self) -> Result<Res, Status> {
+        let mut res = Res::default();
+        let status = self.with_response_message(&mut res).await;
+        if status.code() == StatusCode::Ok {
+            Ok(res)
+        } else {
+            Err(status)
+        }
     }
 }

--- a/grpc-protobuf/src/client/mod.rs
+++ b/grpc-protobuf/src/client/mod.rs
@@ -86,7 +86,7 @@ where
     /// Note: success does *not* indicate successful transmission of the request
     /// or successful receipt of the request by the server.  Success only
     /// indicates that the stream has not yet terminated.
-    pub async fn send_message(&mut self, message: M) -> Result<(), ()> {
+    pub async fn send(&mut self, message: M) -> Result<(), ()> {
         self.tx
             .send(
                 &ProtoSendMessage::from_view(&message),
@@ -122,7 +122,7 @@ where
 
     /// Receives the next response message from the stream into `res` and
     /// returns Ok on success or Err if the stream has ended.
-    pub async fn receive_into(&mut self, res: &mut impl AsMut<MutProxied = M>) -> Result<(), ()> {
+    pub async fn recv_into(&mut self, res: &mut impl AsMut<MutProxied = M>) -> Result<(), ()> {
         let mut res_view = ProtoRecvMessage::from_mut(res);
         let mut i = self.rx.next(&mut res_view).await;
 
@@ -150,9 +150,9 @@ where
 
     /// Returns the next response message from the stream, or `None` if the
     /// stream has completed.
-    pub async fn next(&mut self) -> Option<M> {
+    pub async fn recv(&mut self) -> Option<M> {
         let mut res = M::default();
-        match self.receive_into(&mut res).await {
+        match self.recv_into(&mut res).await {
             Ok(_) => Some(res),
             Err(_) => None,
         }

--- a/grpc-protobuf/src/client/mod.rs
+++ b/grpc-protobuf/src/client/mod.rs
@@ -94,6 +94,11 @@ where
             )
             .await
     }
+
+    /// Sends a "half close" signal to the server to indicate the client is done
+    /// sending by dropping self.  It is safe to just drop(self) instead; this
+    /// method is provided to be explicit.
+    pub fn close(self) {}
 }
 
 /// Provides a streaming RPC's protobuf response messages and status.

--- a/grpc-protobuf/src/client/server_streaming.rs
+++ b/grpc-protobuf/src/client/server_streaming.rs
@@ -23,10 +23,10 @@
  */
 
 use std::marker::PhantomData;
+use std::pin::Pin;
 
 use grpc::client::CallOptions;
 use grpc::client::InvokeOnce;
-use grpc::client::RecvStream;
 use grpc::client::SendOptions;
 use grpc::client::SendStream as _;
 use grpc::client::stream_util::RecvStreamValidator;
@@ -67,9 +67,9 @@ impl<'a, C, ReqMsgView, Res> ServerStreamingCallBuilder<'a, C, ReqMsgView, Res> 
     }
 }
 
-impl<'a, C, ReqMsgView, Res> ServerStreamingCallBuilder<'a, C, ReqMsgView, Res>
+impl<'a, C, ReqMsgView, Res> IntoFuture for ServerStreamingCallBuilder<'a, C, ReqMsgView, Res>
 where
-    C: InvokeOnce,
+    C: InvokeOnce + 'a,
     // ReqMsgView is a proto message view. (Ideally we could just require
     // "AsView" and protobuf would automatically include the rest.)
     ReqMsgView: AsView + Send + Sync + 'a,
@@ -80,13 +80,18 @@ where
     Res: Message + ClearAndParse,
     for<'b> Res::Mut<'b>: MessageMut<'b>,
 {
-    pub async fn start(self) -> GrpcStreamingResponse<Res, impl RecvStream> {
-        let headers = RequestHeaders::new().with_method_name(self.method);
-        let (mut tx, rx) = self.channel.invoke_once(headers, self.args).await;
-        let rx = RecvStreamValidator::new(rx, false);
-        let req = &ProtoSendMessage::from_view(&self.req);
-        let _ = tx.send(req, SendOptions::new().with_final_msg(true)).await;
-        GrpcStreamingResponse::new(rx)
+    type Output = GrpcStreamingResponse<Res, RecvStreamValidator<C::RecvStream>>;
+    type IntoFuture = Pin<Box<dyn Future<Output = Self::Output> + Send + 'a>>;
+
+    fn into_future(self) -> Self::IntoFuture {
+        Box::pin(async move {
+            let headers = RequestHeaders::new().with_method_name(self.method);
+            let (mut tx, rx) = self.channel.invoke_once(headers, self.args).await;
+            let rx = RecvStreamValidator::new(rx, false);
+            let req = &ProtoSendMessage::from_view(&self.req);
+            let _ = tx.send(req, SendOptions::new().with_final_msg(true)).await;
+            GrpcStreamingResponse::new(rx)
+        })
     }
 }
 

--- a/interop/src/client_protobuf.rs
+++ b/interop/src/client_protobuf.rs
@@ -114,7 +114,7 @@ impl InteropTest for TestClient {
             let _ = stream.send(&request).await;
         }
 
-        let result = stream.recv().await;
+        let result = stream.close_and_recv().await;
 
         assertions.push(test_assert!(
             "call must be successful",

--- a/interop/src/client_protobuf.rs
+++ b/interop/src/client_protobuf.rs
@@ -111,10 +111,10 @@ impl InteropTest for TestClient {
         let mut stream = self.streaming_input_call().await;
 
         for request in REQUEST_LENGTHS.iter().map(make_streaming_input_request) {
-            let _ = stream.send_message(&request).await;
+            let _ = stream.send(&request).await;
         }
 
-        let result = stream.await;
+        let result = stream.recv().await;
 
         assertions.push(test_assert!(
             "call must be successful",
@@ -141,10 +141,10 @@ impl InteropTest for TestClient {
                 .map(|len| ResponseParameters::with_size(*len)),
         });
 
-        let mut rx = self.streaming_output_call(req).start().await;
+        let mut rx = self.streaming_output_call(req).await;
 
         let mut responses = Vec::new();
-        while let Some(response) = rx.next().await {
+        while let Some(response) = rx.recv().await {
             responses.push(response);
         }
 
@@ -174,20 +174,18 @@ impl InteropTest for TestClient {
 
     async fn ping_pong(&mut self, assertions: &mut Vec<TestAssertion>) {
         let (mut tx, mut rx) = self.full_duplex_call().await;
-        let _ = tx.send_message(make_ping_pong_request(0)).await;
+        let _ = tx.send(make_ping_pong_request(0)).await;
 
         let mut responses = Vec::new();
         loop {
-            match rx.next().await {
+            match rx.recv().await {
                 Some(message) => {
                     responses.push(message);
                     if responses.len() == RESPONSE_LENGTHS.len() {
                         drop(tx);
                         break;
                     } else {
-                        let _ = tx
-                            .send_message(make_ping_pong_request(responses.len()))
-                            .await;
+                        let _ = tx.send(make_ping_pong_request(responses.len())).await;
                     }
                 }
                 None => {
@@ -226,7 +224,7 @@ impl InteropTest for TestClient {
         drop(tx);
 
         let mut responses = Vec::new();
-        while let Some(response) = rx.next().await {
+        while let Some(response) = rx.recv().await {
             responses.push(response);
         }
         assertions.push(test_assert!(
@@ -285,10 +283,10 @@ impl InteropTest for TestClient {
         validate_response(result, assertions);
 
         let (mut tx, mut rx) = self.full_duplex_call().await;
-        let _ = tx.send_message(duplex_req).await;
+        let _ = tx.send(duplex_req).await;
         drop(tx);
         let mut responses = Vec::new();
-        while let Some(response) = rx.next().await {
+        while let Some(response) = rx.recv().await {
             responses.push(response);
         }
         let status = rx.status().await;
@@ -396,7 +394,7 @@ impl InteropTest for TestClient {
             .with_once_interceptor(hdr_int)
             .with_once_interceptor(trl_int)
             .await;
-        _ = tx.send_message(make_ping_pong_request(0)).await;
+        _ = tx.send(make_ping_pong_request(0)).await;
         drop(tx);
         let status = rx.status().await;
         assert_eq!(

--- a/interop/test.sh
+++ b/interop/test.sh
@@ -31,6 +31,7 @@ echo "Running for OS: ${OSTYPE}"
 case "$OSTYPE" in
   darwin*)  OS="darwin"; EXT="" ;;
   linux*)   OS="linux"; EXT="" ;;
+  cygwin*)  OS="windows"; EXT=".exe" ;;
   msys*)    OS="windows"; EXT=".exe" ;;
   *)        exit 2 ;;
 esac

--- a/protoc-gen-rust-grpc/src/grpc_rust_generator.cc
+++ b/protoc-gen-rust-grpc/src/grpc_rust_generator.cc
@@ -838,8 +838,10 @@ void GenerateService(protobuf::io::Printer &printer,
                      const GrpcOpts &opts) {
   Service service = Service(service_desc);
   client::GenerateClient(service, printer, opts);
-  printer.Print("\n");
-  server::GenerateServer(service, printer, opts);
+  if (!opts.IsClientOnly()) {
+    printer.Print("\n");
+    server::GenerateServer(service, printer, opts);
+  }
 }
 
 std::string GetRsGrpcFile(const protobuf::FileDescriptor &file) {

--- a/protoc-gen-rust-grpc/src/grpc_rust_generator.h
+++ b/protoc-gen-rust-grpc/src/grpc_rust_generator.h
@@ -37,6 +37,14 @@ public:
     return message_module_path_;
   }
 
+  void SetClientOnly(const std::string client_only) {
+    if (client_only == "true") {
+      client_only_ = true;
+    }
+  }
+
+  bool IsClientOnly() const { return client_only_; }
+
   void SetImportPathToCrateName(
       const absl::flat_hash_map<std::string, std::string> mapping) {
     import_path_to_crate_name_ = std::move(mapping);
@@ -72,6 +80,7 @@ private:
   // "self", i.e. the message code and service code are present in the same
   // module.
   std::string message_module_path_ = "self";
+  bool client_only_ = false;
   absl::flat_hash_map<std::string, std::string> import_path_to_crate_name_ = {};
   std::vector<const google::protobuf::FileDescriptor *>
       files_in_current_crate_ = {};

--- a/protoc-gen-rust-grpc/src/grpc_rust_plugin.cc
+++ b/protoc-gen-rust-grpc/src/grpc_rust_plugin.cc
@@ -73,6 +73,8 @@ public:
           *error = std::string(crate_map.status().message());
           return false;
         }
+      } else if (opt.first == "client_only") {
+        grpc_opts.SetClientOnly(opt.second);
       }
     }
 


### PR DESCRIPTION
Also add a temporary `client_only` flag to our generated code to prevent the output of the tonic-protobuf server-side code.