### PR TITLE
grpc: change helloworld example to pass request as a view

### DIFF
--- a/examples/src/grpc-helloworld/client.rs
+++ b/examples/src/grpc-helloworld/client.rs
@@ -35,7 +35,10 @@ async fn main() {
 
     // Send the request and print the response:
     let request = proto!(HelloRequest { name });
-    let response = client.say_hello(request).await.expect("RPC error");
+    let response = client
+        .say_hello(request.as_view())
+        .await
+        .expect("RPC error");
 
     println!("Greeting: {:}", response.message());
 }


### PR DESCRIPTION
The quickstart documentation for gRPC includes repeating this call a second time with a small change.

With the code as-is, the request is moved and is no longer available.  This change allows the user to copy/paste the call and be able to perform it again.