### PR TITLE
interop: support cygwin OSTYPE value used by new windows-latest

### DIFF
--- a/interop/test.sh
+++ b/interop/test.sh
@@ -31,6 +31,7 @@ echo "Running for OS: ${OSTYPE}"
 case "$OSTYPE" in
   darwin*)  OS="darwin"; EXT="" ;;
   linux*)   OS="linux"; EXT="" ;;
+  cygwin*)  OS="windows"; EXT=".exe" ;;
   msys*)    OS="windows"; EXT=".exe" ;;
   *)        exit 2 ;;
 esac


### PR DESCRIPTION
This appears to be https://www.msys2.org/news/#2025-02-14-moving-msys2-closer-to-cygwin trickling into github actions.