### PR TITLE
protoc-gen-rust-grpc: fix macos universal build

### DIFF
--- a/.github/workflows/release-protoc-gen-rust-grpc.yml
+++ b/.github/workflows/release-protoc-gen-rust-grpc.yml
@@ -103,7 +103,7 @@ jobs:
             -DBUILD_PROTOC=OFF \
             -DBUILD_PLUGIN=ON \
             -DRUST_GRPC_VERSION="$VERSION_FROM_TAG" \
-            ${{ matrix.cmake_flags }}
+            "${{ matrix.cmake_flags }}"
 
       - name: Build
         shell: bash


### PR DESCRIPTION
The cmake flags were not properly quoted, so when the mac universal build used a semicolon in them, it was treated as the end of the command by bash.  This fixes that by quoting the flags.