### PR TITLE
examples: add grpc version of helloworld

### DIFF
--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -256,6 +256,12 @@ name = "grpc-routeguide-client"
 path = "src/grpc-routeguide/client.rs"
 required-features = ["grpc-routeguide"]
 
+[[bin]]
+name = "grpc-helloworld-client"
+path = "src/grpc-helloworld/client.rs"
+required-features = ["grpc-helloworld"]
+
+
 [features]
 gcp = ["dep:prost-types", "tonic/tls-ring"]
 routeguide = ["dep:async-stream", "dep:tokio-stream", "dep:rand", "dep:serde", "dep:serde_json"]
@@ -277,7 +283,8 @@ h2c = ["dep:hyper", "dep:tower", "dep:http", "dep:hyper-util"]
 cancellation = ["dep:tokio-util"]
 tower = ["dep:tower", "dep:http"]
 grpc-routeguide = ["dep:grpc", "dep:grpc-protobuf", "dep:protobuf", "dep:rand"]
-full = ["gcp", "routeguide", "reflection", "autoreload", "health", "grpc-web", "tracing", "uds", "streaming", "mock", "json-codec", "compression", "tls", "tls-rustls", "tls-client-auth", "types", "cancellation", "h2c", "grpc-routeguide"]
+grpc-helloworld = ["dep:grpc", "dep:grpc-protobuf", "dep:protobuf"]
+full = ["gcp", "routeguide", "reflection", "autoreload", "health", "grpc-web", "tracing", "uds", "streaming", "mock", "json-codec", "compression", "tls", "tls-rustls", "tls-client-auth", "types", "cancellation", "h2c", "grpc-routeguide", "grpc-helloworld"]
 default = ["full"]
 
 [dependencies]

--- a/examples/src/grpc-helloworld/client.rs
+++ b/examples/src/grpc-helloworld/client.rs
@@ -1,0 +1,41 @@
+#[allow(unused)]
+mod generated {
+    pub mod helloworld {
+        include!("generated/generated.rs"); // Contains messages
+        include!("generated/helloworld_grpc.pb.rs"); // Contains grpc stubs
+    }
+}
+
+use std::env;
+use std::sync::Arc;
+
+use generated::helloworld::HelloRequest;
+use generated::helloworld::greeter_client::GreeterClient;
+use grpc::client::Channel;
+use grpc::client::ChannelOptions;
+use grpc::credentials::LocalChannelCredentials;
+use protobuf::proto;
+
+#[tokio::main]
+async fn main() {
+    let args: Vec<String> = env::args().collect();
+    let name = if args.len() > 1 {
+        args[1].clone()
+    } else {
+        "Rust World".to_owned()
+    };
+
+    // Create a new gRPC channel:
+    let channel = Channel::new(
+        "dns:///[::1]:50051",
+        Arc::new(LocalChannelCredentials::new()),
+        ChannelOptions::default(),
+    );
+    let client = GreeterClient::new(channel);
+
+    // Send the request and print the response:
+    let request = proto!(HelloRequest { name });
+    let response = client.say_hello(request).await.expect("RPC error");
+
+    println!("Greeting: {:}", response.message());
+}

--- a/examples/src/grpc-helloworld/generated/generated.rs
+++ b/examples/src/grpc-helloworld/generated/generated.rs
@@ -1,0 +1,13 @@
+#[path="helloworld.u.pb.rs"]
+#[allow(nonstandard_style)]
+pub mod internal_do_not_use_helloworld;
+
+#[allow(unused_imports, nonstandard_style)]
+pub use internal_do_not_use_helloworld::*;
+pub mod __unstable {
+pub static HELLOWORLD_DESCRIPTOR_INFO: ::protobuf::__internal::runtime::__unstable::DescriptorInfo = ::protobuf::__internal::runtime::__unstable::DescriptorInfo {
+  descriptor: b"\n\x10helloworld.proto\x12\nhelloworld\"\x1c\n\x0cHelloRequest\x12\x0c\n\x04name\x18\x01 \x01(\t\"\x1d\n\nHelloReply\x12\x0f\n\x07message\x18\x01 \x01(\t2I\n\x07Greeter\x12>\n\x08SayHello\x12\x18.helloworld.HelloRequest\x1a\x16.helloworld.HelloReply\"\x00\x42\x30\n\x1bio.grpc.examples.helloworldB\x0fHelloWorldProtoP\x01\x62\x06proto3",
+  deps: &[
+  ],
+};
+}

--- a/examples/src/grpc-helloworld/generated/helloworld.u.pb.rs
+++ b/examples/src/grpc-helloworld/generated/helloworld.u.pb.rs
@@ -1,0 +1,745 @@
+const _: () = ::protobuf::__internal::assert_compatible_gencode_version("4.34.0-release");
+// This variable must not be referenced except by protobuf generated
+// code.
+pub(crate) static mut helloworld__HelloRequest_msg_init: ::protobuf::__internal::runtime::MiniTableInitPtr =
+    ::protobuf::__internal::runtime::MiniTableInitPtr(::protobuf::__internal::runtime::MiniTablePtr::dangling());
+#[allow(non_camel_case_types)]
+pub struct HelloRequest {
+  inner: ::protobuf::__internal::runtime::OwnedMessageInner<HelloRequest>
+}
+
+impl ::protobuf::Message for HelloRequest {}
+
+impl ::std::default::Default for HelloRequest {
+  fn default() -> Self {
+    Self::new()
+  }
+}
+
+impl ::std::fmt::Debug for HelloRequest {
+  fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+    write!(f, "{}", ::protobuf::__internal::runtime::debug_string(self))
+  }
+}
+
+// SAFETY:
+// - `HelloRequest` is `Sync` because it does not implement interior mutability.
+//    Neither does `HelloRequestMut`.
+unsafe impl Sync for HelloRequest {}
+
+// SAFETY:
+// - `HelloRequest` is `Send` because it uniquely owns its arena and does
+//   not use thread-local data.
+unsafe impl Send for HelloRequest {}
+
+impl ::protobuf::Proxied for HelloRequest {
+  type View<'msg> = HelloRequestView<'msg>;
+}
+
+impl ::protobuf::__internal::SealedInternal for HelloRequest {}
+
+impl ::protobuf::MutProxied for HelloRequest {
+  type Mut<'msg> = HelloRequestMut<'msg>;
+}
+
+#[derive(Copy, Clone)]
+#[allow(dead_code)]
+pub struct HelloRequestView<'msg> {
+  inner: ::protobuf::__internal::runtime::MessageViewInner<'msg, HelloRequest>,
+}
+
+impl<'msg> ::protobuf::__internal::SealedInternal for HelloRequestView<'msg> {}
+
+impl<'msg> ::protobuf::MessageView<'msg> for HelloRequestView<'msg> {
+  type Message = HelloRequest;
+}
+
+impl ::std::fmt::Debug for HelloRequestView<'_> {
+  fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+    write!(f, "{}", ::protobuf::__internal::runtime::debug_string(self))
+  }
+}
+
+impl ::std::default::Default for HelloRequestView<'_> {
+  fn default() -> HelloRequestView<'static> {
+    ::protobuf::__internal::runtime::MessageViewInner::default().into()
+  }
+}
+
+impl<'msg> From<::protobuf::__internal::runtime::MessageViewInner<'msg, HelloRequest>> for HelloRequestView<'msg> {
+  fn from(inner: ::protobuf::__internal::runtime::MessageViewInner<'msg, HelloRequest>) -> Self {
+    Self { inner }
+  }
+}
+
+#[allow(dead_code)]
+impl<'msg> HelloRequestView<'msg> {
+
+  pub fn to_owned(&self) -> HelloRequest {
+    ::protobuf::IntoProxied::into_proxied(*self, ::protobuf::__internal::Private)
+  }
+
+  // name: optional string
+  pub fn name(self) -> ::protobuf::View<'msg, ::protobuf::ProtoString> {
+    let str_view = unsafe {
+      self.inner.ptr().get_string_at_index(
+        0, (b"").into()
+      )
+    };
+    // SAFETY: The runtime doesn't require ProtoStr to be UTF-8.
+    unsafe { ::protobuf::ProtoStr::from_utf8_unchecked(str_view.as_ref()) }
+  }
+
+}
+
+// SAFETY:
+// - `HelloRequestView` is `Sync` because it does not support mutation.
+unsafe impl Sync for HelloRequestView<'_> {}
+
+// SAFETY:
+// - `HelloRequestView` is `Send` because while its alive a `HelloRequestMut` cannot.
+// - `HelloRequestView` does not use thread-local data.
+unsafe impl Send for HelloRequestView<'_> {}
+
+impl<'msg> ::protobuf::AsView for HelloRequestView<'msg> {
+  type Proxied = HelloRequest;
+  fn as_view(&self) -> ::protobuf::View<'msg, HelloRequest> {
+    *self
+  }
+}
+
+impl<'msg> ::protobuf::IntoView<'msg> for HelloRequestView<'msg> {
+  fn into_view<'shorter>(self) -> HelloRequestView<'shorter>
+  where
+      'msg: 'shorter {
+    self
+  }
+}
+
+impl<'msg> ::protobuf::IntoProxied<HelloRequest> for HelloRequestView<'msg> {
+  fn into_proxied(self, _private: ::protobuf::__internal::Private) -> HelloRequest {
+    let mut dst = HelloRequest::new();
+    assert!(unsafe {
+      dst.inner.ptr_mut().deep_copy(self.inner.ptr(), dst.inner.arena())
+    });
+    dst
+  }
+}
+
+impl<'msg> ::protobuf::IntoProxied<HelloRequest> for HelloRequestMut<'msg> {
+  fn into_proxied(self, _private: ::protobuf::__internal::Private) -> HelloRequest {
+    ::protobuf::IntoProxied::into_proxied(::protobuf::IntoView::into_view(self), _private)
+  }
+}
+
+impl ::protobuf::__internal::runtime::EntityType for HelloRequest {
+    type Tag = ::protobuf::__internal::runtime::MessageTag;
+}
+
+impl<'msg> ::protobuf::__internal::runtime::EntityType for HelloRequestView<'msg> {
+    type Tag = ::protobuf::__internal::runtime::ViewProxyTag;
+}
+
+impl<'msg> ::protobuf::__internal::runtime::EntityType for HelloRequestMut<'msg> {
+    type Tag = ::protobuf::__internal::runtime::MutProxyTag;
+}
+
+#[allow(dead_code)]
+#[allow(non_camel_case_types)]
+pub struct HelloRequestMut<'msg> {
+  inner: ::protobuf::__internal::runtime::MessageMutInner<'msg, HelloRequest>,
+}
+
+impl<'msg> ::protobuf::__internal::SealedInternal for HelloRequestMut<'msg> {}
+
+impl<'msg> ::protobuf::MessageMut<'msg> for HelloRequestMut<'msg> {
+  type Message = HelloRequest;
+}
+
+impl ::std::fmt::Debug for HelloRequestMut<'_> {
+  fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+    write!(f, "{}", ::protobuf::__internal::runtime::debug_string(self))
+  }
+}
+
+impl<'msg> From<::protobuf::__internal::runtime::MessageMutInner<'msg, HelloRequest>> for HelloRequestMut<'msg> {
+  fn from(inner: ::protobuf::__internal::runtime::MessageMutInner<'msg, HelloRequest>) -> Self {
+    Self { inner }
+  }
+}
+
+#[allow(dead_code)]
+impl<'msg> HelloRequestMut<'msg> {
+
+  #[doc(hidden)]
+  pub fn as_message_mut_inner(&mut self, _private: ::protobuf::__internal::Private)
+    -> ::protobuf::__internal::runtime::MessageMutInner<'msg, HelloRequest> {
+    self.inner
+  }
+
+  pub fn to_owned(&self) -> HelloRequest {
+    ::protobuf::AsView::as_view(self).to_owned()
+  }
+
+  // name: optional string
+  pub fn name(&self) -> ::protobuf::View<'_, ::protobuf::ProtoString> {
+    let str_view = unsafe {
+      self.inner.ptr().get_string_at_index(
+        0, (b"").into()
+      )
+    };
+    // SAFETY: The runtime doesn't require ProtoStr to be UTF-8.
+    unsafe { ::protobuf::ProtoStr::from_utf8_unchecked(str_view.as_ref()) }
+  }
+  pub fn set_name(&mut self, val: impl ::protobuf::IntoProxied<::protobuf::ProtoString>) {
+    unsafe {
+      ::protobuf::__internal::runtime::message_set_string_field(
+        ::protobuf::AsMut::as_mut(self).inner,
+        0,
+        val);
+    }
+  }
+
+}
+
+// SAFETY:
+// - `HelloRequestMut` does not perform any shared mutation.
+unsafe impl Send for HelloRequestMut<'_> {}
+
+// SAFETY:
+// - `HelloRequestMut` does not perform any shared mutation.
+unsafe impl Sync for HelloRequestMut<'_> {}
+
+impl<'msg> ::protobuf::AsView for HelloRequestMut<'msg> {
+  type Proxied = HelloRequest;
+  fn as_view(&self) -> ::protobuf::View<'_, HelloRequest> {
+    HelloRequestView {
+      inner: ::protobuf::__internal::runtime::MessageViewInner::view_of_mut(self.inner)
+    }
+  }
+}
+
+impl<'msg> ::protobuf::IntoView<'msg> for HelloRequestMut<'msg> {
+  fn into_view<'shorter>(self) -> ::protobuf::View<'shorter, HelloRequest>
+  where
+      'msg: 'shorter {
+    HelloRequestView {
+      inner: ::protobuf::__internal::runtime::MessageViewInner::view_of_mut(self.inner)
+    }
+  }
+}
+
+impl<'msg> ::protobuf::AsMut for HelloRequestMut<'msg> {
+  type MutProxied = HelloRequest;
+  fn as_mut(&mut self) -> HelloRequestMut<'msg> {
+    HelloRequestMut { inner: self.inner }
+  }
+}
+
+impl<'msg> ::protobuf::IntoMut<'msg> for HelloRequestMut<'msg> {
+  fn into_mut<'shorter>(self) -> HelloRequestMut<'shorter>
+  where
+      'msg: 'shorter {
+    self
+  }
+}
+
+#[allow(dead_code)]
+impl HelloRequest {
+  pub fn new() -> Self {
+    Self { inner: ::protobuf::__internal::runtime::OwnedMessageInner::<Self>::new() }
+  }
+
+
+  #[doc(hidden)]
+  pub fn as_message_mut_inner(&mut self, _private: ::protobuf::__internal::Private) -> ::protobuf::__internal::runtime::MessageMutInner<'_, HelloRequest> {
+    ::protobuf::__internal::runtime::MessageMutInner::mut_of_owned(&mut self.inner)
+  }
+
+  pub fn as_view(&self) -> HelloRequestView<'_> {
+    ::protobuf::__internal::runtime::MessageViewInner::view_of_owned(&self.inner).into()
+  }
+
+  pub fn as_mut(&mut self) -> HelloRequestMut<'_> {
+    ::protobuf::__internal::runtime::MessageMutInner::mut_of_owned(&mut self.inner).into()
+  }
+
+  // name: optional string
+  pub fn name(&self) -> ::protobuf::View<'_, ::protobuf::ProtoString> {
+    let str_view = unsafe {
+      self.inner.ptr().get_string_at_index(
+        0, (b"").into()
+      )
+    };
+    // SAFETY: The runtime doesn't require ProtoStr to be UTF-8.
+    unsafe { ::protobuf::ProtoStr::from_utf8_unchecked(str_view.as_ref()) }
+  }
+  pub fn set_name(&mut self, val: impl ::protobuf::IntoProxied<::protobuf::ProtoString>) {
+    unsafe {
+      ::protobuf::__internal::runtime::message_set_string_field(
+        ::protobuf::AsMut::as_mut(self).inner,
+        0,
+        val);
+    }
+  }
+
+}  // impl HelloRequest
+
+impl ::std::ops::Drop for HelloRequest {
+  #[inline]
+  fn drop(&mut self) {
+  }
+}
+
+impl ::std::clone::Clone for HelloRequest {
+  fn clone(&self) -> Self {
+    self.as_view().to_owned()
+  }
+}
+
+impl ::protobuf::AsView for HelloRequest {
+  type Proxied = Self;
+  fn as_view(&self) -> HelloRequestView<'_> {
+    self.as_view()
+  }
+}
+
+impl ::protobuf::AsMut for HelloRequest {
+  type MutProxied = Self;
+  fn as_mut(&mut self) -> HelloRequestMut<'_> {
+    self.as_mut()
+  }
+}
+
+unsafe impl ::protobuf::__internal::runtime::AssociatedMiniTable for HelloRequest {
+  fn mini_table() -> ::protobuf::__internal::runtime::MiniTablePtr {
+    static ONCE_LOCK: ::std::sync::OnceLock<::protobuf::__internal::runtime::MiniTableInitPtr> =
+        ::std::sync::OnceLock::new();
+    unsafe {
+      ONCE_LOCK.get_or_init(|| {
+        super::helloworld__HelloRequest_msg_init.0 =
+            ::protobuf::__internal::runtime::build_mini_table("$M1P");
+        ::protobuf::__internal::runtime::link_mini_table(
+            super::helloworld__HelloRequest_msg_init.0, &[], &[]);
+        ::protobuf::__internal::runtime::MiniTableInitPtr(super::helloworld__HelloRequest_msg_init.0)
+      }).0
+    }
+  }
+}
+unsafe impl ::protobuf::__internal::runtime::UpbGetArena for HelloRequest {
+  fn get_arena(&mut self, _private: ::protobuf::__internal::Private) -> &::protobuf::__internal::runtime::Arena {
+    self.inner.arena()
+  }
+}
+
+unsafe impl ::protobuf::__internal::runtime::UpbGetMessagePtrMut for HelloRequest {
+  type Msg = HelloRequest;
+  fn get_ptr_mut(&mut self, _private: ::protobuf::__internal::Private) -> ::protobuf::__internal::runtime::MessagePtr<HelloRequest> {
+    self.inner.ptr_mut()
+  }
+}
+unsafe impl ::protobuf::__internal::runtime::UpbGetMessagePtr for HelloRequest {
+  type Msg = HelloRequest;
+  fn get_ptr(&self, _private: ::protobuf::__internal::Private) -> ::protobuf::__internal::runtime::MessagePtr<HelloRequest> {
+    self.inner.ptr()
+  }
+}
+unsafe impl ::protobuf::__internal::runtime::UpbGetMessagePtrMut for HelloRequestMut<'_> {
+  type Msg = HelloRequest;
+  fn get_ptr_mut(&mut self, _private: ::protobuf::__internal::Private) -> ::protobuf::__internal::runtime::MessagePtr<HelloRequest> {
+    self.inner.ptr_mut()
+  }
+}
+unsafe impl ::protobuf::__internal::runtime::UpbGetMessagePtr for HelloRequestMut<'_> {
+  type Msg = HelloRequest;
+  fn get_ptr(&self, _private: ::protobuf::__internal::Private) -> ::protobuf::__internal::runtime::MessagePtr<HelloRequest> {
+    self.inner.ptr()
+  }
+}
+unsafe impl ::protobuf::__internal::runtime::UpbGetMessagePtr for HelloRequestView<'_> {
+  type Msg = HelloRequest;
+  fn get_ptr(&self, _private: ::protobuf::__internal::Private) -> ::protobuf::__internal::runtime::MessagePtr<HelloRequest> {
+    self.inner.ptr()
+  }
+}
+
+unsafe impl ::protobuf::__internal::runtime::UpbGetArena for HelloRequestMut<'_> {
+  fn get_arena(&mut self, _private: ::protobuf::__internal::Private) -> &::protobuf::__internal::runtime::Arena {
+    self.inner.arena()
+  }
+}
+
+
+
+// This variable must not be referenced except by protobuf generated
+// code.
+pub(crate) static mut helloworld__HelloReply_msg_init: ::protobuf::__internal::runtime::MiniTableInitPtr =
+    ::protobuf::__internal::runtime::MiniTableInitPtr(::protobuf::__internal::runtime::MiniTablePtr::dangling());
+#[allow(non_camel_case_types)]
+pub struct HelloReply {
+  inner: ::protobuf::__internal::runtime::OwnedMessageInner<HelloReply>
+}
+
+impl ::protobuf::Message for HelloReply {}
+
+impl ::std::default::Default for HelloReply {
+  fn default() -> Self {
+    Self::new()
+  }
+}
+
+impl ::std::fmt::Debug for HelloReply {
+  fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+    write!(f, "{}", ::protobuf::__internal::runtime::debug_string(self))
+  }
+}
+
+// SAFETY:
+// - `HelloReply` is `Sync` because it does not implement interior mutability.
+//    Neither does `HelloReplyMut`.
+unsafe impl Sync for HelloReply {}
+
+// SAFETY:
+// - `HelloReply` is `Send` because it uniquely owns its arena and does
+//   not use thread-local data.
+unsafe impl Send for HelloReply {}
+
+impl ::protobuf::Proxied for HelloReply {
+  type View<'msg> = HelloReplyView<'msg>;
+}
+
+impl ::protobuf::__internal::SealedInternal for HelloReply {}
+
+impl ::protobuf::MutProxied for HelloReply {
+  type Mut<'msg> = HelloReplyMut<'msg>;
+}
+
+#[derive(Copy, Clone)]
+#[allow(dead_code)]
+pub struct HelloReplyView<'msg> {
+  inner: ::protobuf::__internal::runtime::MessageViewInner<'msg, HelloReply>,
+}
+
+impl<'msg> ::protobuf::__internal::SealedInternal for HelloReplyView<'msg> {}
+
+impl<'msg> ::protobuf::MessageView<'msg> for HelloReplyView<'msg> {
+  type Message = HelloReply;
+}
+
+impl ::std::fmt::Debug for HelloReplyView<'_> {
+  fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+    write!(f, "{}", ::protobuf::__internal::runtime::debug_string(self))
+  }
+}
+
+impl ::std::default::Default for HelloReplyView<'_> {
+  fn default() -> HelloReplyView<'static> {
+    ::protobuf::__internal::runtime::MessageViewInner::default().into()
+  }
+}
+
+impl<'msg> From<::protobuf::__internal::runtime::MessageViewInner<'msg, HelloReply>> for HelloReplyView<'msg> {
+  fn from(inner: ::protobuf::__internal::runtime::MessageViewInner<'msg, HelloReply>) -> Self {
+    Self { inner }
+  }
+}
+
+#[allow(dead_code)]
+impl<'msg> HelloReplyView<'msg> {
+
+  pub fn to_owned(&self) -> HelloReply {
+    ::protobuf::IntoProxied::into_proxied(*self, ::protobuf::__internal::Private)
+  }
+
+  // message: optional string
+  pub fn message(self) -> ::protobuf::View<'msg, ::protobuf::ProtoString> {
+    let str_view = unsafe {
+      self.inner.ptr().get_string_at_index(
+        0, (b"").into()
+      )
+    };
+    // SAFETY: The runtime doesn't require ProtoStr to be UTF-8.
+    unsafe { ::protobuf::ProtoStr::from_utf8_unchecked(str_view.as_ref()) }
+  }
+
+}
+
+// SAFETY:
+// - `HelloReplyView` is `Sync` because it does not support mutation.
+unsafe impl Sync for HelloReplyView<'_> {}
+
+// SAFETY:
+// - `HelloReplyView` is `Send` because while its alive a `HelloReplyMut` cannot.
+// - `HelloReplyView` does not use thread-local data.
+unsafe impl Send for HelloReplyView<'_> {}
+
+impl<'msg> ::protobuf::AsView for HelloReplyView<'msg> {
+  type Proxied = HelloReply;
+  fn as_view(&self) -> ::protobuf::View<'msg, HelloReply> {
+    *self
+  }
+}
+
+impl<'msg> ::protobuf::IntoView<'msg> for HelloReplyView<'msg> {
+  fn into_view<'shorter>(self) -> HelloReplyView<'shorter>
+  where
+      'msg: 'shorter {
+    self
+  }
+}
+
+impl<'msg> ::protobuf::IntoProxied<HelloReply> for HelloReplyView<'msg> {
+  fn into_proxied(self, _private: ::protobuf::__internal::Private) -> HelloReply {
+    let mut dst = HelloReply::new();
+    assert!(unsafe {
+      dst.inner.ptr_mut().deep_copy(self.inner.ptr(), dst.inner.arena())
+    });
+    dst
+  }
+}
+
+impl<'msg> ::protobuf::IntoProxied<HelloReply> for HelloReplyMut<'msg> {
+  fn into_proxied(self, _private: ::protobuf::__internal::Private) -> HelloReply {
+    ::protobuf::IntoProxied::into_proxied(::protobuf::IntoView::into_view(self), _private)
+  }
+}
+
+impl ::protobuf::__internal::runtime::EntityType for HelloReply {
+    type Tag = ::protobuf::__internal::runtime::MessageTag;
+}
+
+impl<'msg> ::protobuf::__internal::runtime::EntityType for HelloReplyView<'msg> {
+    type Tag = ::protobuf::__internal::runtime::ViewProxyTag;
+}
+
+impl<'msg> ::protobuf::__internal::runtime::EntityType for HelloReplyMut<'msg> {
+    type Tag = ::protobuf::__internal::runtime::MutProxyTag;
+}
+
+#[allow(dead_code)]
+#[allow(non_camel_case_types)]
+pub struct HelloReplyMut<'msg> {
+  inner: ::protobuf::__internal::runtime::MessageMutInner<'msg, HelloReply>,
+}
+
+impl<'msg> ::protobuf::__internal::SealedInternal for HelloReplyMut<'msg> {}
+
+impl<'msg> ::protobuf::MessageMut<'msg> for HelloReplyMut<'msg> {
+  type Message = HelloReply;
+}
+
+impl ::std::fmt::Debug for HelloReplyMut<'_> {
+  fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+    write!(f, "{}", ::protobuf::__internal::runtime::debug_string(self))
+  }
+}
+
+impl<'msg> From<::protobuf::__internal::runtime::MessageMutInner<'msg, HelloReply>> for HelloReplyMut<'msg> {
+  fn from(inner: ::protobuf::__internal::runtime::MessageMutInner<'msg, HelloReply>) -> Self {
+    Self { inner }
+  }
+}
+
+#[allow(dead_code)]
+impl<'msg> HelloReplyMut<'msg> {
+
+  #[doc(hidden)]
+  pub fn as_message_mut_inner(&mut self, _private: ::protobuf::__internal::Private)
+    -> ::protobuf::__internal::runtime::MessageMutInner<'msg, HelloReply> {
+    self.inner
+  }
+
+  pub fn to_owned(&self) -> HelloReply {
+    ::protobuf::AsView::as_view(self).to_owned()
+  }
+
+  // message: optional string
+  pub fn message(&self) -> ::protobuf::View<'_, ::protobuf::ProtoString> {
+    let str_view = unsafe {
+      self.inner.ptr().get_string_at_index(
+        0, (b"").into()
+      )
+    };
+    // SAFETY: The runtime doesn't require ProtoStr to be UTF-8.
+    unsafe { ::protobuf::ProtoStr::from_utf8_unchecked(str_view.as_ref()) }
+  }
+  pub fn set_message(&mut self, val: impl ::protobuf::IntoProxied<::protobuf::ProtoString>) {
+    unsafe {
+      ::protobuf::__internal::runtime::message_set_string_field(
+        ::protobuf::AsMut::as_mut(self).inner,
+        0,
+        val);
+    }
+  }
+
+}
+
+// SAFETY:
+// - `HelloReplyMut` does not perform any shared mutation.
+unsafe impl Send for HelloReplyMut<'_> {}
+
+// SAFETY:
+// - `HelloReplyMut` does not perform any shared mutation.
+unsafe impl Sync for HelloReplyMut<'_> {}
+
+impl<'msg> ::protobuf::AsView for HelloReplyMut<'msg> {
+  type Proxied = HelloReply;
+  fn as_view(&self) -> ::protobuf::View<'_, HelloReply> {
+    HelloReplyView {
+      inner: ::protobuf::__internal::runtime::MessageViewInner::view_of_mut(self.inner)
+    }
+  }
+}
+
+impl<'msg> ::protobuf::IntoView<'msg> for HelloReplyMut<'msg> {
+  fn into_view<'shorter>(self) -> ::protobuf::View<'shorter, HelloReply>
+  where
+      'msg: 'shorter {
+    HelloReplyView {
+      inner: ::protobuf::__internal::runtime::MessageViewInner::view_of_mut(self.inner)
+    }
+  }
+}
+
+impl<'msg> ::protobuf::AsMut for HelloReplyMut<'msg> {
+  type MutProxied = HelloReply;
+  fn as_mut(&mut self) -> HelloReplyMut<'msg> {
+    HelloReplyMut { inner: self.inner }
+  }
+}
+
+impl<'msg> ::protobuf::IntoMut<'msg> for HelloReplyMut<'msg> {
+  fn into_mut<'shorter>(self) -> HelloReplyMut<'shorter>
+  where
+      'msg: 'shorter {
+    self
+  }
+}
+
+#[allow(dead_code)]
+impl HelloReply {
+  pub fn new() -> Self {
+    Self { inner: ::protobuf::__internal::runtime::OwnedMessageInner::<Self>::new() }
+  }
+
+
+  #[doc(hidden)]
+  pub fn as_message_mut_inner(&mut self, _private: ::protobuf::__internal::Private) -> ::protobuf::__internal::runtime::MessageMutInner<'_, HelloReply> {
+    ::protobuf::__internal::runtime::MessageMutInner::mut_of_owned(&mut self.inner)
+  }
+
+  pub fn as_view(&self) -> HelloReplyView<'_> {
+    ::protobuf::__internal::runtime::MessageViewInner::view_of_owned(&self.inner).into()
+  }
+
+  pub fn as_mut(&mut self) -> HelloReplyMut<'_> {
+    ::protobuf::__internal::runtime::MessageMutInner::mut_of_owned(&mut self.inner).into()
+  }
+
+  // message: optional string
+  pub fn message(&self) -> ::protobuf::View<'_, ::protobuf::ProtoString> {
+    let str_view = unsafe {
+      self.inner.ptr().get_string_at_index(
+        0, (b"").into()
+      )
+    };
+    // SAFETY: The runtime doesn't require ProtoStr to be UTF-8.
+    unsafe { ::protobuf::ProtoStr::from_utf8_unchecked(str_view.as_ref()) }
+  }
+  pub fn set_message(&mut self, val: impl ::protobuf::IntoProxied<::protobuf::ProtoString>) {
+    unsafe {
+      ::protobuf::__internal::runtime::message_set_string_field(
+        ::protobuf::AsMut::as_mut(self).inner,
+        0,
+        val);
+    }
+  }
+
+}  // impl HelloReply
+
+impl ::std::ops::Drop for HelloReply {
+  #[inline]
+  fn drop(&mut self) {
+  }
+}
+
+impl ::std::clone::Clone for HelloReply {
+  fn clone(&self) -> Self {
+    self.as_view().to_owned()
+  }
+}
+
+impl ::protobuf::AsView for HelloReply {
+  type Proxied = Self;
+  fn as_view(&self) -> HelloReplyView<'_> {
+    self.as_view()
+  }
+}
+
+impl ::protobuf::AsMut for HelloReply {
+  type MutProxied = Self;
+  fn as_mut(&mut self) -> HelloReplyMut<'_> {
+    self.as_mut()
+  }
+}
+
+unsafe impl ::protobuf::__internal::runtime::AssociatedMiniTable for HelloReply {
+  fn mini_table() -> ::protobuf::__internal::runtime::MiniTablePtr {
+    static ONCE_LOCK: ::std::sync::OnceLock<::protobuf::__internal::runtime::MiniTableInitPtr> =
+        ::std::sync::OnceLock::new();
+    unsafe {
+      ONCE_LOCK.get_or_init(|| {
+        super::helloworld__HelloReply_msg_init.0 =
+            ::protobuf::__internal::runtime::build_mini_table("$M1P");
+        ::protobuf::__internal::runtime::link_mini_table(
+            super::helloworld__HelloReply_msg_init.0, &[], &[]);
+        ::protobuf::__internal::runtime::MiniTableInitPtr(super::helloworld__HelloReply_msg_init.0)
+      }).0
+    }
+  }
+}
+unsafe impl ::protobuf::__internal::runtime::UpbGetArena for HelloReply {
+  fn get_arena(&mut self, _private: ::protobuf::__internal::Private) -> &::protobuf::__internal::runtime::Arena {
+    self.inner.arena()
+  }
+}
+
+unsafe impl ::protobuf::__internal::runtime::UpbGetMessagePtrMut for HelloReply {
+  type Msg = HelloReply;
+  fn get_ptr_mut(&mut self, _private: ::protobuf::__internal::Private) -> ::protobuf::__internal::runtime::MessagePtr<HelloReply> {
+    self.inner.ptr_mut()
+  }
+}
+unsafe impl ::protobuf::__internal::runtime::UpbGetMessagePtr for HelloReply {
+  type Msg = HelloReply;
+  fn get_ptr(&self, _private: ::protobuf::__internal::Private) -> ::protobuf::__internal::runtime::MessagePtr<HelloReply> {
+    self.inner.ptr()
+  }
+}
+unsafe impl ::protobuf::__internal::runtime::UpbGetMessagePtrMut for HelloReplyMut<'_> {
+  type Msg = HelloReply;
+  fn get_ptr_mut(&mut self, _private: ::protobuf::__internal::Private) -> ::protobuf::__internal::runtime::MessagePtr<HelloReply> {
+    self.inner.ptr_mut()
+  }
+}
+unsafe impl ::protobuf::__internal::runtime::UpbGetMessagePtr for HelloReplyMut<'_> {
+  type Msg = HelloReply;
+  fn get_ptr(&self, _private: ::protobuf::__internal::Private) -> ::protobuf::__internal::runtime::MessagePtr<HelloReply> {
+    self.inner.ptr()
+  }
+}
+unsafe impl ::protobuf::__internal::runtime::UpbGetMessagePtr for HelloReplyView<'_> {
+  type Msg = HelloReply;
+  fn get_ptr(&self, _private: ::protobuf::__internal::Private) -> ::protobuf::__internal::runtime::MessagePtr<HelloReply> {
+    self.inner.ptr()
+  }
+}
+
+unsafe impl ::protobuf::__internal::runtime::UpbGetArena for HelloReplyMut<'_> {
+  fn get_arena(&mut self, _private: ::protobuf::__internal::Private) -> &::protobuf::__internal::runtime::Arena {
+    self.inner.arena()
+  }
+}
+
+
+

--- a/examples/src/grpc-helloworld/generated/helloworld_grpc.pb.rs
+++ b/examples/src/grpc-helloworld/generated/helloworld_grpc.pb.rs
@@ -1,0 +1,30 @@
+/// Generated client implementations.
+pub mod greeter_client {
+    use grpc::client::*;
+    use grpc_protobuf::*;
+
+    /// The greeting service definition.
+    #[derive(Debug, Clone)]
+    pub struct GreeterClient<T> {
+        channel: T,
+    }
+
+    impl<T> GreeterClient<T>
+    where
+        T: grpc::client::Invoke,
+    {
+        pub fn new(channel: T) -> Self {
+            Self { channel }
+        }
+
+        /// Sends a greeting
+        pub fn say_hello<ReqMsgView>(
+            &self,
+            request: ReqMsgView,
+        ) -> UnaryCallBuilder<'_, &T, ReqMsgView, super::HelloReply>
+        where
+          ReqMsgView: protobuf::AsView<Proxied = super::HelloRequest> + Send + Sync {
+          UnaryCallBuilder::new(&self.channel, "/helloworld.Greeter/SayHello", request)
+        }
+    }
+}


### PR DESCRIPTION
This is the simple example from, e.g. https://grpc.io/docs/languages/go/quickstart/ and I ran it with the tonic helloworld server to confirm it works properly.