### PR TITLE
grpc: update Channel::new to use impl Into<String>

### DIFF
--- a/examples/src/grpc-routeguide/client.rs
+++ b/examples/src/grpc-routeguide/client.rs
@@ -68,7 +68,10 @@ async fn record_route<T: Invoke>(client: &RouteGuideClient<T>) {
 
     // Send the request messages.
     for point in points {
-        stream.send(&point).await.expect("RPC failed");
+        if stream.send(&point).await.is_err() {
+            // RPC error; break to read the status.
+            break;
+        }
     }
 
     // Receive the response or status.

--- a/examples/src/grpc-routeguide/client.rs
+++ b/examples/src/grpc-routeguide/client.rs
@@ -8,6 +8,7 @@ mod generated {
     }
 }
 
+use std::env;
 use std::sync::Arc;
 
 use grpc::client::Channel;
@@ -125,11 +126,13 @@ async fn route_chat<T: Invoke>(client: &RouteGuideClient<T>) {
     let handle = task::spawn(async move {
         // Send the request messages.
         for note in notes {
-            // Send errors (with a void error) if the stream encounters any
+            // Send errors (with a unit error) if the stream encounters any
             // problem, or if the server terminates the stream before the client
-            // is done sending.  We don't expect that in our RouteGuide
-            // protocol, so we can safely expect() no error.
-            tx.send(note).await.expect("RPC terminated early");
+            // is done sending.  The response stream will provide the RPC status
+            // in this case.
+            if tx.send(note).await.is_err() {
+                return;
+            }
         }
         // Send a "half close" signal to the server to indicate the client is
         // done sending.  This triggers naturally if `tx` is dropped, which will
@@ -147,12 +150,12 @@ async fn route_chat<T: Invoke>(client: &RouteGuideClient<T>) {
         );
     }
 
-    // Assert that spawned task did not encounter an error.
-    handle.await.expect("Sending notes failed");
-
     // Confirm the status.
     let status = rx.status().await;
     assert!(status.is_ok(), "{:?}", status);
+
+    // Wait for the spawned task to complete as part of proper resource cleanup.
+    handle.await.unwrap();
 }
 
 fn random_point() -> Point {
@@ -166,9 +169,17 @@ fn random_point() -> Point {
 
 #[tokio::main]
 async fn main() {
+    let args: Vec<String> = env::args().collect();
+    let address = if args.len() > 1 {
+        args[1].clone()
+    } else {
+        "[::1]:10000".to_owned()
+    };
+    println!("Connecting to {address}...");
+
     // Create a new gRPC channel:
     let channel = Channel::new(
-        "dns:///localhost:50051",
+        format!("dns:///{address}"),
         Arc::new(LocalChannelCredentials::new()),
         ChannelOptions::default(),
     );

--- a/grpc/src/client/channel.rs
+++ b/grpc/src/client/channel.rs
@@ -164,7 +164,7 @@ impl Channel {
     /// target string is invalid, the returned channel will never connect, and
     /// will fail all RPCs.
     // TODO: should this return a Result instead?
-    pub fn new<C>(target: &str, credentials: Arc<C>, options: ChannelOptions) -> Self
+    pub fn new<C>(target: impl Into<String>, credentials: Arc<C>, options: ChannelOptions) -> Self
     where
         C: ChannelCredentials,
         C::Output<Box<dyn GrpcEndpoint>>: GrpcEndpoint + 'static,
@@ -239,13 +239,13 @@ impl PersistentChannel {
     // Channels begin idle so `new()` does not automatically connect.
     // ChannelOption contain only optional parameters.
     fn new(
-        target: &str,
+        target: impl Into<String>,
         runtime: GrpcRuntime,
         options: ChannelOptions,
         credentials: Arc<dyn DynChannelCredentials>,
     ) -> Self {
         // TODO(arjan-bal): Return errors here instead of panicking.
-        let target = Url::from_str(target).unwrap();
+        let target = Url::from_str(&target.into()).unwrap();
         let resolver_builder = global_registry().get(target.scheme()).unwrap();
         let target = name_resolution::Target::from(target);
         let authority = options


### PR DESCRIPTION
Also some small changes in route_guide:

- Comment tweaks
- Don't panic if there is an RPC error while sending messages since users should typically never be doing this
- Make the address a command-line argument and use `[::1]:10000` by default, which is what tonic's route guide server uses.