### PR TITLE
grpc: add payload to load_balancing's work/schedule_work

### DIFF
--- a/grpc/src/client/channel.rs
+++ b/grpc/src/client/channel.rs
@@ -26,7 +26,6 @@
 
 use core::panic;
 use std::error::Error;
-use std::mem;
 use std::str::FromStr;
 use std::sync::Arc;
 use std::sync::Mutex;
@@ -54,6 +53,7 @@ use crate::client::load_balancing::ParsedJsonLbConfig;
 use crate::client::load_balancing::PickResult;
 use crate::client::load_balancing::Picker;
 use crate::client::load_balancing::QueuingPicker;
+use crate::client::load_balancing::WorkData;
 use crate::client::load_balancing::WorkScheduler;
 use crate::client::load_balancing::graceful_switch::GracefulSwitchPolicy;
 use crate::client::load_balancing::pick_first;
@@ -344,15 +344,10 @@ impl ActiveChannel {
                         resolver.work(&mut resolver_channel_controller)
                     }
                     WorkQueueItem::ResolveNow => resolver.resolve_now(),
-                    WorkQueueItem::ScheduleLbPolicy => {
-                        *resolver_channel_controller
-                            .lb_work_scheduler
-                            .pending
-                            .lock()
-                            .unwrap() = false;
+                    WorkQueueItem::ScheduleLbPolicy(data) => {
                         resolver_channel_controller
                             .lb_policy
-                            .work(&mut resolver_channel_controller.lb_channel_controller);
+                            .work(data, &mut resolver_channel_controller.lb_channel_controller);
                     }
                     WorkQueueItem::SubchannelStateUpdate { subchannel, state } => {
                         resolver_channel_controller.lb_policy.subchannel_update(
@@ -447,10 +442,7 @@ impl ResolverChannelController {
         lb_watcher: Arc<Watcher<LbState>>,
         security_opts: SecurityOpts,
     ) -> Self {
-        let lb_work_scheduler = Arc::new(LbWorkScheduler {
-            pending: Mutex::default(),
-            wqtx: wqtx.clone(),
-        });
+        let lb_work_scheduler = Arc::new(LbWorkScheduler { wqtx: wqtx.clone() });
         let lb_channel_controller = LbChannelController {
             lb_work_scheduler: lb_work_scheduler.clone(),
             transport_registry: GLOBAL_TRANSPORT_REGISTRY.clone(),
@@ -538,23 +530,18 @@ impl load_balancing::ChannelController for LbChannelController {
 
 #[derive(Debug)]
 struct LbWorkScheduler {
-    pending: Mutex<bool>,
     wqtx: WorkQueueTx,
 }
 
 impl WorkScheduler for LbWorkScheduler {
-    fn schedule_work(&self) {
-        if mem::replace(&mut *self.pending.lock().unwrap(), true) {
-            // Already had a pending call scheduled.
-            return;
-        }
-        _ = self.wqtx.send(WorkQueueItem::ScheduleLbPolicy);
+    fn schedule_work(&self, data: Option<WorkData>) {
+        _ = self.wqtx.send(WorkQueueItem::ScheduleLbPolicy(data));
     }
 }
 
 pub(super) enum WorkQueueItem {
     // Call the LB policy to do work.
-    ScheduleLbPolicy,
+    ScheduleLbPolicy(Option<WorkData>),
     // Provide the subchannel state update to the LB policy.
     SubchannelStateUpdate {
         subchannel: Arc<dyn Subchannel>,

--- a/grpc/src/client/load_balancing/child_manager.rs
+++ b/grpc/src/client/load_balancing/child_manager.rs
@@ -26,13 +26,11 @@
 //! purposes of forwarding channel updates.
 
 use std::collections::HashMap;
-use std::collections::HashSet;
 use std::error::Error;
 use std::fmt::Debug;
 use std::hash::Hash;
 use std::mem;
 use std::sync::Arc;
-use std::sync::Mutex;
 
 use crate::client::ConnectivityState;
 use crate::client::load_balancing::ChannelController;
@@ -43,6 +41,7 @@ use crate::client::load_balancing::LbPolicyOptions;
 use crate::client::load_balancing::LbState;
 use crate::client::load_balancing::Subchannel;
 use crate::client::load_balancing::SubchannelState;
+use crate::client::load_balancing::WorkData;
 use crate::client::load_balancing::WorkScheduler;
 use crate::client::load_balancing::subchannel::WeakSubchannel;
 use crate::client::name_resolution::Address;
@@ -53,8 +52,8 @@ use crate::rt::GrpcRuntime;
 #[derive(Debug)]
 pub(crate) struct ChildManager<T: Debug> {
     subchannel_to_child_idx: HashMap<WeakSubchannel, usize>,
+    handle_to_child_idx: HashMap<ChildHandle, usize>,
     children: Vec<Child<T>>,
-    pending_work: Arc<Mutex<HashSet<usize>>>,
     runtime: GrpcRuntime,
     updated: bool, // Set when any child updates its picker; cleared when accessed.
     work_scheduler: Arc<dyn WorkScheduler>,
@@ -95,8 +94,8 @@ where
     pub fn new(runtime: GrpcRuntime, work_scheduler: Arc<dyn WorkScheduler>) -> Self {
         Self {
             subchannel_to_child_idx: Default::default(),
+            handle_to_child_idx: Default::default(),
             children: Default::default(),
-            pending_work: Default::default(),
             runtime,
             work_scheduler,
             updated: false,
@@ -193,14 +192,6 @@ where
         ids_builders: impl IntoIterator<Item = (T, Arc<DynLbPolicyBuilder>)>,
         retain_only: bool,
     ) {
-        // Hold the lock to prevent new work requests during this operation and
-        // rewrite the indices.
-        let mut pending_work = self.pending_work.lock().unwrap();
-
-        // Reset pending work; we will re-add any entries it contains with the
-        // right index later.
-        let old_pending_work = mem::take(&mut *pending_work);
-
         // Replace self.children with an empty vec.
         let old_children = mem::take(&mut self.children);
 
@@ -235,20 +226,23 @@ where
             })
             .collect();
 
+        // Clear handle index map.
+        self.handle_to_child_idx.clear();
+
         // Transfer children whose identifiers appear before and after the
         // update, and create new children.  Add entries back into the
         // subchannel map.
-        for (new_idx, (identifier, builder)) in ids_builders.into_iter().enumerate() {
+        for (identifier, builder) in ids_builders {
             let k = (builder.name(), identifier);
             if let Some(old_child) = old_children.remove(&k) {
                 let old_idx = old_child.identifier;
+                let new_child_idx = self.children.len();
                 for subchannel in mem::take(&mut old_child_subchannels[old_idx]) {
-                    self.subchannel_to_child_idx.insert(subchannel, new_idx);
+                    self.subchannel_to_child_idx
+                        .insert(subchannel, new_child_idx);
                 }
-                if old_pending_work.contains(&old_idx) {
-                    pending_work.insert(new_idx);
-                }
-                *old_child.work_scheduler.idx.lock().unwrap() = Some(new_idx);
+                self.handle_to_child_idx
+                    .insert(old_child.work_scheduler.handle.clone(), new_child_idx);
                 self.children.push(Child {
                     builder,
                     identifier: k.1,
@@ -257,10 +251,13 @@ where
                     work_scheduler: old_child.work_scheduler,
                 });
             } else if !retain_only {
+                let handle = ChildHandle(Arc::new(()));
+                let new_child_idx = self.children.len();
+                self.handle_to_child_idx
+                    .insert(handle.clone(), new_child_idx);
                 let work_scheduler = Arc::new(ChildWorkScheduler {
-                    pending_work: self.pending_work.clone(),
-                    idx: Mutex::new(Some(new_idx)),
                     work_scheduler: self.work_scheduler.clone(),
+                    handle,
                 });
                 let policy = builder.build(LbPolicyOptions {
                     work_scheduler: work_scheduler.clone(),
@@ -274,11 +271,6 @@ where
                     work_scheduler,
                 });
             };
-        }
-
-        // Invalidate all deleted children's work_schedulers.
-        for (_, old_child) in old_children {
-            old_child.work_scheduler.invalidate();
         }
         // Anything left in old_children will just be Dropped and cleaned up.
     }
@@ -390,14 +382,19 @@ where
     }
 
     /// Calls work on any children that scheduled work via the work scheduler.
-    pub fn work(&mut self, channel_controller: &mut dyn ChannelController) {
-        let child_idxes = mem::take(&mut *self.pending_work.lock().unwrap());
-        for child_idx in child_idxes {
-            let mut channel_controller = WrappedController::new(channel_controller);
-            self.children[child_idx]
-                .policy
-                .work(&mut channel_controller);
-            self.resolve_child_controller(channel_controller, child_idx);
+    pub fn work(&mut self, data: Option<WorkData>, channel_controller: &mut dyn ChannelController) {
+        if let Some(data) = data
+            && let Ok(child_work_item) = data.downcast::<ChildWorkItem>()
+        {
+            let child_work_item = *child_work_item;
+            if let Some(&child_idx) = self.handle_to_child_idx.get(&child_work_item.handle) {
+                let child = &mut self.children[child_idx];
+                let mut channel_controller = WrappedController::new(channel_controller);
+                child
+                    .policy
+                    .work(child_work_item.data, &mut channel_controller);
+                self.resolve_child_controller(channel_controller, child_idx);
+            }
         }
     }
 
@@ -444,30 +441,41 @@ impl ChannelController for WrappedController<'_> {
     }
 }
 
-#[derive(Debug)]
-struct ChildWorkScheduler {
-    work_scheduler: Arc<dyn WorkScheduler>, // The real work scheduler of the channel.
-    pending_work: Arc<Mutex<HashSet<usize>>>, // Must be taken first for correctness
-    idx: Mutex<Option<usize>>,              // None if the child is deleted.
-}
+#[derive(Clone, Debug)]
+struct ChildHandle(Arc<()>);
 
-impl WorkScheduler for ChildWorkScheduler {
-    fn schedule_work(&self) {
-        let mut pending_work = self.pending_work.lock().unwrap();
-        // If self.idx is None then this WorkScheduler has been invalidated as
-        // it is associated with a deleted child; do nothing in that case.
-        if let Some(idx) = *self.idx.lock().unwrap() {
-            pending_work.insert(idx);
-            self.work_scheduler.schedule_work();
-        }
+impl PartialEq for ChildHandle {
+    fn eq(&self, other: &Self) -> bool {
+        Arc::ptr_eq(&self.0, &other.0)
     }
 }
 
-impl ChildWorkScheduler {
-    // Sets the ChildWorkScheduler so that it will not honor future
-    // schedule_work requests.
-    fn invalidate(&self) {
-        *self.idx.lock().unwrap() = None;
+impl Eq for ChildHandle {}
+
+impl std::hash::Hash for ChildHandle {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        Arc::as_ptr(&self.0).hash(state);
+    }
+}
+
+struct ChildWorkItem {
+    handle: ChildHandle,
+    data: Option<WorkData>,
+}
+
+#[derive(Debug)]
+struct ChildWorkScheduler {
+    work_scheduler: Arc<dyn WorkScheduler>, // The real work scheduler of the channel.
+    handle: ChildHandle,
+}
+
+impl WorkScheduler for ChildWorkScheduler {
+    fn schedule_work(&self, data: Option<WorkData>) {
+        let wrapped: Option<WorkData> = Some(Box::new(ChildWorkItem {
+            handle: self.handle.clone(),
+            data,
+        }));
+        self.work_scheduler.schedule_work(wrapped);
     }
 }
 
@@ -826,7 +834,10 @@ mod test {
         requested_work: bool,
     }
 
-    fn create_funcs_for_schedule_work_tests(name: &'static str) -> StubPolicyFuncs {
+    fn create_funcs_for_schedule_work_tests(
+        name: &'static str,
+        work_called: Arc<Mutex<HashMap<&'static str, bool>>>,
+    ) -> StubPolicyFuncs {
         StubPolicyFuncs {
             resolver_update: Some(Arc::new(move |data, _update, lbcfg, _controller| {
                 if data.test_data.is_none() {
@@ -850,11 +861,11 @@ mod test {
                     .contains_key(name)
                 {
                     stubdata.requested_work = true;
-                    data.lb_policy_options.work_scheduler.schedule_work();
+                    data.lb_policy_options.work_scheduler.schedule_work(None);
                 }
                 Ok(())
             })),
-            work: Some(Arc::new(move |data, _controller| {
+            work: Some(Arc::new(move |data, _workitem, _controller| {
                 println!("work called for {name}");
                 let stubdata = data
                     .test_data
@@ -863,6 +874,7 @@ mod test {
                     .downcast_mut::<ScheduleWorkStubData>()
                     .unwrap();
                 stubdata.requested_work = false;
+                work_called.lock().unwrap().insert(name, true);
             })),
             ..Default::default()
         }
@@ -874,8 +886,16 @@ mod test {
     fn childmanager_schedule_work_works() {
         let name1 = "childmanager_schedule_work_works-one";
         let name2 = "childmanager_schedule_work_works-two";
-        test_utils::reg_stub_policy(name1, create_funcs_for_schedule_work_tests(name1));
-        test_utils::reg_stub_policy(name2, create_funcs_for_schedule_work_tests(name2));
+        let work_called = Arc::new(Mutex::new(HashMap::<&'static str, bool>::new()));
+
+        test_utils::reg_stub_policy(
+            name1,
+            create_funcs_for_schedule_work_tests(name1, work_called.clone()),
+        );
+        test_utils::reg_stub_policy(
+            name2,
+            create_funcs_for_schedule_work_tests(name2, work_called.clone()),
+        );
 
         let (tx_events, rx_events) = mpsc::channel::<TestEvent>();
         let mut tcc = TestChannelController {
@@ -905,43 +925,79 @@ mod test {
         });
         child_manager.update(updates.clone(), &mut tcc).unwrap();
 
+        let child1_handle = child_manager.children[0].work_scheduler.handle.clone();
+        let child2_handle = child_manager.children[1].work_scheduler.handle.clone();
+
         // Confirm that child one has requested work.
-        match rx_events.recv().unwrap() {
-            TestEvent::ScheduleWork => {}
-            other => panic!("unexpected event {:?}", other),
+        let event = rx_events.recv().unwrap();
+        let TestEvent::ScheduleWork(data) = event else {
+            panic!("unexpected event {:?}", event);
         };
-        assert_eq!(child_manager.pending_work.lock().unwrap().len(), 1);
-        let idx = *child_manager
-            .pending_work
-            .lock()
-            .unwrap()
-            .iter()
-            .next()
-            .unwrap();
-        assert_eq!(child_manager.children[idx].builder.name(), name1);
+        // Validate data indicates the child to call.
+        {
+            let wrapped = data
+                .as_ref()
+                .unwrap()
+                .downcast_ref::<super::ChildWorkItem>()
+                .unwrap();
+            assert_eq!(wrapped.handle, child1_handle);
+        }
 
-        // Perform the work call and assert the pending_work set is empty.
-        child_manager.work(&mut tcc);
-        assert_eq!(child_manager.pending_work.lock().unwrap().len(), 0);
+        // Perform the work call.
+        child_manager.work(data, &mut tcc);
+        // Validate that this call made it to the child.
+        assert!(*work_called.lock().unwrap().get(name1).unwrap_or(&false));
+        assert!(!*work_called.lock().unwrap().get(name2).unwrap_or(&false));
 
-        // Now have both children request work.
+        // Clear work_called state.
+        work_called.lock().unwrap().clear();
+
+        // Now request that both children request work.
         children.lock().unwrap().insert(name2, ());
 
         child_manager.update(updates.clone(), &mut tcc).unwrap();
 
-        // Confirm that both children requested work.
-        match rx_events.recv().unwrap() {
-            TestEvent::ScheduleWork => {}
-            other => panic!("unexpected event {:?}", other),
-        };
-        assert_eq!(child_manager.pending_work.lock().unwrap().len(), 2);
+        // Expect two ScheduleWork events. Since they both happened, let's collect them.
+        let mut works = vec![];
+        for _ in 0..2 {
+            let event = rx_events.recv().unwrap();
+            let TestEvent::ScheduleWork(data) = event else {
+                panic!("unexpected event {:?}", event);
+            };
+            works.push(data);
+        }
 
-        // Perform the work call and assert the pending_work set is empty.
-        child_manager.work(&mut tcc);
-        assert_eq!(child_manager.pending_work.lock().unwrap().len(), 0);
+        // We expect one work item for child1 and one for child2.
+        let mut child1_work = None;
+        let mut child2_work = None;
 
-        // Perform one final call to resolver_update which asserts that both
-        // child policies had their work methods called.
-        child_manager.update(updates, &mut tcc).unwrap();
+        for work in works {
+            let handle = work
+                .as_ref()
+                .unwrap()
+                .downcast_ref::<super::ChildWorkItem>()
+                .unwrap()
+                .handle
+                .clone();
+            if handle == child1_handle {
+                child1_work = Some(work);
+            } else if handle == child2_handle {
+                child2_work = Some(work);
+            } else {
+                panic!("unexpected child handle");
+            }
+        }
+
+        let child1_work = child1_work.expect("should have scheduled work for child 1");
+        let child2_work = child2_work.expect("should have scheduled work for child 2");
+
+        // Call work for child 1.
+        child_manager.work(child1_work, &mut tcc);
+        assert!(*work_called.lock().unwrap().get(name1).unwrap_or(&false));
+        assert!(!*work_called.lock().unwrap().get(name2).unwrap_or(&false));
+
+        // Call work for child 2.
+        child_manager.work(child2_work, &mut tcc);
+        assert!(*work_called.lock().unwrap().get(name2).unwrap_or(&false));
     }
 }

--- a/grpc/src/client/load_balancing/child_manager.rs
+++ b/grpc/src/client/load_balancing/child_manager.rs
@@ -383,18 +383,27 @@ where
 
     /// Calls work on any children that scheduled work via the work scheduler.
     pub fn work(&mut self, data: Option<WorkData>, channel_controller: &mut dyn ChannelController) {
-        if let Some(data) = data
-            && let Ok(child_work_item) = data.downcast::<ChildWorkItem>()
-        {
-            let child_work_item = *child_work_item;
-            if let Some(&child_idx) = self.handle_to_child_idx.get(&child_work_item.handle) {
-                let child = &mut self.children[child_idx];
-                let mut channel_controller = WrappedController::new(channel_controller);
-                child
-                    .policy
-                    .work(child_work_item.data, &mut channel_controller);
-                self.resolve_child_controller(channel_controller, child_idx);
+        let Some(data) = data else {
+            debug_assert!(false, "ChildManager::work called with None value");
+            return;
+        };
+        let child_work_item = match data.downcast::<ChildWorkItem>() {
+            Ok(item) => item,
+            Err(data) => {
+                debug_assert!(
+                    false,
+                    "ChildManager::work called with {data:?}; expected ChildWorkItem"
+                );
+                return;
             }
+        };
+        if let Some(&child_idx) = self.handle_to_child_idx.get(&child_work_item.handle) {
+            let child = &mut self.children[child_idx];
+            let mut channel_controller = WrappedController::new(channel_controller);
+            child
+                .policy
+                .work(child_work_item.data, &mut channel_controller);
+            self.resolve_child_controller(channel_controller, child_idx);
         }
     }
 
@@ -458,6 +467,7 @@ impl std::hash::Hash for ChildHandle {
     }
 }
 
+#[derive(Debug)]
 struct ChildWorkItem {
     handle: ChildHandle,
     data: Option<WorkData>,

--- a/grpc/src/client/load_balancing/graceful_switch.rs
+++ b/grpc/src/client/load_balancing/graceful_switch.rs
@@ -35,6 +35,7 @@ use crate::client::load_balancing::LbState;
 use crate::client::load_balancing::ParsedJsonLbConfig;
 use crate::client::load_balancing::Subchannel;
 use crate::client::load_balancing::SubchannelState;
+use crate::client::load_balancing::WorkData;
 use crate::client::load_balancing::WorkScheduler;
 use crate::client::load_balancing::child_manager::ChildManager;
 use crate::client::load_balancing::child_manager::ChildUpdate;
@@ -114,8 +115,8 @@ impl LbPolicy for GracefulSwitchPolicy {
         self.update_picker(channel_controller);
     }
 
-    fn work(&mut self, channel_controller: &mut dyn ChannelController) {
-        self.child_manager.work(channel_controller);
+    fn work(&mut self, data: Option<WorkData>, channel_controller: &mut dyn ChannelController) {
+        self.child_manager.work(data, channel_controller);
         self.update_picker(channel_controller);
     }
 

--- a/grpc/src/client/load_balancing/lazy.rs
+++ b/grpc/src/client/load_balancing/lazy.rs
@@ -24,6 +24,8 @@
 
 use std::mem::replace;
 use std::sync::Arc;
+use std::sync::atomic::AtomicBool;
+use std::sync::atomic::Ordering;
 
 use crate::client::ConnectivityState;
 use crate::client::load_balancing::ChannelController;
@@ -35,6 +37,7 @@ use crate::client::load_balancing::PickResult;
 use crate::client::load_balancing::Picker;
 use crate::client::load_balancing::Subchannel;
 use crate::client::load_balancing::SubchannelState;
+use crate::client::load_balancing::WorkData;
 use crate::client::load_balancing::WorkScheduler;
 use crate::client::name_resolution::ResolverUpdate;
 use crate::core::RequestHeaders;
@@ -119,9 +122,9 @@ where
         }
     }
 
-    fn work(&mut self, channel_controller: &mut dyn ChannelController) {
+    fn work(&mut self, data: Option<WorkData>, channel_controller: &mut dyn ChannelController) {
         if let Inner::Built(delegate) = &mut self.inner {
-            delegate.work(channel_controller);
+            delegate.work(data, channel_controller);
         } else {
             // The channel should only give us a work call if we asked for it
             // via the WakeUpPicker.
@@ -167,17 +170,23 @@ where
 #[derive(Debug)]
 pub struct WakeUpPicker {
     work_scheduler: Arc<dyn WorkScheduler>,
+    triggered_work: AtomicBool,
 }
 
 impl WakeUpPicker {
     fn new(work_scheduler: Arc<dyn WorkScheduler>) -> Self {
-        Self { work_scheduler }
+        Self {
+            work_scheduler,
+            triggered_work: AtomicBool::new(false),
+        }
     }
 }
 
 impl Picker for WakeUpPicker {
     fn pick(&self, request: &RequestHeaders) -> PickResult {
-        self.work_scheduler.schedule_work();
+        if !self.triggered_work.swap(true, Ordering::Relaxed) {
+            self.work_scheduler.schedule_work(None);
+        }
         PickResult::Queue
     }
 }
@@ -278,16 +287,53 @@ mod tests {
 
         // Picking should have scheduled work.
         let event = rx_events.recv().unwrap();
-        assert!(matches!(event, TestEvent::ScheduleWork));
+        assert!(matches!(event, TestEvent::ScheduleWork(None)));
 
         // Call work on lazy to honor its request.
-        lazy.work(&mut cc);
+        lazy.work(None, &mut cc);
 
         // Verify delegate was built and received the pending update.
         assert_eq!(rx.recv().unwrap(), MockEvent::Build);
         assert_eq!(rx.recv().unwrap(), MockEvent::ResolverUpdate);
         // Verify no more events.
         assert!(rx.try_recv().is_err());
+    }
+
+    // Tests that calling pick multiple times on the WakeUpPicker only schedules
+    // a single work event.
+    #[test]
+    fn test_lazy_pick_squashes_work_calls() {
+        let (builder, _rx) = MockPolicy::new();
+
+        let (tx_events, rx_events) = mpsc::channel();
+        let mut cc = TestChannelController {
+            tx_events: tx_events.clone(),
+        };
+        let options = LbPolicyOptions {
+            work_scheduler: Arc::new(TestWorkScheduler { tx_events }),
+            runtime: crate::rt::default_runtime(),
+        };
+
+        let _lazy = Lazy::new(builder, options, &mut cc);
+
+        // Get the initial picker.
+        let event = rx_events.recv().unwrap();
+        let TestEvent::UpdatePicker(lb_state) = event else {
+            panic!("expected UpdatePicker event");
+        };
+
+        // Call pick multiple times.
+        for _ in 0..10 {
+            let res = lb_state.picker.pick(&new_request_headers());
+            assert!(matches!(res, PickResult::Queue));
+        }
+
+        // We should only receive a single ScheduleWork event.
+        let event = rx_events.recv().unwrap();
+        assert!(matches!(event, TestEvent::ScheduleWork(None)));
+
+        // There should be no more events in the channel.
+        assert!(rx_events.try_recv().is_err());
     }
 
     // Tests that the delegate policy is constructed only after exit_idle is
@@ -354,10 +400,10 @@ mod tests {
 
         // Picking should have scheduled work.
         let event = rx_events.recv().unwrap();
-        assert!(matches!(event, TestEvent::ScheduleWork));
+        assert!(matches!(event, TestEvent::ScheduleWork(None)));
 
         // Call work on lazy to honor its request.
-        lazy.work(&mut cc);
+        lazy.work(None, &mut cc);
 
         // Verify delegate was built and received an exit_idle call.
         assert_eq!(rx.recv().unwrap(), MockEvent::Build);
@@ -412,7 +458,11 @@ mod tests {
         ) {
             self.tx.send(MockEvent::SubchannelUpdate).unwrap();
         }
-        fn work(&mut self, _channel_controller: &mut dyn ChannelController) {
+        fn work(
+            &mut self,
+            _work_data: Option<WorkData>,
+            _channel_controller: &mut dyn ChannelController,
+        ) {
             self.tx.send(MockEvent::Work).unwrap();
         }
         fn exit_idle(&mut self, _channel_controller: &mut dyn ChannelController) {

--- a/grpc/src/client/load_balancing/mod.rs
+++ b/grpc/src/client/load_balancing/mod.rs
@@ -111,7 +111,7 @@ pub(crate) trait LbPolicy: Send + Sync + Debug + 'static {
 
     /// Called by the channel in response to a call from the LB policy to the
     /// WorkScheduler's request_work method.
-    fn work(&mut self, channel_controller: &mut dyn ChannelController);
+    fn work(&mut self, data: Option<WorkData>, channel_controller: &mut dyn ChannelController);
 
     /// Called by the channel when an LbPolicy goes idle and the channel
     /// wants it to start connecting to subchannels again.
@@ -128,6 +128,8 @@ pub(crate) struct LbPolicyOptions {
     pub runtime: GrpcRuntime,
 }
 
+pub(crate) type WorkData = Box<dyn Any + Send>;
+
 /// Used to asynchronously request a call into the LbPolicy's work method if
 /// the LbPolicy needs to provide an update without waiting for an update
 /// from the channel first.
@@ -135,7 +137,7 @@ pub(crate) trait WorkScheduler: Send + Sync + Debug {
     // Schedules a call into the LbPolicy's work method.  If there is already a
     // pending work call that has not yet started, this may not schedule another
     // call.
-    fn schedule_work(&self);
+    fn schedule_work(&self, data: Option<WorkData>);
 }
 
 /// Abstract representation of the configuration for any LB policy, stored as
@@ -412,8 +414,8 @@ impl<T: LbPolicy + ?Sized> LbPolicy for Box<T> {
         (**self).subchannel_update(subchannel, state, channel_controller);
     }
 
-    fn work(&mut self, channel_controller: &mut dyn ChannelController) {
-        (**self).work(channel_controller);
+    fn work(&mut self, data: Option<WorkData>, channel_controller: &mut dyn ChannelController) {
+        (**self).work(data, channel_controller);
     }
 
     fn exit_idle(&mut self, channel_controller: &mut dyn ChannelController) {

--- a/grpc/src/client/load_balancing/mod.rs
+++ b/grpc/src/client/load_balancing/mod.rs
@@ -128,9 +128,45 @@ pub(crate) struct LbPolicyOptions {
     pub runtime: GrpcRuntime,
 }
 
+/// A trait to add `Debug` to an `Any` for [`WorkData`] to allow debugging data
+/// to be printed more readily.  Blanket implemented on all types that are Any +
+/// Send + Debug.  `dyn WorkDataTrait` also implements downcast methods like
+/// [`Any`] for convenience.
+pub(crate) trait WorkDataTrait: Any + Send + Debug {}
+
+impl<T: Any + Send + Debug> WorkDataTrait for T {}
+
+impl dyn WorkDataTrait {
+    /// Like [`Box<dyn Any>::downcast`] but for this wrapper trait.
+    pub(crate) fn downcast<T: Any>(self: Box<Self>) -> Result<Box<T>, Box<Self>> {
+        // If we directly call downcast then we can't return `Self` anymore
+        // (only a Box<dyn Any + Send>), so we first have to check `is` and only
+        // downcast when we know it will succeed.
+        if (&*self as &(dyn Any + Send)).is::<T>() {
+            Ok((self as Box<dyn Any + Send>).downcast().unwrap())
+        } else {
+            Err(self)
+        }
+    }
+
+    /// Like
+    /// [`downcast_ref`](https://doc.rust-lang.org/std/any/trait.Any.html#method.downcast_ref)
+    /// implemented on [`dyn Any`](Any), but for this wrapper trait.
+    pub(crate) fn downcast_ref<T: Any>(&self) -> Option<&T> {
+        (self as &(dyn Any + Send)).downcast_ref::<T>()
+    }
+
+    /// Like
+    /// [`downcast_mut`](https://doc.rust-lang.org/std/any/trait.Any.html#method.downcast_mut)
+    /// implemented on [`dyn Any`](Any), but for this wrapper trait.
+    pub(crate) fn downcast_mut<T: Any>(&mut self) -> Option<&mut T> {
+        (self as &mut (dyn Any + Send)).downcast_mut::<T>()
+    }
+}
+
 /// A dynamic payload passed between [`WorkScheduler::schedule_work`] and its
 /// associated policy's [`work`](LbPolicy::work) method.
-pub(crate) type WorkData = Box<dyn Any + Send>;
+pub(crate) type WorkData = Box<dyn WorkDataTrait>;
 
 /// Used to asynchronously request a call into the LbPolicy's work method if
 /// the LbPolicy needs to provide an update without waiting for an update

--- a/grpc/src/client/load_balancing/mod.rs
+++ b/grpc/src/client/load_balancing/mod.rs
@@ -128,6 +128,8 @@ pub(crate) struct LbPolicyOptions {
     pub runtime: GrpcRuntime,
 }
 
+/// A dynamic payload passed between [`WorkScheduler::schedule_work`] and its
+/// associated policy's [`work`](LbPolicy::work) method.
 pub(crate) type WorkData = Box<dyn Any + Send>;
 
 /// Used to asynchronously request a call into the LbPolicy's work method if

--- a/grpc/src/client/load_balancing/pick_first.rs
+++ b/grpc/src/client/load_balancing/pick_first.rs
@@ -586,7 +586,8 @@ impl LbPolicy for PickFirstPolicy {
         }
     }
 
-    fn work(&mut self, _data: Option<WorkData>, channel_controller: &mut dyn ChannelController) {
+    fn work(&mut self, data: Option<WorkData>, channel_controller: &mut dyn ChannelController) {
+        debug_assert!(data.is_none(), "expected no data but got {data:?}");
         if self.connectivity_state == ConnectivityState::Idle {
             // TODO: is it safe to assume any call to work() while idle means we
             // should connect?

--- a/grpc/src/client/load_balancing/pick_first.rs
+++ b/grpc/src/client/load_balancing/pick_first.rs
@@ -43,6 +43,7 @@ use crate::client::load_balancing::Pick;
 use crate::client::load_balancing::PickResult;
 use crate::client::load_balancing::Picker;
 use crate::client::load_balancing::QueuingPicker;
+use crate::client::load_balancing::WorkData;
 use crate::client::load_balancing::WorkScheduler;
 use crate::client::load_balancing::subchannel::Subchannel;
 use crate::client::load_balancing::subchannel::SubchannelState;
@@ -585,7 +586,7 @@ impl LbPolicy for PickFirstPolicy {
         }
     }
 
-    fn work(&mut self, channel_controller: &mut dyn ChannelController) {
+    fn work(&mut self, _data: Option<WorkData>, channel_controller: &mut dyn ChannelController) {
         if self.connectivity_state == ConnectivityState::Idle {
             // TODO: is it safe to assume any call to work() while idle means we
             // should connect?
@@ -618,7 +619,7 @@ impl Timer {
         let handle = runtime.clone().spawn(Box::pin(async move {
             runtime.sleep(std::time::Duration::from_millis(250)).await;
             expired_clone.store(true, Ordering::SeqCst);
-            work_scheduler.schedule_work();
+            work_scheduler.schedule_work(None);
         }));
         Self { expired, handle }
     }
@@ -668,7 +669,7 @@ impl IdlePicker {
 impl Picker for IdlePicker {
     fn pick(&self, _: &RequestHeaders) -> PickResult {
         if !self.triggered_work.swap(true, Ordering::Relaxed) {
-            self.work_scheduler.schedule_work();
+            self.work_scheduler.schedule_work(None);
         }
         PickResult::Queue
     }
@@ -824,7 +825,7 @@ mod test {
 
     fn expect_schedule_work(rx: &mpsc::Receiver<TestEvent>) {
         match rx.try_recv() {
-            Ok(TestEvent::ScheduleWork) => {}
+            Ok(TestEvent::ScheduleWork(_)) => {}
             Ok(other) => panic!("expected ScheduleWork, got {:?}", other),
             Err(e) => panic!("expected ScheduleWork, got error: {:?}", e),
         }
@@ -1220,7 +1221,7 @@ mod test {
             .store(true, std::sync::atomic::Ordering::SeqCst);
 
         // Manually call work() to process the timer expiration.
-        policy.work(controller.as_mut());
+        policy.work(None, controller.as_mut());
 
         // Expect Connect event for addr2 due to timer expiration.
         let addr = expect_connect(&rx);
@@ -1496,7 +1497,7 @@ mod test {
             .unwrap()
             .expired
             .store(true, Ordering::SeqCst);
-        policy.work(controller.as_mut());
+        policy.work(None, controller.as_mut());
 
         let addr = expect_connect(&rx);
         assert_eq!(addr.address.to_string(), "addr2");
@@ -1613,7 +1614,7 @@ mod test {
         expect_schedule_work(&rx);
 
         // 6. Call work to execute the scheduled connection attempt.
-        policy.work(controller.as_mut());
+        policy.work(None, controller.as_mut());
 
         // 7. Verify that the policy initiates a reconnection to addr1.
         let addr = expect_connect(&rx);

--- a/grpc/src/client/load_balancing/registry.rs
+++ b/grpc/src/client/load_balancing/registry.rs
@@ -36,6 +36,7 @@ use crate::client::load_balancing::LbPolicy;
 use crate::client::load_balancing::LbPolicyBuilder;
 use crate::client::load_balancing::LbPolicyOptions;
 use crate::client::load_balancing::ParsedJsonLbConfig;
+use crate::client::load_balancing::WorkData;
 use crate::client::load_balancing::subchannel::Subchannel;
 use crate::client::load_balancing::subchannel::SubchannelState;
 use crate::client::name_resolution::ResolverUpdate;
@@ -135,8 +136,8 @@ impl<T: LbPolicy> LbPolicy for DynAdapter<T> {
             .subchannel_update(subchannel, state, channel_controller);
     }
 
-    fn work(&mut self, channel_controller: &mut dyn ChannelController) {
-        self.0.work(channel_controller);
+    fn work(&mut self, data: Option<WorkData>, channel_controller: &mut dyn ChannelController) {
+        self.0.work(data, channel_controller);
     }
 
     fn exit_idle(&mut self, channel_controller: &mut dyn ChannelController) {

--- a/grpc/src/client/load_balancing/round_robin.rs
+++ b/grpc/src/client/load_balancing/round_robin.rs
@@ -41,6 +41,7 @@ use crate::client::load_balancing::PickResult;
 use crate::client::load_balancing::Picker;
 use crate::client::load_balancing::Subchannel;
 use crate::client::load_balancing::SubchannelState;
+use crate::client::load_balancing::WorkData;
 use crate::client::load_balancing::child_manager::ChildManager;
 use crate::client::load_balancing::child_manager::ChildUpdate;
 use crate::client::load_balancing::pick_first;
@@ -208,8 +209,8 @@ impl LbPolicy for RoundRobinPolicy {
         self.update_picker(channel_controller);
     }
 
-    fn work(&mut self, channel_controller: &mut dyn ChannelController) {
-        self.child_manager.work(channel_controller);
+    fn work(&mut self, data: Option<WorkData>, channel_controller: &mut dyn ChannelController) {
+        self.child_manager.work(data, channel_controller);
         self.update_picker(channel_controller);
     }
 

--- a/grpc/src/client/load_balancing/subchannel_sharing.rs
+++ b/grpc/src/client/load_balancing/subchannel_sharing.rs
@@ -36,6 +36,7 @@ use crate::client::load_balancing::LbPolicy;
 use crate::client::load_balancing::LbState;
 use crate::client::load_balancing::PickResult;
 use crate::client::load_balancing::Picker;
+use crate::client::load_balancing::WorkData;
 use crate::client::load_balancing::subchannel::ForwardingSubchannel;
 use crate::client::load_balancing::subchannel::Subchannel;
 use crate::client::load_balancing::subchannel::SubchannelState;
@@ -129,12 +130,12 @@ impl<T: LbPolicy> LbPolicy for SubchannelSharing<T> {
         }
     }
 
-    fn work(&mut self, channel_controller: &mut dyn ChannelController) {
+    fn work(&mut self, data: Option<WorkData>, channel_controller: &mut dyn ChannelController) {
         let mut channel_controller = SharingChannelController {
             balancer_inner: self.inner.clone(),
             delegate: channel_controller,
         };
-        self.delegate.work(&mut channel_controller);
+        self.delegate.work(data, &mut channel_controller);
     }
 
     fn exit_idle(&mut self, channel_controller: &mut dyn ChannelController) {
@@ -332,7 +333,7 @@ mod tests {
 
         let mock = StubPolicy::new(
             StubPolicyFuncs {
-                work: Some(Arc::new(move |_data, cc| {
+                work: Some(Arc::new(move |_data, _workitem, cc| {
                     let addr = Address {
                         address: "127.0.0.1:80".to_string().into(),
                         ..Default::default()
@@ -347,7 +348,7 @@ mod tests {
 
         let mut sharing = SubchannelSharing::new(mock);
 
-        sharing.work(&mut cc);
+        sharing.work(None, &mut cc);
 
         let event = rx_events.recv().unwrap();
         let TestEvent::NewSubchannel(internal_sc) = event else {
@@ -376,7 +377,7 @@ mod tests {
 
         let mock = StubPolicy::new(
             StubPolicyFuncs {
-                work: Some(Arc::new(move |_data, cc| {
+                work: Some(Arc::new(move |_data, _workitem, cc| {
                     let addr = Address {
                         address: "127.0.0.1:80".to_string().into(),
                         ..Default::default()
@@ -391,7 +392,7 @@ mod tests {
 
         let mut sharing = SubchannelSharing::new(mock);
 
-        sharing.work(&mut cc);
+        sharing.work(None, &mut cc);
 
         // Confirm that only one new_subchannel was seen by the underlying
         // channel controller.
@@ -430,7 +431,7 @@ mod tests {
 
         let mock = StubPolicy::new(
             StubPolicyFuncs {
-                work: Some(Arc::new(move |_data, cc| {
+                work: Some(Arc::new(move |_data, _workitem, cc| {
                     let addr1 = Address {
                         address: "127.0.0.1:80".to_string().into(),
                         ..Default::default()
@@ -449,7 +450,7 @@ mod tests {
 
         let mut sharing = SubchannelSharing::new(mock);
 
-        sharing.work(&mut cc);
+        sharing.work(None, &mut cc);
 
         // Verify that two new_subchannel calls occurred.
         let event1 = rx_events.recv().unwrap();
@@ -492,7 +493,7 @@ mod tests {
 
         let mock = StubPolicy::new(
             StubPolicyFuncs {
-                work: Some(Arc::new(move |_data, cc| {
+                work: Some(Arc::new(move |_data, _workitem, cc| {
                     let addr = Address {
                         address: "127.0.0.1:80".to_string().into(),
                         ..Default::default()
@@ -517,7 +518,7 @@ mod tests {
         let mut sharing = SubchannelSharing::new(mock);
 
         // The first call to work should create sc1 and sc2.
-        sharing.work(&mut cc);
+        sharing.work(None, &mut cc);
         let _ = rx_events.recv().unwrap();
 
         let external_sc1 = sc_out1.lock().unwrap().take().unwrap();
@@ -561,7 +562,7 @@ mod tests {
 
         // Create a subchannel with the same address again and confirm that a
         // new underlying subchannel is created.
-        sharing.work(&mut cc);
+        sharing.work(None, &mut cc);
         let event = rx_events.recv().unwrap();
         assert!(matches!(event, TestEvent::NewSubchannel(_)));
 
@@ -591,7 +592,7 @@ mod tests {
 
         let mock = StubPolicy::new(
             StubPolicyFuncs {
-                work: Some(Arc::new(move |_data, cc| {
+                work: Some(Arc::new(move |_data, _workitem, cc| {
                     let addr = Address {
                         address: "127.0.0.1:80".to_string().into(),
                         ..Default::default()
@@ -609,7 +610,7 @@ mod tests {
 
         let mut sharing = SubchannelSharing::new(mock);
 
-        sharing.work(&mut cc);
+        sharing.work(None, &mut cc);
         let _ = rx_events.recv().unwrap();
 
         let external_sc1 = sc_out1.lock().unwrap().take().unwrap();
@@ -646,7 +647,7 @@ mod tests {
 
         let mock = StubPolicy::new(
             StubPolicyFuncs {
-                work: Some(Arc::new(move |_data, cc| {
+                work: Some(Arc::new(move |_data, _workitem, cc| {
                     let addr = Address {
                         address: "127.0.0.1:80".to_string().into(),
                         ..Default::default()
@@ -680,7 +681,7 @@ mod tests {
 
         let mut sharing = SubchannelSharing::new(mock);
 
-        sharing.work(&mut cc);
+        sharing.work(None, &mut cc);
         let _ = rx_events.recv().unwrap();
 
         let event = rx_events.recv().unwrap();
@@ -722,7 +723,7 @@ mod tests {
                 })),
                 work: Some(Arc::new({
                     let called_clone = called.clone();
-                    move |_data, cc| {
+                    move |_data, _workitem, cc| {
                         called_clone.lock().unwrap().push("work");
                         cc.request_resolution();
                     }
@@ -740,7 +741,7 @@ mod tests {
 
         let update = ResolverUpdate::default();
         sharing.resolver_update(update, None, &mut cc).unwrap();
-        sharing.work(&mut cc);
+        sharing.work(None, &mut cc);
         sharing.exit_idle(&mut cc);
 
         assert_eq!(
@@ -766,7 +767,7 @@ mod tests {
 
         let mock = StubPolicy::new(
             StubPolicyFuncs {
-                work: Some(Arc::new(move |_data, cc| {
+                work: Some(Arc::new(move |_data, _workitem, cc| {
                     let addr = Address {
                         address: "127.0.0.1:80".to_string().into(),
                         ..Default::default()
@@ -789,7 +790,7 @@ mod tests {
 
         let mut sharing = SubchannelSharing::new(mock);
 
-        sharing.work(&mut cc);
+        sharing.work(None, &mut cc);
         let event = rx_events.recv().unwrap();
         let TestEvent::NewSubchannel(_int_sc) = event else {
             panic!("expected NewSubchannel")
@@ -823,7 +824,7 @@ mod tests {
 
         let mock = StubPolicy::new(
             StubPolicyFuncs {
-                work: Some(Arc::new(move |_data, cc| {
+                work: Some(Arc::new(move |_data, _workitem, cc| {
                     (rx_work.lock().unwrap().recv().unwrap())(cc);
                 })),
                 ..Default::default()
@@ -850,7 +851,7 @@ mod tests {
                 *sc1_clone.lock().unwrap() = Some(sc);
             }))
             .unwrap();
-        sharing.work(&mut cc);
+        sharing.work(None, &mut cc);
 
         let event = rx_events.recv().unwrap();
         let TestEvent::NewSubchannel(int_sc) = event else {
@@ -869,7 +870,7 @@ mod tests {
                 assert_eq!(state.connectivity_state, ConnectivityState::Connecting);
             }))
             .unwrap();
-        sharing.work(&mut cc);
+        sharing.work(None, &mut cc);
 
         // Update the state to Ready.
         sharing.subchannel_update(int_sc.clone(), &SubchannelState::ready(), &mut cc);
@@ -883,6 +884,6 @@ mod tests {
                 assert_eq!(state.connectivity_state, ConnectivityState::Ready);
             }))
             .unwrap();
-        sharing.work(&mut cc);
+        sharing.work(None, &mut cc);
     }
 }

--- a/grpc/src/client/load_balancing/test_utils.rs
+++ b/grpc/src/client/load_balancing/test_utils.rs
@@ -41,6 +41,7 @@ use crate::client::load_balancing::LbState;
 use crate::client::load_balancing::ParsedJsonLbConfig;
 use crate::client::load_balancing::Subchannel;
 use crate::client::load_balancing::SubchannelState;
+use crate::client::load_balancing::WorkData;
 use crate::client::load_balancing::WorkScheduler;
 use crate::client::load_balancing::subchannel::ForwardingSubchannel;
 use crate::client::name_resolution::Address;
@@ -102,7 +103,7 @@ pub(crate) enum TestEvent {
     UpdatePicker(LbState),
     RequestResolution,
     Connect(Address),
-    ScheduleWork,
+    ScheduleWork(Option<WorkData>),
 }
 
 // TODO(easwars): Remove this and instead derive Debug.
@@ -113,7 +114,7 @@ impl Debug for TestEvent {
             Self::UpdatePicker(state) => write!(f, "UpdatePicker({})", state.connectivity_state),
             Self::RequestResolution => write!(f, "RequestResolution"),
             Self::Connect(addr) => write!(f, "Connect({:?})", addr.address),
-            Self::ScheduleWork => write!(f, "ScheduleWork"),
+            Self::ScheduleWork(data) => write!(f, "ScheduleWork({:?})", data),
         }
     }
 }
@@ -153,8 +154,8 @@ pub(crate) struct TestWorkScheduler {
 }
 
 impl WorkScheduler for TestWorkScheduler {
-    fn schedule_work(&self) {
-        self.tx_events.send(TestEvent::ScheduleWork).unwrap();
+    fn schedule_work(&self, data: Option<WorkData>) {
+        self.tx_events.send(TestEvent::ScheduleWork(data)).unwrap();
     }
 }
 
@@ -179,7 +180,8 @@ type SubchannelUpdateFn = Arc<
 
 type ExitIdleFn = Arc<dyn Fn(&mut StubPolicyData, &mut dyn ChannelController) + Send + Sync>;
 
-type WorkFn = Arc<dyn Fn(&mut StubPolicyData, &mut dyn ChannelController) + Send + Sync>;
+type WorkFn =
+    Arc<dyn Fn(&mut StubPolicyData, Option<WorkData>, &mut dyn ChannelController) + Send + Sync>;
 
 /// This struct holds `LbPolicy` trait stub functions that tests are expected to
 /// implement.
@@ -253,9 +255,9 @@ impl LbPolicy for StubPolicy {
         }
     }
 
-    fn work(&mut self, channel_controller: &mut dyn ChannelController) {
+    fn work(&mut self, data: Option<WorkData>, channel_controller: &mut dyn ChannelController) {
         if let Some(f) = &self.funcs.work {
-            f(&mut self.data, channel_controller);
+            f(&mut self.data, data, channel_controller);
         }
     }
 }


### PR DESCRIPTION
This allows for providing data directly to the LB policy that scheduled the work item -- note the pattern in child_manager for wrapping the payload in order to route it.  This will be leveraged for future things like subchannel health checking results.

API-wise, this is a two-line change:
- `WorkScheduler::schedule_work` adds a data payload field
- `LbPolicy::work` adds a matching field that is populated from the above

Aside from basic plumbing, some other changes are needed:
- We no longer squash duplicate calls in the channel
- The `ChildManager` policy leverages the payload to encode which child the payload should be sent to.  This is done with an anonymous handle instead of the current index of the child in the internal tracking vector, which makes it directly resilient to changes that could happen at any time.
- The `Lazy` policy's idle picker needs an atomic bool to squash the work calls produced by its picks to avoid flooding it if many RPCs happen at once.

cc @YutaoMa @gu0keno0 as FYI - this slightly changes the APIs we talked about yesterday.
