### PR TITLE
Add config for Gemini Code Assist, similar to other gRPC repos.

### DIFF
--- a/.gemini/config.yaml
+++ b/.gemini/config.yaml
@@ -1,0 +1,13 @@
+have_fun: false
+memory_config:
+  disabled: false
+code_review:
+  disable: false
+  comment_severity_threshold: MEDIUM
+  max_review_comments: -1
+  pull_request_opened:
+    help: false
+    summary: false
+    code_review: false
+    include_drafts: false
+ignore_patterns: []


### PR DESCRIPTION
Add config to prevent Gemini Code Assist from automatically generating summaries and code reviews, similar to other gRPC repos. Gemini Code Assist is available for use by running `/gemini review`, but not on every change automatically.