### PR TITLE
cleanup(grpc): Mark metadata as sensitive by default and prevent flag propagation to the Tonic metadata map

### DIFF
--- a/grpc/src/metadata/encoding.rs
+++ b/grpc/src/metadata/encoding.rs
@@ -74,13 +74,6 @@ pub trait ValueEncoding: Clone + Eq + PartialEq + Hash {
         b: &UnencodedHeaderValue,
         _: private::Internal,
     ) -> bool;
-
-    #[doc(hidden)]
-    fn fmt(
-        value: &UnencodedHeaderValue,
-        f: &mut fmt::Formatter<'_>,
-        _: private::Internal,
-    ) -> fmt::Result;
 }
 
 /// gRPC metadata values can be either ASCII strings or binary. Note that only
@@ -203,14 +196,6 @@ impl ValueEncoding for Ascii {
         a == b
     }
 
-    fn fmt(
-        value: &UnencodedHeaderValue,
-        f: &mut fmt::Formatter<'_>,
-        _: private::Internal,
-    ) -> fmt::Result {
-        fmt::Debug::fmt(value, f)
-    }
-
     fn encode(value: Bytes, _: private::Internal) -> Bytes {
         value
     }
@@ -297,14 +282,6 @@ impl ValueEncoding for Binary {
         _: private::Internal,
     ) -> bool {
         a.as_bytes() == b.as_bytes()
-    }
-
-    fn fmt(
-        value: &UnencodedHeaderValue,
-        f: &mut fmt::Formatter<'_>,
-        _: private::Internal,
-    ) -> fmt::Result {
-        write!(f, "{:?}", value.as_bytes())
     }
 
     fn encode(value: Bytes, _: private::Internal) -> Bytes {

--- a/grpc/src/metadata/map.rs
+++ b/grpc/src/metadata/map.rs
@@ -176,15 +176,13 @@ impl MetadataMap {
             if Ascii::is_valid_key(key_str) {
                 // We copy the header value here because the `HeaderValue`
                 // struct doesn't provide an API to fetch the underlying `Bytes`.
-                if let Ok(mut mv) = MetadataValue::<Ascii>::try_from(value.as_bytes()) {
-                    mv.set_sensitive(value.is_sensitive());
+                if let Ok(mv) = MetadataValue::<Ascii>::try_from(value.as_bytes()) {
                     ret.push((k.clone(), mv.into_inner()));
                 }
             } else if Binary::is_valid_key(key_str)
                 && let Ok(b) = Binary::decode(value.as_bytes(), private::Internal)
             {
-                let mut mv = unsafe { MetadataValue::<Binary>::from_shared_unchecked(b) };
-                mv.set_sensitive(value.is_sensitive());
+                let mv = unsafe { MetadataValue::<Binary>::from_shared_unchecked(b) };
                 ret.push((k.clone(), mv.into_inner()));
             }
         }
@@ -193,6 +191,10 @@ impl MetadataMap {
     }
 
     /// Convert a MetadataMap into a HTTP HeaderMap.
+    ///
+    /// Note that the "sensitive" field is not propagated as that will disable
+    /// use of dynamic table in HPACK compression. Other gRPC implementations
+    /// don't disable HPACK, so we don't do it too.
     pub(crate) fn into_headers(self) -> HeaderMap {
         let mut ret = HeaderMap::with_capacity(self.capacity());
         for (key, value) in self.headers {
@@ -1560,9 +1562,17 @@ mod tests {
         assert_eq!(tonic_map.get("x-host").unwrap(), "example.com");
         assert_eq!(tonic_map.get_bin("trace-proto-bin").unwrap(), "Hello!!");
 
+        // The sensitive field must not be propagated.
+        assert!(!tonic_map.get("x-host").unwrap().is_sensitive());
+        assert!(!tonic_map.get_bin("trace-proto-bin").unwrap().is_sensitive());
+
         let back_map: MetadataMap = tonic_map.into();
         assert_eq!(back_map.len(), 2);
         assert_eq!(back_map.get("x-host").unwrap(), "example.com");
         assert_eq!(back_map.get_bin("trace-proto-bin").unwrap(), "Hello!!");
+
+        // Values are marked as sensitive by default.
+        assert!(back_map.get("x-host").unwrap().is_sensitive());
+        assert!(back_map.get_bin("trace-proto-bin").unwrap().is_sensitive());
     }
 }

--- a/grpc/src/metadata/value.rs
+++ b/grpc/src/metadata/value.rs
@@ -25,6 +25,7 @@
 use std::cmp;
 use std::error::Error;
 use std::fmt;
+use std::fmt::Debug;
 use std::fmt::Write;
 use std::hash::Hash;
 use std::hash::Hasher;
@@ -55,18 +56,26 @@ pub struct MetadataValue<VE> {
     _phantom: PhantomData<VE>,
 }
 
-#[derive(Clone, PartialEq, Eq)]
+#[derive(Clone)]
 pub struct UnencodedHeaderValue {
     data: Bytes,
     is_sensitive: bool,
 }
+
+impl PartialEq for UnencodedHeaderValue {
+    fn eq(&self, other: &Self) -> bool {
+        self.data == other.data
+    }
+}
+
+impl Eq for UnencodedHeaderValue {}
 
 impl UnencodedHeaderValue {
     // Assumes that the bytes have already been validated.
     pub(crate) fn from_bytes(bytes: Bytes) -> Self {
         UnencodedHeaderValue {
             data: bytes,
-            is_sensitive: false,
+            is_sensitive: true,
         }
     }
 
@@ -83,7 +92,7 @@ const fn is_visible_ascii(b: u8) -> bool {
     b >= 32 && b < 127 || b == b'\t'
 }
 
-impl fmt::Debug for UnencodedHeaderValue {
+impl Debug for UnencodedHeaderValue {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         if self.is_sensitive {
             f.write_str("Sensitive")
@@ -139,7 +148,10 @@ impl<VE> MetadataValue<VE> {
         }
     }
 
-    /// Mark that the metadata value represents sensitive information.
+    /// Mark that the metadata value represents sensitive information. Sensitive
+    /// values are not included in the [std::fmt::Debug] output.
+    ///
+    /// Metadata values are sensitive by default.
     ///
     /// # Examples
     ///
@@ -147,7 +159,6 @@ impl<VE> MetadataValue<VE> {
     /// # use grpc::metadata::*;
     /// let mut val = AsciiMetadataValue::from_static("my secret");
     ///
-    /// val.set_sensitive(true);
     /// assert!(val.is_sensitive());
     ///
     /// val.set_sensitive(false);
@@ -160,10 +171,7 @@ impl<VE> MetadataValue<VE> {
 
     /// Returns `true` if the value represents sensitive data.
     ///
-    /// Sensitive data could represent passwords or other data that should not
-    /// be stored on disk or in memory. This setting can be used by components
-    /// like caches to avoid storing the value. HPACK encoders must set the
-    /// metadata field to never index when `is_sensitive` returns true.
+    /// Sensitive values are not included in the [std::fmt::Debug] output.
     ///
     /// Note that sensitivity is not factored into equality or ordering.
     ///
@@ -451,9 +459,9 @@ impl MetadataValue<Binary> {
     }
 }
 
-impl<VE: ValueEncoding> fmt::Debug for MetadataValue<VE> {
+impl<VE: ValueEncoding> Debug for MetadataValue<VE> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        VE::fmt(&self.inner, f, private::Internal)
+        Debug::fmt(&self.inner, f)
     }
 }
 
@@ -735,14 +743,15 @@ mod test {
         ];
 
         for &(value, expected) in cases {
-            let val = AsciiMetadataValue::try_from(value.as_bytes()).unwrap();
+            let mut val = AsciiMetadataValue::try_from(value.as_bytes()).unwrap();
+            // vales are sensitive by default.
+            let actual = format!("{val:?}");
+            assert_eq!("Sensitive", actual);
+
+            val.set_sensitive(false);
             let actual = format!("{val:?}");
             assert_eq!(expected, actual);
         }
-
-        let mut sensitive = AsciiMetadataValue::from_static("password");
-        sensitive.set_sensitive(true);
-        assert_eq!("Sensitive", format!("{sensitive:?}"));
     }
 
     #[test]
@@ -785,6 +794,21 @@ mod test {
                 Bmv::from_shared_unchecked(Bytes::from_static(b"{}.."))
             );
         }
+    }
+
+    #[test]
+    fn test_value_eq_ignores_sensitivity() {
+        let mut val1 = AsciiMetadataValue::from_static("abc");
+        let val2 = AsciiMetadataValue::from_static("abc");
+        assert_eq!(val1, val2);
+        val1.set_sensitive(false);
+        assert_eq!(val1, val2);
+
+        let mut val1 = BinaryMetadataValue::from_bytes(b"abc");
+        let val2 = BinaryMetadataValue::from_bytes(b"abc");
+        assert_eq!(val1, val2);
+        val1.set_sensitive(false);
+        assert_eq!(val1, val2);
     }
 
     #[test]


### PR DESCRIPTION
This change ensures that metadata values are excluded from `Debug` output by default. It also prevents the propagation of the "sensitive" flag to and from Tonic’s `MetadataMap`. 

This is done to avoid disabling the HPACK dynamic table for sensitive metadata. Other gRPC implementations do not provide configurations to disable HPACK indexing for sensitive headers as the security concerns outlined in [RFC 7541 Section 7.1](https://datatracker.ietf.org/doc/html/rfc7541#section-7.1) do not apply to gRPC metadata.

Additionally, this change fixes a couple of bugs:
1. The `Debug` implementation for binary metadata was ignoring the sensitive flag.
2. The sensitive flag was incorrectly being included in equality checks.