### PR TITLE
nix: a collection of improvements to the flake

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ target/
 **/*.rs.bk
 Cargo.lock
 tags
+.pre-commit-config.yaml

--- a/flake.lock
+++ b/flake.lock
@@ -1,26 +1,5 @@
 {
   "nodes": {
-    "fenix": {
-      "inputs": {
-        "nixpkgs": [
-          "nixpkgs"
-        ],
-        "rust-analyzer-src": "rust-analyzer-src"
-      },
-      "locked": {
-        "lastModified": 1779099656,
-        "narHash": "sha256-x+PMKsZHKbgNbWrkyNP58xb4LrQfzzFd0QJVnPc+VnY=",
-        "owner": "nix-community",
-        "repo": "fenix",
-        "rev": "f553608656def48a8aa2984b85f27fbee7c83dd8",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-community",
-        "repo": "fenix",
-        "type": "github"
-      }
-    },
     "flake-compat": {
       "flake": false,
       "locked": {
@@ -131,27 +110,9 @@
     },
     "root": {
       "inputs": {
-        "fenix": "fenix",
         "flake-parts": "flake-parts",
         "git-hooks": "git-hooks",
         "nixpkgs": "nixpkgs"
-      }
-    },
-    "rust-analyzer-src": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1779074864,
-        "narHash": "sha256-0M3WqsWmtXmv9Ev/vnFfCHosWvISDwiuuhQ104UO3CI=",
-        "owner": "rust-lang",
-        "repo": "rust-analyzer",
-        "rev": "cdfe408d4b436e806ff525cb3e67588a6a009ed1",
-        "type": "github"
-      },
-      "original": {
-        "owner": "rust-lang",
-        "ref": "nightly",
-        "repo": "rust-analyzer",
-        "type": "github"
       }
     }
   },

--- a/flake.lock
+++ b/flake.lock
@@ -8,11 +8,11 @@
         "rust-analyzer-src": "rust-analyzer-src"
       },
       "locked": {
-        "lastModified": 1755585599,
-        "narHash": "sha256-tl/0cnsqB/Yt7DbaGMel2RLa7QG5elA8lkaOXli6VdY=",
+        "lastModified": 1779099656,
+        "narHash": "sha256-x+PMKsZHKbgNbWrkyNP58xb4LrQfzzFd0QJVnPc+VnY=",
         "owner": "nix-community",
         "repo": "fenix",
-        "rev": "6ed03ef4c8ec36d193c18e06b9ecddde78fb7e42",
+        "rev": "f553608656def48a8aa2984b85f27fbee7c83dd8",
         "type": "github"
       },
       "original": {
@@ -24,15 +24,15 @@
     "flake-compat": {
       "flake": false,
       "locked": {
-        "lastModified": 1747046372,
-        "narHash": "sha256-CIVLLkVgvHYbgI2UpXvIIBJ12HWgX+fjA8Xf8PUmqCY=",
-        "owner": "edolstra",
+        "lastModified": 1767039857,
+        "narHash": "sha256-vNpUSpF5Nuw8xvDLj2KCwwksIbjua2LZCqhV1LNRDns=",
+        "owner": "NixOS",
         "repo": "flake-compat",
-        "rev": "9100a0f413b0c601e0533d1d94ffd501ce2e7885",
+        "rev": "5edf11c44bc78a0d334f6334cdaf7d60d732daab",
         "type": "github"
       },
       "original": {
-        "owner": "edolstra",
+        "owner": "NixOS",
         "repo": "flake-compat",
         "type": "github"
       }
@@ -42,11 +42,11 @@
         "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
-        "lastModified": 1754487366,
-        "narHash": "sha256-pHYj8gUBapuUzKV/kN/tR3Zvqc7o6gdFB9XKXIp1SQ8=",
+        "lastModified": 1778716662,
+        "narHash": "sha256-m1Yf0wZ8j1OHjTc2UwHwyQRSnNeSgLJOd7q5Y45hzi4=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "af66ad14b28a127c5c0f3bbb298218fc63528a18",
+        "rev": "f7c1a2d347e4c52d5fb8d10cb4d94b5884e546fb",
         "type": "github"
       },
       "original": {
@@ -64,11 +64,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1755446520,
-        "narHash": "sha256-I0Ok1OGDwc1jPd8cs2VvAYZsHriUVFGIUqW+7uSsOUM=",
+        "lastModified": 1778507602,
+        "narHash": "sha256-kTwur1wV+01SdqskVMSo6JMEpg71ps3HpbFY2GsflKs=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "4b04db83821b819bbbe32ed0a025b31e7971f22e",
+        "rev": "61ab0e80d9c7ab14c256b5b453d8b3fb0189ba0a",
         "type": "github"
       },
       "original": {
@@ -100,11 +100,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1755186698,
-        "narHash": "sha256-wNO3+Ks2jZJ4nTHMuks+cxAiVBGNuEBXsT29Bz6HASo=",
+        "lastModified": 1778869304,
+        "narHash": "sha256-30sZNZoA1cqF5JNO9fVX+wgiQYjB7HJqqJ4ztCDeBZE=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "fbcf476f790d8a217c3eab4e12033dc4a0f6d23c",
+        "rev": "d233902339c02a9c334e7e593de68855ad26c4cb",
         "type": "github"
       },
       "original": {
@@ -116,11 +116,11 @@
     },
     "nixpkgs-lib": {
       "locked": {
-        "lastModified": 1753579242,
-        "narHash": "sha256-zvaMGVn14/Zz8hnp4VWT9xVnhc8vuL3TStRqwk22biA=",
+        "lastModified": 1777168982,
+        "narHash": "sha256-GOkGPcboWE9BmGCRMLX3worL4EMnsnG8MyKmXNeYuhQ=",
         "owner": "nix-community",
         "repo": "nixpkgs.lib",
-        "rev": "0f36c44e01a6129be94e3ade315a5883f0228a6e",
+        "rev": "f5901329dade4a6ea039af1433fb087bd9c1fe14",
         "type": "github"
       },
       "original": {
@@ -140,11 +140,11 @@
     "rust-analyzer-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1755504847,
-        "narHash": "sha256-VX0B9hwhJypCGqncVVLC+SmeMVd/GAYbJZ0MiiUn2Pk=",
+        "lastModified": 1779074864,
+        "narHash": "sha256-0M3WqsWmtXmv9Ev/vnFfCHosWvISDwiuuhQ104UO3CI=",
         "owner": "rust-lang",
         "repo": "rust-analyzer",
-        "rev": "a905e3b21b144d77e1b304e49f3264f6f8d4db75",
+        "rev": "cdfe408d4b436e806ff525cb3e67588a6a009ed1",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -4,11 +4,6 @@
   inputs = {
     flake-parts.url = "github:hercules-ci/flake-parts";
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
-    fenix = {
-      url = "github:nix-community/fenix";
-      inputs.nixpkgs.follows = "nixpkgs";
-    };
-
     git-hooks = {
       url = "github:cachix/git-hooks.nix";
       inputs = {
@@ -36,15 +31,8 @@
           system,
           ...
         }:
-        let
-          rustToolchain = pkgs.fenix.stable;
-        in
         {
-          _module.args.pkgs = import inputs.nixpkgs {
-            inherit system;
-            overlays = [ inputs.fenix.overlays.default ];
-            config = { };
-          };
+          _module.args.pkgs = import inputs.nixpkgs { inherit system; };
 
           formatter = config.treefmt.build.wrapper;
           checks.formatting = config.treefmt.build.check self;
@@ -54,27 +42,14 @@
             settings.hooks = {
               actionlint.enable = true;
               shellcheck.enable = true;
-              clippy = {
-                enable = true;
-                packageOverrides = {
-                  cargo = rustToolchain.cargo;
-                  clippy = rustToolchain.clippy;
-                };
-              };
+              clippy.enable = true;
               cargo-check = {
                 enable = true;
-                package = rustToolchain.cargo;
-                entry = "${rustToolchain.cargo}/bin/cargo check --workspace --all-features";
+                entry = "${pkgs.lib.getExe pkgs.cargo} check --workspace --all-features";
                 files = "\\.rs$";
                 pass_filenames = false;
               };
-              rustfmt = {
-                enable = true;
-                packageOverrides = {
-                  rustfmt = rustToolchain.rustfmt;
-                  cargo = rustToolchain.cargo;
-                };
-              };
+              rustfmt.enable = true;
             };
           };
 
@@ -85,14 +60,11 @@
               cmake
               protobuf
 
-              (rustToolchain.withComponents [
-                "cargo"
-                "clippy"
-                "rust-src"
-                "rustc"
-                "rustfmt"
-                "rust-analyzer"
-              ])
+              cargo
+              clippy
+              rustc
+              rustfmt
+              rust-analyzer
             ];
 
             hardeningDisable = [ "fortify" ];

--- a/flake.nix
+++ b/flake.nix
@@ -1,14 +1,12 @@
 {
-  description = "Description for the project";
+  description = "Tonic - A native gRPC client & server implementation with async/await support.";
 
   inputs = {
     flake-parts.url = "github:hercules-ci/flake-parts";
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
     git-hooks = {
       url = "github:cachix/git-hooks.nix";
-      inputs = {
-        nixpkgs.follows = "nixpkgs";
-      };
+      inputs.nixpkgs.follows = "nixpkgs";
     };
   };
 

--- a/flake.nix
+++ b/flake.nix
@@ -83,6 +83,7 @@
               cargo-nextest
               pre-commit
               cmake
+              protobuf
 
               (rustToolchain.withComponents [
                 "cargo"


### PR DESCRIPTION
Hi! I'm using tonic for a personal project of mine and cloned it locally to take a better look at the examples.

As a nix user my first instinct was to check whether the project had a devShell, which it did! Yay!
Immediately after entering it, though, I saw that git started tracking `.pre-commit-config.yaml`, which is created automatic by the `git-hooks` in the flake.
The first commit adds this file to `.gitignore`.

Then I opened the example I wanted and noticed that the build scripts failed to compile and rust-analyzer complained that `OUT_DIR` wasn't set. I looked at the LSP logs and saw that `protoc` wasn't in the path, which I would've expected to have been made available by the devShell.
The second commit adds `protobuf` to the devShell.

Now the `OUT_DIR` error was gone but there were still build-script related failures. This time the LSP logs revealed that `protoc` v34 was expected but I was using v31.
The third commit updates the lockfile so that the newest v34 protoc is used :)

After updating the lockfile, I noticed that devShell took quite a bit to build, and realized that it was because the project uses [`fenix`](https://github.com/nix-community/fenix) to obtain a rust toolchain. This turns out to be completely unnecessary since the project uses a stable toolchain, which nixpkgs already has packages for, so we can just them. This makes the devShell _significantly_ faster to build since all of those packages can be substituted.
The fourth commit replaces `fenix` with nixpkgs's toolchain.

The fifth and final commit is simply some cosmetic adjustments to the flake's description and input formatting.

-----

Thanks a lot for the project. It's been wonderful to use.
