### PR TITLE
feat(xds-client): gRFC A78 XdsClient metrics + extension point

### DIFF
--- a/tonic-xds/src/client/channel.rs
+++ b/tonic-xds/src/client/channel.rs
@@ -197,7 +197,8 @@ impl XdsChannelBuilder {
         )?);
 
         let node = Node::try_from(bootstrap.node)?;
-        let client_config = ClientConfig::new(node, &server_uri);
+        let client_config =
+            ClientConfig::new(node, &server_uri).with_target(self.config.target_uri.to_string());
         let xds_client =
             XdsClient::builder(client_config, transport_builder, ProstCodec, TokioRuntime).build();
 

--- a/tonic-xds/src/xds/uri.rs
+++ b/tonic-xds/src/xds/uri.rs
@@ -1,3 +1,5 @@
+use std::fmt;
+
 use thiserror::Error;
 use url::Url;
 
@@ -52,5 +54,13 @@ impl XdsUri {
         let target = uri.path().trim_start_matches('/').to_string();
 
         Ok(Self { target })
+    }
+}
+
+impl fmt::Display for XdsUri {
+    /// Formats as the canonical xDS URI string (e.g. `xds:///my-service`).
+    /// Round-trips with [`XdsUri::parse`].
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{XDS_SCHEME}:///{}", self.target)
     }
 }

--- a/xds-client/src/client/config.rs
+++ b/xds-client/src/client/config.rs
@@ -57,6 +57,15 @@ pub struct ClientConfig {
     ///
     /// Default: 30 seconds. Set to `None` to disable the timeout.
     pub(crate) resource_initial_timeout: Option<Duration>,
+
+    /// gRPC channel target this xDS client serves (per gRFC A78).
+    ///
+    /// Used as the `grpc.target` attribute on emitted metrics. This identifies
+    /// the consumer-facing data-plane channel (e.g. `xds:///my-service`).
+    ///
+    /// Set this when constructing the client. When unset, the `grpc.target`
+    /// attribute is emitted as an empty string.
+    pub(crate) target: Option<String>,
     // Future extensions:
     // - `authorities: HashMap<String, AuthorityConfig>` for xDS federation (gRFC A47)
     // - Locality / zone information for locality-aware routing
@@ -84,6 +93,7 @@ impl ClientConfig {
             retry_policy: RetryPolicy::default(),
             servers: vec![ServerConfig::new(server_uri)],
             resource_initial_timeout: Some(DEFAULT_RESOURCE_INITIAL_TIMEOUT),
+            target: None,
         }
     }
 
@@ -108,6 +118,7 @@ impl ClientConfig {
             retry_policy: RetryPolicy::default(),
             servers,
             resource_initial_timeout: Some(DEFAULT_RESOURCE_INITIAL_TIMEOUT),
+            target: None,
         }
     }
 
@@ -157,6 +168,19 @@ impl ClientConfig {
     /// ```
     pub fn with_resource_initial_timeout(mut self, timeout: Option<Duration>) -> Self {
         self.resource_initial_timeout = timeout;
+        self
+    }
+
+    /// Set the gRPC channel target name (per gRFC A78).
+    ///
+    /// Used as the `grpc.target` attribute on emitted metrics. This is the
+    /// data-plane channel target (e.g. `xds:///my-service`).
+    ///
+    /// Consumers that wrap `xds-client` in a channel layer (e.g. tonic-xds)
+    /// should set this to the channel target. When unset, the `grpc.target`
+    /// attribute is emitted as an empty string.
+    pub fn with_target(mut self, target: impl Into<String>) -> Self {
+        self.target = Some(target.into());
         self
     }
 }

--- a/xds-client/src/client/mod.rs
+++ b/xds-client/src/client/mod.rs
@@ -9,7 +9,7 @@ use crate::client::config::ClientConfig;
 use crate::client::watch::ResourceWatcher;
 use crate::client::worker::{AdsWorker, WatcherId, WorkerCommand};
 use crate::codec::XdsCodec;
-use crate::metrics::{MetricsRecorder, NoOpRecorder};
+use crate::metrics::MetricsRecorder;
 use crate::resource::{DecodedResource, DecoderFn, Resource};
 use crate::runtime::Runtime;
 use crate::transport::TransportBuilder;
@@ -25,7 +25,7 @@ pub struct XdsClientBuilder<TB, C, R> {
     transport_builder: TB,
     codec: C,
     runtime: R,
-    recorder: Arc<dyn MetricsRecorder>,
+    recorder: Option<Arc<dyn MetricsRecorder>>,
 }
 
 impl<TB: fmt::Debug, C: fmt::Debug, R: fmt::Debug> fmt::Debug for XdsClientBuilder<TB, C, R> {
@@ -35,7 +35,14 @@ impl<TB: fmt::Debug, C: fmt::Debug, R: fmt::Debug> fmt::Debug for XdsClientBuild
             .field("transport_builder", &self.transport_builder)
             .field("codec", &self.codec)
             .field("runtime", &self.runtime)
-            .field("recorder", &"Arc<dyn MetricsRecorder>")
+            .field(
+                "recorder",
+                &self
+                    .recorder
+                    .as_ref()
+                    .map(|_| "Some(Arc<dyn MetricsRecorder>)")
+                    .unwrap_or("None"),
+            )
             .finish()
     }
 }
@@ -48,7 +55,8 @@ where
 {
     /// Create a new builder with the given configuration, transport builder, codec, and runtime.
     ///
-    /// Defaults to a [`NoOpRecorder`] for metrics; configure with
+    /// No metrics recorder is configured by default; the worker skips all A78
+    /// metric emission. Configure a backend with
     /// [`with_metrics_recorder`](Self::with_metrics_recorder) to receive measurements.
     pub fn new(config: ClientConfig, transport_builder: TB, codec: C, runtime: R) -> Self {
         Self {
@@ -56,7 +64,7 @@ where
             transport_builder,
             codec,
             runtime,
-            recorder: Arc::new(NoOpRecorder),
+            recorder: None,
         }
     }
 
@@ -66,13 +74,14 @@ where
     ///
     /// ```ignore
     /// use std::sync::Arc;
-    /// use xds_client::NoOpRecorder;
+    /// use xds_client::MetricsRecorder;
     ///
+    /// let recorder: Arc<dyn MetricsRecorder> = Arc::new(MyOtelRecorder::new());
     /// let builder = XdsClient::builder(config, transport, codec, runtime)
-    ///     .with_metrics_recorder(Arc::new(NoOpRecorder));
+    ///     .with_metrics_recorder(recorder);
     /// ```
     pub fn with_metrics_recorder(mut self, recorder: Arc<dyn MetricsRecorder>) -> Self {
-        self.recorder = recorder;
+        self.recorder = Some(recorder);
         self
     }
 

--- a/xds-client/src/client/mod.rs
+++ b/xds-client/src/client/mod.rs
@@ -1,11 +1,15 @@
 //! Client interface through which the user can watch and receive updates for xDS resources.
 
+use std::fmt;
+use std::sync::Arc;
+
 use tokio::sync::mpsc;
 
 use crate::client::config::ClientConfig;
 use crate::client::watch::ResourceWatcher;
 use crate::client::worker::{AdsWorker, WatcherId, WorkerCommand};
 use crate::codec::XdsCodec;
+use crate::metrics::{MetricsRecorder, NoOpRecorder};
 use crate::resource::{DecodedResource, DecoderFn, Resource};
 use crate::runtime::Runtime;
 use crate::transport::TransportBuilder;
@@ -16,12 +20,24 @@ pub mod watch;
 pub mod worker;
 
 /// Builder for [`XdsClient`].
-#[derive(Debug)]
 pub struct XdsClientBuilder<TB, C, R> {
     config: ClientConfig,
     transport_builder: TB,
     codec: C,
     runtime: R,
+    recorder: Arc<dyn MetricsRecorder>,
+}
+
+impl<TB: fmt::Debug, C: fmt::Debug, R: fmt::Debug> fmt::Debug for XdsClientBuilder<TB, C, R> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("XdsClientBuilder")
+            .field("config", &self.config)
+            .field("transport_builder", &self.transport_builder)
+            .field("codec", &self.codec)
+            .field("runtime", &self.runtime)
+            .field("recorder", &"Arc<dyn MetricsRecorder>")
+            .finish()
+    }
 }
 
 impl<TB, C, R> XdsClientBuilder<TB, C, R>
@@ -31,13 +47,33 @@ where
     R: Runtime,
 {
     /// Create a new builder with the given configuration, transport builder, codec, and runtime.
+    ///
+    /// Defaults to a [`NoOpRecorder`] for metrics; configure with
+    /// [`with_metrics_recorder`](Self::with_metrics_recorder) to receive measurements.
     pub fn new(config: ClientConfig, transport_builder: TB, codec: C, runtime: R) -> Self {
         Self {
             config,
             transport_builder,
             codec,
             runtime,
+            recorder: Arc::new(NoOpRecorder),
         }
+    }
+
+    /// Set the metrics recorder.
+    ///
+    /// # Example
+    ///
+    /// ```ignore
+    /// use std::sync::Arc;
+    /// use xds_client::NoOpRecorder;
+    ///
+    /// let builder = XdsClient::builder(config, transport, codec, runtime)
+    ///     .with_metrics_recorder(Arc::new(NoOpRecorder));
+    /// ```
+    pub fn with_metrics_recorder(mut self, recorder: Arc<dyn MetricsRecorder>) -> Self {
+        self.recorder = recorder;
+        self
     }
 
     /// Build the client and start the background worker.
@@ -54,6 +90,7 @@ where
             self.config,
             command_tx.clone(),
             command_rx,
+            self.recorder,
         );
 
         self.runtime.spawn(async move {

--- a/xds-client/src/client/worker.rs
+++ b/xds-client/src/client/worker.rs
@@ -44,75 +44,89 @@ impl ClientAttrs {
         ]
     }
 
-    fn type_attrs(&self, type_url: &str) -> [KeyValue; 3] {
+    fn type_attrs(&self, type_url: &Arc<str>) -> [KeyValue; 3] {
         [
             KeyValue::str(metrics::attrs::GRPC_TARGET, Arc::clone(&self.target)),
             KeyValue::str(metrics::attrs::GRPC_XDS_SERVER, Arc::clone(&self.server)),
-            KeyValue::str(metrics::attrs::GRPC_XDS_RESOURCE_TYPE, type_url.to_string()),
+            KeyValue::str(metrics::attrs::GRPC_XDS_RESOURCE_TYPE, Arc::clone(type_url)),
         ]
     }
 
-    fn cache_state_attrs(&self, type_url: &str, cache_state: &'static str) -> [KeyValue; 4] {
+    fn cache_state_attrs(&self, type_url: &Arc<str>, cache_state: &'static str) -> [KeyValue; 4] {
         [
             KeyValue::str(metrics::attrs::GRPC_TARGET, Arc::clone(&self.target)),
             KeyValue::str(metrics::attrs::GRPC_XDS_SERVER, Arc::clone(&self.server)),
-            KeyValue::str(metrics::attrs::GRPC_XDS_RESOURCE_TYPE, type_url.to_string()),
+            KeyValue::str(metrics::attrs::GRPC_XDS_RESOURCE_TYPE, Arc::clone(type_url)),
             KeyValue::str(metrics::attrs::GRPC_XDS_CACHE_STATE, cache_state),
         ]
     }
 }
 
-/// A78 metric emission verbs on the worker's recorder.
-///
-/// Inherent methods on `dyn MetricsRecorder` (legal because the trait is
-/// defined in this crate). `pub(crate)` keeps them invisible to downstream
-/// consumers — the methods exist only for use by this crate's worker.
-///
-/// Call sites look like `self.recorder.record_X(&self.attrs, ...)`. The
-/// receiver and `attrs` borrow are split-borrow-friendly with `&mut self`
-/// borrows on other worker fields (e.g. `self.type_states`), so the mutation
-/// handlers don't need to be restructured to defer emission.
-impl dyn MetricsRecorder {
+/// Worker-side wrapper around an optional [`MetricsRecorder`] backend.
+pub(crate) struct RecorderHandle {
+    recorder: Option<Arc<dyn MetricsRecorder>>,
+    attrs: ClientAttrs,
+}
+
+impl RecorderHandle {
+    pub(crate) fn new(recorder: Option<Arc<dyn MetricsRecorder>>, target: Arc<str>) -> Self {
+        Self {
+            recorder,
+            attrs: ClientAttrs {
+                target,
+                server: Arc::from(""),
+            },
+        }
+    }
+
+    /// Update the `grpc.xds.server` attribute for subsequent emissions.
+    pub(crate) fn set_server(&mut self, server: Arc<str>) {
+        self.attrs.server = server;
+    }
+
     /// `grpc.xds_client.connected` — 1 for connected, 0 for disconnected.
-    fn record_connected(&self, attrs: &ClientAttrs, connected: bool) {
-        self.record_gauge_i64(
+    fn record_connected(&self, connected: bool) {
+        let Some(recorder) = &self.recorder else {
+            return;
+        };
+        recorder.record_gauge_i64(
             &metrics::instruments::XDS_CLIENT_CONNECTED,
             if connected { 1 } else { 0 },
-            &attrs.connection_attrs(),
+            &self.attrs.connection_attrs(),
         );
     }
 
     /// `grpc.xds_client.server_failure` — incremented once per failed connection cycle.
-    fn record_server_failure(&self, attrs: &ClientAttrs) {
-        self.add_counter_u64(
+    fn record_server_failure(&self) {
+        let Some(recorder) = &self.recorder else {
+            return;
+        };
+        recorder.add_counter_u64(
             &metrics::instruments::XDS_CLIENT_SERVER_FAILURE,
             1,
-            &attrs.connection_attrs(),
+            &self.attrs.connection_attrs(),
         );
     }
 
     /// `grpc.xds_client.resource_updates_valid` + `_invalid`, with aggregated
     /// counts from a single response.
-    fn record_resource_updates(
-        &self,
-        attrs: &ClientAttrs,
-        type_url: &str,
-        valid: u64,
-        invalid: u64,
-    ) {
+    fn record_resource_updates(&self, type_url: &Arc<str>, valid: u64, invalid: u64) {
+        let Some(recorder) = &self.recorder else {
+            return;
+        };
         if valid == 0 && invalid == 0 {
             return;
         }
-        let type_attrs = attrs.type_attrs(type_url);
+        let type_attrs = self.attrs.type_attrs(type_url);
         if valid > 0 {
-            self.add_counter_u64(
+            recorder.add_counter_u64(
                 &metrics::instruments::XDS_CLIENT_RESOURCE_UPDATES_VALID,
                 valid,
                 &type_attrs,
             );
         }
         if invalid > 0 {
-            self.add_counter_u64(
+            recorder.add_counter_u64(
                 &metrics::instruments::XDS_CLIENT_RESOURCE_UPDATES_INVALID,
                 invalid,
                 &type_attrs,
@@ -124,27 +138,29 @@ impl dyn MetricsRecorder {
     /// `prev` is `None` when the resource is being inserted into the cache for the first time.
     fn record_resource_transition(
         &self,
-        attrs: &ClientAttrs,
-        type_url: &str,
+        type_url: &Arc<str>,
         prev: Option<&ResourceState>,
         new: &ResourceState,
     ) {
+        let Some(recorder) = &self.recorder else {
+            return;
+        };
         let new_label = new.cache_state_label();
         let prev_label = prev.map(ResourceState::cache_state_label);
         if prev_label == Some(new_label) {
             return;
         }
         if let Some(prev) = prev_label {
-            self.add_up_down_counter_i64(
+            recorder.add_up_down_counter_i64(
                 &metrics::instruments::XDS_CLIENT_RESOURCES,
                 -1,
-                &attrs.cache_state_attrs(type_url, prev),
+                &self.attrs.cache_state_attrs(type_url, prev),
             );
         }
-        self.add_up_down_counter_i64(
+        recorder.add_up_down_counter_i64(
             &metrics::instruments::XDS_CLIENT_RESOURCES,
             1,
-            &attrs.cache_state_attrs(type_url, new_label),
+            &self.attrs.cache_state_attrs(type_url, new_label),
         );
     }
 }
@@ -330,6 +346,9 @@ impl CachedResource {
 
 /// Per-type_url state tracking.
 struct TypeState {
+    /// Reference-counted type URL, shared with metric attribute slots so
+    /// per-emission attribute construction is a cheap.
+    type_url: Arc<str>,
     /// Decoder function for this resource type.
     decoder: DecoderFn,
     /// Version from last successful response.
@@ -349,6 +368,7 @@ struct TypeState {
 impl std::fmt::Debug for TypeState {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("TypeState")
+            .field("type_url", &self.type_url)
             .field("decoder", &"<decoder fn>")
             .field("version_info", &self.version_info)
             .field("nonce", &self.nonce)
@@ -364,8 +384,9 @@ impl std::fmt::Debug for TypeState {
 }
 
 impl TypeState {
-    fn new(decoder: DecoderFn, all_resources_required_in_sotw: bool) -> Self {
+    fn new(type_url: Arc<str>, decoder: DecoderFn, all_resources_required_in_sotw: bool) -> Self {
         Self {
+            type_url,
             decoder,
             version_info: String::new(),
             nonce: String::new(),
@@ -482,10 +503,9 @@ pub(crate) struct AdsWorker<TB, C, R> {
     /// Cancellation handles for resource timers (gRFC A57).
     /// Key is (type_url, resource_name). Dropping the sender cancels the timer.
     resource_timers: HashMap<(String, String), oneshot::Sender<()>>,
-    /// Backend for recording metrics emitted by the worker (gRFC A78).
-    recorder: Arc<dyn MetricsRecorder>,
-    /// Per-client A78 metric attributes (`grpc.target` + `grpc.xds.server`).
-    attrs: ClientAttrs,
+    /// Optional backend + per-client A78 metric attributes
+    /// (`grpc.target` + `grpc.xds.server`).
+    recorder: RecorderHandle,
 }
 
 impl<TB, C, R> AdsWorker<TB, C, R>
@@ -502,8 +522,9 @@ where
         config: ClientConfig,
         command_tx: mpsc::Sender<WorkerCommand>,
         command_rx: mpsc::Receiver<WorkerCommand>,
-        recorder: Arc<dyn MetricsRecorder>,
+        recorder: Option<Arc<dyn MetricsRecorder>>,
     ) -> Self {
+        let target: Arc<str> = Arc::from(config.target.unwrap_or_default());
         Self {
             transport_builder,
             codec,
@@ -516,11 +537,7 @@ where
             command_rx,
             type_states: HashMap::new(),
             resource_timers: HashMap::new(),
-            recorder,
-            attrs: ClientAttrs {
-                target: Arc::from(config.target.unwrap_or_default()),
-                server: Arc::from(""),
-            },
+            recorder: RecorderHandle::new(recorder, target),
         }
     }
 
@@ -555,7 +572,7 @@ where
                 Some(s) => s,
                 None => return, // No servers configured
             };
-            self.attrs.server = Arc::from(server.uri());
+            self.recorder.set_server(Arc::from(server.uri()));
 
             let transport = match self.transport_builder.build(server).await {
                 Ok(t) => t,
@@ -582,14 +599,14 @@ where
                 }
             };
 
-            self.recorder.record_connected(&self.attrs, true);
+            self.recorder.record_connected(true);
             let result = self.run_connected(stream).await;
-            self.recorder.record_connected(&self.attrs, false);
+            self.recorder.record_connected(false);
 
             match result {
                 Ok(()) => return, // shutdown
                 Err(_e) => {
-                    self.recorder.record_server_failure(&self.attrs);
+                    self.recorder.record_server_failure();
                     match self.backoff.next_backoff() {
                         Some(backoff) => self.runtime.sleep(backoff).await,
                         None => return, // Max attempts exceeded
@@ -722,7 +739,9 @@ where
         let type_state = self
             .type_states
             .entry(type_url_string.clone())
-            .or_insert_with(|| TypeState::new(decoder, all_resources_required_in_sotw));
+            .or_insert_with(|| {
+                TypeState::new(Arc::from(type_url), decoder, all_resources_required_in_sotw)
+            });
 
         let old_subscription = type_state.subscription.clone();
         let watcher_subscription = WatcherSubscription::from_name(name.clone());
@@ -768,8 +787,7 @@ where
         // Emit resources gauge transition for newly-inserted cache entry.
         if was_new {
             self.recorder.record_resource_transition(
-                &self.attrs,
-                &type_url_string,
+                &type_state.type_url,
                 None,
                 &ResourceState::Requested,
             );
@@ -849,8 +867,8 @@ where
         let response = self.codec.decode_response(bytes)?;
         let type_url = response.type_url.clone();
 
-        let decoder = match self.type_states.get(&type_url) {
-            Some(s) => &s.decoder,
+        let (type_url_arc, decoder) = match self.type_states.get(&type_url) {
+            Some(s) => (Arc::clone(&s.type_url), &s.decoder),
             None => {
                 return Ok(());
             }
@@ -884,7 +902,7 @@ where
         let valid_count = valid_resources.len() as u64;
         let invalid_count = (top_level_errors.len() + per_resource_errors.len()) as u64;
         self.recorder
-            .record_resource_updates(&self.attrs, &type_url, valid_count, invalid_count);
+            .record_resource_updates(&type_url_arc, valid_count, invalid_count);
 
         if let Some(type_state) = self.type_states.get_mut(&type_url) {
             type_state.nonce = response.nonce.clone();
@@ -967,8 +985,7 @@ where
                         CachedResource::received(Arc::new(resource.clone())),
                     );
                     self.recorder.record_resource_transition(
-                        &self.attrs,
-                        type_url,
+                        &s.type_url,
                         prev.as_ref().map(|c| &c.state),
                         &ResourceState::Received,
                     );
@@ -1024,8 +1041,7 @@ where
             CachedResource::nacked(error.to_string()),
         );
         self.recorder.record_resource_transition(
-            &self.attrs,
-            type_url,
+            &type_state.type_url,
             prev.as_ref().map(|c| &c.state),
             &ResourceState::NACKed(error.to_string()),
         );
@@ -1079,8 +1095,7 @@ where
                 .cache
                 .insert(name.clone(), CachedResource::does_not_exist());
             self.recorder.record_resource_transition(
-                &self.attrs,
-                type_url,
+                &type_state.type_url,
                 prev.as_ref().map(|c| &c.state),
                 &ResourceState::DoesNotExist,
             );
@@ -1215,8 +1230,7 @@ where
             .cache
             .insert(name.to_string(), CachedResource::does_not_exist());
         self.recorder.record_resource_transition(
-            &self.attrs,
-            type_url,
+            &type_state.type_url,
             prev.as_ref().map(|c| &c.state),
             &ResourceState::DoesNotExist,
         );
@@ -1331,31 +1345,25 @@ mod tests {
             .map(|(_, v)| v.as_str())
     }
 
-    fn test_attrs() -> ClientAttrs {
-        ClientAttrs {
-            target: Arc::from("xds:///my-service"),
-            server: Arc::from("xds.example.com:443"),
-        }
-    }
-
-    /// Returns a (capturing recorder, `dyn`-coerced clone) pair so tests can
-    /// drive emissions through the dyn handle and inspect the recorded events
-    /// through the typed handle.
-    fn test_recorder() -> (Arc<CapturingRecorder>, Arc<dyn MetricsRecorder>) {
+    /// Build a [`RecorderHandle`] backed by a [`CapturingRecorder`], wired
+    /// with the canonical test attributes used by the transition tests.
+    fn test_handle() -> (Arc<CapturingRecorder>, RecorderHandle) {
         let recorder = Arc::new(CapturingRecorder::default());
         let dyn_recorder: Arc<dyn MetricsRecorder> = recorder.clone();
-        (recorder, dyn_recorder)
+        let mut handle = RecorderHandle::new(Some(dyn_recorder), Arc::from("xds:///my-service"));
+        handle.set_server(Arc::from("xds.example.com:443"));
+        (recorder, handle)
+    }
+
+    fn test_type_url() -> Arc<str> {
+        Arc::from("envoy.config.listener.v3.Listener")
     }
 
     #[test]
     fn transition_from_none_emits_only_increment() {
-        let (recorder, dyn_recorder) = test_recorder();
-        dyn_recorder.record_resource_transition(
-            &test_attrs(),
-            "envoy.config.listener.v3.Listener",
-            None,
-            &ResourceState::Requested,
-        );
+        let (recorder, handle) = test_handle();
+        let type_url = test_type_url();
+        handle.record_resource_transition(&type_url, None, &ResourceState::Requested);
 
         let events = recorder.take();
         assert_eq!(events.len(), 1);
@@ -1375,10 +1383,10 @@ mod tests {
 
     #[test]
     fn transition_emits_decrement_then_increment() {
-        let (recorder, dyn_recorder) = test_recorder();
-        dyn_recorder.record_resource_transition(
-            &test_attrs(),
-            "envoy.config.listener.v3.Listener",
+        let (recorder, handle) = test_handle();
+        let type_url = test_type_url();
+        handle.record_resource_transition(
+            &type_url,
             Some(&ResourceState::Received),
             &ResourceState::NACKed("validation failed".into()),
         );
@@ -1393,10 +1401,10 @@ mod tests {
 
     #[test]
     fn transition_to_same_state_is_a_no_op() {
-        let (recorder, dyn_recorder) = test_recorder();
-        dyn_recorder.record_resource_transition(
-            &test_attrs(),
-            "envoy.config.listener.v3.Listener",
+        let (recorder, handle) = test_handle();
+        let type_url = test_type_url();
+        handle.record_resource_transition(
+            &type_url,
             Some(&ResourceState::NACKed("first".into())),
             &ResourceState::NACKed("second".into()),
         );

--- a/xds-client/src/client/worker.rs
+++ b/xds-client/src/client/worker.rs
@@ -37,6 +37,15 @@ struct ClientAttrs {
 }
 
 impl ClientAttrs {
+    /// Sentinel `grpc.xds.authority` value used for the unnamed top-level
+    /// (non-federated) authority.
+    ///
+    /// Matches grpc-go's top-level placeholder.
+    ///
+    /// TODO: once federated bootstrap support lands, derive the authority from
+    /// the resource name (`xdstp://<authority>/...`) on a per-resource basis.
+    const TOP_LEVEL_AUTHORITY: &'static str = "#old";
+
     fn connection_attrs(&self) -> [KeyValue; 2] {
         [
             KeyValue::str(metrics::attrs::GRPC_TARGET, Arc::clone(&self.target)),
@@ -55,7 +64,10 @@ impl ClientAttrs {
     fn cache_state_attrs(&self, type_url: &Arc<str>, cache_state: &'static str) -> [KeyValue; 4] {
         [
             KeyValue::str(metrics::attrs::GRPC_TARGET, Arc::clone(&self.target)),
-            KeyValue::str(metrics::attrs::GRPC_XDS_SERVER, Arc::clone(&self.server)),
+            KeyValue::str(
+                metrics::attrs::GRPC_XDS_AUTHORITY,
+                Self::TOP_LEVEL_AUTHORITY,
+            ),
             KeyValue::str(metrics::attrs::GRPC_XDS_RESOURCE_TYPE, Arc::clone(type_url)),
             KeyValue::str(metrics::attrs::GRPC_XDS_CACHE_STATE, cache_state),
         ]
@@ -161,6 +173,21 @@ impl RecorderHandle {
             &metrics::instruments::XDS_CLIENT_RESOURCES,
             1,
             &self.attrs.cache_state_attrs(type_url, new_label),
+        );
+    }
+
+    /// `grpc.xds_client.resources` — emit a `-1` delta for a resource
+    /// that is leaving the cache without any successor state.
+    fn record_resource_removal(&self, type_url: &Arc<str>, prev: &ResourceState) {
+        let Some(recorder) = &self.recorder else {
+            return;
+        };
+        recorder.add_up_down_counter_i64(
+            &metrics::instruments::XDS_CLIENT_RESOURCES,
+            -1,
+            &self
+                .attrs
+                .cache_state_attrs(type_url, prev.cache_state_label()),
         );
     }
 }
@@ -577,6 +604,7 @@ where
             let transport = match self.transport_builder.build(server).await {
                 Ok(t) => t,
                 Err(_) => {
+                    self.recorder.record_server_failure();
                     match self.backoff.next_backoff() {
                         Some(backoff) => self.runtime.sleep(backoff).await,
                         None => return, // Max attempts exceeded
@@ -591,6 +619,7 @@ where
                     s
                 }
                 Err(_) => {
+                    self.recorder.record_server_failure();
                     match self.backoff.next_backoff() {
                         Some(backoff) => self.runtime.sleep(backoff).await,
                         None => return, // Max attempts exceeded
@@ -822,6 +851,10 @@ where
         let subscriptions_changed = type_state.subscription != old_subscription;
 
         if type_state.watchers.is_empty() {
+            for cached in type_state.cache.values() {
+                self.recorder
+                    .record_resource_removal(&type_state.type_url, &cached.state);
+            }
             self.type_states.remove(&type_url);
             // Cancel all pending resource timers for this type.
             self.resource_timers.retain(|key, _| key.0 != type_url);
@@ -1375,10 +1408,8 @@ mod tests {
             Some("envoy.config.listener.v3.Listener")
         );
         assert_eq!(attr(&events[0], "grpc.target"), Some("xds:///my-service"));
-        assert_eq!(
-            attr(&events[0], "grpc.xds.server"),
-            Some("xds.example.com:443")
-        );
+        assert_eq!(attr(&events[0], "grpc.xds.authority"), Some("#old"));
+        assert_eq!(attr(&events[0], "grpc.xds.server"), None);
     }
 
     #[test]
@@ -1410,5 +1441,41 @@ mod tests {
         );
 
         assert!(recorder.take().is_empty());
+    }
+
+    #[test]
+    fn removal_emits_single_decrement_against_prev_state() {
+        let (recorder, handle) = test_handle();
+        let type_url = test_type_url();
+        handle.record_resource_removal(&type_url, &ResourceState::Received);
+
+        let events = recorder.take();
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].instrument, "grpc.xds_client.resources");
+        assert_eq!(events[0].kind, Measurement::UpDownI64(-1));
+        assert_eq!(attr(&events[0], "grpc.xds.cache_state"), Some("acked"));
+        assert_eq!(
+            attr(&events[0], "grpc.xds.resource_type"),
+            Some("envoy.config.listener.v3.Listener")
+        );
+    }
+
+    #[test]
+    fn add_then_remove_balances_to_zero() {
+        let (recorder, handle) = test_handle();
+        let type_url = test_type_url();
+        handle.record_resource_transition(&type_url, None, &ResourceState::Received);
+        handle.record_resource_removal(&type_url, &ResourceState::Received);
+
+        let events = recorder.take();
+        assert_eq!(events.len(), 2);
+        let net: i64 = events
+            .iter()
+            .map(|e| match e.kind {
+                Measurement::UpDownI64(v) => v,
+                _ => 0,
+            })
+            .sum();
+        assert_eq!(net, 0);
     }
 }

--- a/xds-client/src/client/worker.rs
+++ b/xds-client/src/client/worker.rs
@@ -6,6 +6,7 @@
 //! - Dispatching resources to watchers
 //! - ACK/NACK protocol
 
+use std::collections::hash_map::Entry;
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
@@ -20,9 +21,133 @@ use crate::client::watch::{ProcessingDone, ResourceEvent};
 use crate::codec::XdsCodec;
 use crate::error::{Error, Result};
 use crate::message::{DiscoveryRequest, DiscoveryResponse, ErrorDetail, Node};
+use crate::metrics::{self, KeyValue, MetricsRecorder};
 use crate::resource::{DecodedResource, DecoderFn};
 use crate::runtime::Runtime;
 use crate::transport::{Transport, TransportBuilder, TransportStream};
+
+/// Per-client A78 metric attributes (`grpc.target` + `grpc.xds.server`).
+///
+/// Both values are stored as `Arc<str>` so each emission clones them as a
+/// cheap atomic op (via the `StringValue::RefCounted` variant) instead of
+/// allocating a new `String` per attribute slot.
+struct ClientAttrs {
+    target: Arc<str>,
+    server: Arc<str>,
+}
+
+impl ClientAttrs {
+    fn connection_attrs(&self) -> [KeyValue; 2] {
+        [
+            KeyValue::str(metrics::attrs::GRPC_TARGET, Arc::clone(&self.target)),
+            KeyValue::str(metrics::attrs::GRPC_XDS_SERVER, Arc::clone(&self.server)),
+        ]
+    }
+
+    fn type_attrs(&self, type_url: &str) -> [KeyValue; 3] {
+        [
+            KeyValue::str(metrics::attrs::GRPC_TARGET, Arc::clone(&self.target)),
+            KeyValue::str(metrics::attrs::GRPC_XDS_SERVER, Arc::clone(&self.server)),
+            KeyValue::str(metrics::attrs::GRPC_XDS_RESOURCE_TYPE, type_url.to_string()),
+        ]
+    }
+
+    fn cache_state_attrs(&self, type_url: &str, cache_state: &'static str) -> [KeyValue; 4] {
+        [
+            KeyValue::str(metrics::attrs::GRPC_TARGET, Arc::clone(&self.target)),
+            KeyValue::str(metrics::attrs::GRPC_XDS_SERVER, Arc::clone(&self.server)),
+            KeyValue::str(metrics::attrs::GRPC_XDS_RESOURCE_TYPE, type_url.to_string()),
+            KeyValue::str(metrics::attrs::GRPC_XDS_CACHE_STATE, cache_state),
+        ]
+    }
+}
+
+/// A78 metric emission verbs on the worker's recorder.
+///
+/// Inherent methods on `dyn MetricsRecorder` (legal because the trait is
+/// defined in this crate). `pub(crate)` keeps them invisible to downstream
+/// consumers — the methods exist only for use by this crate's worker.
+///
+/// Call sites look like `self.recorder.record_X(&self.attrs, ...)`. The
+/// receiver and `attrs` borrow are split-borrow-friendly with `&mut self`
+/// borrows on other worker fields (e.g. `self.type_states`), so the mutation
+/// handlers don't need to be restructured to defer emission.
+impl dyn MetricsRecorder {
+    /// `grpc.xds_client.connected` — 1 for connected, 0 for disconnected.
+    fn record_connected(&self, attrs: &ClientAttrs, connected: bool) {
+        self.record_gauge_i64(
+            &metrics::instruments::XDS_CLIENT_CONNECTED,
+            if connected { 1 } else { 0 },
+            &attrs.connection_attrs(),
+        );
+    }
+
+    /// `grpc.xds_client.server_failure` — incremented once per failed connection cycle.
+    fn record_server_failure(&self, attrs: &ClientAttrs) {
+        self.add_counter_u64(
+            &metrics::instruments::XDS_CLIENT_SERVER_FAILURE,
+            1,
+            &attrs.connection_attrs(),
+        );
+    }
+
+    /// `grpc.xds_client.resource_updates_valid` + `_invalid`, with aggregated
+    /// counts from a single response.
+    fn record_resource_updates(
+        &self,
+        attrs: &ClientAttrs,
+        type_url: &str,
+        valid: u64,
+        invalid: u64,
+    ) {
+        if valid == 0 && invalid == 0 {
+            return;
+        }
+        let type_attrs = attrs.type_attrs(type_url);
+        if valid > 0 {
+            self.add_counter_u64(
+                &metrics::instruments::XDS_CLIENT_RESOURCE_UPDATES_VALID,
+                valid,
+                &type_attrs,
+            );
+        }
+        if invalid > 0 {
+            self.add_counter_u64(
+                &metrics::instruments::XDS_CLIENT_RESOURCE_UPDATES_INVALID,
+                invalid,
+                &type_attrs,
+            );
+        }
+    }
+
+    /// `grpc.xds_client.resources` — up-down-counter deltas for a state transition.
+    /// `prev` is `None` when the resource is being inserted into the cache for the first time.
+    fn record_resource_transition(
+        &self,
+        attrs: &ClientAttrs,
+        type_url: &str,
+        prev: Option<&ResourceState>,
+        new: &ResourceState,
+    ) {
+        let new_label = new.cache_state_label();
+        let prev_label = prev.map(ResourceState::cache_state_label);
+        if prev_label == Some(new_label) {
+            return;
+        }
+        if let Some(prev) = prev_label {
+            self.add_up_down_counter_i64(
+                &metrics::instruments::XDS_CLIENT_RESOURCES,
+                -1,
+                &attrs.cache_state_attrs(type_url, prev),
+            );
+        }
+        self.add_up_down_counter_i64(
+            &metrics::instruments::XDS_CLIENT_RESOURCES,
+            1,
+            &attrs.cache_state_attrs(type_url, new_label),
+        );
+    }
+}
 
 /// Global counter for generating unique watcher IDs.
 static NEXT_WATCHER_ID: AtomicU64 = AtomicU64::new(1);
@@ -112,6 +237,21 @@ enum ResourceState {
     NACKed(String),
     /// Resource does not exist (server indicated deletion or absence).
     DoesNotExist,
+}
+
+impl ResourceState {
+    /// Canonical A78 `grpc.xds.cache_state` attribute value for this state.
+    ///
+    /// When gRFC A88 (data error caching) is implemented, a `NACKedButCached`
+    /// variant will map to `"nacked_but_cached"` here.
+    fn cache_state_label(&self) -> &'static str {
+        match self {
+            ResourceState::Requested => "requested",
+            ResourceState::Received => "acked",
+            ResourceState::NACKed(_) => "nacked",
+            ResourceState::DoesNotExist => "does_not_exist",
+        }
+    }
 }
 
 /// A cached resource entry.
@@ -342,6 +482,10 @@ pub(crate) struct AdsWorker<TB, C, R> {
     /// Cancellation handles for resource timers (gRFC A57).
     /// Key is (type_url, resource_name). Dropping the sender cancels the timer.
     resource_timers: HashMap<(String, String), oneshot::Sender<()>>,
+    /// Backend for recording metrics emitted by the worker (gRFC A78).
+    recorder: Arc<dyn MetricsRecorder>,
+    /// Per-client A78 metric attributes (`grpc.target` + `grpc.xds.server`).
+    attrs: ClientAttrs,
 }
 
 impl<TB, C, R> AdsWorker<TB, C, R>
@@ -358,6 +502,7 @@ where
         config: ClientConfig,
         command_tx: mpsc::Sender<WorkerCommand>,
         command_rx: mpsc::Receiver<WorkerCommand>,
+        recorder: Arc<dyn MetricsRecorder>,
     ) -> Self {
         Self {
             transport_builder,
@@ -371,6 +516,11 @@ where
             command_rx,
             type_states: HashMap::new(),
             resource_timers: HashMap::new(),
+            recorder,
+            attrs: ClientAttrs {
+                target: Arc::from(config.target.unwrap_or_default()),
+                server: Arc::from(""),
+            },
         }
     }
 
@@ -405,6 +555,7 @@ where
                 Some(s) => s,
                 None => return, // No servers configured
             };
+            self.attrs.server = Arc::from(server.uri());
 
             let transport = match self.transport_builder.build(server).await {
                 Ok(t) => t,
@@ -431,9 +582,14 @@ where
                 }
             };
 
-            match self.run_connected(stream).await {
+            self.recorder.record_connected(&self.attrs, true);
+            let result = self.run_connected(stream).await;
+            self.recorder.record_connected(&self.attrs, false);
+
+            match result {
                 Ok(()) => return, // shutdown
                 Err(_e) => {
+                    self.recorder.record_server_failure(&self.attrs);
                     match self.backoff.next_backoff() {
                         Some(backoff) => self.runtime.sleep(backoff).await,
                         None => return, // Max attempts exceeded
@@ -573,14 +729,19 @@ where
 
         // Track if we need to start a timer (resource in Requested state)
         let mut start_timer_for: Option<String> = None;
+        // Track newly-inserted cache entry for the resources gauge (None -> Requested).
+        let mut was_new = false;
 
         // For named subscriptions, check cache and send cached state to new watcher.
         // For wildcard subscriptions, watchers receive updates as they come in.
         if let WatcherSubscription::Named(ref resource_name) = watcher_subscription {
-            let cached = type_state
-                .cache
-                .entry(resource_name.clone())
-                .or_insert_with(CachedResource::requested);
+            let cached = match type_state.cache.entry(resource_name.clone()) {
+                Entry::Vacant(v) => {
+                    was_new = true;
+                    v.insert(CachedResource::requested())
+                }
+                Entry::Occupied(o) => o.into_mut(),
+            };
 
             if let Some(event) = cached.to_event() {
                 // Send cached state to watcher (non-blocking, ignore if full)
@@ -603,6 +764,16 @@ where
         type_state.recalculate_subscriptions();
 
         let subscriptions_changed = type_state.subscription != old_subscription;
+
+        // Emit resources gauge transition for newly-inserted cache entry.
+        if was_new {
+            self.recorder.record_resource_transition(
+                &self.attrs,
+                &type_url_string,
+                None,
+                &ResourceState::Requested,
+            );
+        }
 
         // Start timer if resource is in Requested state
         if let (Some(resource_name), Some(timeout)) =
@@ -708,6 +879,13 @@ where
             }
         }
 
+        // Emit A78 resource_updates_valid/invalid counters once per response with
+        // aggregated counts (equivalent to per-resource increments in any backend).
+        let valid_count = valid_resources.len() as u64;
+        let invalid_count = (top_level_errors.len() + per_resource_errors.len()) as u64;
+        self.recorder
+            .record_resource_updates(&self.attrs, &type_url, valid_count, invalid_count);
+
         if let Some(type_state) = self.type_states.get_mut(&type_url) {
             type_state.nonce = response.nonce.clone();
         }
@@ -784,9 +962,15 @@ where
             Some(s) => {
                 for resource in &resources {
                     let resource_name = resource.name().to_string();
-                    s.cache.insert(
+                    let prev = s.cache.insert(
                         resource_name,
                         CachedResource::received(Arc::new(resource.clone())),
+                    );
+                    self.recorder.record_resource_transition(
+                        &self.attrs,
+                        type_url,
+                        prev.as_ref().map(|c| &c.state),
+                        &ResourceState::Received,
                     );
                 }
                 s.watchers
@@ -835,9 +1019,15 @@ where
             None => return,
         };
 
-        type_state.cache.insert(
+        let prev = type_state.cache.insert(
             resource_name.to_string(),
             CachedResource::nacked(error.to_string()),
+        );
+        self.recorder.record_resource_transition(
+            &self.attrs,
+            type_url,
+            prev.as_ref().map(|c| &c.state),
+            &ResourceState::NACKed(error.to_string()),
         );
 
         // Cancel the resource timer (gRFC A57).
@@ -885,9 +1075,15 @@ where
             .collect();
 
         for name in deleted_names {
-            type_state
+            let prev = type_state
                 .cache
                 .insert(name.clone(), CachedResource::does_not_exist());
+            self.recorder.record_resource_transition(
+                &self.attrs,
+                type_url,
+                prev.as_ref().map(|c| &c.state),
+                &ResourceState::DoesNotExist,
+            );
 
             for event_tx in type_state.matching_watchers(&name) {
                 let (done, rx) = ProcessingDone::channel();
@@ -1015,9 +1211,15 @@ where
             return;
         }
 
-        type_state
+        let prev = type_state
             .cache
             .insert(name.to_string(), CachedResource::does_not_exist());
+        self.recorder.record_resource_transition(
+            &self.attrs,
+            type_url,
+            prev.as_ref().map(|c| &c.state),
+            &ResourceState::DoesNotExist,
+        );
 
         for event_tx in type_state.matching_watchers(name) {
             let (done, _rx) = ProcessingDone::channel();
@@ -1027,5 +1229,178 @@ where
             };
             let _ = event_tx.send(event).await;
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Mutex;
+
+    use super::*;
+
+    /// Captures every measurement so tests can assert on the call sequence.
+    #[derive(Default)]
+    struct CapturingRecorder {
+        events: Mutex<Vec<Recorded>>,
+    }
+
+    #[derive(Debug, PartialEq)]
+    struct Recorded {
+        instrument: &'static str,
+        kind: Measurement,
+        attrs: Vec<(&'static str, String)>,
+    }
+
+    #[derive(Debug, PartialEq)]
+    enum Measurement {
+        CounterU64(u64),
+        UpDownI64(i64),
+        Gauge(i64),
+    }
+
+    impl CapturingRecorder {
+        fn take(&self) -> Vec<Recorded> {
+            std::mem::take(&mut *self.events.lock().unwrap())
+        }
+    }
+
+    fn stringify(attrs: &[KeyValue]) -> Vec<(&'static str, String)> {
+        attrs
+            .iter()
+            .map(|kv| {
+                let v = match &kv.value {
+                    metrics::Value::Bool(b) => b.to_string(),
+                    metrics::Value::Int(i) => i.to_string(),
+                    metrics::Value::F64(f) => f.to_string(),
+                    metrics::Value::Str(s) => s.to_string(),
+                };
+                (kv.key, v)
+            })
+            .collect()
+    }
+
+    impl MetricsRecorder for CapturingRecorder {
+        fn add_counter_u64(
+            &self,
+            instrument: &'static metrics::Instrument,
+            value: u64,
+            attrs: &[KeyValue],
+        ) {
+            self.events.lock().unwrap().push(Recorded {
+                instrument: instrument.name,
+                kind: Measurement::CounterU64(value),
+                attrs: stringify(attrs),
+            });
+        }
+
+        fn add_up_down_counter_i64(
+            &self,
+            instrument: &'static metrics::Instrument,
+            value: i64,
+            attrs: &[KeyValue],
+        ) {
+            self.events.lock().unwrap().push(Recorded {
+                instrument: instrument.name,
+                kind: Measurement::UpDownI64(value),
+                attrs: stringify(attrs),
+            });
+        }
+
+        fn record_histogram_f64(&self, _: &'static metrics::Instrument, _: f64, _: &[KeyValue]) {
+            unreachable!("worker emits no histograms");
+        }
+
+        fn record_gauge_i64(
+            &self,
+            instrument: &'static metrics::Instrument,
+            value: i64,
+            attrs: &[KeyValue],
+        ) {
+            self.events.lock().unwrap().push(Recorded {
+                instrument: instrument.name,
+                kind: Measurement::Gauge(value),
+                attrs: stringify(attrs),
+            });
+        }
+    }
+
+    fn attr<'a>(rec: &'a Recorded, key: &str) -> Option<&'a str> {
+        rec.attrs
+            .iter()
+            .find(|(k, _)| *k == key)
+            .map(|(_, v)| v.as_str())
+    }
+
+    fn test_attrs() -> ClientAttrs {
+        ClientAttrs {
+            target: Arc::from("xds:///my-service"),
+            server: Arc::from("xds.example.com:443"),
+        }
+    }
+
+    /// Returns a (capturing recorder, `dyn`-coerced clone) pair so tests can
+    /// drive emissions through the dyn handle and inspect the recorded events
+    /// through the typed handle.
+    fn test_recorder() -> (Arc<CapturingRecorder>, Arc<dyn MetricsRecorder>) {
+        let recorder = Arc::new(CapturingRecorder::default());
+        let dyn_recorder: Arc<dyn MetricsRecorder> = recorder.clone();
+        (recorder, dyn_recorder)
+    }
+
+    #[test]
+    fn transition_from_none_emits_only_increment() {
+        let (recorder, dyn_recorder) = test_recorder();
+        dyn_recorder.record_resource_transition(
+            &test_attrs(),
+            "envoy.config.listener.v3.Listener",
+            None,
+            &ResourceState::Requested,
+        );
+
+        let events = recorder.take();
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].instrument, "grpc.xds_client.resources");
+        assert_eq!(events[0].kind, Measurement::UpDownI64(1));
+        assert_eq!(attr(&events[0], "grpc.xds.cache_state"), Some("requested"));
+        assert_eq!(
+            attr(&events[0], "grpc.xds.resource_type"),
+            Some("envoy.config.listener.v3.Listener")
+        );
+        assert_eq!(attr(&events[0], "grpc.target"), Some("xds:///my-service"));
+        assert_eq!(
+            attr(&events[0], "grpc.xds.server"),
+            Some("xds.example.com:443")
+        );
+    }
+
+    #[test]
+    fn transition_emits_decrement_then_increment() {
+        let (recorder, dyn_recorder) = test_recorder();
+        dyn_recorder.record_resource_transition(
+            &test_attrs(),
+            "envoy.config.listener.v3.Listener",
+            Some(&ResourceState::Received),
+            &ResourceState::NACKed("validation failed".into()),
+        );
+
+        let events = recorder.take();
+        assert_eq!(events.len(), 2);
+        assert_eq!(events[0].kind, Measurement::UpDownI64(-1));
+        assert_eq!(attr(&events[0], "grpc.xds.cache_state"), Some("acked"));
+        assert_eq!(events[1].kind, Measurement::UpDownI64(1));
+        assert_eq!(attr(&events[1], "grpc.xds.cache_state"), Some("nacked"));
+    }
+
+    #[test]
+    fn transition_to_same_state_is_a_no_op() {
+        let (recorder, dyn_recorder) = test_recorder();
+        dyn_recorder.record_resource_transition(
+            &test_attrs(),
+            "envoy.config.listener.v3.Listener",
+            Some(&ResourceState::NACKed("first".into())),
+            &ResourceState::NACKed("second".into()),
+        );
+
+        assert!(recorder.take().is_empty());
     }
 }

--- a/xds-client/src/client/worker.rs
+++ b/xds-client/src/client/worker.rs
@@ -535,6 +535,17 @@ pub(crate) struct AdsWorker<TB, C, R> {
     recorder: RecorderHandle,
 }
 
+/// Outcome of a connected ADS session (see [`AdsWorker::run_connected`]).
+enum ConnectedOutcome {
+    /// All `XdsClient` handles were dropped; the worker should shut down.
+    Shutdown,
+    /// The ADS stream failed; the worker should reconnect. `saw_response`
+    /// indicates whether at least one response was received before the failure
+    /// — per gRFC A78, a stream that fails after a response is not counted as a
+    /// server failure.
+    Failed { saw_response: bool },
+}
+
 impl<TB, C, R> AdsWorker<TB, C, R>
 where
     TB: TransportBuilder,
@@ -573,6 +584,11 @@ where
     /// This method runs until all `XdsClient` handles are dropped
     /// (which closes the command channel).
     pub(crate) async fn run(mut self) {
+        // gRFC A78 defines `grpc.xds_client.server_failure` as a count of xDS
+        // servers *going from healthy to unhealthy*. `healthy` mirrors the
+        // `connected` gauge so the counter (and gauge) are recorded only on that
+        // transition.
+        let mut healthy = false;
         loop {
             // Wait for at least one subscription before connecting.
             // This prevents deadlock with servers that require a message before
@@ -604,7 +620,7 @@ where
             let transport = match self.transport_builder.build(server).await {
                 Ok(t) => t,
                 Err(_) => {
-                    self.recorder.record_server_failure();
+                    self.record_unhealthy(&mut healthy);
                     match self.backoff.next_backoff() {
                         Some(backoff) => self.runtime.sleep(backoff).await,
                         None => return, // Max attempts exceeded
@@ -619,7 +635,7 @@ where
                     s
                 }
                 Err(_) => {
-                    self.recorder.record_server_failure();
+                    self.record_unhealthy(&mut healthy);
                     match self.backoff.next_backoff() {
                         Some(backoff) => self.runtime.sleep(backoff).await,
                         None => return, // Max attempts exceeded
@@ -628,14 +644,21 @@ where
                 }
             };
 
-            self.recorder.record_connected(true);
-            let result = self.run_connected(stream).await;
-            self.recorder.record_connected(false);
+            if !healthy {
+                self.recorder.record_connected(true);
+                healthy = true;
+            }
 
-            match result {
-                Ok(()) => return, // shutdown
-                Err(_e) => {
-                    self.recorder.record_server_failure();
+            match self.run_connected(stream).await {
+                ConnectedOutcome::Shutdown => return,
+                ConnectedOutcome::Failed { saw_response } => {
+                    // gRFC A78: a server goes unhealthy (one `server_failure`) on
+                    // a connectivity failure or when the ADS stream fails
+                    // *without* seeing a response message. A stream that failed
+                    // after receiving a response is not counted; just reconnect.
+                    if !saw_response {
+                        self.record_unhealthy(&mut healthy);
+                    }
                     match self.backoff.next_backoff() {
                         Some(backoff) => self.runtime.sleep(backoff).await,
                         None => return, // Max attempts exceeded
@@ -643,6 +666,19 @@ where
                     continue;
                 }
             }
+        }
+    }
+
+    /// Record an xDS server transition to unhealthy (gRFC A78
+    /// `grpc.xds_client.server_failure`). Increments the `server_failure`
+    /// counter and drops the `connected` gauge to 0, but only on the
+    /// healthy -> unhealthy edge, so repeated reconnect attempts during a single
+    /// outage are not counted.
+    fn record_unhealthy(&self, healthy: &mut bool) {
+        if *healthy {
+            self.recorder.record_server_failure();
+            self.recorder.record_connected(false);
+            *healthy = false;
         }
     }
 
@@ -679,28 +715,38 @@ where
 
     /// Run the main event loop while connected.
     ///
-    /// Returns `Ok(())` if the worker should shut down (command channel closed).
-    /// Returns `Err` if an error occurred and the worker should reconnect.
-    async fn run_connected<S: TransportStream>(&mut self, mut stream: S) -> Result<()> {
+    /// Returns [`ConnectedOutcome::Shutdown`] if the worker should shut down
+    /// (command channel closed), or [`ConnectedOutcome::Failed`] if the stream
+    /// failed and the worker should reconnect (carrying whether a response was
+    /// seen, per gRFC A78).
+    async fn run_connected<S: TransportStream>(&mut self, mut stream: S) -> ConnectedOutcome {
+        // Whether at least one response was received on this stream. Per gRFC
+        // A78 a stream that fails *after* receiving a response is not counted as
+        // a server failure.
+        let mut saw_response = false;
         loop {
             tokio::select! {
                 result = stream.recv() => {
                     match result {
                         Ok(Some(bytes)) => {
-                            self.handle_response(&mut stream, bytes).await?;
+                            saw_response = true;
+                            if self.handle_response(&mut stream, bytes).await.is_err() {
+                                return ConnectedOutcome::Failed { saw_response };
+                            }
                         }
-                        // Stream closed by server; return Err to trigger reconnection
-                        Ok(None) => return Err(Error::StreamClosed),
-                        Err(e) => return Err(e),
+                        // Stream closed by server or errored; reconnect.
+                        Ok(None) | Err(_) => return ConnectedOutcome::Failed { saw_response },
                     }
                 }
 
                 cmd = self.command_rx.recv() => {
                     match cmd {
                         Some(cmd) => {
-                            self.handle_command(Some(&mut stream), cmd).await?;
+                            if self.handle_command(Some(&mut stream), cmd).await.is_err() {
+                                return ConnectedOutcome::Failed { saw_response };
+                            }
                         }
-                        None => return Ok(()),
+                        None => return ConnectedOutcome::Shutdown,
                     }
                 }
             }

--- a/xds-client/src/lib.rs
+++ b/xds-client/src/lib.rs
@@ -67,9 +67,7 @@ pub use client::{XdsClient, XdsClientBuilder};
 pub use codec::XdsCodec;
 pub use error::{Error, Result};
 pub use message::{DiscoveryRequest, DiscoveryResponse, ErrorDetail, Locality, Node, ResourceAny};
-pub use metrics::{
-    Instrument, InstrumentKind, KeyValue, MetricsRecorder, NoOpRecorder, StringValue, Value,
-};
+pub use metrics::{Instrument, InstrumentKind, KeyValue, MetricsRecorder, StringValue, Value};
 pub use resource::{DecodeResult, DecodedResource, Resource};
 pub use runtime::Runtime;
 pub use transport::{Transport, TransportBuilder, TransportStream};

--- a/xds-client/src/lib.rs
+++ b/xds-client/src/lib.rs
@@ -55,6 +55,7 @@ pub mod client;
 pub mod codec;
 pub mod error;
 pub mod message;
+pub mod metrics;
 pub mod resource;
 pub mod runtime;
 pub mod transport;
@@ -66,6 +67,9 @@ pub use client::{XdsClient, XdsClientBuilder};
 pub use codec::XdsCodec;
 pub use error::{Error, Result};
 pub use message::{DiscoveryRequest, DiscoveryResponse, ErrorDetail, Locality, Node, ResourceAny};
+pub use metrics::{
+    Instrument, InstrumentKind, KeyValue, MetricsRecorder, NoOpRecorder, StringValue, Value,
+};
 pub use resource::{DecodeResult, DecodedResource, Resource};
 pub use runtime::Runtime;
 pub use transport::{Transport, TransportBuilder, TransportStream};

--- a/xds-client/src/metrics.rs
+++ b/xds-client/src/metrics.rs
@@ -1,0 +1,301 @@
+//! Metrics extension point for xds-client.
+//!
+//! Defines a framework-agnostic [`MetricsRecorder`] trait that backends implement
+//! to receive metric measurements emitted by the client. Modeled after gRFC A79's
+//! `MetricsRecorder` abstraction.
+//!
+//! Only [`NoOpRecorder`] is provided in this crate today; consumers wanting to
+//! ship metrics to a real backend must implement [`MetricsRecorder`] themselves.
+//! A bundled OpenTelemetry implementation behind an `otel` Cargo feature is
+//! planned but not yet implemented.
+//!
+//! # Example
+//!
+//! ```ignore
+//! use std::sync::Arc;
+//! use xds_client::metrics::{MetricsRecorder, NoOpRecorder};
+//!
+//! let recorder: Arc<dyn MetricsRecorder> = Arc::new(NoOpRecorder);
+//! let client = XdsClient::builder(config, transport, codec, runtime)
+//!     .with_metrics_recorder(recorder)
+//!     .build();
+//! ```
+
+use std::borrow::Cow;
+use std::fmt;
+use std::sync::Arc;
+
+/// Static descriptor for a metric instrument.
+///
+/// One `Instrument` is declared per metric as a `pub static` constant. Call
+/// sites reference instruments by `&'static Instrument`. Backend implementations
+/// may use the instrument address as a cache key (`instrument as *const _`).
+#[derive(Debug)]
+pub struct Instrument {
+    /// Metric name (e.g. `"grpc.xds_client.connected"`).
+    pub name: &'static str,
+    /// Human-readable description.
+    pub description: &'static str,
+    /// OpenTelemetry unit notation (e.g. `"s"`, `"By"`, `"{bool}"`, `"{resource}"`).
+    pub unit: &'static str,
+    /// The kind of instrument.
+    pub kind: InstrumentKind,
+}
+
+/// The kind of metric instrument.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum InstrumentKind {
+    /// Monotonic `u64` counter.
+    Counter,
+    /// Bidirectional `i64` counter, used for gauges emitted as deltas
+    /// (e.g. `grpc.xds_client.resources`).
+    UpDownCounter,
+    /// Distribution of `f64` values.
+    Histogram,
+    /// Last-value `i64` gauge (push model).
+    Gauge,
+}
+
+/// An attribute key/value pair attached to a single measurement.
+#[derive(Debug, Clone)]
+pub struct KeyValue {
+    /// Attribute name. Keys are `'static` because the set of attribute keys
+    /// per metric is fixed.
+    pub key: &'static str,
+    /// Attribute value.
+    pub value: Value,
+}
+
+impl KeyValue {
+    /// Construct a string-valued attribute.
+    ///
+    /// Accepts any value convertible to [`StringValue`]: `&'static str`,
+    /// `String`, `Box<str>`, `Arc<str>`, or `Cow<'static, str>`. The choice
+    /// affects allocation cost — see [`StringValue`].
+    pub fn str(key: &'static str, value: impl Into<StringValue>) -> Self {
+        Self {
+            key,
+            value: Value::Str(value.into()),
+        }
+    }
+
+    /// Construct a boolean-valued attribute.
+    pub fn bool(key: &'static str, value: bool) -> Self {
+        Self {
+            key,
+            value: Value::Bool(value),
+        }
+    }
+
+    /// Construct an integer-valued attribute.
+    pub fn int(key: &'static str, value: i64) -> Self {
+        Self {
+            key,
+            value: Value::Int(value),
+        }
+    }
+
+    /// Construct an f64-valued attribute.
+    pub fn f64(key: &'static str, value: f64) -> Self {
+        Self {
+            key,
+            value: Value::F64(value),
+        }
+    }
+}
+
+/// A typed attribute value.
+#[derive(Debug, Clone)]
+pub enum Value {
+    /// Boolean value.
+    Bool(bool),
+    /// Signed 64-bit integer value.
+    Int(i64),
+    /// 64-bit floating-point value.
+    F64(f64),
+    /// String value. See [`StringValue`] for ownership modes.
+    Str(StringValue),
+}
+
+/// String attribute value with three ownership modes.
+///
+/// Mirrors the `OtelString` design from the OpenTelemetry Rust SDK: a single
+/// non-lifetime-parameterized type that supports static borrows, owned strings,
+/// and refcounted strings. This keeps [`MetricsRecorder`] trait object-safe
+/// while letting callers pick the cheapest representation for the value at
+/// hand:
+///
+/// - [`Static`](Self::Static) — for compile-time-known values
+///   (e.g. cache_state labels like `"acked"`). Zero allocation.
+/// - [`Owned`](Self::Owned) — for runtime-built strings the recorder will own.
+///   One heap allocation per value.
+/// - [`RefCounted`](Self::RefCounted) — for runtime values shared across many
+///   emissions (e.g. the channel target stored on the worker). Cloning is one
+///   atomic op, no allocation.
+///
+/// `From` impls cover the common conversions, so call sites usually need only
+/// `KeyValue::str(KEY, value)` with whatever string-like type they have.
+#[derive(Debug, Clone)]
+pub enum StringValue {
+    /// Compile-time known string. Zero-cost.
+    Static(&'static str),
+    /// Owned runtime-built string.
+    Owned(Box<str>),
+    /// Reference-counted string. Cheap to clone (atomic op only).
+    RefCounted(Arc<str>),
+}
+
+impl StringValue {
+    /// Borrow the string content regardless of variant.
+    pub fn as_str(&self) -> &str {
+        match self {
+            StringValue::Static(s) => s,
+            StringValue::Owned(s) => s,
+            StringValue::RefCounted(s) => s,
+        }
+    }
+}
+
+impl AsRef<str> for StringValue {
+    fn as_ref(&self) -> &str {
+        self.as_str()
+    }
+}
+
+impl fmt::Display for StringValue {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+impl From<&'static str> for StringValue {
+    fn from(s: &'static str) -> Self {
+        StringValue::Static(s)
+    }
+}
+
+impl From<String> for StringValue {
+    fn from(s: String) -> Self {
+        StringValue::Owned(s.into_boxed_str())
+    }
+}
+
+impl From<Box<str>> for StringValue {
+    fn from(s: Box<str>) -> Self {
+        StringValue::Owned(s)
+    }
+}
+
+impl From<Arc<str>> for StringValue {
+    fn from(s: Arc<str>) -> Self {
+        StringValue::RefCounted(s)
+    }
+}
+
+impl From<Cow<'static, str>> for StringValue {
+    fn from(c: Cow<'static, str>) -> Self {
+        match c {
+            Cow::Borrowed(s) => StringValue::Static(s),
+            Cow::Owned(s) => StringValue::Owned(s.into_boxed_str()),
+        }
+    }
+}
+
+/// Backend interface for recording metric measurements.
+///
+/// Implementors translate calls into measurements on their telemetry backend.
+/// Implementations must be cheap and lock-free where possible since these calls
+/// happen on hot paths.
+pub trait MetricsRecorder: Send + Sync + 'static {
+    /// Add a value to a monotonic counter.
+    fn add_counter_u64(&self, instrument: &'static Instrument, value: u64, attrs: &[KeyValue]);
+
+    /// Add a (possibly negative) delta to an up-down counter.
+    fn add_up_down_counter_i64(
+        &self,
+        instrument: &'static Instrument,
+        value: i64,
+        attrs: &[KeyValue],
+    );
+
+    /// Record a value in a histogram.
+    fn record_histogram_f64(&self, instrument: &'static Instrument, value: f64, attrs: &[KeyValue]);
+
+    /// Record the current value of a push-model gauge.
+    fn record_gauge_i64(&self, instrument: &'static Instrument, value: i64, attrs: &[KeyValue]);
+}
+
+/// A zero-cost recorder that discards all measurements.
+///
+/// Used as the default when no backend is configured.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct NoOpRecorder;
+
+impl MetricsRecorder for NoOpRecorder {
+    fn add_counter_u64(&self, _: &'static Instrument, _: u64, _: &[KeyValue]) {}
+    fn add_up_down_counter_i64(&self, _: &'static Instrument, _: i64, _: &[KeyValue]) {}
+    fn record_histogram_f64(&self, _: &'static Instrument, _: f64, _: &[KeyValue]) {}
+    fn record_gauge_i64(&self, _: &'static Instrument, _: i64, _: &[KeyValue]) {}
+}
+
+/// Instrument descriptors for the gRFC A78 XdsClient metrics emitted by this crate.
+pub mod instruments {
+    use super::{Instrument, InstrumentKind};
+
+    /// `grpc.xds_client.connected` — gauge indicating whether the client has an active ADS stream.
+    pub static XDS_CLIENT_CONNECTED: Instrument = Instrument {
+        name: "grpc.xds_client.connected",
+        description: "Whether the xDS client currently has an active ADS stream to the xDS server.",
+        unit: "{bool}",
+        kind: InstrumentKind::Gauge,
+    };
+
+    /// `grpc.xds_client.server_failure` — counter of xDS server failure transitions.
+    pub static XDS_CLIENT_SERVER_FAILURE: Instrument = Instrument {
+        name: "grpc.xds_client.server_failure",
+        description: "Number of times the xDS server transitioned from healthy to unhealthy.",
+        unit: "{failure}",
+        kind: InstrumentKind::Counter,
+    };
+
+    /// `grpc.xds_client.resource_updates_valid` — counter of resources received and successfully decoded.
+    pub static XDS_CLIENT_RESOURCE_UPDATES_VALID: Instrument = Instrument {
+        name: "grpc.xds_client.resource_updates_valid",
+        description: "Number of resources received and successfully decoded.",
+        unit: "{resource}",
+        kind: InstrumentKind::Counter,
+    };
+
+    /// `grpc.xds_client.resource_updates_invalid` — counter of resources that failed codec-level validation.
+    pub static XDS_CLIENT_RESOURCE_UPDATES_INVALID: Instrument = Instrument {
+        name: "grpc.xds_client.resource_updates_invalid",
+        description: "Number of resources received that failed codec-level validation.",
+        unit: "{resource}",
+        kind: InstrumentKind::Counter,
+    };
+
+    /// `grpc.xds_client.resources` — gauge of cached xDS resources, emitted as up-down-counter deltas.
+    ///
+    /// Use `cache_state` attribute values from [`super::cache_state`].
+    pub static XDS_CLIENT_RESOURCES: Instrument = Instrument {
+        name: "grpc.xds_client.resources",
+        description: "Number of xDS resources currently cached, broken down by cache state.",
+        unit: "{resource}",
+        kind: InstrumentKind::UpDownCounter,
+    };
+}
+
+/// Attribute keys used by the gRFC A78 XdsClient metrics.
+pub mod attrs {
+    /// `grpc.target` — the channel target (configured xDS URI).
+    pub const GRPC_TARGET: &str = "grpc.target";
+    /// `grpc.xds.server` — URI of the xDS server.
+    pub const GRPC_XDS_SERVER: &str = "grpc.xds.server";
+    /// `grpc.xds.authority` — xDS authority name (when bootstrap defines named authorities).
+    pub const GRPC_XDS_AUTHORITY: &str = "grpc.xds.authority";
+    /// `grpc.xds.cache_state` — cache state of a resource. Canonical values per
+    /// gRFC A78: `requested`, `acked`, `nacked`, `does_not_exist`, `nacked_but_cached`.
+    pub const GRPC_XDS_CACHE_STATE: &str = "grpc.xds.cache_state";
+    /// `grpc.xds.resource_type` — type URL of the resource.
+    pub const GRPC_XDS_RESOURCE_TYPE: &str = "grpc.xds.resource_type";
+}

--- a/xds-client/src/metrics.rs
+++ b/xds-client/src/metrics.rs
@@ -4,18 +4,21 @@
 //! to receive metric measurements emitted by the client. Modeled after gRFC A79's
 //! `MetricsRecorder` abstraction.
 //!
-//! Only [`NoOpRecorder`] is provided in this crate today; consumers wanting to
-//! ship metrics to a real backend must implement [`MetricsRecorder`] themselves.
-//! A bundled OpenTelemetry implementation behind an `otel` Cargo feature is
-//! planned but not yet implemented.
+//! No bundled implementation is provided in this crate today; consumers wanting
+//! to ship metrics to a real backend must implement [`MetricsRecorder`]
+//! themselves. A bundled OpenTelemetry implementation behind an `otel` Cargo
+//! feature is planned but not yet implemented.
 //!
 //! # Example
 //!
 //! ```ignore
 //! use std::sync::Arc;
-//! use xds_client::metrics::{MetricsRecorder, NoOpRecorder};
+//! use xds_client::metrics::MetricsRecorder;
 //!
-//! let recorder: Arc<dyn MetricsRecorder> = Arc::new(NoOpRecorder);
+//! struct MyRecorder;
+//! impl MetricsRecorder for MyRecorder { /* ... */ }
+//!
+//! let recorder: Arc<dyn MetricsRecorder> = Arc::new(MyRecorder);
 //! let client = XdsClient::builder(config, transport, codec, runtime)
 //!     .with_metrics_recorder(recorder)
 //!     .build();
@@ -223,19 +226,6 @@ pub trait MetricsRecorder: Send + Sync + 'static {
 
     /// Record the current value of a push-model gauge.
     fn record_gauge_i64(&self, instrument: &'static Instrument, value: i64, attrs: &[KeyValue]);
-}
-
-/// A zero-cost recorder that discards all measurements.
-///
-/// Used as the default when no backend is configured.
-#[derive(Debug, Default, Clone, Copy)]
-pub struct NoOpRecorder;
-
-impl MetricsRecorder for NoOpRecorder {
-    fn add_counter_u64(&self, _: &'static Instrument, _: u64, _: &[KeyValue]) {}
-    fn add_up_down_counter_i64(&self, _: &'static Instrument, _: i64, _: &[KeyValue]) {}
-    fn record_histogram_f64(&self, _: &'static Instrument, _: f64, _: &[KeyValue]) {}
-    fn record_gauge_i64(&self, _: &'static Instrument, _: i64, _: &[KeyValue]) {}
 }
 
 /// Instrument descriptors for the gRFC A78 XdsClient metrics emitted by this crate.


### PR DESCRIPTION
## Motivation

Ref: #2444 

Improve the production readiness of `tonic-xds` library by supporting metrics.

## Solution

This PR builds the foundation for the following metrics-related gRFCs support in `tonic-xds`:

1. [A78: XdsClient metrics](https://github.com/grpc/proposal/blob/master/A78-grpc-metrics-wrr-pf-xds.md)
2. [A79: framework-agnostic non-per-call metrics abstraction](https://github.com/grpc/proposal/blob/master/A79-non-per-call-metrics-architecture.md)

It adds the following:

1. `MetricsRecorder` trait, allowing external users to build any telemetry framework integration they need.
2.  5 A78 XdsClient metrics definition: `grpc.xds_client.{connected, server_failure, resource_updates_valid, resource_updates_invalid, resources}`

A follow-up PR to add a bundled OpenTelemetry implementation is planned.