### PR TITLE
feat(tonic-xds): make XdsChannelGrpc Sync

### DIFF
--- a/tonic-xds/src/client/channel.rs
+++ b/tonic-xds/src/client/channel.rs
@@ -15,7 +15,7 @@ use std::fmt::Debug;
 use std::sync::Arc;
 use std::task::{Context, Poll};
 use tonic::{body::Body as TonicBody, client::GrpcService, transport::channel::Channel};
-use tower::{BoxError, Service, ServiceBuilder, util::BoxCloneService};
+use tower::{BoxError, Service, ServiceBuilder, util::BoxCloneSyncService};
 use xds_client::{ClientConfig, Node, ProstCodec, TokioRuntime, TonicTransportBuilder, XdsClient};
 
 use crate::client::retry::{GrpcRetryPolicy, GrpcRetryPolicyConfig, RetryLayer};
@@ -129,13 +129,21 @@ where
 
 /// A [`tonic::client::GrpcService`] implementation that can route and load-balance
 /// gRPC requests based on xDS configuration.
+///
+/// `Send + Sync + Clone`. Cloning is cheap (the inner service stack is
+/// reference-counted); callers that need exclusive access for
+/// [`tower::Service::call`] should clone per call site rather than share a
+/// single instance through a lock.
 pub type XdsChannelGrpc =
-    BoxCloneService<http::Request<TonicBody>, http::Response<TonicBody>, BoxError>;
+    BoxCloneSyncService<http::Request<TonicBody>, http::Response<TonicBody>, BoxError>;
 
-// Static assertion that XdsChannelGrpc implements GrpcService
+// Static assertions: XdsChannelGrpc implements GrpcService and is shareable
+// across tasks (Send + Sync).
 const _: fn() = || {
     fn assert_grpc_service<T: GrpcService<TonicBody>>() {}
+    fn assert_send_sync<T: Send + Sync>() {}
     assert_grpc_service::<XdsChannelGrpc>();
+    assert_send_sync::<XdsChannelGrpc>();
 };
 
 /// Builder for creating an [`XdsChannel`] or [`XdsChannelGrpc`].
@@ -228,7 +236,7 @@ impl XdsChannelBuilder {
             })
             .service(lb_service);
 
-        BoxCloneService::new(XdsChannel {
+        BoxCloneSyncService::new(XdsChannel {
             config: self.config.clone(),
             inner,
             _resources: Some(resources),
@@ -261,7 +269,7 @@ impl XdsChannelBuilder {
                 req.map(TonicBody::new)
             })
             .service(lb_service);
-        BoxCloneService::new(XdsChannel {
+        BoxCloneSyncService::new(XdsChannel {
             config: self.config.clone(),
             inner,
             _resources: None,


### PR DESCRIPTION
## Motivation

Ref: https://github.com/hyperium/tonic/issues/2444#issuecomment-4372486769

`XdsChannelGrpc` was aliased to `tower::util::BoxCloneService`, whose trait object is `+ Send` only — so the type was `Send + Clone` but not `Sync`. Consumers that need to share the channel by reference across tasks (anything requiring `T: Sync`) hit `the trait Sync is not implemented for dyn CloneService<...> + Send`.

## Solution

Switch the alias to use `BoxCloneSyncService`. The wrapped service stack (`XdsRoutingLayer` → `RetryLayer` → `map_request` → `XdsLbService`) is already `Send + Sync`, so this is a pure tightening of the public alias with no runtime cost difference. Adds a `Send + Sync` static assertion alongside the existing `GrpcService` one so a future non-`Sync` layer fails to compile rather than silently demoting the alias.
