### PR TITLE
refactor(grpc): eliminate ResponseStreamItem in favor of ClientResponseStreamItem

### DIFF
--- a/grpc-protobuf/src/client/mod.rs
+++ b/grpc-protobuf/src/client/mod.rs
@@ -139,7 +139,7 @@ where
         // 2. If we receive Trailers, we will only ever receive StreamClosed.
         match i {
             ClientResponseStreamItem::Headers(_) => unreachable!(),
-            ClientResponseStreamItem::Message(_) => Ok(()),
+            ClientResponseStreamItem::Message => Ok(()),
             ClientResponseStreamItem::Trailers(trailers) => {
                 self.status = Some(trailers.into_status());
                 Err(())

--- a/grpc/examples/inmemory.rs
+++ b/grpc/examples/inmemory.rs
@@ -188,7 +188,7 @@ async fn run_rpc(chan: &Channel) -> String {
         let mut res = MyResMessage::default();
         match rx.next(&mut res).await {
             ClientResponseStreamItem::Headers(_) => continue,
-            ClientResponseStreamItem::Message(_) => {
+            ClientResponseStreamItem::Message => {
                 println!("CALL RESPONSE: {}", res.0);
                 if let Some(id) = res
                     .0

--- a/grpc/src/client/stream_util.rs
+++ b/grpc/src/client/stream_util.rs
@@ -35,7 +35,6 @@ use crate::client::interceptor::Intercept;
 use crate::core::ClientResponseStreamItem;
 use crate::core::RecvMessage;
 use crate::core::RequestHeaders;
-use crate::core::ResponseStreamItem;
 use crate::core::SendMessage;
 use crate::core::Trailers;
 
@@ -109,7 +108,7 @@ where
     /// containing the error message.
     fn error(&mut self, s: impl Into<String>) -> ClientResponseStreamItem {
         self.state = RecvStreamState::Done;
-        ResponseStreamItem::Trailers(Trailers::new(Status::new(StatusCode::Internal, s)))
+        ClientResponseStreamItem::Trailers(Trailers::new(Status::new(StatusCode::Internal, s)))
     }
 }
 
@@ -120,13 +119,13 @@ where
     async fn next(&mut self, msg: &mut dyn RecvMessage) -> ClientResponseStreamItem {
         // Never call the underlying RecvStream if done.
         if matches!(self.state, RecvStreamState::Done) {
-            return ResponseStreamItem::StreamClosed;
+            return ClientResponseStreamItem::StreamClosed;
         }
 
         let item = self.recv_stream.next(msg).await;
 
         match item {
-            ResponseStreamItem::Headers(_) => {
+            ClientResponseStreamItem::Headers(_) => {
                 if matches!(self.state, RecvStreamState::AwaitingHeaders) {
                     self.state = RecvStreamState::AwaitingMessagesOrTrailers;
                     item
@@ -134,7 +133,7 @@ where
                     self.error("stream received multiple headers")
                 }
             }
-            ResponseStreamItem::Message(_) => {
+            ClientResponseStreamItem::Message => {
                 if matches!(self.state, RecvStreamState::AwaitingMessagesOrTrailers) {
                     if self.unary_response {
                         self.state = RecvStreamState::AwaitingTrailers;
@@ -146,7 +145,7 @@ where
                     self.error("stream received messages without headers")
                 }
             }
-            ResponseStreamItem::Trailers(t) => {
+            ClientResponseStreamItem::Trailers(t) => {
                 if self.unary_response
                     && !matches!(self.state, RecvStreamState::AwaitingTrailers)
                     && t.status().code() == StatusCode::Ok
@@ -156,9 +155,9 @@ where
                 // Always return a trailers result immediately - it is valid any
                 // time but sets the stream's state to Done.
                 self.state = RecvStreamState::Done;
-                ResponseStreamItem::Trailers(t)
+                ClientResponseStreamItem::Trailers(t)
             }
-            ResponseStreamItem::StreamClosed => {
+            ClientResponseStreamItem::StreamClosed => {
                 // Trailers were never received or we would be Done.
                 self.error("stream ended without trailers")
             }
@@ -214,12 +213,12 @@ mod test {
     // Tests that an error occurs if messages are received before headers.
     #[tokio::test]
     async fn test_validator_messages_before_headers() {
-        let scenarios = [vec![ResponseStreamItem::Message(())]];
+        let scenarios = [vec![ClientResponseStreamItem::Message]];
 
         for scenario in scenarios {
             validate_scenario(
                 &scenario,
-                ResponseStreamItem::Trailers(Trailers::new(Status::new(
+                ClientResponseStreamItem::Trailers(Trailers::new(Status::new(
                     StatusCode::Internal,
                     "received messages without headers",
                 ))),
@@ -233,22 +232,22 @@ mod test {
     #[tokio::test]
     async fn test_validator_stream_closed_before_trailers() {
         let scenarios = [
-            vec![ResponseStreamItem::StreamClosed],
+            vec![ClientResponseStreamItem::StreamClosed],
             vec![
-                ResponseStreamItem::Headers(ResponseHeaders::default()),
-                ResponseStreamItem::StreamClosed,
+                ClientResponseStreamItem::Headers(ResponseHeaders::default()),
+                ClientResponseStreamItem::StreamClosed,
             ],
             vec![
-                ResponseStreamItem::Headers(ResponseHeaders::default()),
-                ResponseStreamItem::Message(()),
-                ResponseStreamItem::StreamClosed,
+                ClientResponseStreamItem::Headers(ResponseHeaders::default()),
+                ClientResponseStreamItem::Message,
+                ClientResponseStreamItem::StreamClosed,
             ],
         ];
 
         for scenario in &scenarios {
             validate_scenario(
                 scenario,
-                ResponseStreamItem::Trailers(Trailers::new(Status::new(
+                ClientResponseStreamItem::Trailers(Trailers::new(Status::new(
                     StatusCode::Internal,
                     "ended without trailers",
                 ))),
@@ -263,20 +262,20 @@ mod test {
     async fn test_validator_headers_repeated() {
         let scenarios = [
             vec![
-                ResponseStreamItem::Headers(ResponseHeaders::default()),
-                ResponseStreamItem::Headers(ResponseHeaders::default()),
+                ClientResponseStreamItem::Headers(ResponseHeaders::default()),
+                ClientResponseStreamItem::Headers(ResponseHeaders::default()),
             ],
             vec![
-                ResponseStreamItem::Headers(ResponseHeaders::default()),
-                ResponseStreamItem::Message(()),
-                ResponseStreamItem::Headers(ResponseHeaders::default()),
+                ClientResponseStreamItem::Headers(ResponseHeaders::default()),
+                ClientResponseStreamItem::Message,
+                ClientResponseStreamItem::Headers(ResponseHeaders::default()),
             ],
         ];
 
         for scenario in &scenarios {
             validate_scenario(
                 scenario,
-                ResponseStreamItem::Trailers(Trailers::new(Status::new(
+                ClientResponseStreamItem::Trailers(Trailers::new(Status::new(
                     StatusCode::Internal,
                     "received multiple headers",
                 ))),
@@ -289,20 +288,19 @@ mod test {
     #[tokio::test]
     async fn test_validator_unary_ok_without_message() {
         let scenarios = [
-            vec![ResponseStreamItem::Trailers(Trailers::new(Status::new(
-                StatusCode::Ok,
-                "",
-            )))],
+            vec![ClientResponseStreamItem::Trailers(Trailers::new(
+                Status::new(StatusCode::Ok, ""),
+            ))],
             vec![
-                ResponseStreamItem::Headers(ResponseHeaders::default()),
-                ResponseStreamItem::Trailers(Trailers::new(Status::new(StatusCode::Ok, ""))),
+                ClientResponseStreamItem::Headers(ResponseHeaders::default()),
+                ClientResponseStreamItem::Trailers(Trailers::new(Status::new(StatusCode::Ok, ""))),
             ],
         ];
 
         for scenario in &scenarios {
             validate_scenario(
                 scenario,
-                ResponseStreamItem::Trailers(Trailers::new(Status::new(
+                ClientResponseStreamItem::Trailers(Trailers::new(Status::new(
                     StatusCode::Internal,
                     "received zero messages",
                 ))),
@@ -315,15 +313,15 @@ mod test {
     #[tokio::test]
     async fn test_validator_unary_multiple_messages() {
         let scenarios = [vec![
-            ResponseStreamItem::Headers(ResponseHeaders::default()),
-            ResponseStreamItem::Message(()),
-            ResponseStreamItem::Message(()),
+            ClientResponseStreamItem::Headers(ResponseHeaders::default()),
+            ClientResponseStreamItem::Message,
+            ClientResponseStreamItem::Message,
         ]];
 
         for scenario in &scenarios {
             validate_scenario(
                 scenario,
-                ResponseStreamItem::Trailers(Trailers::new(Status::new(
+                ClientResponseStreamItem::Trailers(Trailers::new(Status::new(
                     StatusCode::Internal,
                     "received multiple messages",
                 ))),
@@ -336,17 +334,17 @@ mod test {
     #[tokio::test]
     async fn test_validator_successful_stream() {
         let scenarios = [vec![
-            ResponseStreamItem::Headers(ResponseHeaders::default()),
-            ResponseStreamItem::Message(()),
-            ResponseStreamItem::Message(()),
-            ResponseStreamItem::Message(()),
-            ResponseStreamItem::Trailers(Trailers::new(Status::new(StatusCode::Ok, ""))),
+            ClientResponseStreamItem::Headers(ResponseHeaders::default()),
+            ClientResponseStreamItem::Message,
+            ClientResponseStreamItem::Message,
+            ClientResponseStreamItem::Message,
+            ClientResponseStreamItem::Trailers(Trailers::new(Status::new(StatusCode::Ok, ""))),
         ]];
 
         for scenario in &scenarios {
             validate_scenario(
                 scenario,
-                ResponseStreamItem::Trailers(Trailers::new(Status::new(StatusCode::Ok, ""))),
+                ClientResponseStreamItem::Trailers(Trailers::new(Status::new(StatusCode::Ok, ""))),
                 false,
             )
             .await;
@@ -356,11 +354,11 @@ mod test {
     #[tokio::test]
     async fn test_validator_erroring_stream() {
         let scenarios = [vec![
-            ResponseStreamItem::Headers(ResponseHeaders::default()),
-            ResponseStreamItem::Message(()),
-            ResponseStreamItem::Message(()),
-            ResponseStreamItem::Message(()),
-            ResponseStreamItem::Trailers(Trailers::new(Status::new(
+            ClientResponseStreamItem::Headers(ResponseHeaders::default()),
+            ClientResponseStreamItem::Message,
+            ClientResponseStreamItem::Message,
+            ClientResponseStreamItem::Message,
+            ClientResponseStreamItem::Trailers(Trailers::new(Status::new(
                 StatusCode::Aborted,
                 "some err",
             ))),
@@ -369,7 +367,7 @@ mod test {
         for scenario in &scenarios {
             validate_scenario(
                 scenario,
-                ResponseStreamItem::Trailers(Trailers::new(Status::new(
+                ClientResponseStreamItem::Trailers(Trailers::new(Status::new(
                     StatusCode::Aborted,
                     "some err",
                 ))),
@@ -382,15 +380,15 @@ mod test {
     #[tokio::test]
     async fn test_validator_successful_unary() {
         let scenarios = [vec![
-            ResponseStreamItem::Headers(ResponseHeaders::default()),
-            ResponseStreamItem::Message(()),
-            ResponseStreamItem::Trailers(Trailers::new(Status::new(StatusCode::Ok, ""))),
+            ClientResponseStreamItem::Headers(ResponseHeaders::default()),
+            ClientResponseStreamItem::Message,
+            ClientResponseStreamItem::Trailers(Trailers::new(Status::new(StatusCode::Ok, ""))),
         ]];
 
         for scenario in &scenarios {
             validate_scenario(
                 scenario,
-                ResponseStreamItem::Trailers(Trailers::new(Status::new(StatusCode::Ok, ""))),
+                ClientResponseStreamItem::Trailers(Trailers::new(Status::new(StatusCode::Ok, ""))),
                 true,
             )
             .await;
@@ -400,21 +398,20 @@ mod test {
     #[tokio::test]
     async fn test_validator_erroring_unary() {
         let scenarios = [
-            vec![ResponseStreamItem::Trailers(Trailers::new(Status::new(
-                StatusCode::Aborted,
-                "some err",
-            )))],
+            vec![ClientResponseStreamItem::Trailers(Trailers::new(
+                Status::new(StatusCode::Aborted, "some err"),
+            ))],
             vec![
-                ResponseStreamItem::Headers(ResponseHeaders::default()),
-                ResponseStreamItem::Trailers(Trailers::new(Status::new(
+                ClientResponseStreamItem::Headers(ResponseHeaders::default()),
+                ClientResponseStreamItem::Trailers(Trailers::new(Status::new(
                     StatusCode::Aborted,
                     "some err",
                 ))),
             ],
             vec![
-                ResponseStreamItem::Headers(ResponseHeaders::default()),
-                ResponseStreamItem::Message(()),
-                ResponseStreamItem::Trailers(Trailers::new(Status::new(
+                ClientResponseStreamItem::Headers(ResponseHeaders::default()),
+                ClientResponseStreamItem::Message,
+                ClientResponseStreamItem::Trailers(Trailers::new(Status::new(
                     StatusCode::Aborted,
                     "some err",
                 ))),
@@ -424,7 +421,7 @@ mod test {
         for scenario in &scenarios {
             validate_scenario(
                 scenario,
-                ResponseStreamItem::Trailers(Trailers::new(Status::new(
+                ClientResponseStreamItem::Trailers(Trailers::new(Status::new(
                     StatusCode::Aborted,
                     "some err",
                 ))),
@@ -435,8 +432,8 @@ mod test {
     }
 
     async fn validate_scenario(
-        scenario: &[ResponseStreamItem<()>],
-        expect: ResponseStreamItem<()>,
+        scenario: &[ClientResponseStreamItem],
+        expect: ClientResponseStreamItem,
         unary: bool,
     ) {
         let (invoker, mut tx) = MockInvoker::new();
@@ -459,8 +456,8 @@ mod test {
         tx.send_resp(scenario[scenario.len() - 1].clone()).await;
         let got = validator.next(&mut NopRecvMessage).await;
         assert!(matches!(&got, expect));
-        if let ResponseStreamItem::Trailers(got_t) = got {
-            let ResponseStreamItem::Trailers(expect_t) = expect else {
+        if let ClientResponseStreamItem::Trailers(got_t) = got {
+            let ClientResponseStreamItem::Trailers(expect_t) = expect else {
                 unreachable!(); // per matches check above
             };
             // Assert the codes match.

--- a/grpc/src/client/transport/tonic/mod.rs
+++ b/grpc/src/client/transport/tonic/mod.rs
@@ -273,7 +273,7 @@ impl RecvStream for TonicRecvStream {
                     Ok(()) => {
                         // More messages may remain in the stream; set receiver again.
                         self.state = StreamState::Streaming(stream);
-                        ClientResponseStreamItem::Message(())
+                        ClientResponseStreamItem::Message
                     }
                     // TODO: in this case, tonic believes the stream is still
                     // running, but our decoding failed -- do we need to terminate

--- a/grpc/src/client/transport/tonic/test.rs
+++ b/grpc/src/client/transport/tonic/test.rs
@@ -194,7 +194,7 @@ pub(crate) async fn tonic_transport_rpc() {
             // Wait for the reply
             let mut recv_msg = WrappedEchoResponse(EchoResponse { message: "".into() });
             match rx.next(&mut recv_msg).await {
-                ClientResponseStreamItem::Message(()) => {
+                ClientResponseStreamItem::Message => {
                     let echo_response = recv_msg.0;
                     println!("Got response: {echo_response:?}");
                     assert_eq!(echo_response.message, message);
@@ -571,7 +571,7 @@ async fn perform_unary_echo(
         panic!("Expected Headers first");
     };
 
-    let ClientResponseStreamItem::Message(()) = rx.next(&mut resp).await else {
+    let ClientResponseStreamItem::Message = rx.next(&mut resp).await else {
         panic!("Expected Message after Headers");
     };
     let echo_resp = std::mem::take(&mut resp.0);

--- a/grpc/src/core/mod.rs
+++ b/grpc/src/core/mod.rs
@@ -101,32 +101,28 @@ impl dyn RecvMessage + '_ {
     }
 }
 
-/// ResponseStreamItem represents an item in a response stream from the client's view.
+/// ClientResponseStreamItem represents an item in a response stream from the client's view.
 ///
 /// A response stream must always contain items exactly as follows:
 ///
 /// [Headers *Message] Trailers *StreamClosed
 ///
-/// That is: optionaly, a Headers value and any number of Message values
+/// That is: optionally, a Headers value and any number of Message values
 /// (including zero), followed by a required Trailers value.  A response stream
 /// should not be used after Trailers, but reads should return StreamClosed if
 /// it is.
 #[derive(Debug, Clone)]
-pub enum ResponseStreamItem<M> {
+pub enum ClientResponseStreamItem {
     /// Indicates the headers for the stream.
     Headers(ResponseHeaders),
     /// Indicates a message on the stream.
-    Message(M),
+    Message,
     /// Indicates trailers were received on the stream and includes the trailers.
     Trailers(Trailers),
     /// Indicates the response stream was closed.  Trailers must have been
     /// provided before this value may be used.
     StreamClosed,
 }
-
-/// The client's view of a ResponseStream in a RecvStream: the message type is
-/// void as the received message is passed in via the `next` method.
-pub type ClientResponseStreamItem = ResponseStreamItem<()>;
 
 /// The server's view of a ResponseStream in a SendStream, using references to avoid allocations.
 pub enum ServerResponseStreamItem<'a> {

--- a/grpc/src/inmemory/mod.rs
+++ b/grpc/src/inmemory/mod.rs
@@ -314,7 +314,7 @@ impl ClientRecvStream for InMemoryClientRecvStream {
             Some(InMemoryResponseStreamItem::Headers(h)) => ClientResponseStreamItem::Headers(h),
             Some(InMemoryResponseStreamItem::Message(mut buf)) => {
                 msg.decode(&mut buf).unwrap();
-                ClientResponseStreamItem::Message(())
+                ClientResponseStreamItem::Message
             }
             _ => {
                 if let Some(trailer_rx) = self.trailer_rx.take() {


### PR DESCRIPTION

The generic `ResponseStreamItem<M>` was only used on the client side with `M = ()`. This change eliminates the generic type and redefines `ClientResponseStreamItem` as a non-generic enum to simplify the API.

As part of this change, the unit type `()` has been removed from the `Message` variant, simplifying `ClientResponseStreamItem::Message(())` to `ClientResponseStreamItem::Message`.

Fixed all occurrences and test breakages across the workspace:

- `grpc/src/core/mod.rs`
- `grpc/src/client/stream_util.rs`
- `grpc/src/inmemory/mod.rs`
- `grpc/src/client/transport/tonic/mod.rs`
- `grpc/src/client/transport/tonic/test.rs`
- `grpc-protobuf/src/client/mod.rs`
- `grpc/examples/inmemory.rs`