### PR TITLE
refactor(grpc): Use gRPC metadata instead of tonic metadata

### DIFF
--- a/grpc-google/src/lib.rs
+++ b/grpc-google/src/lib.rs
@@ -37,9 +37,9 @@ use grpc::credentials::SecurityLevel;
 use grpc::credentials::call::CallCredentials;
 use grpc::credentials::call::CallDetails;
 use grpc::credentials::call::ClientConnectionSecurityInfo;
+use grpc::metadata::AsciiMetadataValue;
+use grpc::metadata::MetadataMap;
 use tonic::async_trait;
-use tonic::metadata::AsciiMetadataValue;
-use tonic::metadata::MetadataMap;
 
 const DEFAULT_CLOUD_PLATFORM_SCOPE: &str = "https://www.googleapis.com/auth/cloud-platform";
 
@@ -162,7 +162,7 @@ mod tests {
         assert!(res.is_ok());
 
         let auth_header = metadata.get("authorization").unwrap();
-        assert_eq!(auth_header.to_str().unwrap(), "Bearer valid_token");
+        assert_eq!(auth_header.to_str(), "Bearer valid_token");
     }
 
     #[tokio::test]
@@ -184,7 +184,7 @@ mod tests {
     async fn non_ascii_token_internal_error() {
         let creds = GcpCallCredentials {
             provider: MockTokenProvider {
-                result: Ok("invalid character\n".into()),
+                result: Ok("invalid\ncharacter".into()),
             },
         };
         let (cd, auth_info) = fake_args();

--- a/grpc/Cargo.toml
+++ b/grpc/Cargo.toml
@@ -28,6 +28,7 @@ _runtime-tokio = [
     "tokio/time",
     "dep:socket2",
     "dep:tower",
+    "dep:futures",
 ]
 # Used for testing with udeps as it wants this feature to exist
 # to be able to do its checks.
@@ -44,7 +45,7 @@ tls-rustls = [
 [dependencies]
 base64 = "0.22"
 bytes = "1.10.1"
-futures = { version = "0.3", default-features = false }
+futures = { version = "0.3", default-features = false, optional = true }
 hickory-resolver = { version = "0.25.1", optional = true }
 http = "1.1.0"
 http-body = "1.0.1"

--- a/grpc/Cargo.toml
+++ b/grpc/Cargo.toml
@@ -44,6 +44,7 @@ tls-rustls = [
 [dependencies]
 base64 = "0.22"
 bytes = "1.10.1"
+futures = { version = "0.3", default-features = false }
 hickory-resolver = { version = "0.25.1", optional = true }
 http = "1.1.0"
 http-body = "1.0.1"

--- a/grpc/src/client/load_balancing/graceful_switch.rs
+++ b/grpc/src/client/load_balancing/graceful_switch.rs
@@ -252,8 +252,6 @@ mod test {
     use std::sync::mpsc;
     use std::time::Duration;
 
-    use tonic::metadata::MetadataMap;
-
     use crate::client::load_balancing::ChannelController;
     use crate::client::load_balancing::LbPolicy;
     use crate::client::load_balancing::LbState;
@@ -276,6 +274,7 @@ mod test {
     use crate::client::name_resolution::Endpoint;
     use crate::client::name_resolution::ResolverUpdate;
     use crate::core::RequestHeaders;
+    use crate::metadata::MetadataMap;
     use crate::rt::default_runtime;
 
     const DEFAULT_TEST_SHORT_TIMEOUT: Duration = Duration::from_millis(10);

--- a/grpc/src/client/load_balancing/mod.rs
+++ b/grpc/src/client/load_balancing/mod.rs
@@ -29,8 +29,6 @@ use std::fmt::Debug;
 use std::fmt::Display;
 use std::sync::Arc;
 
-use tonic::metadata::MetadataMap;
-
 use crate::StatusCodeError;
 use crate::StatusError;
 use crate::client::ConnectivityState;
@@ -39,6 +37,7 @@ use crate::client::load_balancing::subchannel::SubchannelState;
 use crate::client::name_resolution::Address;
 use crate::client::name_resolution::ResolverUpdate;
 use crate::core::RequestHeaders;
+use crate::metadata::MetadataMap;
 use crate::rt::GrpcRuntime;
 
 pub(crate) mod child_manager;

--- a/grpc/src/client/load_balancing/round_robin.rs
+++ b/grpc/src/client/load_balancing/round_robin.rs
@@ -257,8 +257,6 @@ mod test {
     use std::sync::Arc;
     use std::sync::mpsc;
 
-    use tonic::metadata::MetadataMap;
-
     use crate::StatusCodeError;
     use crate::client::ConnectivityState;
     use crate::client::load_balancing::ChannelController;
@@ -286,6 +284,7 @@ mod test {
     use crate::client::name_resolution::Endpoint;
     use crate::client::name_resolution::ResolverUpdate;
     use crate::core::RequestHeaders;
+    use crate::metadata::MetadataMap;
     use crate::rt::default_runtime;
 
     const DEFAULT_TEST_SHORT_TIMEOUT: std::time::Duration = std::time::Duration::from_millis(100);

--- a/grpc/src/client/load_balancing/subchannel_sharing.rs
+++ b/grpc/src/client/load_balancing/subchannel_sharing.rs
@@ -291,8 +291,6 @@ mod tests {
     use std::sync::Mutex;
     use std::sync::mpsc;
 
-    use tonic::metadata::MetadataMap;
-
     use super::*;
     use crate::client::ConnectivityState;
     use crate::client::load_balancing::LbPolicy;
@@ -309,6 +307,7 @@ mod tests {
     use crate::client::load_balancing::test_utils::new_request_headers;
     use crate::client::name_resolution::Address;
     use crate::client::name_resolution::ResolverUpdate;
+    use crate::metadata::MetadataMap;
     use crate::rt::default_runtime;
 
     fn test_lb_policy_options(tx_events: mpsc::Sender<TestEvent>) -> LbPolicyOptions {

--- a/grpc/src/client/metadata_utils.rs
+++ b/grpc/src/client/metadata_utils.rs
@@ -23,7 +23,6 @@
  */
 
 use tokio::sync::oneshot;
-use tonic::metadata::MetadataMap;
 
 use crate::client::CallOptions;
 use crate::client::InvokeOnce;
@@ -31,6 +30,7 @@ use crate::client::RecvStream;
 use crate::client::interceptor::Intercept;
 use crate::client::interceptor::InterceptOnce;
 use crate::core::RequestHeaders;
+use crate::metadata::MetadataMap;
 
 /// An interceptor that attaches metadata to outgoing RPC headers.
 pub struct AttachHeadersInterceptor {
@@ -53,16 +53,16 @@ impl<I: InvokeOnce> Intercept<I> for AttachHeadersInterceptor {
         options: CallOptions,
         next: I,
     ) -> (Self::SendStream, Self::RecvStream) {
-        headers
-            .metadata_mut()
-            .as_mut()
-            .extend(self.md.as_ref().clone());
-
-        let md = headers.metadata_mut();
-        for entry in self.md.iter() {
-            match entry {
-                tonic::metadata::KeyAndValueRef::Ascii(k, v) => _ = md.insert(k, v.clone()),
-                tonic::metadata::KeyAndValueRef::Binary(k, v) => _ = md.insert_bin(k, v.clone()),
+        let incoming_meta = headers.metadata_mut();
+        incoming_meta.reserve(self.md.len());
+        for kv in self.md.iter() {
+            match kv {
+                crate::metadata::KeyAndValueRef::Ascii(key, value) => {
+                    incoming_meta.append(key, value.clone())
+                }
+                crate::metadata::KeyAndValueRef::Binary(key, value) => {
+                    incoming_meta.append_bin(key, value.clone())
+                }
             }
         }
         next.invoke_once(headers, options).await
@@ -179,6 +179,7 @@ mod tests {
     use crate::core::ClientResponseStreamItem;
     use crate::core::ResponseHeaders;
     use crate::core::Trailers;
+    use crate::metadata::BinaryMetadataValue;
 
     #[tokio::test]
     async fn test_attach_headers_interceptor() {
@@ -187,7 +188,7 @@ mod tests {
         md.insert("x-test-header", "test-value".parse().unwrap());
         md.insert_bin(
             "x-test-header-bin",
-            tonic::metadata::MetadataValue::from_bytes(b"test-bin"),
+            BinaryMetadataValue::from_bytes(b"test-bin"),
         );
         let interceptor = AttachHeadersInterceptor::new(md);
 

--- a/grpc/src/client/transport/tonic/mod.rs
+++ b/grpc/src/client/transport/tonic/mod.rs
@@ -213,17 +213,7 @@ fn trailers_from_tonic_status(
             status.message(),
         )),
     };
-
-    let trailers = match md.map(TryInto::try_into) {
-        Some(Err(e)) => Trailers::new(Err(StatusError::new(
-            StatusCodeError::Internal,
-            format!("failed to parse metadata: {e}"),
-        ))),
-        Some(Ok(metadata)) => Trailers::new(status_res).with_metadata(metadata),
-        None => Trailers::new(status_res),
-    };
-
-    ClientResponseStreamItem::Trailers(trailers)
+    trailers_from_status(status_res, md)
 }
 
 // Builds a trailers with a status

--- a/grpc/src/client/transport/tonic/mod.rs
+++ b/grpc/src/client/transport/tonic/mod.rs
@@ -56,7 +56,7 @@ use tonic::codec::Codec;
 use tonic::codec::Decoder;
 use tonic::codec::EncodeBuf;
 use tonic::codec::Encoder;
-use tonic::metadata::MetadataMap;
+use tonic::metadata::MetadataMap as TonicMeta;
 use tower::ServiceBuilder;
 use tower::buffer::Buffer;
 use tower::buffer::future::ResponseFuture as BufferResponseFuture;
@@ -154,7 +154,7 @@ impl Invoke for TonicTransport {
         let request_stream = ReceiverStream::new(req_rx);
         let mut request = TonicRequest::new(Box::pin(request_stream));
         let (method, metadata) = headers.into_parts();
-        *request.metadata_mut() = metadata;
+        *request.metadata_mut() = metadata.into();
 
         let Ok(path) = PathAndQuery::from_maybe_shared(method) else {
             return err_streams(StatusError::new(StatusCodeError::Internal, "invalid path"));
@@ -192,28 +192,38 @@ impl Invoke for TonicTransport {
 // Converts from a tonic status to a trailers stream item.
 fn trailers_from_tonic_status(
     status: TonicStatus,
-    md: Option<MetadataMap>,
+    md: Option<TonicMeta>,
 ) -> ClientResponseStreamItem {
-    let mut trailers = Trailers::new(if status.code() == Code::Ok {
-        Ok(())
-    } else {
-        Err(StatusError::new(
-            StatusCodeError::from(status.code() as i32),
+    let status_res = match status.code() {
+        Code::Ok => Ok(()),
+        code => Err(StatusError::new(
+            StatusCodeError::from(code as i32),
             status.message(),
-        ))
-    });
-    if let Some(md) = md {
-        trailers = trailers.with_metadata(md);
-    }
+        )),
+    };
+
+    let trailers = match md.map(TryInto::try_into) {
+        Some(Err(e)) => Trailers::new(Err(StatusError::new(
+            StatusCodeError::Internal,
+            format!("failed to parse metadata: {e}"),
+        ))),
+        Some(Ok(metadata)) => Trailers::new(status_res).with_metadata(metadata),
+        None => Trailers::new(status_res),
+    };
+
     ClientResponseStreamItem::Trailers(trailers)
 }
 
 // Builds a trailers with a status
-fn trailers_from_status(status: Status, md: Option<MetadataMap>) -> ClientResponseStreamItem {
-    let mut trailers = Trailers::new(status);
-    if let Some(md) = md {
-        trailers = trailers.with_metadata(md);
-    }
+fn trailers_from_status(status: Status, md: Option<TonicMeta>) -> ClientResponseStreamItem {
+    let trailers = match md.map(TryInto::try_into) {
+        Some(Err(e)) => Trailers::new(Err(StatusError::new(
+            StatusCodeError::Internal,
+            format!("failed to parse metadata: {e}"),
+        ))),
+        Some(Ok(metadata)) => Trailers::new(status).with_metadata(metadata),
+        None => Trailers::new(status),
+    };
     ClientResponseStreamItem::Trailers(trailers)
 }
 
@@ -262,11 +272,32 @@ impl RecvStream for TonicRecvStream {
             StreamState::AwaitingHeaders(rx) => match rx.await {
                 Ok(Ok(response)) => {
                     let (metadata, stream, _extensions) = response.into_parts();
-                    // Start streaming and return the headers.
-                    self.state = StreamState::Streaming(stream);
-                    ClientResponseStreamItem::Headers(
-                        ResponseHeaders::new().with_metadata(metadata),
-                    )
+                    // Tonic decodes base64-encoded binary headers lazily. It
+                    // does not fail the RPC upon receiving invalid base64 data;
+                    // the error only surfaces when the application attempts to
+                    // read the metadata.
+                    // In contrast, standard gRPC implementations eagerly decode
+                    // these headers and immediately fail the RPC with an
+                    // Internal status.
+                    // TODO: in this case, tonic believes the stream is still
+                    // running, but our parsing failed -- do we need to terminate
+                    // the request stream now even though the Streaming is dropped?
+                    match metadata.try_into() {
+                        Ok(md) => {
+                            // Start streaming and return the headers.
+                            self.state = StreamState::Streaming(stream);
+                            ClientResponseStreamItem::Headers(
+                                ResponseHeaders::new().with_metadata(md),
+                            )
+                        }
+                        Err(e) => trailers_from_status(
+                            Err(StatusError::new(
+                                StatusCodeError::Internal,
+                                format!("error decoding response: {e}"),
+                            )),
+                            None,
+                        ),
+                    }
                 }
                 // Stay closed after sending trailers.
                 Err(_) => trailers_from_status(

--- a/grpc/src/client/transport/tonic/mod.rs
+++ b/grpc/src/client/transport/tonic/mod.rs
@@ -279,9 +279,6 @@ impl RecvStream for TonicRecvStream {
                     // In contrast, standard gRPC implementations eagerly decode
                     // these headers and immediately fail the RPC with an
                     // Internal status.
-                    // TODO: in this case, tonic believes the stream is still
-                    // running, but our parsing failed -- do we need to terminate
-                    // the request stream now even though the Streaming is dropped?
                     match metadata.try_into() {
                         Ok(md) => {
                             // Start streaming and return the headers.
@@ -290,6 +287,10 @@ impl RecvStream for TonicRecvStream {
                                 ResponseHeaders::new().with_metadata(md),
                             )
                         }
+                        // TODO: in this case, tonic believes the stream is
+                        // still running, but our parsing failed -- do we need
+                        // to terminate the request stream now even though the
+                        // Streaming is dropped?
                         Err(e) => trailers_from_status(
                             Err(StatusError::new(
                                 StatusCodeError::Internal,

--- a/grpc/src/client/transport/tonic/mod.rs
+++ b/grpc/src/client/transport/tonic/mod.rs
@@ -161,8 +161,8 @@ impl Invoke for TonicTransport {
         // dropped. We use `take_until` with this Notify to explicitly force the
         // stream to yield `None`, which tells Tonic to cancel the stream.
         let stop_notify_clone = stop_notify.clone();
-        let request_stream = ReceiverStream::new(req_rx)
-            .take_until(Box::pin(async move { stop_notify_clone.notified().await }));
+        let request_stream =
+            ReceiverStream::new(req_rx).take_until(stop_notify_clone.notified_owned());
         let mut request = TonicRequest::new(Box::pin(request_stream));
         let (method, metadata) = headers.into_parts();
         *request.metadata_mut() = metadata.into();
@@ -349,7 +349,7 @@ impl RecvStream for TonicRecvStream {
 
 impl Drop for TonicRecvStream {
     fn drop(&mut self) {
-        if let Some(notify) = self.stop_notify.take() {
+        if let Some(notify) = &self.stop_notify {
             notify.notify_one();
         }
     }

--- a/grpc/src/client/transport/tonic/mod.rs
+++ b/grpc/src/client/transport/tonic/mod.rs
@@ -28,6 +28,7 @@ use std::net::SocketAddr;
 use std::path::PathBuf;
 use std::pin::Pin;
 use std::str::FromStr;
+use std::sync::Arc;
 use std::task::Context;
 use std::task::Poll;
 use std::time::Instant;
@@ -35,12 +36,14 @@ use std::time::Instant;
 use bytes::Buf;
 use bytes::BufMut as _;
 use bytes::Bytes;
+use futures::stream::StreamExt;
 use http::Request as HttpRequest;
 use http::Response as HttpResponse;
 use http::Uri;
 use http::uri::PathAndQuery;
 use hyper::client::conn::http2::Builder;
 use hyper::client::conn::http2::SendRequest;
+use tokio::sync::Notify;
 use tokio::sync::mpsc;
 use tokio::sync::oneshot;
 use tokio_stream::Stream;
@@ -151,7 +154,15 @@ impl Invoke for TonicTransport {
         options: CallOptions,
     ) -> (Self::SendStream, Self::RecvStream) {
         let (req_tx, req_rx) = mpsc::channel(1);
-        let request_stream = ReceiverStream::new(req_rx);
+        let stop_notify = Arc::new(Notify::new());
+
+        // Tonic runs the outbound request stream in a background task. It will
+        // NOT automatically stop sending if the inbound response stream is
+        // dropped. We use `take_until` with this Notify to explicitly force the
+        // stream to yield `None`, which tells Tonic to cancel the stream.
+        let stop_notify_clone = stop_notify.clone();
+        let request_stream = ReceiverStream::new(req_rx)
+            .take_until(Box::pin(async move { stop_notify_clone.notified().await }));
         let mut request = TonicRequest::new(Box::pin(request_stream));
         let (method, metadata) = headers.into_parts();
         *request.metadata_mut() = metadata.into();
@@ -184,6 +195,7 @@ impl Invoke for TonicTransport {
             TonicSendStream { sender: Ok(req_tx) },
             TonicRecvStream {
                 state: StreamState::AwaitingHeaders(resp_rx),
+                stop_notify: Some(stop_notify),
             },
         )
     }
@@ -248,6 +260,7 @@ impl SendStream for TonicSendStream {
 
 struct TonicRecvStream {
     state: StreamState,
+    stop_notify: Option<Arc<Notify>>,
 }
 
 enum StreamState {
@@ -287,17 +300,18 @@ impl RecvStream for TonicRecvStream {
                                 ResponseHeaders::new().with_metadata(md),
                             )
                         }
-                        // TODO: in this case, tonic believes the stream is
-                        // still running, but our parsing failed -- do we need
-                        // to terminate the request stream now even though the
-                        // Streaming is dropped?
-                        Err(e) => trailers_from_status(
-                            Err(StatusError::new(
-                                StatusCodeError::Internal,
-                                format!("error decoding response: {e}"),
-                            )),
-                            None,
-                        ),
+                        Err(e) => {
+                            if let Some(notify) = self.stop_notify.take() {
+                                notify.notify_one();
+                            }
+                            trailers_from_status(
+                                Err(StatusError::new(
+                                    StatusCodeError::Internal,
+                                    format!("error decoding response: {e}"),
+                                )),
+                                None,
+                            )
+                        }
                     }
                 }
                 // Stay closed after sending trailers.
@@ -314,16 +328,18 @@ impl RecvStream for TonicRecvStream {
                         self.state = StreamState::Streaming(stream);
                         ClientResponseStreamItem::Message
                     }
-                    // TODO: in this case, tonic believes the stream is still
-                    // running, but our decoding failed -- do we need to terminate
-                    // the request stream now even though the Streaming is dropped?
-                    Err(e) => trailers_from_status(
-                        Err(StatusError::new(
-                            StatusCodeError::Internal,
-                            format!("error decoding response: {e}"),
-                        )),
-                        None,
-                    ),
+                    Err(e) => {
+                        if let Some(notify) = self.stop_notify.take() {
+                            notify.notify_one();
+                        }
+                        trailers_from_status(
+                            Err(StatusError::new(
+                                StatusCodeError::Internal,
+                                format!("error decoding response: {e}"),
+                            )),
+                            None,
+                        )
+                    }
                 },
                 // Stay closed after sending trailers.
                 Err(status) => {
@@ -346,6 +362,7 @@ fn err_streams(status: StatusError) -> (TonicSendStream, TonicRecvStream) {
         TonicSendStream { sender: Err(()) },
         TonicRecvStream {
             state: StreamState::Error(status),
+            stop_notify: None,
         },
     )
 }

--- a/grpc/src/client/transport/tonic/mod.rs
+++ b/grpc/src/client/transport/tonic/mod.rs
@@ -347,6 +347,14 @@ impl RecvStream for TonicRecvStream {
     }
 }
 
+impl Drop for TonicRecvStream {
+    fn drop(&mut self) {
+        if let Some(notify) = self.stop_notify.take() {
+            notify.notify_one();
+        }
+    }
+}
+
 fn err_streams(status: StatusError) -> (TonicSendStream, TonicRecvStream) {
     (
         TonicSendStream { sender: Err(()) },

--- a/grpc/src/client/transport/tonic/test.rs
+++ b/grpc/src/client/transport/tonic/test.rs
@@ -25,12 +25,16 @@
 use std::fs;
 use std::path::PathBuf;
 use std::pin::Pin;
+use std::result::Result;
 use std::sync::Arc;
 use std::sync::Once;
 use std::time::Duration;
 
 use bytes::Buf;
 use bytes::Bytes;
+use http::HeaderMap;
+use http::HeaderName;
+use http::HeaderValue;
 use tokio::net::TcpListener;
 use tokio::sync::Notify;
 use tokio::sync::oneshot;
@@ -41,6 +45,7 @@ use tokio_stream::wrappers::ReceiverStream;
 use tokio_stream::wrappers::TcpListenerStream;
 use tonic::Response;
 use tonic::async_trait;
+use tonic::metadata::MetadataMap as TonicMetadata;
 use tonic::transport::Server;
 use tonic_prost::prost::Message as ProstMessage;
 
@@ -129,7 +134,9 @@ pub(crate) async fn tonic_transport_rpc() {
     let shutdown_notify_copy = shutdown_notify.clone();
     println!("EchoServer listening on: {addr}");
     let server_handle = tokio::spawn(async move {
-        let echo_server = EchoService {};
+        let echo_server = EchoService {
+            response_headers: None,
+        };
         let svc = EchoServer::new(echo_server);
         let _ = Server::builder()
             .add_service(svc)
@@ -228,7 +235,9 @@ async fn grpc_invoke_tonic_unary() {
 
     // Spawn a task for the server.
     let server_handle = tokio::spawn(async move {
-        let echo_server = EchoService {};
+        let echo_server = EchoService {
+            response_headers: None,
+        };
         let svc = EchoServer::new(echo_server);
         let _ = Server::builder()
             .add_service(svc)
@@ -284,7 +293,9 @@ mod unix_tests {
         let shutdown_notify_copy = shutdown_notify.clone();
 
         let server_handle = tokio::spawn(async move {
-            let echo_server = EchoService {};
+            let echo_server = EchoService {
+                response_headers: None,
+            };
             let svc = EchoServer::new(echo_server);
             let _ = Server::builder()
                 .add_service(svc)
@@ -419,7 +430,9 @@ async fn grpc_invoke_tonic_unary_tls() {
 
     // Spawn a task for the server.
     let server_handle = tokio::spawn(async move {
-        let echo_server = EchoService {};
+        let echo_server = EchoService {
+            response_headers: None,
+        };
         let svc = EchoServer::new(echo_server);
         let _ = Server::builder()
             .tls_config(tls_config)
@@ -472,7 +485,9 @@ async fn grpc_invoke_failure_cases() {
     let shutdown_notify_copy = shutdown_notify.clone();
 
     tokio::spawn(async move {
-        let echo_server = EchoService {};
+        let echo_server = EchoService {
+            response_headers: None,
+        };
         let svc = EchoServer::new(echo_server);
         let _ = Server::builder()
             .add_service(svc)
@@ -622,6 +637,90 @@ async fn perform_unary_echo_failure(channel: &Channel) -> Trailers {
     t
 }
 
+#[tokio::test]
+async fn tonic_transport_invalid_base64_headers() {
+    super::reg();
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let shutdown_notify = Arc::new(Notify::new());
+    let shutdown_notify_copy = shutdown_notify.clone();
+
+    let mut headers = HeaderMap::new();
+    headers.insert(
+        HeaderName::from_static("test-bin"),
+        HeaderValue::from_static("invalid base64 data"),
+    );
+    let response_headers = Some(TonicMetadata::from_headers(headers));
+
+    let server_handle = tokio::spawn(async move {
+        let echo_server = EchoService { response_headers };
+        let svc = EchoServer::new(echo_server);
+        let _ = Server::builder()
+            .add_service(svc)
+            .serve_with_incoming_shutdown(
+                TcpListenerStream::new(listener),
+                shutdown_notify_copy.notified(),
+            )
+            .await;
+    });
+
+    let builder = GLOBAL_TRANSPORT_REGISTRY
+        .get_transport(TCP_IP_NETWORK_TYPE)
+        .unwrap();
+    let config = Arc::new(TransportOptions::default());
+    let securty_opts = SecurityOpts {
+        credentials: LocalChannelCredentials::new_arc(),
+        authority: Authority::new("localhost".to_string(), None),
+        handshake_info: ClientHandshakeInfo::default(),
+    };
+    let (conn, _sec_info, _disconnection_listener) = builder
+        .dyn_connect(
+            addr.to_string(),
+            GrpcRuntime::new(TokioRuntime::default()),
+            &securty_opts,
+            &config,
+        )
+        .await
+        .unwrap();
+
+    let (mut tx, mut rx) = conn
+        .dyn_invoke(
+            RequestHeaders::new()
+                .with_method_name("/grpc.examples.echo.Echo/BidirectionalStreamingEcho"),
+            CallOptions::default(),
+        )
+        .await;
+
+    let mut dummy_msg = WrappedEchoResponse(EchoResponse { message: "".into() });
+
+    match rx.next(&mut dummy_msg).await {
+        ClientResponseStreamItem::Trailers(trailers) => {
+            println!("Got trailers as expected due to invalid headers");
+            let status = trailers.status().as_ref().unwrap_err();
+            assert_eq!(status.code(), StatusCodeError::Internal);
+        }
+        item => panic!("Expected Trailers with error, got {:?}", item),
+    }
+
+    let request = EchoRequest {
+        message: "hello".into(),
+    };
+    let req = WrappedEchoRequest(request);
+
+    tokio::time::timeout(Duration::from_secs(10), async {
+        loop {
+            if tx.send(&req, SendOptions::default()).await.is_err() {
+                break;
+            }
+        }
+    })
+    .await
+    .expect("send did not fail within 10 seconds");
+
+    shutdown_notify.notify_one();
+    server_handle.await.unwrap();
+}
+
 struct WrappedEchoRequest(EchoRequest);
 struct WrappedEchoResponse(EchoResponse);
 
@@ -640,14 +739,16 @@ impl RecvMessage for WrappedEchoResponse {
 }
 
 #[derive(Debug)]
-pub(crate) struct EchoService {}
+struct EchoService {
+    response_headers: Option<TonicMetadata>,
+}
 
 #[async_trait]
 impl Echo for EchoService {
     async fn unary_echo(
         &self,
         request: tonic::Request<EchoRequest>,
-    ) -> std::result::Result<tonic::Response<EchoResponse>, tonic::Status> {
+    ) -> Result<tonic::Response<EchoResponse>, tonic::Status> {
         let metadata = request.metadata().clone();
         let message = request.into_inner().message;
         let mut response = tonic::Response::new(EchoResponse { message });
@@ -664,14 +765,14 @@ impl Echo for EchoService {
     async fn server_streaming_echo(
         &self,
         _: tonic::Request<EchoRequest>,
-    ) -> std::result::Result<tonic::Response<Self::ServerStreamingEchoStream>, tonic::Status> {
+    ) -> Result<tonic::Response<Self::ServerStreamingEchoStream>, tonic::Status> {
         unimplemented!()
     }
 
     async fn client_streaming_echo(
         &self,
         _: tonic::Request<tonic::Streaming<EchoRequest>>,
-    ) -> std::result::Result<tonic::Response<EchoResponse>, tonic::Status> {
+    ) -> Result<tonic::Response<EchoResponse>, tonic::Status> {
         unimplemented!()
     }
     type BidirectionalStreamingEchoStream =
@@ -680,8 +781,7 @@ impl Echo for EchoService {
     async fn bidirectional_streaming_echo(
         &self,
         request: tonic::Request<tonic::Streaming<EchoRequest>>,
-    ) -> std::result::Result<tonic::Response<Self::BidirectionalStreamingEchoStream>, tonic::Status>
-    {
+    ) -> Result<tonic::Response<Self::BidirectionalStreamingEchoStream>, tonic::Status> {
         let metadata = request.metadata().clone();
         if let Some(val) = metadata.get("x-test-metadata")
             && val == "test-value"
@@ -702,8 +802,11 @@ impl Echo for EchoService {
             println!("Server closing stream");
         };
 
-        Ok(Response::new(
-            Box::pin(outbound) as Self::BidirectionalStreamingEchoStream
-        ))
+        let mut response =
+            Response::new(Box::pin(outbound) as Self::BidirectionalStreamingEchoStream);
+        if let Some(headers) = &self.response_headers {
+            *response.metadata_mut() = headers.clone();
+        }
+        Ok(response)
     }
 }

--- a/grpc/src/client/transport/tonic/test.rs
+++ b/grpc/src/client/transport/tonic/test.rs
@@ -707,15 +707,11 @@ async fn tonic_transport_invalid_base64_headers() {
     };
     let req = WrappedEchoRequest(request);
 
-    tokio::time::timeout(Duration::from_secs(10), async {
-        loop {
-            if tx.send(&req, SendOptions::default()).await.is_err() {
-                break;
-            }
-        }
+    tokio::time::timeout(DEFAULT_TEST_DURATION, async {
+        while tx.send(&req, SendOptions::default()).await.is_ok() {}
     })
     .await
-    .expect("send did not fail within 10 seconds");
+    .expect("timed out waiting for stream to close");
 
     shutdown_notify.notify_one();
     server_handle.await.unwrap();

--- a/grpc/src/client/transport/tonic/test.rs
+++ b/grpc/src/client/transport/tonic/test.rs
@@ -717,6 +717,72 @@ async fn tonic_transport_invalid_base64_headers() {
     server_handle.await.unwrap();
 }
 
+#[tokio::test]
+async fn tonic_transport_recv_drop_cancels_send() {
+    super::reg();
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let shutdown_notify = Arc::new(Notify::new());
+    let shutdown_notify_copy = shutdown_notify.clone();
+
+    let server_handle = tokio::spawn(async move {
+        let echo_server = EchoService {
+            response_headers: None,
+        };
+        let svc = EchoServer::new(echo_server);
+        let _ = Server::builder()
+            .add_service(svc)
+            .serve_with_incoming_shutdown(
+                TcpListenerStream::new(listener),
+                shutdown_notify_copy.notified(),
+            )
+            .await;
+    });
+
+    let builder = GLOBAL_TRANSPORT_REGISTRY
+        .get_transport(TCP_IP_NETWORK_TYPE)
+        .unwrap();
+    let config = Arc::new(TransportOptions::default());
+    let securty_opts = SecurityOpts {
+        credentials: InsecureChannelCredentials::new_arc(),
+        authority: Authority::new("localhost".to_string(), None),
+        handshake_info: ClientHandshakeInfo::default(),
+    };
+    let (conn, _sec_info, _disconnection_listener) = builder
+        .dyn_connect(
+            addr.to_string(),
+            GrpcRuntime::new(TokioRuntime::default()),
+            &securty_opts,
+            &config,
+        )
+        .await
+        .unwrap();
+
+    let (mut tx, rx) = conn
+        .dyn_invoke(
+            RequestHeaders::new()
+                .with_method_name("/grpc.examples.echo.Echo/BidirectionalStreamingEcho"),
+            CallOptions::default(),
+        )
+        .await;
+
+    drop(rx);
+
+    let request = EchoRequest {
+        message: "hello".into(),
+    };
+    let req = WrappedEchoRequest(request);
+
+    tokio::time::timeout(DEFAULT_TEST_DURATION, async {
+        while tx.send(&req, SendOptions::default()).await.is_ok() {}
+    })
+    .await
+    .expect("timed out waiting for stream to close");
+
+    shutdown_notify.notify_one();
+    server_handle.await.unwrap();
+}
+
 struct WrappedEchoRequest(EchoRequest);
 struct WrappedEchoResponse(EchoResponse);
 

--- a/grpc/src/client/transport/tonic/test.rs
+++ b/grpc/src/client/transport/tonic/test.rs
@@ -41,7 +41,6 @@ use tokio_stream::wrappers::ReceiverStream;
 use tokio_stream::wrappers::TcpListenerStream;
 use tonic::Response;
 use tonic::async_trait;
-use tonic::metadata::MetadataMap;
 use tonic::transport::Server;
 use tonic_prost::prost::Message as ProstMessage;
 
@@ -80,6 +79,8 @@ use crate::echo_pb::EchoRequest;
 use crate::echo_pb::EchoResponse;
 use crate::echo_pb::echo_server::Echo;
 use crate::echo_pb::echo_server::EchoServer;
+use crate::metadata::AsciiMetadataKey;
+use crate::metadata::MetadataMap;
 use crate::rt::GrpcRuntime;
 use crate::rt::tokio::TokioRuntime;
 
@@ -103,8 +104,7 @@ impl CallCredentials for MockCallCredentials {
         }
         for (key, val) in &self.metadata {
             metadata.insert(
-                key.parse::<tonic::metadata::MetadataKey<tonic::metadata::Ascii>>()
-                    .unwrap(),
+                key.parse::<AsciiMetadataKey>().unwrap(),
                 val.parse().unwrap(),
             );
         }

--- a/grpc/src/core/mod.rs
+++ b/grpc/src/core/mod.rs
@@ -29,8 +29,8 @@
 use std::any::TypeId;
 
 use bytes::Buf;
-use tonic::metadata::MetadataMap;
 
+use crate::metadata::MetadataMap;
 use crate::status::Status;
 
 #[allow(unused)]

--- a/grpc/src/credentials/call.rs
+++ b/grpc/src/credentials/call.rs
@@ -26,11 +26,11 @@ use std::fmt::Debug;
 use std::sync::Arc;
 
 use tonic::async_trait;
-use tonic::metadata::MetadataMap;
 
 use crate::StatusError;
 use crate::attributes::Attributes;
 use crate::credentials::SecurityLevel;
+use crate::metadata::MetadataMap;
 
 /// Details regarding the call.
 ///
@@ -175,9 +175,9 @@ impl CallCredentials for CompositeCallCredentials {
 
 #[cfg(test)]
 mod tests {
-    use tonic::metadata::MetadataValue;
-
     use super::*;
+    use crate::metadata::AsciiMetadataKey;
+    use crate::metadata::AsciiMetadataValue;
 
     #[derive(Debug)]
     struct MockCallCredentials {
@@ -195,10 +195,8 @@ mod tests {
             metadata: &mut MetadataMap,
         ) -> Result<(), StatusError> {
             metadata.insert(
-                self.key
-                    .parse::<tonic::metadata::MetadataKey<tonic::metadata::Ascii>>()
-                    .unwrap(),
-                MetadataValue::try_from(&self.value).unwrap(),
+                self.key.parse::<AsciiMetadataKey>().unwrap(),
+                AsciiMetadataValue::try_from(&self.value).unwrap(),
             );
             Ok(())
         }

--- a/grpc/src/credentials/client.rs
+++ b/grpc/src/credentials/client.rs
@@ -203,8 +203,6 @@ impl<T: ChannelCredentials> ChannelCredentials for CompositeChannelCredentials<T
 mod tests {
     use tokio::net::TcpListener;
     use tonic::async_trait;
-    use tonic::metadata::MetadataMap;
-    use tonic::metadata::MetadataValue;
 
     use super::*;
     use crate::StatusError;
@@ -213,6 +211,9 @@ mod tests {
     use crate::credentials::call::ClientConnectionSecurityInfo;
     use crate::credentials::insecure::InsecureChannelCredentials;
     use crate::credentials::local::LocalChannelCredentials;
+    use crate::metadata::AsciiMetadataKey;
+    use crate::metadata::AsciiMetadataValue;
+    use crate::metadata::MetadataMap;
     use crate::rt;
     use crate::rt::TcpOptions;
 
@@ -232,10 +233,8 @@ mod tests {
             metadata: &mut MetadataMap,
         ) -> Result<(), StatusError> {
             metadata.insert(
-                self.key
-                    .parse::<tonic::metadata::MetadataKey<tonic::metadata::Ascii>>()
-                    .unwrap(),
-                MetadataValue::try_from(self.value).unwrap(),
+                self.key.parse::<AsciiMetadataKey>().unwrap(),
+                AsciiMetadataValue::try_from(self.value).unwrap(),
             );
             Ok(())
         }

--- a/grpc/src/metadata/map.rs
+++ b/grpc/src/metadata/map.rs
@@ -158,7 +158,11 @@ impl MetadataMap {
     }
 
     /// Convert an HTTP HeaderMap to a MetadataMap
-    pub(crate) fn from_headers(headers: HeaderMap) -> Self {
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if base64 decoding of a binary metadata value fails.
+    pub(crate) fn from_headers(headers: HeaderMap) -> Result<Self, String> {
         let mut ret = Vec::with_capacity(headers.len());
         let mut current_key: Option<HeaderName> = None;
 
@@ -180,16 +184,16 @@ impl MetadataMap {
                     mv.set_sensitive(value.is_sensitive());
                     ret.push((k.clone(), mv.into_inner()));
                 }
-            } else if Binary::is_valid_key(key_str)
-                && let Ok(b) = Binary::decode(value.as_bytes(), private::Internal)
-            {
+            } else if Binary::is_valid_key(key_str) {
+                let b = Binary::decode(value.as_bytes(), private::Internal)
+                    .map_err(|e| format!("failed to decode base64 value: {e}"))?;
                 let mut mv = unsafe { MetadataValue::<Binary>::from_shared_unchecked(b) };
                 mv.set_sensitive(value.is_sensitive());
                 ret.push((k.clone(), mv.into_inner()));
             }
         }
 
-        Self { headers: ret }
+        Ok(Self { headers: ret })
     }
 
     /// Convert a MetadataMap into a HTTP HeaderMap.
@@ -911,8 +915,10 @@ impl MetadataMap {
     }
 }
 
-impl From<tonic::metadata::MetadataMap> for MetadataMap {
-    fn from(tonic_map: tonic::metadata::MetadataMap) -> Self {
+impl TryFrom<tonic::metadata::MetadataMap> for MetadataMap {
+    type Error = String;
+
+    fn try_from(tonic_map: tonic::metadata::MetadataMap) -> Result<Self, Self::Error> {
         Self::from_headers(tonic_map.into_headers())
     }
 }
@@ -1418,10 +1424,7 @@ mod tests {
         // in gRPC MetadataValue<Ascii>.
         http_map.insert("x-invalid-ascii", HeaderValue::from_bytes(&[0xFA]).unwrap());
 
-        // Invalid Binary value (not valid base64)
-        http_map.insert("invalid-bin", "not-base64-!!!".parse().unwrap());
-
-        let map = MetadataMap::from_headers(http_map);
+        let map = MetadataMap::from_headers(http_map).unwrap();
 
         assert_eq!(map.len(), 2);
         assert_eq!(map.get("x-host").unwrap(), "example.com");
@@ -1429,7 +1432,17 @@ mod tests {
 
         assert!(!map.contains_key("x-host!"));
         assert!(!map.contains_key("x-invalid-ascii"));
-        assert!(!map.contains_key("invalid-bin"));
+    }
+
+    #[test]
+    fn test_from_headers_fails_on_invalid_bin_header() {
+        let mut http_map = http::HeaderMap::new();
+
+        // Invalid Binary value (not valid base64)
+        http_map.insert("invalid-bin", "not-base64-!!!".parse().unwrap());
+
+        let result = MetadataMap::from_headers(http_map);
+        assert!(result.is_err());
     }
 
     #[test]
@@ -1560,7 +1573,7 @@ mod tests {
         assert_eq!(tonic_map.get("x-host").unwrap(), "example.com");
         assert_eq!(tonic_map.get_bin("trace-proto-bin").unwrap(), "Hello!!");
 
-        let back_map: MetadataMap = tonic_map.into();
+        let back_map: MetadataMap = tonic_map.try_into().unwrap();
         assert_eq!(back_map.len(), 2);
         assert_eq!(back_map.get("x-host").unwrap(), "example.com");
         assert_eq!(back_map.get_bin("trace-proto-bin").unwrap(), "Hello!!");

--- a/grpc/src/metadata/map.rs
+++ b/grpc/src/metadata/map.rs
@@ -185,8 +185,9 @@ impl MetadataMap {
                     ret.push((k.clone(), mv.into_inner()));
                 }
             } else if Binary::is_valid_key(key_str) {
-                let b = Binary::decode(value.as_bytes(), private::Internal)
-                    .map_err(|e| format!("failed to decode base64 value: {e}"))?;
+                let b = Binary::decode(value.as_bytes(), private::Internal).map_err(|e| {
+                    format!("failed to decode base64 value for key '{key_str}': {e}")
+                })?;
                 let mut mv = unsafe { MetadataValue::<Binary>::from_shared_unchecked(b) };
                 mv.set_sensitive(value.is_sensitive());
                 ret.push((k.clone(), mv.into_inner()));

--- a/grpc/src/metadata/value.rs
+++ b/grpc/src/metadata/value.rs
@@ -440,7 +440,7 @@ impl MetadataValue<Binary> {
     /// # Examples
     ///
     /// ```
-    /// # use tonic::metadata::*;
+    /// # use grpc::metadata::*;
     /// let val = BinaryMetadataValue::from_bytes(b"hello\xfa");
     /// assert_eq!(val, &b"hello\xfa"[..]);
     /// ```

--- a/interop/src/client_protobuf.rs
+++ b/interop/src/client_protobuf.rs
@@ -28,12 +28,12 @@ use grpc::client::Channel;
 use grpc::client::metadata_utils::AttachHeadersInterceptor;
 use grpc::client::metadata_utils::CaptureHeadersInterceptor;
 use grpc::client::metadata_utils::CaptureTrailersInterceptor;
+use grpc::metadata::MetadataMap;
+use grpc::metadata::MetadataValue;
 use grpc_protobuf::CallBuilder;
 use protobuf::message_eq;
 use protobuf::proto;
 use tonic::async_trait;
-use tonic::metadata::MetadataMap;
-use tonic::metadata::MetadataValue;
 
 use crate::TestAssertion;
 use crate::client::InteropTest;


### PR DESCRIPTION
This PR migrates the gRPC crates to use the gRPC `MetadataMap` introduced in #2567, replacing the dependency on `tonic` types.

This PR also includes the following fixes:
* Explicit failure on invalid binary metadata: Converting `http::HeaderMap` to the gRPC `MetadataMap` now fails explicitly when encountering invalid base64-encoded binary metadata, rather than silently dropping the values. The `tonic` transport now returns an `INTERNAL` status in these cases to ensure consistency with other gRPC implementations.
* Stream cancellation: The HTTP/2 stream is now cancelled whenever message or header decoding fails, or when the application drops the `RecvStream`.