### PR TITLE
Fix mapping of well-known types when compiling a `FileDescriptionSet`

### DIFF
--- a/tonic-prost-build/src/lib.rs
+++ b/tonic-prost-build/src/lib.rs
@@ -904,6 +904,10 @@ impl Builder {
             config.include_file(path);
         }
 
+        if self.with_extended_rust_types {
+            NON_PATH_TYPE_ALLOWLIST.set(EXTENDED_NON_PATH_TYPE_ALLOWLIST);
+        }
+
         // Note: We don't pass self.disable_comments to prost Config here
         // because those are meant for service/method paths which are handled
         // by the ServiceGenerator, not for message paths


### PR DESCRIPTION
Respect the recently added `Builder::with_extended_rust_types` when compiling a `FileDescriptionSet` via e.g. `Builder::compile_fds` or `Builder::compile_fds_with_config`.
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

If this change is intended for tonic `v0.14.x` please make this PR against that branch
otherwise, it may not get included in a relase for a long time.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/hyperium/tonic/blob/master/CONTRIBUTING.md
-->

## Motivation

 When `with_extended_rust_types` was added in https://github.com/hyperium/tonic/pull/2544, only the code paths compiling .proto files from source were updated to include the extended mappings of well-known types. This makes it harder to use the option when compiling .proto files using [protox](https://crates.io/crates/protox), for example.

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? If a new feature is being added, describe the intended
use case that feature fulfills.
-->

## Solution

Duplicate the code path from `Builder::compile_with_config` extending `NON_PATH_TYPE_ALLOWLIST` with `EXTENDED_NON_PATH_TYPE_ALLOWLIST` when compiling .proto sources via `Builder::compile_fds_with_config`.

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
