### PR TITLE
name_resolution: include structural attributes in Address PartialEq

### DIFF
--- a/grpc/src/client/name_resolution/mod.rs
+++ b/grpc/src/client/name_resolution/mod.rs
@@ -323,7 +323,6 @@ impl PartialEq for Address {
     }
 }
 
-
 impl Hash for Address {
     fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
         self.network_type.hash(state);

--- a/grpc/src/client/name_resolution/mod.rs
+++ b/grpc/src/client/name_resolution/mod.rs
@@ -298,7 +298,7 @@ impl Hash for Endpoint {
 
 /// An Address is an identifier that indicates how to connect to a server.
 #[non_exhaustive]
-#[derive(Debug, Clone, Default, Ord, PartialOrd)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, Ord, PartialOrd)]
 pub(crate) struct Address {
     /// The network type is used to identify what kind of transport to create
     /// when connecting to this address.  Typically TCP_IP_ADDRESS_TYPE.
@@ -313,15 +313,6 @@ pub(crate) struct Address {
     pub attributes: Attributes,
 }
 
-impl Eq for Address {}
-
-impl PartialEq for Address {
-    fn eq(&self, other: &Self) -> bool {
-        self.network_type == other.network_type
-            && self.address == other.address
-            && self.attributes == other.attributes
-    }
-}
 
 impl Hash for Address {
     fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
@@ -452,4 +443,57 @@ mod test {
             assert_eq!(&target.to_string(), tc.want_str);
         }
     }
+
+    // This test ensures that the Address struct correctly maintains its asymmetric PartialEq and Hash contracts.
+    // Specifically, two addresses with the same physical coordinates but different metadata attributes must
+    // hash to the same HashMap bucket (intentional collision) but fail strict equality, forcing collection layers 
+    // (like load balancers and connection pools) to safely treat them as distinct endpoints without corrupting the map.
+    #[test]
+    fn test_address_hashmap_asymmetric_collision() {
+        use std::collections::HashMap;
+        use std::hash::{Hash, Hasher};
+        use std::collections::hash_map::DefaultHasher;
+        use crate::client::name_resolution::Address;
+        use crate::attributes::Attributes;
+        use crate::byte_str::ByteStr;
+
+        let addr_base = "127.0.0.1:8080";
+
+        // Address A: No metadata attributes
+        let addr_a = Address {
+            network_type: "tcp",
+            address: ByteStr::from(addr_base.to_string()),
+            attributes: Attributes::new(),
+        };
+
+        // Address B: Identical text/type coordinates, but WITH metadata attributes
+        let attrs = Attributes::new().add("metadata_payload".to_string());
+        let addr_b = Address {
+            network_type: "tcp",
+            address: ByteStr::from(addr_base.to_string()),
+            attributes: attrs,
+        };
+
+        // Invariant Verification: Stricter equality must say they differ
+        assert_ne!(addr_a, addr_b, "Address equality must be distinct when attributes mutate!");
+        
+        // Invariant Verification: Hashing must ignore attributes (intentional collision)
+        let mut hasher_a = DefaultHasher::new();
+        let mut hasher_b = DefaultHasher::new();
+        addr_a.hash(&mut hasher_a);
+        addr_b.hash(&mut hasher_b);
+        assert_eq!(hasher_a.finish(), hasher_b.finish(), "Address hashes MUST remain identical to ensure same HashMap memory bucket routing!");
+
+        // Map Functional Verification
+        let mut map = HashMap::new();
+        map.insert(addr_a.clone(), "subchannel_a");
+
+        // Querying or removing using B (mutated attributes) must FAIL due to asymmetric == check
+        assert!(map.remove(&addr_b).is_none(), "Flaw: HashMap incorrectly matched key despite mismatched attributes!");
+        
+        // Querying or removing using A (exact match) must SUCCEED
+        assert_eq!(map.remove(&addr_a), Some("subchannel_a"));
+        assert!(map.is_empty());
+    }
 }
+

--- a/grpc/src/client/name_resolution/mod.rs
+++ b/grpc/src/client/name_resolution/mod.rs
@@ -317,9 +317,12 @@ impl Eq for Address {}
 
 impl PartialEq for Address {
     fn eq(&self, other: &Self) -> bool {
-        self.network_type == other.network_type && self.address == other.address
+        self.network_type == other.network_type
+            && self.address == other.address
+            && self.attributes == other.attributes
     }
 }
+
 
 impl Hash for Address {
     fn hash<H: std::hash::Hasher>(&self, state: &mut H) {

--- a/grpc/src/client/name_resolution/mod.rs
+++ b/grpc/src/client/name_resolution/mod.rs
@@ -313,7 +313,6 @@ pub(crate) struct Address {
     pub attributes: Attributes,
 }
 
-
 impl Hash for Address {
     fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
         self.network_type.hash(state);
@@ -381,6 +380,12 @@ impl NopResolver {
 #[cfg(test)]
 mod test {
     use super::Target;
+    use crate::attributes::Attributes;
+    use crate::byte_str::ByteStr;
+    use crate::client::name_resolution::Address;
+    use std::collections::HashMap;
+    use std::collections::hash_map::DefaultHasher;
+    use std::hash::{Hash, Hasher};
 
     #[test]
     pub fn parse_target() {
@@ -444,29 +449,25 @@ mod test {
         }
     }
 
-    // This test ensures that the Address struct correctly maintains its asymmetric PartialEq and Hash contracts.
-    // Specifically, two addresses with the same physical coordinates but different metadata attributes must
-    // hash to the same HashMap bucket (intentional collision) but fail strict equality, forcing collection layers 
-    // (like load balancers and connection pools) to safely treat them as distinct endpoints without corrupting the map.
+    // This test ensures that the Address struct correctly maintains its
+    // asymmetric PartialEq and Hash contracts.
+    // Specifically, two addresses with the same physical coordinates but
+    // different metadata attributes must hash to the same HashMap bucket
+    // (intentional collision) but fail strict equality, forcing collection
+    // layers (e.g., load balancers and connection pools) to safely treat them
+    // as distinct endpoints without corrupting the map.
     #[test]
     fn test_address_hashmap_asymmetric_collision() {
-        use std::collections::HashMap;
-        use std::hash::{Hash, Hasher};
-        use std::collections::hash_map::DefaultHasher;
-        use crate::client::name_resolution::Address;
-        use crate::attributes::Attributes;
-        use crate::byte_str::ByteStr;
-
         let addr_base = "127.0.0.1:8080";
 
-        // Address A: No metadata attributes
+        // Address A: without metadata attributes
         let addr_a = Address {
             network_type: "tcp",
             address: ByteStr::from(addr_base.to_string()),
             attributes: Attributes::new(),
         };
 
-        // Address B: Identical text/type coordinates, but WITH metadata attributes
+        // Address B: with metadata attributes
         let attrs = Attributes::new().add("metadata_payload".to_string());
         let addr_b = Address {
             network_type: "tcp",
@@ -474,26 +475,59 @@ mod test {
             attributes: attrs,
         };
 
-        // Invariant Verification: Stricter equality must say they differ
-        assert_ne!(addr_a, addr_b, "Address equality must be distinct when attributes mutate!");
-        
-        // Invariant Verification: Hashing must ignore attributes (intentional collision)
+        // Hashing must ignore attributes (intentional collision)
         let mut hasher_a = DefaultHasher::new();
         let mut hasher_b = DefaultHasher::new();
         addr_a.hash(&mut hasher_a);
         addr_b.hash(&mut hasher_b);
-        assert_eq!(hasher_a.finish(), hasher_b.finish(), "Address hashes MUST remain identical to ensure same HashMap memory bucket routing!");
+        assert_eq!(
+            hasher_a.finish(),
+            hasher_b.finish(),
+            "Identical Address hashes must route to the same HashMap memory bucket!"
+        );
+
+        let hash_a = hasher_a.finish();
+
+        // Verify that changing network_type changes the hash
+        let addr_diff_net = Address {
+            network_type: "uds",
+            address: ByteStr::from(addr_base.to_string()),
+            attributes: Attributes::new(),
+        };
+        let mut hasher_diff_net = DefaultHasher::new();
+        addr_diff_net.hash(&mut hasher_diff_net);
+        assert_ne!(
+            hash_a,
+            hasher_diff_net.finish(),
+            "Changing network_type must change the hash!"
+        );
+
+        // Verify that changing address changes the hash
+        let addr_diff_addr = Address {
+            network_type: "tcp",
+            address: ByteStr::from("127.0.0.1:8081".to_string()),
+            attributes: Attributes::new(),
+        };
+        let mut hasher_diff_addr = DefaultHasher::new();
+        addr_diff_addr.hash(&mut hasher_diff_addr);
+        assert_ne!(
+            hash_a,
+            hasher_diff_addr.finish(),
+            "Changing address must change the hash!"
+        );
 
         // Map Functional Verification
         let mut map = HashMap::new();
         map.insert(addr_a.clone(), "subchannel_a");
 
-        // Querying or removing using B (mutated attributes) must FAIL due to asymmetric == check
-        assert!(map.remove(&addr_b).is_none(), "Flaw: HashMap incorrectly matched key despite mismatched attributes!");
-        
-        // Querying or removing using A (exact match) must SUCCEED
+        // Removing using B (different attributes) should fail.
+        assert!(
+            map.remove(&addr_b).is_none(),
+            "HashMap incorrectly matched key despite mismatched attributes!"
+        );
+
+        // Removing using A (same attributes) should succeed.
         assert_eq!(map.remove(&addr_a), Some("subchannel_a"));
         assert!(map.is_empty());
     }
 }
-


### PR DESCRIPTION
This PR is for the grpc-Rust official library, and not for tonic.

## Motivation

In the process of writing the Pick First LB policy, I realized that there were edge cases characterized by the following:
* The name resolver provides a new list of addresses
* Some of those addresses match to the previous list of addresses based on the hashed fields, even though they should not because they have different attribute fields, causing a false positive match.

The reason for this is that the addresses cannot be included in the hashing, because they are type-erased. I think all load balancers are likely to run into this issue. 

## Solution

Updating PartialEq in order to validate that the address attributes are equal in addition to the network type and address field. This means new Addresses with different attributes should be hashed into the same bucket but that looking an address with attribute set A will not fetch an address with attribute set B. 

There may be a better way to handle this, or a reason it hasn't been done already - I'd be grateful for any feedback that anyone can provide on this front.
