### PR TITLE
fix(grpc): Fix grpc-google build

### DIFF
--- a/grpc-google/src/lib.rs
+++ b/grpc-google/src/lib.rs
@@ -31,8 +31,8 @@
 use std::fmt::Debug;
 
 use google_cloud_auth::credentials::AccessTokenCredentials;
-use grpc::Status;
-use grpc::StatusCode;
+use grpc::StatusCodeError;
+use grpc::StatusError;
 use grpc::credentials::SecurityLevel;
 use grpc::credentials::call::CallCredentials;
 use grpc::credentials::call::CallDetails;
@@ -99,15 +99,15 @@ impl<P: TokenProvider> CallCredentials for GcpCallCredentials<P> {
         _call_details: &CallDetails,
         _auth_info: &ClientConnectionSecurityInfo,
         metadata: &mut MetadataMap,
-    ) -> Result<(), Status> {
+    ) -> Result<(), StatusError> {
         let token = self
             .provider
             .get_token()
             .await
-            .map_err(|e| Status::new(StatusCode::Unavailable, e))?;
+            .map_err(|e| StatusError::new(StatusCodeError::Unavailable, e))?;
         let mut value: AsciiMetadataValue = format!("Bearer {}", token).parse().map_err(|e| {
-            Status::new(
-                StatusCode::Internal,
+            StatusError::new(
+                StatusCodeError::Internal,
                 format!("invalid values in authorization header value: {}", e),
             )
         })?;
@@ -177,7 +177,7 @@ mod tests {
 
         let res = creds.get_metadata(&cd, &auth_info, &mut metadata).await;
         let status = res.unwrap_err();
-        assert_eq!(status.code(), grpc::StatusCode::Unavailable);
+        assert_eq!(status.code(), grpc::StatusCodeError::Unavailable);
     }
 
     #[tokio::test]
@@ -192,7 +192,7 @@ mod tests {
 
         let res = creds.get_metadata(&cd, &auth_info, &mut metadata).await;
         let status = res.unwrap_err();
-        assert_eq!(status.code(), grpc::StatusCode::Internal);
+        assert_eq!(status.code(), grpc::StatusCodeError::Internal);
     }
 
     #[test]


### PR DESCRIPTION
The `CallCredentials` trait was updated in #2620. However, those changes were not merged with the trait impl in #2610, causing the build to break.