### PR TITLE
fix(codec): respect server's enabled encodings when selecting response compression

### DIFF
--- a/tonic/CHANGELOG.md
+++ b/tonic/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- *(codec)* respect server's enabled encodings when selecting response compression, fixing a case where a server configured with `send_compressed(Zstd)` would still gzip responses when the client listed `gzip` before `zstd` in `grpc-accept-encoding`
+
 ## [0.14.6](https://github.com/hyperium/tonic/compare/tonic-v0.14.5...tonic-v0.14.6) - 2026-05-06
 
 ### Added

--- a/tonic/src/codec/compression.rs
+++ b/tonic/src/codec/compression.rs
@@ -118,11 +118,17 @@ impl CompressionEncoding {
 
         split_by_comma(header_value_str).find_map(|value| match value {
             #[cfg(feature = "gzip")]
-            "gzip" => Some(CompressionEncoding::Gzip),
+            "gzip" if enabled_encodings.is_enabled(CompressionEncoding::Gzip) => {
+                Some(CompressionEncoding::Gzip)
+            }
             #[cfg(feature = "deflate")]
-            "deflate" => Some(CompressionEncoding::Deflate),
+            "deflate" if enabled_encodings.is_enabled(CompressionEncoding::Deflate) => {
+                Some(CompressionEncoding::Deflate)
+            }
             #[cfg(feature = "zstd")]
-            "zstd" => Some(CompressionEncoding::Zstd),
+            "zstd" if enabled_encodings.is_enabled(CompressionEncoding::Zstd) => {
+                Some(CompressionEncoding::Zstd)
+            }
             _ => None,
         })
     }
@@ -355,6 +361,87 @@ mod tests {
         };
 
         assert_eq!(encodings.into_accept_encoding_header_value().unwrap(), ZSTD);
+    }
+
+    #[test]
+    #[cfg(all(feature = "gzip", feature = "zstd"))]
+    fn from_accept_encoding_header_respects_server_enabled_encodings() {
+        // Regression test for the case where the client advertises multiple
+        // encodings in its `grpc-accept-encoding` header but the server only
+        // enabled a subset of them via `.send_compressed(...)`.
+        //
+        // Previously, `from_accept_encoding_header` would pick the first
+        // encoding in the client's list whose `cfg(feature = ...)` was
+        // compiled in, without checking whether the server actually enabled
+        // that encoding. That meant a server configured for Zstd-only would
+        // gzip its responses whenever a client listed `gzip` before `zstd`
+        // in `grpc-accept-encoding` — even though the server never asked for
+        // gzip and (in `into_accept_encoding_header_value`) would never have
+        // advertised it.
+        //
+        // The selected encoding must come from the intersection of the
+        // server's enabled set and the client's accept list, preserving the
+        // client's preference order.
+        let mut enabled = EnabledCompressionEncodings::default();
+        enabled.enable(CompressionEncoding::Zstd);
+        assert!(enabled.is_enabled(CompressionEncoding::Zstd));
+        assert!(!enabled.is_enabled(CompressionEncoding::Gzip));
+
+        let mut headers = http::HeaderMap::new();
+        headers.insert(
+            ACCEPT_ENCODING_HEADER,
+            HeaderValue::from_static("gzip,zstd,identity"),
+        );
+
+        assert_eq!(
+            CompressionEncoding::from_accept_encoding_header(&headers, enabled),
+            Some(CompressionEncoding::Zstd),
+            "server has only Zstd enabled; must not pick Gzip just because \
+             the client listed it first",
+        );
+    }
+
+    #[test]
+    #[cfg(all(feature = "gzip", feature = "zstd"))]
+    fn from_accept_encoding_header_returns_none_when_no_overlap() {
+        // If the client's `grpc-accept-encoding` and the server's enabled
+        // encodings have no overlap, no compression should be selected — the
+        // server should fall back to sending the response uncompressed.
+        let mut enabled = EnabledCompressionEncodings::default();
+        enabled.enable(CompressionEncoding::Zstd);
+
+        let mut headers = http::HeaderMap::new();
+        headers.insert(
+            ACCEPT_ENCODING_HEADER,
+            HeaderValue::from_static("gzip,identity"),
+        );
+
+        assert_eq!(
+            CompressionEncoding::from_accept_encoding_header(&headers, enabled),
+            None,
+        );
+    }
+
+    #[test]
+    #[cfg(all(feature = "gzip", feature = "zstd"))]
+    fn from_accept_encoding_header_uses_client_preference_order() {
+        // When multiple enabled encodings appear in the client's accept list,
+        // the client's ordering wins. Both encodings are enabled on the
+        // server, but the client prefers gzip.
+        let mut enabled = EnabledCompressionEncodings::default();
+        enabled.enable(CompressionEncoding::Zstd);
+        enabled.enable(CompressionEncoding::Gzip);
+
+        let mut headers = http::HeaderMap::new();
+        headers.insert(
+            ACCEPT_ENCODING_HEADER,
+            HeaderValue::from_static("gzip,zstd,identity"),
+        );
+
+        assert_eq!(
+            CompressionEncoding::from_accept_encoding_header(&headers, enabled),
+            Some(CompressionEncoding::Gzip),
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Motivation

`CompressionEncoding::from_accept_encoding_header` selects a response compression encoding based purely on the client's `grpc-accept-encoding` header and the *compile-time* feature set, not the *runtime* set of encodings the server enabled via `Server::send_compressed(...)`.

When the server has only zstd enabled but the client advertises `gzip,zstd,identity`, tonic compresses the response with gzip, which is an encoding the server never opted into and would not have advertised back.

The sibling `from_encoding_header` (used for request decompression) already has the correct `if enabled_encodings.is_enabled(...)` guards per match arm. This PR brings the accept-side in line.

**Observed in production** with tonic 0.14.6: server configured `send_compressed(Zstd)` only, ~38% of server CPU in `miniz_oxide::deflate`. Worked around downstream with a tower layer that rewrites the incoming `grpc-accept-encoding` header to `"zstd,identity"` to force the buggy selection onto the correct path. After the fix, that work-around will no longer be needed.

The bug affects all four RPC kinds — `from_accept_encoding_header` is called from `unary` / `server_streaming` / `client_streaming` / `streaming` in `tonic/src/server/grpc.rs`.

## Solution

Add a runtime `is_enabled` guard to each match arm of `from_accept_encoding_header` so the function returns the first encoding in the intersection of (server-enabled, client-accepted), preserving the client's preference order. Returns `None` if the intersection is empty so the server falls back to identity-encoded responses.

Adds three unit tests in `mod tests` of `tonic/src/codec/compression.rs`:

| Test | Server enabled | Client `grpc-accept-encoding` | Expected |
|---|---|---|---|
| `from_accept_encoding_header_respects_server_enabled_encodings` | `Zstd` | `gzip,zstd,identity` | `Some(Zstd)` |
| `from_accept_encoding_header_returns_none_when_no_overlap` | `Zstd` | `gzip,identity` | `None` |
| `from_accept_encoding_header_uses_client_preference_order` | `Zstd`, `Gzip` | `gzip,zstd,identity` | `Some(Gzip)` |

All three unit tests fail on master without the code fix; all pass with it. Existing `tonic` unit tests (79) and `compression` integration tests (63) continue to pass.

## Backport note

This fix applies cleanly. Flagging that the `v0.14.x` branch head appears to be behind the `tonic-v0.14.6` tag (latest commit there is `chore: prepare v0.14.5 release`), so I targeted master like v0.14.6 did. Happy to open a parallel PR against `v0.14.x` if maintainers want a backport.
