### PR TITLE
feat(tonic-build): add ability to configure tonic crate path

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,8 @@ members = [
   "tests/web",
   "tests/default_stubs",
   "tests/deprecated_methods",
+  "tests/tonic_path/wrapper",
+  "tests/tonic_path/my_application",
 ]
 resolver = "2"
 

--- a/grpc/src/generated/grpc_examples_echo.rs
+++ b/grpc/src/generated/grpc_examples_echo.rs
@@ -20,26 +20,26 @@ pub mod echo_client {
         clippy::wildcard_imports,
         clippy::let_unit_value,
     )]
-    use tonic::codegen::*;
-    use tonic::codegen::http::Uri;
+    use ::tonic::codegen::*;
+    use ::tonic::codegen::http::Uri;
     /// Echo is the echo service.
     #[derive(Debug, Clone)]
     pub struct EchoClient<T> {
-        inner: tonic::client::Grpc<T>,
+        inner: ::tonic::client::Grpc<T>,
     }
     impl<T> EchoClient<T>
     where
-        T: tonic::client::GrpcService<tonic::body::Body>,
+        T: ::tonic::client::GrpcService<::tonic::body::Body>,
         T::Error: Into<StdError>,
         T::ResponseBody: Body<Data = Bytes> + std::marker::Send + 'static,
         <T::ResponseBody as Body>::Error: Into<StdError> + std::marker::Send,
     {
         pub fn new(inner: T) -> Self {
-            let inner = tonic::client::Grpc::new(inner);
+            let inner = ::tonic::client::Grpc::new(inner);
             Self { inner }
         }
         pub fn with_origin(inner: T, origin: Uri) -> Self {
-            let inner = tonic::client::Grpc::with_origin(inner, origin);
+            let inner = ::tonic::client::Grpc::with_origin(inner, origin);
             Self { inner }
         }
         pub fn with_interceptor<F>(
@@ -47,16 +47,18 @@ pub mod echo_client {
             interceptor: F,
         ) -> EchoClient<InterceptedService<T, F>>
         where
-            F: tonic::service::Interceptor,
+            F: ::tonic::service::Interceptor,
             T::ResponseBody: Default,
-            T: tonic::codegen::Service<
-                http::Request<tonic::body::Body>,
+            T: ::tonic::codegen::Service<
+                http::Request<::tonic::body::Body>,
                 Response = http::Response<
-                    <T as tonic::client::GrpcService<tonic::body::Body>>::ResponseBody,
+                    <T as ::tonic::client::GrpcService<
+                        ::tonic::body::Body,
+                    >>::ResponseBody,
                 >,
             >,
-            <T as tonic::codegen::Service<
-                http::Request<tonic::body::Body>,
+            <T as ::tonic::codegen::Service<
+                http::Request<::tonic::body::Body>,
             >>::Error: Into<StdError> + std::marker::Send + std::marker::Sync,
         {
             EchoClient::new(InterceptedService::new(inner, interceptor))
@@ -95,13 +97,16 @@ pub mod echo_client {
         /// UnaryEcho is unary echo.
         pub async fn unary_echo(
             &mut self,
-            request: impl tonic::IntoRequest<super::EchoRequest>,
-        ) -> std::result::Result<tonic::Response<super::EchoResponse>, tonic::Status> {
+            request: impl ::tonic::IntoRequest<super::EchoRequest>,
+        ) -> std::result::Result<
+            ::tonic::Response<super::EchoResponse>,
+            ::tonic::Status,
+        > {
             self.inner
                 .ready()
                 .await
                 .map_err(|e| {
-                    tonic::Status::unknown(
+                    ::tonic::Status::unknown(
                         format!("Service was not ready: {}", e.into()),
                     )
                 })?;
@@ -117,16 +122,16 @@ pub mod echo_client {
         /// ServerStreamingEcho is server side streaming.
         pub async fn server_streaming_echo(
             &mut self,
-            request: impl tonic::IntoRequest<super::EchoRequest>,
+            request: impl ::tonic::IntoRequest<super::EchoRequest>,
         ) -> std::result::Result<
-            tonic::Response<tonic::codec::Streaming<super::EchoResponse>>,
-            tonic::Status,
+            ::tonic::Response<::tonic::codec::Streaming<super::EchoResponse>>,
+            ::tonic::Status,
         > {
             self.inner
                 .ready()
                 .await
                 .map_err(|e| {
-                    tonic::Status::unknown(
+                    ::tonic::Status::unknown(
                         format!("Service was not ready: {}", e.into()),
                     )
                 })?;
@@ -144,13 +149,16 @@ pub mod echo_client {
         /// ClientStreamingEcho is client side streaming.
         pub async fn client_streaming_echo(
             &mut self,
-            request: impl tonic::IntoStreamingRequest<Message = super::EchoRequest>,
-        ) -> std::result::Result<tonic::Response<super::EchoResponse>, tonic::Status> {
+            request: impl ::tonic::IntoStreamingRequest<Message = super::EchoRequest>,
+        ) -> std::result::Result<
+            ::tonic::Response<super::EchoResponse>,
+            ::tonic::Status,
+        > {
             self.inner
                 .ready()
                 .await
                 .map_err(|e| {
-                    tonic::Status::unknown(
+                    ::tonic::Status::unknown(
                         format!("Service was not ready: {}", e.into()),
                     )
                 })?;
@@ -168,16 +176,16 @@ pub mod echo_client {
         /// BidirectionalStreamingEcho is bidi streaming.
         pub async fn bidirectional_streaming_echo(
             &mut self,
-            request: impl tonic::IntoStreamingRequest<Message = super::EchoRequest>,
+            request: impl ::tonic::IntoStreamingRequest<Message = super::EchoRequest>,
         ) -> std::result::Result<
-            tonic::Response<tonic::codec::Streaming<super::EchoResponse>>,
-            tonic::Status,
+            ::tonic::Response<::tonic::codec::Streaming<super::EchoResponse>>,
+            ::tonic::Status,
         > {
             self.inner
                 .ready()
                 .await
                 .map_err(|e| {
-                    tonic::Status::unknown(
+                    ::tonic::Status::unknown(
                         format!("Service was not ready: {}", e.into()),
                     )
                 })?;
@@ -206,47 +214,53 @@ pub mod echo_server {
         clippy::wildcard_imports,
         clippy::let_unit_value,
     )]
-    use tonic::codegen::*;
+    use ::tonic::codegen::*;
     /// Generated trait containing gRPC methods that should be implemented for use with EchoServer.
     #[async_trait]
     pub trait Echo: std::marker::Send + std::marker::Sync + 'static {
         /// UnaryEcho is unary echo.
         async fn unary_echo(
             &self,
-            request: tonic::Request<super::EchoRequest>,
-        ) -> std::result::Result<tonic::Response<super::EchoResponse>, tonic::Status>;
+            request: ::tonic::Request<super::EchoRequest>,
+        ) -> std::result::Result<
+            ::tonic::Response<super::EchoResponse>,
+            ::tonic::Status,
+        >;
         /// Server streaming response type for the ServerStreamingEcho method.
-        type ServerStreamingEchoStream: tonic::codegen::tokio_stream::Stream<
-                Item = std::result::Result<super::EchoResponse, tonic::Status>,
+        type ServerStreamingEchoStream: ::tonic::codegen::tokio_stream::Stream<
+                Item = std::result::Result<super::EchoResponse, ::tonic::Status>,
             >
             + std::marker::Send
             + 'static;
         /// ServerStreamingEcho is server side streaming.
         async fn server_streaming_echo(
             &self,
-            request: tonic::Request<super::EchoRequest>,
+            request: ::tonic::Request<super::EchoRequest>,
         ) -> std::result::Result<
-            tonic::Response<Self::ServerStreamingEchoStream>,
-            tonic::Status,
+            ::tonic::Response<Self::ServerStreamingEchoStream>,
+            ::tonic::Status,
         >;
         /// ClientStreamingEcho is client side streaming.
         async fn client_streaming_echo(
             &self,
-            request: tonic::Request<tonic::Streaming<super::EchoRequest>>,
-        ) -> std::result::Result<tonic::Response<super::EchoResponse>, tonic::Status>;
+            request: ::tonic::Request<::tonic::Streaming<super::EchoRequest>>,
+        ) -> std::result::Result<
+            ::tonic::Response<super::EchoResponse>,
+            ::tonic::Status,
+        >;
         /// Server streaming response type for the BidirectionalStreamingEcho method.
-        type BidirectionalStreamingEchoStream: tonic::codegen::tokio_stream::Stream<
-                Item = std::result::Result<super::EchoResponse, tonic::Status>,
+        type BidirectionalStreamingEchoStream: ::tonic::codegen::tokio_stream::Stream<
+                Item = std::result::Result<super::EchoResponse, ::tonic::Status>,
             >
             + std::marker::Send
             + 'static;
         /// BidirectionalStreamingEcho is bidi streaming.
         async fn bidirectional_streaming_echo(
             &self,
-            request: tonic::Request<tonic::Streaming<super::EchoRequest>>,
+            request: ::tonic::Request<::tonic::Streaming<super::EchoRequest>>,
         ) -> std::result::Result<
-            tonic::Response<Self::BidirectionalStreamingEchoStream>,
-            tonic::Status,
+            ::tonic::Response<Self::BidirectionalStreamingEchoStream>,
+            ::tonic::Status,
         >;
     }
     /// Echo is the echo service.
@@ -276,7 +290,7 @@ pub mod echo_server {
             interceptor: F,
         ) -> InterceptedService<Self, F>
         where
-            F: tonic::service::Interceptor,
+            F: ::tonic::service::Interceptor,
         {
             InterceptedService::new(Self::new(inner), interceptor)
         }
@@ -309,13 +323,13 @@ pub mod echo_server {
             self
         }
     }
-    impl<T, B> tonic::codegen::Service<http::Request<B>> for EchoServer<T>
+    impl<T, B> ::tonic::codegen::Service<http::Request<B>> for EchoServer<T>
     where
         T: Echo,
         B: Body + std::marker::Send + 'static,
         B::Error: Into<StdError> + std::marker::Send + 'static,
     {
-        type Response = http::Response<tonic::body::Body>;
+        type Response = http::Response<::tonic::body::Body>;
         type Error = std::convert::Infallible;
         type Future = BoxFuture<Self::Response, Self::Error>;
         fn poll_ready(
@@ -329,16 +343,16 @@ pub mod echo_server {
                 "/grpc.examples.echo.Echo/UnaryEcho" => {
                     #[allow(non_camel_case_types)]
                     struct UnaryEchoSvc<T: Echo>(pub Arc<T>);
-                    impl<T: Echo> tonic::server::UnaryService<super::EchoRequest>
+                    impl<T: Echo> ::tonic::server::UnaryService<super::EchoRequest>
                     for UnaryEchoSvc<T> {
                         type Response = super::EchoResponse;
                         type Future = BoxFuture<
-                            tonic::Response<Self::Response>,
-                            tonic::Status,
+                            ::tonic::Response<Self::Response>,
+                            ::tonic::Status,
                         >;
                         fn call(
                             &mut self,
-                            request: tonic::Request<super::EchoRequest>,
+                            request: ::tonic::Request<super::EchoRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
@@ -355,7 +369,7 @@ pub mod echo_server {
                     let fut = async move {
                         let method = UnaryEchoSvc(inner);
                         let codec = tonic_prost::ProstCodec::default();
-                        let mut grpc = tonic::server::Grpc::new(codec)
+                        let mut grpc = ::tonic::server::Grpc::new(codec)
                             .apply_compression_config(
                                 accept_compression_encodings,
                                 send_compression_encodings,
@@ -374,17 +388,17 @@ pub mod echo_server {
                     struct ServerStreamingEchoSvc<T: Echo>(pub Arc<T>);
                     impl<
                         T: Echo,
-                    > tonic::server::ServerStreamingService<super::EchoRequest>
+                    > ::tonic::server::ServerStreamingService<super::EchoRequest>
                     for ServerStreamingEchoSvc<T> {
                         type Response = super::EchoResponse;
                         type ResponseStream = T::ServerStreamingEchoStream;
                         type Future = BoxFuture<
-                            tonic::Response<Self::ResponseStream>,
-                            tonic::Status,
+                            ::tonic::Response<Self::ResponseStream>,
+                            ::tonic::Status,
                         >;
                         fn call(
                             &mut self,
-                            request: tonic::Request<super::EchoRequest>,
+                            request: ::tonic::Request<super::EchoRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
@@ -401,7 +415,7 @@ pub mod echo_server {
                     let fut = async move {
                         let method = ServerStreamingEchoSvc(inner);
                         let codec = tonic_prost::ProstCodec::default();
-                        let mut grpc = tonic::server::Grpc::new(codec)
+                        let mut grpc = ::tonic::server::Grpc::new(codec)
                             .apply_compression_config(
                                 accept_compression_encodings,
                                 send_compression_encodings,
@@ -420,16 +434,18 @@ pub mod echo_server {
                     struct ClientStreamingEchoSvc<T: Echo>(pub Arc<T>);
                     impl<
                         T: Echo,
-                    > tonic::server::ClientStreamingService<super::EchoRequest>
+                    > ::tonic::server::ClientStreamingService<super::EchoRequest>
                     for ClientStreamingEchoSvc<T> {
                         type Response = super::EchoResponse;
                         type Future = BoxFuture<
-                            tonic::Response<Self::Response>,
-                            tonic::Status,
+                            ::tonic::Response<Self::Response>,
+                            ::tonic::Status,
                         >;
                         fn call(
                             &mut self,
-                            request: tonic::Request<tonic::Streaming<super::EchoRequest>>,
+                            request: ::tonic::Request<
+                                ::tonic::Streaming<super::EchoRequest>,
+                            >,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
@@ -446,7 +462,7 @@ pub mod echo_server {
                     let fut = async move {
                         let method = ClientStreamingEchoSvc(inner);
                         let codec = tonic_prost::ProstCodec::default();
-                        let mut grpc = tonic::server::Grpc::new(codec)
+                        let mut grpc = ::tonic::server::Grpc::new(codec)
                             .apply_compression_config(
                                 accept_compression_encodings,
                                 send_compression_encodings,
@@ -463,17 +479,19 @@ pub mod echo_server {
                 "/grpc.examples.echo.Echo/BidirectionalStreamingEcho" => {
                     #[allow(non_camel_case_types)]
                     struct BidirectionalStreamingEchoSvc<T: Echo>(pub Arc<T>);
-                    impl<T: Echo> tonic::server::StreamingService<super::EchoRequest>
+                    impl<T: Echo> ::tonic::server::StreamingService<super::EchoRequest>
                     for BidirectionalStreamingEchoSvc<T> {
                         type Response = super::EchoResponse;
                         type ResponseStream = T::BidirectionalStreamingEchoStream;
                         type Future = BoxFuture<
-                            tonic::Response<Self::ResponseStream>,
-                            tonic::Status,
+                            ::tonic::Response<Self::ResponseStream>,
+                            ::tonic::Status,
                         >;
                         fn call(
                             &mut self,
-                            request: tonic::Request<tonic::Streaming<super::EchoRequest>>,
+                            request: ::tonic::Request<
+                                ::tonic::Streaming<super::EchoRequest>,
+                            >,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
@@ -491,7 +509,7 @@ pub mod echo_server {
                     let fut = async move {
                         let method = BidirectionalStreamingEchoSvc(inner);
                         let codec = tonic_prost::ProstCodec::default();
-                        let mut grpc = tonic::server::Grpc::new(codec)
+                        let mut grpc = ::tonic::server::Grpc::new(codec)
                             .apply_compression_config(
                                 accept_compression_encodings,
                                 send_compression_encodings,
@@ -508,18 +526,18 @@ pub mod echo_server {
                 _ => {
                     Box::pin(async move {
                         let mut response = http::Response::new(
-                            tonic::body::Body::default(),
+                            ::tonic::body::Body::default(),
                         );
                         let headers = response.headers_mut();
                         headers
                             .insert(
-                                tonic::Status::GRPC_STATUS,
-                                (tonic::Code::Unimplemented as i32).into(),
+                                ::tonic::Status::GRPC_STATUS,
+                                (::tonic::Code::Unimplemented as i32).into(),
                             );
                         headers
                             .insert(
                                 http::header::CONTENT_TYPE,
-                                tonic::metadata::GRPC_CONTENT_TYPE,
+                                ::tonic::metadata::GRPC_CONTENT_TYPE,
                             );
                         Ok(response)
                     })
@@ -541,7 +559,7 @@ pub mod echo_server {
     }
     /// Generated gRPC service name
     pub const SERVICE_NAME: &str = "grpc.examples.echo.Echo";
-    impl<T> tonic::server::NamedService for EchoServer<T> {
+    impl<T> ::tonic::server::NamedService for EchoServer<T> {
         const NAME: &'static str = SERVICE_NAME;
     }
 }

--- a/tests/tonic_path/my_application/Cargo.toml
+++ b/tests/tonic_path/my_application/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "my_application_tonic_path"
+edition = "2024"
+license = "MIT"
+publish = false
+
+[dependencies]
+prost = "0.14"
+wrapper = { path = "../wrapper" }
+
+[build-dependencies]
+tonic-prost-build = { path = "../../../tonic-prost-build" }

--- a/tests/tonic_path/my_application/build.rs
+++ b/tests/tonic_path/my_application/build.rs
@@ -1,0 +1,7 @@
+fn main() -> Result<(), std::io::Error> {
+    tonic_prost_build::configure()
+        .tonic_path("wrapper::tonic")
+        .codec_path("wrapper::tonic_prost::ProstCodec")
+        .compile_protos(&["greeter/greeter.proto"], &["../proto"])?;
+    Ok(())
+}

--- a/tests/tonic_path/my_application/src/main.rs
+++ b/tests/tonic_path/my_application/src/main.rs
@@ -1,0 +1,34 @@
+mod pb {
+    include!(concat!(env!("OUT_DIR"), "/greeter.rs"));
+}
+
+#[derive(Default)]
+struct MyGreeter;
+
+#[wrapper::tonic::async_trait]
+impl pb::greeter_server::Greeter for MyGreeter {
+    async fn say_hello(
+        &self,
+        request: wrapper::tonic::Request<pb::HelloRequest>,
+    ) -> Result<wrapper::tonic::Response<pb::HelloResponse>, wrapper::tonic::Status> {
+        let name = request.into_inner().name;
+        Ok(wrapper::tonic::Response::new(pb::HelloResponse {
+            message: format!("Hello, {name}!"),
+        }))
+    }
+}
+
+fn main() {
+    let _server = pb::greeter_server::GreeterServer::new(MyGreeter);
+}
+
+#[cfg(test)]
+#[test]
+fn test_generated_types_resolve_through_wrapper() {
+    // Constructing both the server and client types proves the generated
+    // code resolved `wrapper::tonic::*` and `wrapper::tonic_prost::ProstCodec`
+    // without any direct `tonic` dependency in this crate's manifest.
+    let _server = pb::greeter_server::GreeterServer::new(MyGreeter);
+    fn _assert_client_type<T>() {}
+    _assert_client_type::<pb::greeter_client::GreeterClient<wrapper::tonic::transport::Channel>>();
+}

--- a/tests/tonic_path/proto/greeter/greeter.proto
+++ b/tests/tonic_path/proto/greeter/greeter.proto
@@ -1,0 +1,15 @@
+syntax = "proto3";
+
+package greeter;
+
+message HelloRequest {
+    string name = 1;
+}
+
+message HelloResponse {
+    string message = 1;
+}
+
+service Greeter {
+    rpc SayHello(HelloRequest) returns (HelloResponse);
+}

--- a/tests/tonic_path/wrapper/Cargo.toml
+++ b/tests/tonic_path/wrapper/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "wrapper"
+edition = "2024"
+license = "MIT"
+publish = false
+
+[dependencies]
+tonic = { path = "../../../tonic" }
+tonic-prost = { path = "../../../tonic-prost" }

--- a/tests/tonic_path/wrapper/src/lib.rs
+++ b/tests/tonic_path/wrapper/src/lib.rs
@@ -1,0 +1,2 @@
+pub use ::tonic;
+pub use ::tonic_prost;

--- a/tonic-build/src/client.rs
+++ b/tonic-build/src/client.rs
@@ -8,6 +8,7 @@ use crate::{
 use proc_macro2::TokenStream;
 use quote::{format_ident, quote};
 
+#[allow(clippy::too_many_arguments)]
 pub(crate) fn generate_internal<T: Service>(
     service: &T,
     emit_package: bool,
@@ -16,6 +17,7 @@ pub(crate) fn generate_internal<T: Service>(
     build_transport: bool,
     attributes: &Attributes,
     disable_comments: &HashSet<String>,
+    tonic_path: &syn::Path,
 ) -> TokenStream {
     let service_ident = quote::format_ident!("{}Client", service.name());
     let client_mod = quote::format_ident!("{}_client", naive_snake_case(service.name()));
@@ -25,9 +27,10 @@ pub(crate) fn generate_internal<T: Service>(
         proto_path,
         compile_well_known_types,
         disable_comments,
+        tonic_path,
     );
 
-    let connect = generate_connect(&service_ident, build_transport);
+    let connect = generate_connect(&service_ident, build_transport, tonic_path);
 
     let package = if emit_package { service.package() } else { "" };
     let service_name = format_service_name(service, emit_package);
@@ -53,44 +56,44 @@ pub(crate) fn generate_internal<T: Service>(
                 // will trigger if compression is disabled
                 clippy::let_unit_value,
             )]
-            use tonic::codegen::*;
-            use tonic::codegen::http::Uri;
+            use #tonic_path::codegen::*;
+            use #tonic_path::codegen::http::Uri;
 
             #service_doc
             #(#struct_attributes)*
             #[derive(Debug, Clone)]
             pub struct #service_ident<T> {
-                inner: tonic::client::Grpc<T>,
+                inner: #tonic_path::client::Grpc<T>,
             }
 
             #connect
 
             impl<T> #service_ident<T>
             where
-                T: tonic::client::GrpcService<tonic::body::Body>,
+                T: #tonic_path::client::GrpcService<#tonic_path::body::Body>,
                 T::Error: Into<StdError>,
                 T::ResponseBody: Body<Data = Bytes> + std::marker::Send  + 'static,
                 <T::ResponseBody as Body>::Error: Into<StdError> + std::marker::Send,
             {
                 pub fn new(inner: T) -> Self {
-                    let inner = tonic::client::Grpc::new(inner);
+                    let inner = #tonic_path::client::Grpc::new(inner);
                     Self { inner }
                 }
 
                 pub fn with_origin(inner: T, origin: Uri) -> Self {
-                    let inner = tonic::client::Grpc::with_origin(inner, origin);
+                    let inner = #tonic_path::client::Grpc::with_origin(inner, origin);
                     Self { inner }
                 }
 
                 pub fn with_interceptor<F>(inner: T, interceptor: F) -> #service_ident<InterceptedService<T, F>>
                 where
-                    F: tonic::service::Interceptor,
+                    F: #tonic_path::service::Interceptor,
                     T::ResponseBody: Default,
-                    T: tonic::codegen::Service<
-                        http::Request<tonic::body::Body>,
-                        Response = http::Response<<T as tonic::client::GrpcService<tonic::body::Body>>::ResponseBody>
+                    T: #tonic_path::codegen::Service<
+                        http::Request<#tonic_path::body::Body>,
+                        Response = http::Response<<T as #tonic_path::client::GrpcService<#tonic_path::body::Body>>::ResponseBody>
                     >,
-                    <T as tonic::codegen::Service<http::Request<tonic::body::Body>>>::Error: Into<StdError> + std::marker::Send + std::marker::Sync,
+                    <T as #tonic_path::codegen::Service<http::Request<#tonic_path::body::Body>>>::Error: Into<StdError> + std::marker::Send + std::marker::Sync,
                 {
                     #service_ident::new(InterceptedService::new(inner, interceptor))
                 }
@@ -137,16 +140,20 @@ pub(crate) fn generate_internal<T: Service>(
 }
 
 #[cfg(feature = "transport")]
-fn generate_connect(service_ident: &syn::Ident, enabled: bool) -> TokenStream {
+fn generate_connect(
+    service_ident: &syn::Ident,
+    enabled: bool,
+    tonic_path: &syn::Path,
+) -> TokenStream {
     let connect_impl = quote! {
-        impl #service_ident<tonic::transport::Channel> {
+        impl #service_ident<#tonic_path::transport::Channel> {
             /// Attempt to create a new client by connecting to a given endpoint.
-            pub async fn connect<D>(dst: D) -> Result<Self, tonic::transport::Error>
+            pub async fn connect<D>(dst: D) -> Result<Self, #tonic_path::transport::Error>
             where
-                D: TryInto<tonic::transport::Endpoint>,
+                D: TryInto<#tonic_path::transport::Endpoint>,
                 D::Error: Into<StdError>,
             {
-                let conn = tonic::transport::Endpoint::new(dst)?.connect().await?;
+                let conn = #tonic_path::transport::Endpoint::new(dst)?.connect().await?;
                 Ok(Self::new(conn))
             }
         }
@@ -160,7 +167,11 @@ fn generate_connect(service_ident: &syn::Ident, enabled: bool) -> TokenStream {
 }
 
 #[cfg(not(feature = "transport"))]
-fn generate_connect(_service_ident: &syn::Ident, _enabled: bool) -> TokenStream {
+fn generate_connect(
+    _service_ident: &syn::Ident,
+    _enabled: bool,
+    _tonic_path: &syn::Path,
+) -> TokenStream {
     TokenStream::new()
 }
 
@@ -170,6 +181,7 @@ fn generate_methods<T: Service>(
     proto_path: &str,
     compile_well_known_types: bool,
     disable_comments: &HashSet<String>,
+    tonic_path: &syn::Path,
 ) -> TokenStream {
     let mut stream = TokenStream::new();
 
@@ -188,6 +200,7 @@ fn generate_methods<T: Service>(
                 emit_package,
                 proto_path,
                 compile_well_known_types,
+                tonic_path,
             ),
             (false, true) => generate_server_streaming(
                 service,
@@ -195,6 +208,7 @@ fn generate_methods<T: Service>(
                 emit_package,
                 proto_path,
                 compile_well_known_types,
+                tonic_path,
             ),
             (true, false) => generate_client_streaming(
                 service,
@@ -202,6 +216,7 @@ fn generate_methods<T: Service>(
                 emit_package,
                 proto_path,
                 compile_well_known_types,
+                tonic_path,
             ),
             (true, true) => generate_streaming(
                 service,
@@ -209,6 +224,7 @@ fn generate_methods<T: Service>(
                 emit_package,
                 proto_path,
                 compile_well_known_types,
+                tonic_path,
             ),
         };
 
@@ -224,6 +240,7 @@ fn generate_unary<T: Service>(
     emit_package: bool,
     proto_path: &str,
     compile_well_known_types: bool,
+    tonic_path: &syn::Path,
 ) -> TokenStream {
     let codec_name = syn::parse_str::<syn::Path>(method.codec_path()).unwrap();
     let ident = format_ident!("{}", method.name());
@@ -235,10 +252,10 @@ fn generate_unary<T: Service>(
     quote! {
         pub async fn #ident(
             &mut self,
-            request: impl tonic::IntoRequest<#request>,
-        ) -> std::result::Result<tonic::Response<#response>, tonic::Status> {
+            request: impl #tonic_path::IntoRequest<#request>,
+        ) -> std::result::Result<#tonic_path::Response<#response>, #tonic_path::Status> {
            self.inner.ready().await.map_err(|e| {
-               tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
+               #tonic_path::Status::unknown(format!("Service was not ready: {}", e.into()))
            })?;
            let codec = #codec_name::default();
            let path = http::uri::PathAndQuery::from_static(#path);
@@ -255,6 +272,7 @@ fn generate_server_streaming<T: Service>(
     emit_package: bool,
     proto_path: &str,
     compile_well_known_types: bool,
+    tonic_path: &syn::Path,
 ) -> TokenStream {
     let codec_name = syn::parse_str::<syn::Path>(method.codec_path()).unwrap();
     let ident = format_ident!("{}", method.name());
@@ -266,10 +284,10 @@ fn generate_server_streaming<T: Service>(
     quote! {
         pub async fn #ident(
             &mut self,
-            request: impl tonic::IntoRequest<#request>,
-        ) -> std::result::Result<tonic::Response<tonic::codec::Streaming<#response>>, tonic::Status> {
+            request: impl #tonic_path::IntoRequest<#request>,
+        ) -> std::result::Result<#tonic_path::Response<#tonic_path::codec::Streaming<#response>>, #tonic_path::Status> {
             self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
+                #tonic_path::Status::unknown(format!("Service was not ready: {}", e.into()))
             })?;
             let codec = #codec_name::default();
             let path = http::uri::PathAndQuery::from_static(#path);
@@ -286,6 +304,7 @@ fn generate_client_streaming<T: Service>(
     emit_package: bool,
     proto_path: &str,
     compile_well_known_types: bool,
+    tonic_path: &syn::Path,
 ) -> TokenStream {
     let codec_name = syn::parse_str::<syn::Path>(method.codec_path()).unwrap();
     let ident = format_ident!("{}", method.name());
@@ -297,10 +316,10 @@ fn generate_client_streaming<T: Service>(
     quote! {
         pub async fn #ident(
             &mut self,
-            request: impl tonic::IntoStreamingRequest<Message = #request>
-        ) -> std::result::Result<tonic::Response<#response>, tonic::Status> {
+            request: impl #tonic_path::IntoStreamingRequest<Message = #request>
+        ) -> std::result::Result<#tonic_path::Response<#response>, #tonic_path::Status> {
             self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
+                #tonic_path::Status::unknown(format!("Service was not ready: {}", e.into()))
             })?;
             let codec = #codec_name::default();
             let path = http::uri::PathAndQuery::from_static(#path);
@@ -317,6 +336,7 @@ fn generate_streaming<T: Service>(
     emit_package: bool,
     proto_path: &str,
     compile_well_known_types: bool,
+    tonic_path: &syn::Path,
 ) -> TokenStream {
     let codec_name = syn::parse_str::<syn::Path>(method.codec_path()).unwrap();
     let ident = format_ident!("{}", method.name());
@@ -328,10 +348,10 @@ fn generate_streaming<T: Service>(
     quote! {
         pub async fn #ident(
             &mut self,
-            request: impl tonic::IntoStreamingRequest<Message = #request>
-        ) -> std::result::Result<tonic::Response<tonic::codec::Streaming<#response>>, tonic::Status> {
+            request: impl #tonic_path::IntoStreamingRequest<Message = #request>
+        ) -> std::result::Result<#tonic_path::Response<#tonic_path::codec::Streaming<#response>>, #tonic_path::Status> {
             self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
+                #tonic_path::Status::unknown(format!("Service was not ready: {}", e.into()))
             })?;
             let codec = #codec_name::default();
             let path = http::uri::PathAndQuery::from_static(#path);

--- a/tonic-build/src/code_gen.rs
+++ b/tonic-build/src/code_gen.rs
@@ -19,6 +19,7 @@ pub struct CodeGenBuilder {
     disable_comments: HashSet<String>,
     use_arc_self: bool,
     generate_default_stubs: bool,
+    tonic_path: String,
 }
 
 impl CodeGenBuilder {
@@ -70,6 +71,15 @@ impl CodeGenBuilder {
         self
     }
 
+    /// Set the path to the `tonic` crate for generated code.
+    ///
+    /// Useful for crates that re-export `tonic` under a different path (e.g.
+    /// `my_lib::tonic`). When unset, the default of `::tonic` is used.
+    pub fn tonic_path(&mut self, path: impl AsRef<str>) -> &mut Self {
+        self.tonic_path = path.as_ref().to_string();
+        self
+    }
+
     /// Enable or disable returning automatic unimplemented gRPC error code for generated traits.
     pub fn generate_default_stubs(&mut self, generate_default_stubs: bool) -> &mut Self {
         self.generate_default_stubs = generate_default_stubs;
@@ -81,6 +91,7 @@ impl CodeGenBuilder {
     /// This takes some `Service` and will generate a `TokenStream` that contains
     /// a public module with the generated client.
     pub fn generate_client(&self, service: &impl Service, proto_path: &str) -> TokenStream {
+        let tonic_path = self.parse_tonic_path();
         crate::client::generate_internal(
             service,
             self.emit_package,
@@ -89,6 +100,7 @@ impl CodeGenBuilder {
             self.build_transport,
             &self.attributes,
             &self.disable_comments,
+            &tonic_path,
         )
     }
 
@@ -97,6 +109,7 @@ impl CodeGenBuilder {
     /// This takes some `Service` and will generate a `TokenStream` that contains
     /// a public module with the generated client.
     pub fn generate_server(&self, service: &impl Service, proto_path: &str) -> TokenStream {
+        let tonic_path = self.parse_tonic_path();
         crate::server::generate_internal(
             service,
             self.emit_package,
@@ -106,7 +119,12 @@ impl CodeGenBuilder {
             &self.disable_comments,
             self.use_arc_self,
             self.generate_default_stubs,
+            &tonic_path,
         )
+    }
+
+    fn parse_tonic_path(&self) -> syn::Path {
+        syn::parse_str(&self.tonic_path).expect("invalid tonic path")
     }
 }
 
@@ -120,6 +138,7 @@ impl Default for CodeGenBuilder {
             disable_comments: HashSet::default(),
             use_arc_self: false,
             generate_default_stubs: false,
+            tonic_path: "::tonic".to_string(),
         }
     }
 }

--- a/tonic-build/src/manual.rs
+++ b/tonic-build/src/manual.rs
@@ -361,20 +361,26 @@ struct ServiceGenerator {
 impl ServiceGenerator {
     fn generate(&mut self, service: &Service) {
         if self.builder.build_server {
-            let server = CodeGenBuilder::new()
-                .emit_package(true)
-                .compile_well_known_types(false)
-                .generate_server(service, "");
+            let mut builder = CodeGenBuilder::new();
+            builder.emit_package(true).compile_well_known_types(false);
+            if let Some(tonic_path) = &self.builder.tonic_path {
+                builder.tonic_path(tonic_path);
+            }
+            let server = builder.generate_server(service, "");
 
             self.servers.extend(server);
         }
 
         if self.builder.build_client {
-            let client = CodeGenBuilder::new()
+            let mut builder = CodeGenBuilder::new();
+            builder
                 .emit_package(true)
                 .compile_well_known_types(false)
-                .build_transport(self.builder.build_transport)
-                .generate_client(service, "");
+                .build_transport(self.builder.build_transport);
+            if let Some(tonic_path) = &self.builder.tonic_path {
+                builder.tonic_path(tonic_path);
+            }
+            let client = builder.generate_client(service, "");
 
             self.clients.extend(client);
         }
@@ -419,6 +425,7 @@ pub struct Builder {
     build_transport: bool,
 
     out_dir: Option<PathBuf>,
+    tonic_path: Option<String>,
 }
 
 impl Default for Builder {
@@ -428,6 +435,7 @@ impl Default for Builder {
             build_client: true,
             build_transport: true,
             out_dir: None,
+            tonic_path: None,
         }
     }
 }
@@ -468,6 +476,15 @@ impl Builder {
     /// Defaults to the `OUT_DIR` environment variable.
     pub fn out_dir(mut self, out_dir: impl AsRef<Path>) -> Self {
         self.out_dir = Some(out_dir.as_ref().to_path_buf());
+        self
+    }
+
+    /// Set the path to the `tonic` crate for generated code.
+    ///
+    /// Useful for crates that re-export `tonic` under a different path (e.g.
+    /// `my_lib::tonic`). When unset, the default of `::tonic` is used.
+    pub fn tonic_path(mut self, path: impl AsRef<str>) -> Self {
+        self.tonic_path = Some(path.as_ref().to_string());
         self
     }
 

--- a/tonic-build/src/server.rs
+++ b/tonic-build/src/server.rs
@@ -19,6 +19,7 @@ pub(crate) fn generate_internal<T: Service>(
     disable_comments: &HashSet<String>,
     use_arc_self: bool,
     generate_default_stubs: bool,
+    tonic_path: &syn::Path,
 ) -> TokenStream {
     let methods = generate_methods(
         service,
@@ -27,6 +28,7 @@ pub(crate) fn generate_internal<T: Service>(
         compile_well_known_types,
         use_arc_self,
         generate_default_stubs,
+        tonic_path,
     );
 
     let server_service = quote::format_ident!("{}Server", service.name());
@@ -43,6 +45,7 @@ pub(crate) fn generate_internal<T: Service>(
         use_arc_self,
         generate_default_stubs,
         trait_attributes,
+        tonic_path,
     );
     let package = if emit_package { service.package() } else { "" };
     // Transport based implementations
@@ -54,7 +57,7 @@ pub(crate) fn generate_internal<T: Service>(
         generate_doc_comments(service.comment())
     };
 
-    let named = generate_named(&server_service, &service_name);
+    let named = generate_named(&server_service, &service_name, tonic_path);
     let mod_attributes = attributes.for_mod(package);
     let struct_attributes = attributes.for_struct(&service_name);
 
@@ -106,7 +109,7 @@ pub(crate) fn generate_internal<T: Service>(
                 // will trigger if compression is disabled
                 clippy::let_unit_value,
             )]
-            use tonic::codegen::*;
+            use #tonic_path::codegen::*;
 
             #generated_trait
 
@@ -138,7 +141,7 @@ pub(crate) fn generate_internal<T: Service>(
 
                 pub fn with_interceptor<F>(inner: T, interceptor: F) -> InterceptedService<Self, F>
                 where
-                    F: tonic::service::Interceptor,
+                    F: #tonic_path::service::Interceptor,
                 {
                     InterceptedService::new(Self::new(inner), interceptor)
                 }
@@ -148,13 +151,13 @@ pub(crate) fn generate_internal<T: Service>(
                 #configure_max_message_size_methods
             }
 
-            impl<T, B> tonic::codegen::Service<http::Request<B>> for #server_service<T>
+            impl<T, B> #tonic_path::codegen::Service<http::Request<B>> for #server_service<T>
                 where
                     T: #server_trait,
                     B: Body + std::marker::Send + 'static,
                     B::Error: Into<StdError> + std::marker::Send + 'static,
             {
-                type Response = http::Response<tonic::body::Body>;
+                type Response = http::Response<#tonic_path::body::Body>;
                 type Error = std::convert::Infallible;
                 type Future = BoxFuture<Self::Response, Self::Error>;
 
@@ -167,10 +170,10 @@ pub(crate) fn generate_internal<T: Service>(
                         #methods
 
                         _ => Box::pin(async move {
-                            let mut response = http::Response::new(tonic::body::Body::default());
+                            let mut response = http::Response::new(#tonic_path::body::Body::default());
                             let headers = response.headers_mut();
-                            headers.insert(tonic::Status::GRPC_STATUS, (tonic::Code::Unimplemented as i32).into());
-                            headers.insert(http::header::CONTENT_TYPE, tonic::metadata::GRPC_CONTENT_TYPE);
+                            headers.insert(#tonic_path::Status::GRPC_STATUS, (#tonic_path::Code::Unimplemented as i32).into());
+                            headers.insert(http::header::CONTENT_TYPE, #tonic_path::metadata::GRPC_CONTENT_TYPE);
                             Ok(response)
                         }),
                     }
@@ -206,6 +209,7 @@ fn generate_trait<T: Service>(
     use_arc_self: bool,
     generate_default_stubs: bool,
     trait_attributes: Vec<syn::Attribute>,
+    tonic_path: &syn::Path,
 ) -> TokenStream {
     let methods = generate_trait_methods(
         service,
@@ -215,6 +219,7 @@ fn generate_trait<T: Service>(
         disable_comments,
         use_arc_self,
         generate_default_stubs,
+        tonic_path,
     );
     let trait_doc = generate_doc_comment(format!(
         " Generated trait containing gRPC methods that should be implemented for use with {}Server.",
@@ -231,6 +236,7 @@ fn generate_trait<T: Service>(
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 fn generate_trait_methods<T: Service>(
     service: &T,
     emit_package: bool,
@@ -239,6 +245,7 @@ fn generate_trait_methods<T: Service>(
     disable_comments: &HashSet<String>,
     use_arc_self: bool,
     generate_default_stubs: bool,
+    tonic_path: &syn::Path,
 ) -> TokenStream {
     let mut stream = TokenStream::new();
 
@@ -269,41 +276,41 @@ fn generate_trait_methods<T: Service>(
             (false, false, true) => {
                 quote! {
                     #method_doc
-                    async fn #name(#self_param, request: tonic::Request<#req_message>)
-                        -> std::result::Result<tonic::Response<#res_message>, tonic::Status> {
-                        Err(tonic::Status::unimplemented("Not yet implemented"))
+                    async fn #name(#self_param, request: #tonic_path::Request<#req_message>)
+                        -> std::result::Result<#tonic_path::Response<#res_message>, #tonic_path::Status> {
+                        Err(#tonic_path::Status::unimplemented("Not yet implemented"))
                     }
                 }
             }
             (false, false, false) => {
                 quote! {
                     #method_doc
-                    async fn #name(#self_param, request: tonic::Request<#req_message>)
-                        -> std::result::Result<tonic::Response<#res_message>, tonic::Status>;
+                    async fn #name(#self_param, request: #tonic_path::Request<#req_message>)
+                        -> std::result::Result<#tonic_path::Response<#res_message>, #tonic_path::Status>;
                 }
             }
             (true, false, true) => {
                 quote! {
                     #method_doc
-                    async fn #name(#self_param, request: tonic::Request<tonic::Streaming<#req_message>>)
-                        -> std::result::Result<tonic::Response<#res_message>, tonic::Status> {
-                        Err(tonic::Status::unimplemented("Not yet implemented"))
+                    async fn #name(#self_param, request: #tonic_path::Request<#tonic_path::Streaming<#req_message>>)
+                        -> std::result::Result<#tonic_path::Response<#res_message>, #tonic_path::Status> {
+                        Err(#tonic_path::Status::unimplemented("Not yet implemented"))
                     }
                 }
             }
             (true, false, false) => {
                 quote! {
                     #method_doc
-                    async fn #name(#self_param, request: tonic::Request<tonic::Streaming<#req_message>>)
-                        -> std::result::Result<tonic::Response<#res_message>, tonic::Status>;
+                    async fn #name(#self_param, request: #tonic_path::Request<#tonic_path::Streaming<#req_message>>)
+                        -> std::result::Result<#tonic_path::Response<#res_message>, #tonic_path::Status>;
                 }
             }
             (false, true, true) => {
                 quote! {
                     #method_doc
-                    async fn #name(#self_param, request: tonic::Request<#req_message>)
-                        -> std::result::Result<tonic::Response<BoxStream<#res_message>>, tonic::Status> {
-                        Err(tonic::Status::unimplemented("Not yet implemented"))
+                    async fn #name(#self_param, request: #tonic_path::Request<#req_message>)
+                        -> std::result::Result<#tonic_path::Response<BoxStream<#res_message>>, #tonic_path::Status> {
+                        Err(#tonic_path::Status::unimplemented("Not yet implemented"))
                     }
                 }
             }
@@ -316,19 +323,19 @@ fn generate_trait_methods<T: Service>(
 
                 quote! {
                     #stream_doc
-                    type #stream: tonic::codegen::tokio_stream::Stream<Item = std::result::Result<#res_message, tonic::Status>> + std::marker::Send + 'static;
+                    type #stream: #tonic_path::codegen::tokio_stream::Stream<Item = std::result::Result<#res_message, #tonic_path::Status>> + std::marker::Send + 'static;
 
                     #method_doc
-                    async fn #name(#self_param, request: tonic::Request<#req_message>)
-                        -> std::result::Result<tonic::Response<Self::#stream>, tonic::Status>;
+                    async fn #name(#self_param, request: #tonic_path::Request<#req_message>)
+                        -> std::result::Result<#tonic_path::Response<Self::#stream>, #tonic_path::Status>;
                 }
             }
             (true, true, true) => {
                 quote! {
                     #method_doc
-                    async fn #name(#self_param, request: tonic::Request<tonic::Streaming<#req_message>>)
-                        -> std::result::Result<tonic::Response<BoxStream<#res_message>>, tonic::Status> {
-                        Err(tonic::Status::unimplemented("Not yet implemented"))
+                    async fn #name(#self_param, request: #tonic_path::Request<#tonic_path::Streaming<#req_message>>)
+                        -> std::result::Result<#tonic_path::Response<BoxStream<#res_message>>, #tonic_path::Status> {
+                        Err(#tonic_path::Status::unimplemented("Not yet implemented"))
                     }
                 }
             }
@@ -341,11 +348,11 @@ fn generate_trait_methods<T: Service>(
 
                 quote! {
                     #stream_doc
-                    type #stream: tonic::codegen::tokio_stream::Stream<Item = std::result::Result<#res_message, tonic::Status>> + std::marker::Send + 'static;
+                    type #stream: #tonic_path::codegen::tokio_stream::Stream<Item = std::result::Result<#res_message, #tonic_path::Status>> + std::marker::Send + 'static;
 
                     #method_doc
-                    async fn #name(#self_param, request: tonic::Request<tonic::Streaming<#req_message>>)
-                        -> std::result::Result<tonic::Response<Self::#stream>, tonic::Status>;
+                    async fn #name(#self_param, request: #tonic_path::Request<#tonic_path::Streaming<#req_message>>)
+                        -> std::result::Result<#tonic_path::Response<Self::#stream>, #tonic_path::Status>;
                 }
             }
         };
@@ -356,7 +363,11 @@ fn generate_trait_methods<T: Service>(
     stream
 }
 
-fn generate_named(server_service: &syn::Ident, service_name: &str) -> TokenStream {
+fn generate_named(
+    server_service: &syn::Ident,
+    service_name: &str,
+    tonic_path: &syn::Path,
+) -> TokenStream {
     let service_name = syn::LitStr::new(service_name, proc_macro2::Span::call_site());
     let name_doc = generate_doc_comment(" Generated gRPC service name");
 
@@ -364,7 +375,7 @@ fn generate_named(server_service: &syn::Ident, service_name: &str) -> TokenStrea
         #name_doc
         pub const SERVICE_NAME: &str = #service_name;
 
-        impl<T> tonic::server::NamedService for #server_service<T> {
+        impl<T> #tonic_path::server::NamedService for #server_service<T> {
             const NAME: &'static str = SERVICE_NAME;
         }
     }
@@ -377,6 +388,7 @@ fn generate_methods<T: Service>(
     compile_well_known_types: bool,
     use_arc_self: bool,
     generate_default_stubs: bool,
+    tonic_path: &syn::Path,
 ) -> TokenStream {
     let mut stream = TokenStream::new();
 
@@ -394,6 +406,7 @@ fn generate_methods<T: Service>(
                 ident,
                 server_trait,
                 use_arc_self,
+                tonic_path,
             ),
 
             (false, true) => generate_server_streaming(
@@ -404,6 +417,7 @@ fn generate_methods<T: Service>(
                 server_trait,
                 use_arc_self,
                 generate_default_stubs,
+                tonic_path,
             ),
             (true, false) => generate_client_streaming(
                 method,
@@ -412,6 +426,7 @@ fn generate_methods<T: Service>(
                 ident.clone(),
                 server_trait,
                 use_arc_self,
+                tonic_path,
             ),
 
             (true, true) => generate_streaming(
@@ -422,6 +437,7 @@ fn generate_methods<T: Service>(
                 server_trait,
                 use_arc_self,
                 generate_default_stubs,
+                tonic_path,
             ),
         };
 
@@ -443,6 +459,7 @@ fn generate_unary<T: Method>(
     method_ident: Ident,
     server_trait: Ident,
     use_arc_self: bool,
+    tonic_path: &syn::Path,
 ) -> TokenStream {
     let codec_name = syn::parse_str::<syn::Path>(method.codec_path()).unwrap();
 
@@ -460,11 +477,11 @@ fn generate_unary<T: Method>(
         #[allow(non_camel_case_types)]
         struct #service_ident<T: #server_trait >(pub Arc<T>);
 
-        impl<T: #server_trait> tonic::server::UnaryService<#request> for #service_ident<T> {
+        impl<T: #server_trait> #tonic_path::server::UnaryService<#request> for #service_ident<T> {
             type Response = #response;
-            type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+            type Future = BoxFuture<#tonic_path::Response<Self::Response>, #tonic_path::Status>;
 
-            fn call(&mut self, request: tonic::Request<#request>) -> Self::Future {
+            fn call(&mut self, request: #tonic_path::Request<#request>) -> Self::Future {
                 let inner = Arc::clone(&self.0);
                 let fut = async move {
                     <T as #server_trait>::#method_ident(#inner_arg, request).await
@@ -482,7 +499,7 @@ fn generate_unary<T: Method>(
             let method = #service_ident(inner);
             let codec = #codec_name::default();
 
-            let mut grpc = tonic::server::Grpc::new(codec)
+            let mut grpc = #tonic_path::server::Grpc::new(codec)
                 .apply_compression_config(accept_compression_encodings, send_compression_encodings)
                 .apply_max_message_size_config(max_decoding_message_size, max_encoding_message_size);
 
@@ -494,6 +511,7 @@ fn generate_unary<T: Method>(
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 fn generate_server_streaming<T: Method>(
     method: &T,
     proto_path: &str,
@@ -502,6 +520,7 @@ fn generate_server_streaming<T: Method>(
     server_trait: Ident,
     use_arc_self: bool,
     generate_default_stubs: bool,
+    tonic_path: &syn::Path,
 ) -> TokenStream {
     let codec_name = syn::parse_str::<syn::Path>(method.codec_path()).unwrap();
 
@@ -526,12 +545,12 @@ fn generate_server_streaming<T: Method>(
         #[allow(non_camel_case_types)]
         struct #service_ident<T: #server_trait >(pub Arc<T>);
 
-        impl<T: #server_trait> tonic::server::ServerStreamingService<#request> for #service_ident<T> {
+        impl<T: #server_trait> #tonic_path::server::ServerStreamingService<#request> for #service_ident<T> {
             type Response = #response;
             #response_stream;
-            type Future = BoxFuture<tonic::Response<Self::ResponseStream>, tonic::Status>;
+            type Future = BoxFuture<#tonic_path::Response<Self::ResponseStream>, #tonic_path::Status>;
 
-            fn call(&mut self, request: tonic::Request<#request>) -> Self::Future {
+            fn call(&mut self, request: #tonic_path::Request<#request>) -> Self::Future {
                 let inner = Arc::clone(&self.0);
                 let fut = async move {
                     <T as #server_trait>::#method_ident(#inner_arg, request).await
@@ -549,7 +568,7 @@ fn generate_server_streaming<T: Method>(
             let method = #service_ident(inner);
             let codec = #codec_name::default();
 
-            let mut grpc = tonic::server::Grpc::new(codec)
+            let mut grpc = #tonic_path::server::Grpc::new(codec)
                 .apply_compression_config(accept_compression_encodings, send_compression_encodings)
                 .apply_max_message_size_config(max_decoding_message_size, max_encoding_message_size);
 
@@ -568,6 +587,7 @@ fn generate_client_streaming<T: Method>(
     method_ident: Ident,
     server_trait: Ident,
     use_arc_self: bool,
+    tonic_path: &syn::Path,
 ) -> TokenStream {
     let service_ident = quote::format_ident!("{}Svc", method.identifier());
 
@@ -584,12 +604,12 @@ fn generate_client_streaming<T: Method>(
         #[allow(non_camel_case_types)]
         struct #service_ident<T: #server_trait >(pub Arc<T>);
 
-        impl<T: #server_trait> tonic::server::ClientStreamingService<#request> for #service_ident<T>
+        impl<T: #server_trait> #tonic_path::server::ClientStreamingService<#request> for #service_ident<T>
         {
             type Response = #response;
-            type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+            type Future = BoxFuture<#tonic_path::Response<Self::Response>, #tonic_path::Status>;
 
-            fn call(&mut self, request: tonic::Request<tonic::Streaming<#request>>) -> Self::Future {
+            fn call(&mut self, request: #tonic_path::Request<#tonic_path::Streaming<#request>>) -> Self::Future {
                 let inner = Arc::clone(&self.0);
                 let fut = async move {
                     <T as #server_trait>::#method_ident(#inner_arg, request).await
@@ -607,7 +627,7 @@ fn generate_client_streaming<T: Method>(
             let method = #service_ident(inner);
             let codec = #codec_name::default();
 
-            let mut grpc = tonic::server::Grpc::new(codec)
+            let mut grpc = #tonic_path::server::Grpc::new(codec)
                 .apply_compression_config(accept_compression_encodings, send_compression_encodings)
                 .apply_max_message_size_config(max_decoding_message_size, max_encoding_message_size);
 
@@ -619,6 +639,7 @@ fn generate_client_streaming<T: Method>(
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 fn generate_streaming<T: Method>(
     method: &T,
     proto_path: &str,
@@ -627,6 +648,7 @@ fn generate_streaming<T: Method>(
     server_trait: Ident,
     use_arc_self: bool,
     generate_default_stubs: bool,
+    tonic_path: &syn::Path,
 ) -> TokenStream {
     let codec_name = syn::parse_str::<syn::Path>(method.codec_path()).unwrap();
 
@@ -651,13 +673,13 @@ fn generate_streaming<T: Method>(
         #[allow(non_camel_case_types)]
         struct #service_ident<T: #server_trait>(pub Arc<T>);
 
-        impl<T: #server_trait> tonic::server::StreamingService<#request> for #service_ident<T>
+        impl<T: #server_trait> #tonic_path::server::StreamingService<#request> for #service_ident<T>
         {
             type Response = #response;
             #response_stream;
-            type Future = BoxFuture<tonic::Response<Self::ResponseStream>, tonic::Status>;
+            type Future = BoxFuture<#tonic_path::Response<Self::ResponseStream>, #tonic_path::Status>;
 
-            fn call(&mut self, request: tonic::Request<tonic::Streaming<#request>>) -> Self::Future {
+            fn call(&mut self, request: #tonic_path::Request<#tonic_path::Streaming<#request>>) -> Self::Future {
                 let inner = Arc::clone(&self.0);
                 let fut = async move {
                     <T as #server_trait>::#method_ident(#inner_arg, request).await
@@ -675,7 +697,7 @@ fn generate_streaming<T: Method>(
             let method = #service_ident(inner);
             let codec = #codec_name::default();
 
-            let mut grpc = tonic::server::Grpc::new(codec)
+            let mut grpc = #tonic_path::server::Grpc::new(codec)
                 .apply_compression_config(accept_compression_encodings, send_compression_encodings)
                 .apply_max_message_size_config(max_decoding_message_size, max_encoding_message_size);
 

--- a/tonic-health/src/generated/grpc_health_v1.rs
+++ b/tonic-health/src/generated/grpc_health_v1.rs
@@ -64,25 +64,25 @@ pub mod health_client {
         clippy::wildcard_imports,
         clippy::let_unit_value,
     )]
-    use tonic::codegen::*;
-    use tonic::codegen::http::Uri;
+    use ::tonic::codegen::*;
+    use ::tonic::codegen::http::Uri;
     #[derive(Debug, Clone)]
     pub struct HealthClient<T> {
-        inner: tonic::client::Grpc<T>,
+        inner: ::tonic::client::Grpc<T>,
     }
     impl<T> HealthClient<T>
     where
-        T: tonic::client::GrpcService<tonic::body::Body>,
+        T: ::tonic::client::GrpcService<::tonic::body::Body>,
         T::Error: Into<StdError>,
         T::ResponseBody: Body<Data = Bytes> + std::marker::Send + 'static,
         <T::ResponseBody as Body>::Error: Into<StdError> + std::marker::Send,
     {
         pub fn new(inner: T) -> Self {
-            let inner = tonic::client::Grpc::new(inner);
+            let inner = ::tonic::client::Grpc::new(inner);
             Self { inner }
         }
         pub fn with_origin(inner: T, origin: Uri) -> Self {
-            let inner = tonic::client::Grpc::with_origin(inner, origin);
+            let inner = ::tonic::client::Grpc::with_origin(inner, origin);
             Self { inner }
         }
         pub fn with_interceptor<F>(
@@ -90,16 +90,18 @@ pub mod health_client {
             interceptor: F,
         ) -> HealthClient<InterceptedService<T, F>>
         where
-            F: tonic::service::Interceptor,
+            F: ::tonic::service::Interceptor,
             T::ResponseBody: Default,
-            T: tonic::codegen::Service<
-                http::Request<tonic::body::Body>,
+            T: ::tonic::codegen::Service<
+                http::Request<::tonic::body::Body>,
                 Response = http::Response<
-                    <T as tonic::client::GrpcService<tonic::body::Body>>::ResponseBody,
+                    <T as ::tonic::client::GrpcService<
+                        ::tonic::body::Body,
+                    >>::ResponseBody,
                 >,
             >,
-            <T as tonic::codegen::Service<
-                http::Request<tonic::body::Body>,
+            <T as ::tonic::codegen::Service<
+                http::Request<::tonic::body::Body>,
             >>::Error: Into<StdError> + std::marker::Send + std::marker::Sync,
         {
             HealthClient::new(InterceptedService::new(inner, interceptor))
@@ -139,16 +141,16 @@ pub mod health_client {
         /// NOT_FOUND.
         pub async fn check(
             &mut self,
-            request: impl tonic::IntoRequest<super::HealthCheckRequest>,
+            request: impl ::tonic::IntoRequest<super::HealthCheckRequest>,
         ) -> std::result::Result<
-            tonic::Response<super::HealthCheckResponse>,
-            tonic::Status,
+            ::tonic::Response<super::HealthCheckResponse>,
+            ::tonic::Status,
         > {
             self.inner
                 .ready()
                 .await
                 .map_err(|e| {
-                    tonic::Status::unknown(
+                    ::tonic::Status::unknown(
                         format!("Service was not ready: {}", e.into()),
                     )
                 })?;
@@ -178,16 +180,16 @@ pub mod health_client {
         /// clients should retry the call with appropriate exponential backoff.
         pub async fn watch(
             &mut self,
-            request: impl tonic::IntoRequest<super::HealthCheckRequest>,
+            request: impl ::tonic::IntoRequest<super::HealthCheckRequest>,
         ) -> std::result::Result<
-            tonic::Response<tonic::codec::Streaming<super::HealthCheckResponse>>,
-            tonic::Status,
+            ::tonic::Response<::tonic::codec::Streaming<super::HealthCheckResponse>>,
+            ::tonic::Status,
         > {
             self.inner
                 .ready()
                 .await
                 .map_err(|e| {
-                    tonic::Status::unknown(
+                    ::tonic::Status::unknown(
                         format!("Service was not ready: {}", e.into()),
                     )
                 })?;
@@ -211,7 +213,7 @@ pub mod health_server {
         clippy::wildcard_imports,
         clippy::let_unit_value,
     )]
-    use tonic::codegen::*;
+    use ::tonic::codegen::*;
     /// Generated trait containing gRPC methods that should be implemented for use with HealthServer.
     #[async_trait]
     pub trait Health: std::marker::Send + std::marker::Sync + 'static {
@@ -219,14 +221,14 @@ pub mod health_server {
         /// NOT_FOUND.
         async fn check(
             &self,
-            request: tonic::Request<super::HealthCheckRequest>,
+            request: ::tonic::Request<super::HealthCheckRequest>,
         ) -> std::result::Result<
-            tonic::Response<super::HealthCheckResponse>,
-            tonic::Status,
+            ::tonic::Response<super::HealthCheckResponse>,
+            ::tonic::Status,
         >;
         /// Server streaming response type for the Watch method.
-        type WatchStream: tonic::codegen::tokio_stream::Stream<
-                Item = std::result::Result<super::HealthCheckResponse, tonic::Status>,
+        type WatchStream: ::tonic::codegen::tokio_stream::Stream<
+                Item = std::result::Result<super::HealthCheckResponse, ::tonic::Status>,
             >
             + std::marker::Send
             + 'static;
@@ -247,8 +249,8 @@ pub mod health_server {
         /// clients should retry the call with appropriate exponential backoff.
         async fn watch(
             &self,
-            request: tonic::Request<super::HealthCheckRequest>,
-        ) -> std::result::Result<tonic::Response<Self::WatchStream>, tonic::Status>;
+            request: ::tonic::Request<super::HealthCheckRequest>,
+        ) -> std::result::Result<::tonic::Response<Self::WatchStream>, ::tonic::Status>;
     }
     #[derive(Debug)]
     pub struct HealthServer<T> {
@@ -276,7 +278,7 @@ pub mod health_server {
             interceptor: F,
         ) -> InterceptedService<Self, F>
         where
-            F: tonic::service::Interceptor,
+            F: ::tonic::service::Interceptor,
         {
             InterceptedService::new(Self::new(inner), interceptor)
         }
@@ -309,13 +311,13 @@ pub mod health_server {
             self
         }
     }
-    impl<T, B> tonic::codegen::Service<http::Request<B>> for HealthServer<T>
+    impl<T, B> ::tonic::codegen::Service<http::Request<B>> for HealthServer<T>
     where
         T: Health,
         B: Body + std::marker::Send + 'static,
         B::Error: Into<StdError> + std::marker::Send + 'static,
     {
-        type Response = http::Response<tonic::body::Body>;
+        type Response = http::Response<::tonic::body::Body>;
         type Error = std::convert::Infallible;
         type Future = BoxFuture<Self::Response, Self::Error>;
         fn poll_ready(
@@ -331,16 +333,16 @@ pub mod health_server {
                     struct CheckSvc<T: Health>(pub Arc<T>);
                     impl<
                         T: Health,
-                    > tonic::server::UnaryService<super::HealthCheckRequest>
+                    > ::tonic::server::UnaryService<super::HealthCheckRequest>
                     for CheckSvc<T> {
                         type Response = super::HealthCheckResponse;
                         type Future = BoxFuture<
-                            tonic::Response<Self::Response>,
-                            tonic::Status,
+                            ::tonic::Response<Self::Response>,
+                            ::tonic::Status,
                         >;
                         fn call(
                             &mut self,
-                            request: tonic::Request<super::HealthCheckRequest>,
+                            request: ::tonic::Request<super::HealthCheckRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
@@ -357,7 +359,7 @@ pub mod health_server {
                     let fut = async move {
                         let method = CheckSvc(inner);
                         let codec = tonic_prost::ProstCodec::default();
-                        let mut grpc = tonic::server::Grpc::new(codec)
+                        let mut grpc = ::tonic::server::Grpc::new(codec)
                             .apply_compression_config(
                                 accept_compression_encodings,
                                 send_compression_encodings,
@@ -376,17 +378,17 @@ pub mod health_server {
                     struct WatchSvc<T: Health>(pub Arc<T>);
                     impl<
                         T: Health,
-                    > tonic::server::ServerStreamingService<super::HealthCheckRequest>
+                    > ::tonic::server::ServerStreamingService<super::HealthCheckRequest>
                     for WatchSvc<T> {
                         type Response = super::HealthCheckResponse;
                         type ResponseStream = T::WatchStream;
                         type Future = BoxFuture<
-                            tonic::Response<Self::ResponseStream>,
-                            tonic::Status,
+                            ::tonic::Response<Self::ResponseStream>,
+                            ::tonic::Status,
                         >;
                         fn call(
                             &mut self,
-                            request: tonic::Request<super::HealthCheckRequest>,
+                            request: ::tonic::Request<super::HealthCheckRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
@@ -403,7 +405,7 @@ pub mod health_server {
                     let fut = async move {
                         let method = WatchSvc(inner);
                         let codec = tonic_prost::ProstCodec::default();
-                        let mut grpc = tonic::server::Grpc::new(codec)
+                        let mut grpc = ::tonic::server::Grpc::new(codec)
                             .apply_compression_config(
                                 accept_compression_encodings,
                                 send_compression_encodings,
@@ -420,18 +422,18 @@ pub mod health_server {
                 _ => {
                     Box::pin(async move {
                         let mut response = http::Response::new(
-                            tonic::body::Body::default(),
+                            ::tonic::body::Body::default(),
                         );
                         let headers = response.headers_mut();
                         headers
                             .insert(
-                                tonic::Status::GRPC_STATUS,
-                                (tonic::Code::Unimplemented as i32).into(),
+                                ::tonic::Status::GRPC_STATUS,
+                                (::tonic::Code::Unimplemented as i32).into(),
                             );
                         headers
                             .insert(
                                 http::header::CONTENT_TYPE,
-                                tonic::metadata::GRPC_CONTENT_TYPE,
+                                ::tonic::metadata::GRPC_CONTENT_TYPE,
                             );
                         Ok(response)
                     })
@@ -453,7 +455,7 @@ pub mod health_server {
     }
     /// Generated gRPC service name
     pub const SERVICE_NAME: &str = "grpc.health.v1.Health";
-    impl<T> tonic::server::NamedService for HealthServer<T> {
+    impl<T> ::tonic::server::NamedService for HealthServer<T> {
         const NAME: &'static str = SERVICE_NAME;
     }
 }

--- a/tonic-prost-build/src/lib.rs
+++ b/tonic-prost-build/src/lib.rs
@@ -85,6 +85,7 @@ pub fn configure() -> Builder {
         use_arc_self: false,
         generate_default_stubs: false,
         codec_path: "tonic_prost::ProstCodec".to_string(),
+        tonic_path: None,
         skip_debug: HashSet::default(),
     }
 }
@@ -328,6 +329,7 @@ struct ServiceGenerator {
     proto_path: String,
     compile_well_known_types: bool,
     codec_path: String,
+    tonic_path: Option<String>,
     disable_comments: HashSet<String>,
 }
 
@@ -345,6 +347,7 @@ impl ServiceGenerator {
         proto_path: String,
         compile_well_known_types: bool,
         codec_path: String,
+        tonic_path: Option<String>,
         disable_comments: HashSet<String>,
     ) -> Self {
         ServiceGenerator {
@@ -358,6 +361,7 @@ impl ServiceGenerator {
             proto_path,
             compile_well_known_types,
             codec_path,
+            tonic_path,
             disable_comments,
         }
     }
@@ -375,6 +379,10 @@ impl prost_build::ServiceGenerator for ServiceGenerator {
             .disable_comments(self.disable_comments.clone())
             .use_arc_self(self.use_arc_self)
             .generate_default_stubs(self.generate_default_stubs);
+
+        if let Some(p) = &self.tonic_path {
+            builder.tonic_path(p);
+        }
 
         let mut tokens = TokenStream::new();
 
@@ -425,6 +433,7 @@ pub struct Builder {
     use_arc_self: bool,
     generate_default_stubs: bool,
     codec_path: String,
+    tonic_path: Option<String>,
     skip_debug: HashSet<String>,
 }
 
@@ -700,6 +709,15 @@ impl Builder {
         self
     }
 
+    /// Set the path to the `tonic` crate for generated code.
+    ///
+    /// Useful for crates that re-export `tonic` under a different path (e.g.
+    /// `my_lib::tonic`). When unset, the default of `::tonic` is used.
+    pub fn tonic_path(mut self, path: impl AsRef<str>) -> Self {
+        self.tonic_path = Some(path.as_ref().to_string());
+        self
+    }
+
     /// Configure the code generator not to strip the `Debug` implementation for the request and
     /// response types from the generated code.
     ///
@@ -829,7 +847,8 @@ impl Builder {
                 self.generate_default_stubs,
                 self.proto_path,
                 self.compile_well_known_types,
-                self.codec_path.clone(),
+                self.codec_path,
+                self.tonic_path,
                 self.disable_comments,
             );
 
@@ -931,7 +950,8 @@ impl Builder {
                 self.generate_default_stubs,
                 self.proto_path,
                 self.compile_well_known_types,
-                self.codec_path.clone(),
+                self.codec_path,
+                self.tonic_path,
                 self.disable_comments,
             );
 
@@ -956,7 +976,8 @@ impl Builder {
             self.generate_default_stubs,
             self.proto_path,
             self.compile_well_known_types,
-            self.codec_path.clone(),
+            self.codec_path,
+            self.tonic_path,
             self.disable_comments,
         ))
     }

--- a/tonic-reflection/src/generated/grpc_reflection_v1.rs
+++ b/tonic-reflection/src/generated/grpc_reflection_v1.rs
@@ -153,25 +153,25 @@ pub mod server_reflection_client {
         clippy::wildcard_imports,
         clippy::let_unit_value,
     )]
-    use tonic::codegen::*;
-    use tonic::codegen::http::Uri;
+    use ::tonic::codegen::*;
+    use ::tonic::codegen::http::Uri;
     #[derive(Debug, Clone)]
     pub struct ServerReflectionClient<T> {
-        inner: tonic::client::Grpc<T>,
+        inner: ::tonic::client::Grpc<T>,
     }
     impl<T> ServerReflectionClient<T>
     where
-        T: tonic::client::GrpcService<tonic::body::Body>,
+        T: ::tonic::client::GrpcService<::tonic::body::Body>,
         T::Error: Into<StdError>,
         T::ResponseBody: Body<Data = Bytes> + std::marker::Send + 'static,
         <T::ResponseBody as Body>::Error: Into<StdError> + std::marker::Send,
     {
         pub fn new(inner: T) -> Self {
-            let inner = tonic::client::Grpc::new(inner);
+            let inner = ::tonic::client::Grpc::new(inner);
             Self { inner }
         }
         pub fn with_origin(inner: T, origin: Uri) -> Self {
-            let inner = tonic::client::Grpc::with_origin(inner, origin);
+            let inner = ::tonic::client::Grpc::with_origin(inner, origin);
             Self { inner }
         }
         pub fn with_interceptor<F>(
@@ -179,16 +179,18 @@ pub mod server_reflection_client {
             interceptor: F,
         ) -> ServerReflectionClient<InterceptedService<T, F>>
         where
-            F: tonic::service::Interceptor,
+            F: ::tonic::service::Interceptor,
             T::ResponseBody: Default,
-            T: tonic::codegen::Service<
-                http::Request<tonic::body::Body>,
+            T: ::tonic::codegen::Service<
+                http::Request<::tonic::body::Body>,
                 Response = http::Response<
-                    <T as tonic::client::GrpcService<tonic::body::Body>>::ResponseBody,
+                    <T as ::tonic::client::GrpcService<
+                        ::tonic::body::Body,
+                    >>::ResponseBody,
                 >,
             >,
-            <T as tonic::codegen::Service<
-                http::Request<tonic::body::Body>,
+            <T as ::tonic::codegen::Service<
+                http::Request<::tonic::body::Body>,
             >>::Error: Into<StdError> + std::marker::Send + std::marker::Sync,
         {
             ServerReflectionClient::new(InterceptedService::new(inner, interceptor))
@@ -228,18 +230,20 @@ pub mod server_reflection_client {
         /// all related requests go to a single server.
         pub async fn server_reflection_info(
             &mut self,
-            request: impl tonic::IntoStreamingRequest<
+            request: impl ::tonic::IntoStreamingRequest<
                 Message = super::ServerReflectionRequest,
             >,
         ) -> std::result::Result<
-            tonic::Response<tonic::codec::Streaming<super::ServerReflectionResponse>>,
-            tonic::Status,
+            ::tonic::Response<
+                ::tonic::codec::Streaming<super::ServerReflectionResponse>,
+            >,
+            ::tonic::Status,
         > {
             self.inner
                 .ready()
                 .await
                 .map_err(|e| {
-                    tonic::Status::unknown(
+                    ::tonic::Status::unknown(
                         format!("Service was not ready: {}", e.into()),
                     )
                 })?;
@@ -268,15 +272,15 @@ pub mod server_reflection_server {
         clippy::wildcard_imports,
         clippy::let_unit_value,
     )]
-    use tonic::codegen::*;
+    use ::tonic::codegen::*;
     /// Generated trait containing gRPC methods that should be implemented for use with ServerReflectionServer.
     #[async_trait]
     pub trait ServerReflection: std::marker::Send + std::marker::Sync + 'static {
         /// Server streaming response type for the ServerReflectionInfo method.
-        type ServerReflectionInfoStream: tonic::codegen::tokio_stream::Stream<
+        type ServerReflectionInfoStream: ::tonic::codegen::tokio_stream::Stream<
                 Item = std::result::Result<
                     super::ServerReflectionResponse,
-                    tonic::Status,
+                    ::tonic::Status,
                 >,
             >
             + std::marker::Send
@@ -285,10 +289,10 @@ pub mod server_reflection_server {
         /// all related requests go to a single server.
         async fn server_reflection_info(
             &self,
-            request: tonic::Request<tonic::Streaming<super::ServerReflectionRequest>>,
+            request: ::tonic::Request<::tonic::Streaming<super::ServerReflectionRequest>>,
         ) -> std::result::Result<
-            tonic::Response<Self::ServerReflectionInfoStream>,
-            tonic::Status,
+            ::tonic::Response<Self::ServerReflectionInfoStream>,
+            ::tonic::Status,
         >;
     }
     #[derive(Debug)]
@@ -317,7 +321,7 @@ pub mod server_reflection_server {
             interceptor: F,
         ) -> InterceptedService<Self, F>
         where
-            F: tonic::service::Interceptor,
+            F: ::tonic::service::Interceptor,
         {
             InterceptedService::new(Self::new(inner), interceptor)
         }
@@ -350,13 +354,13 @@ pub mod server_reflection_server {
             self
         }
     }
-    impl<T, B> tonic::codegen::Service<http::Request<B>> for ServerReflectionServer<T>
+    impl<T, B> ::tonic::codegen::Service<http::Request<B>> for ServerReflectionServer<T>
     where
         T: ServerReflection,
         B: Body + std::marker::Send + 'static,
         B::Error: Into<StdError> + std::marker::Send + 'static,
     {
-        type Response = http::Response<tonic::body::Body>;
+        type Response = http::Response<::tonic::body::Body>;
         type Error = std::convert::Infallible;
         type Future = BoxFuture<Self::Response, Self::Error>;
         fn poll_ready(
@@ -372,18 +376,18 @@ pub mod server_reflection_server {
                     struct ServerReflectionInfoSvc<T: ServerReflection>(pub Arc<T>);
                     impl<
                         T: ServerReflection,
-                    > tonic::server::StreamingService<super::ServerReflectionRequest>
+                    > ::tonic::server::StreamingService<super::ServerReflectionRequest>
                     for ServerReflectionInfoSvc<T> {
                         type Response = super::ServerReflectionResponse;
                         type ResponseStream = T::ServerReflectionInfoStream;
                         type Future = BoxFuture<
-                            tonic::Response<Self::ResponseStream>,
-                            tonic::Status,
+                            ::tonic::Response<Self::ResponseStream>,
+                            ::tonic::Status,
                         >;
                         fn call(
                             &mut self,
-                            request: tonic::Request<
-                                tonic::Streaming<super::ServerReflectionRequest>,
+                            request: ::tonic::Request<
+                                ::tonic::Streaming<super::ServerReflectionRequest>,
                             >,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
@@ -405,7 +409,7 @@ pub mod server_reflection_server {
                     let fut = async move {
                         let method = ServerReflectionInfoSvc(inner);
                         let codec = tonic_prost::ProstCodec::default();
-                        let mut grpc = tonic::server::Grpc::new(codec)
+                        let mut grpc = ::tonic::server::Grpc::new(codec)
                             .apply_compression_config(
                                 accept_compression_encodings,
                                 send_compression_encodings,
@@ -422,18 +426,18 @@ pub mod server_reflection_server {
                 _ => {
                     Box::pin(async move {
                         let mut response = http::Response::new(
-                            tonic::body::Body::default(),
+                            ::tonic::body::Body::default(),
                         );
                         let headers = response.headers_mut();
                         headers
                             .insert(
-                                tonic::Status::GRPC_STATUS,
-                                (tonic::Code::Unimplemented as i32).into(),
+                                ::tonic::Status::GRPC_STATUS,
+                                (::tonic::Code::Unimplemented as i32).into(),
                             );
                         headers
                             .insert(
                                 http::header::CONTENT_TYPE,
-                                tonic::metadata::GRPC_CONTENT_TYPE,
+                                ::tonic::metadata::GRPC_CONTENT_TYPE,
                             );
                         Ok(response)
                     })
@@ -455,7 +459,7 @@ pub mod server_reflection_server {
     }
     /// Generated gRPC service name
     pub const SERVICE_NAME: &str = "grpc.reflection.v1.ServerReflection";
-    impl<T> tonic::server::NamedService for ServerReflectionServer<T> {
+    impl<T> ::tonic::server::NamedService for ServerReflectionServer<T> {
         const NAME: &'static str = SERVICE_NAME;
     }
 }

--- a/tonic-reflection/src/generated/grpc_reflection_v1alpha.rs
+++ b/tonic-reflection/src/generated/grpc_reflection_v1alpha.rs
@@ -153,25 +153,25 @@ pub mod server_reflection_client {
         clippy::wildcard_imports,
         clippy::let_unit_value,
     )]
-    use tonic::codegen::*;
-    use tonic::codegen::http::Uri;
+    use ::tonic::codegen::*;
+    use ::tonic::codegen::http::Uri;
     #[derive(Debug, Clone)]
     pub struct ServerReflectionClient<T> {
-        inner: tonic::client::Grpc<T>,
+        inner: ::tonic::client::Grpc<T>,
     }
     impl<T> ServerReflectionClient<T>
     where
-        T: tonic::client::GrpcService<tonic::body::Body>,
+        T: ::tonic::client::GrpcService<::tonic::body::Body>,
         T::Error: Into<StdError>,
         T::ResponseBody: Body<Data = Bytes> + std::marker::Send + 'static,
         <T::ResponseBody as Body>::Error: Into<StdError> + std::marker::Send,
     {
         pub fn new(inner: T) -> Self {
-            let inner = tonic::client::Grpc::new(inner);
+            let inner = ::tonic::client::Grpc::new(inner);
             Self { inner }
         }
         pub fn with_origin(inner: T, origin: Uri) -> Self {
-            let inner = tonic::client::Grpc::with_origin(inner, origin);
+            let inner = ::tonic::client::Grpc::with_origin(inner, origin);
             Self { inner }
         }
         pub fn with_interceptor<F>(
@@ -179,16 +179,18 @@ pub mod server_reflection_client {
             interceptor: F,
         ) -> ServerReflectionClient<InterceptedService<T, F>>
         where
-            F: tonic::service::Interceptor,
+            F: ::tonic::service::Interceptor,
             T::ResponseBody: Default,
-            T: tonic::codegen::Service<
-                http::Request<tonic::body::Body>,
+            T: ::tonic::codegen::Service<
+                http::Request<::tonic::body::Body>,
                 Response = http::Response<
-                    <T as tonic::client::GrpcService<tonic::body::Body>>::ResponseBody,
+                    <T as ::tonic::client::GrpcService<
+                        ::tonic::body::Body,
+                    >>::ResponseBody,
                 >,
             >,
-            <T as tonic::codegen::Service<
-                http::Request<tonic::body::Body>,
+            <T as ::tonic::codegen::Service<
+                http::Request<::tonic::body::Body>,
             >>::Error: Into<StdError> + std::marker::Send + std::marker::Sync,
         {
             ServerReflectionClient::new(InterceptedService::new(inner, interceptor))
@@ -228,18 +230,20 @@ pub mod server_reflection_client {
         /// all related requests go to a single server.
         pub async fn server_reflection_info(
             &mut self,
-            request: impl tonic::IntoStreamingRequest<
+            request: impl ::tonic::IntoStreamingRequest<
                 Message = super::ServerReflectionRequest,
             >,
         ) -> std::result::Result<
-            tonic::Response<tonic::codec::Streaming<super::ServerReflectionResponse>>,
-            tonic::Status,
+            ::tonic::Response<
+                ::tonic::codec::Streaming<super::ServerReflectionResponse>,
+            >,
+            ::tonic::Status,
         > {
             self.inner
                 .ready()
                 .await
                 .map_err(|e| {
-                    tonic::Status::unknown(
+                    ::tonic::Status::unknown(
                         format!("Service was not ready: {}", e.into()),
                     )
                 })?;
@@ -268,15 +272,15 @@ pub mod server_reflection_server {
         clippy::wildcard_imports,
         clippy::let_unit_value,
     )]
-    use tonic::codegen::*;
+    use ::tonic::codegen::*;
     /// Generated trait containing gRPC methods that should be implemented for use with ServerReflectionServer.
     #[async_trait]
     pub trait ServerReflection: std::marker::Send + std::marker::Sync + 'static {
         /// Server streaming response type for the ServerReflectionInfo method.
-        type ServerReflectionInfoStream: tonic::codegen::tokio_stream::Stream<
+        type ServerReflectionInfoStream: ::tonic::codegen::tokio_stream::Stream<
                 Item = std::result::Result<
                     super::ServerReflectionResponse,
-                    tonic::Status,
+                    ::tonic::Status,
                 >,
             >
             + std::marker::Send
@@ -285,10 +289,10 @@ pub mod server_reflection_server {
         /// all related requests go to a single server.
         async fn server_reflection_info(
             &self,
-            request: tonic::Request<tonic::Streaming<super::ServerReflectionRequest>>,
+            request: ::tonic::Request<::tonic::Streaming<super::ServerReflectionRequest>>,
         ) -> std::result::Result<
-            tonic::Response<Self::ServerReflectionInfoStream>,
-            tonic::Status,
+            ::tonic::Response<Self::ServerReflectionInfoStream>,
+            ::tonic::Status,
         >;
     }
     #[derive(Debug)]
@@ -317,7 +321,7 @@ pub mod server_reflection_server {
             interceptor: F,
         ) -> InterceptedService<Self, F>
         where
-            F: tonic::service::Interceptor,
+            F: ::tonic::service::Interceptor,
         {
             InterceptedService::new(Self::new(inner), interceptor)
         }
@@ -350,13 +354,13 @@ pub mod server_reflection_server {
             self
         }
     }
-    impl<T, B> tonic::codegen::Service<http::Request<B>> for ServerReflectionServer<T>
+    impl<T, B> ::tonic::codegen::Service<http::Request<B>> for ServerReflectionServer<T>
     where
         T: ServerReflection,
         B: Body + std::marker::Send + 'static,
         B::Error: Into<StdError> + std::marker::Send + 'static,
     {
-        type Response = http::Response<tonic::body::Body>;
+        type Response = http::Response<::tonic::body::Body>;
         type Error = std::convert::Infallible;
         type Future = BoxFuture<Self::Response, Self::Error>;
         fn poll_ready(
@@ -372,18 +376,18 @@ pub mod server_reflection_server {
                     struct ServerReflectionInfoSvc<T: ServerReflection>(pub Arc<T>);
                     impl<
                         T: ServerReflection,
-                    > tonic::server::StreamingService<super::ServerReflectionRequest>
+                    > ::tonic::server::StreamingService<super::ServerReflectionRequest>
                     for ServerReflectionInfoSvc<T> {
                         type Response = super::ServerReflectionResponse;
                         type ResponseStream = T::ServerReflectionInfoStream;
                         type Future = BoxFuture<
-                            tonic::Response<Self::ResponseStream>,
-                            tonic::Status,
+                            ::tonic::Response<Self::ResponseStream>,
+                            ::tonic::Status,
                         >;
                         fn call(
                             &mut self,
-                            request: tonic::Request<
-                                tonic::Streaming<super::ServerReflectionRequest>,
+                            request: ::tonic::Request<
+                                ::tonic::Streaming<super::ServerReflectionRequest>,
                             >,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
@@ -405,7 +409,7 @@ pub mod server_reflection_server {
                     let fut = async move {
                         let method = ServerReflectionInfoSvc(inner);
                         let codec = tonic_prost::ProstCodec::default();
-                        let mut grpc = tonic::server::Grpc::new(codec)
+                        let mut grpc = ::tonic::server::Grpc::new(codec)
                             .apply_compression_config(
                                 accept_compression_encodings,
                                 send_compression_encodings,
@@ -422,18 +426,18 @@ pub mod server_reflection_server {
                 _ => {
                     Box::pin(async move {
                         let mut response = http::Response::new(
-                            tonic::body::Body::default(),
+                            ::tonic::body::Body::default(),
                         );
                         let headers = response.headers_mut();
                         headers
                             .insert(
-                                tonic::Status::GRPC_STATUS,
-                                (tonic::Code::Unimplemented as i32).into(),
+                                ::tonic::Status::GRPC_STATUS,
+                                (::tonic::Code::Unimplemented as i32).into(),
                             );
                         headers
                             .insert(
                                 http::header::CONTENT_TYPE,
-                                tonic::metadata::GRPC_CONTENT_TYPE,
+                                ::tonic::metadata::GRPC_CONTENT_TYPE,
                             );
                         Ok(response)
                     })
@@ -455,7 +459,7 @@ pub mod server_reflection_server {
     }
     /// Generated gRPC service name
     pub const SERVICE_NAME: &str = "grpc.reflection.v1alpha.ServerReflection";
-    impl<T> tonic::server::NamedService for ServerReflectionServer<T> {
+    impl<T> ::tonic::server::NamedService for ServerReflectionServer<T> {
         const NAME: &'static str = SERVICE_NAME;
     }
 }


### PR DESCRIPTION
Hi guys,

thanks for the great work :)

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

If this change is intended for tonic `v0.14.x` please make this PR against that branch
otherwise, it may not get included in a relase for a long time.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/hyperium/tonic/blob/master/CONTRIBUTING.md
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? If a new feature is being added, describe the intended
use case that feature fulfills.
-->

Following the issue #699, I would like to add the capability to configure the path to the `tonic` crate in generated code in `tonic-build`. This allows other library crates building on top of `tonic` to re-export `tonic`, so users of the library (using `tonic`) don't have to to include a dependency to `tonic`.

My use case:
I'm currently building a library for the [SiLA](https://sila-standard.com/) protocol on top of tonic [here](https://gitlab.com/SiLA2/sila_rust) and it would be really nice to ditch the tonic dependency from crates using that library.

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

Inspired by how prost is doing it with [prost_path](https://docs.rs/prost-build/latest/prost_build/struct.Config.html#method.prost_path), I added a new method `tonic_path` that allows to set the path to `tonic` in the module `code_gen` (crate `tonic_build`). The same I did for the public `manual` module where the path is then passed further to the `CodeGenBuilder`. If the builder-method is not called `::tonic` is used by default. I also added the method to `tonic-prost-build`.

I then made sure this path is passed down to client and server code generation, so there is no "hardcoded" tonic-path anymore.

### Additional Notes

* I set the default path to `::tonic` since I saw `prost` is doing it the same way. Although probably not a too big deal, I feel like it makes more sense to make it absolute for generated code to have the path crystal clear. That's also why I had to change many of the code in `generated`. Let me know if you see a problem in that. I can easily revert it. It pollutes the changeset quite a bit.

* In the test, I also re-exported `tonic_prost`and configured the path using `codec_path(...)` which appears to be enough to also ditch the `tonic_prost` dependency from `my_application`. Let me know if you feel like I should only focus on re-exporting `tonic`.

* For some methods, I had to add an additional `#[allow(clippy::too_many_arguments)]` where I thought it's probably ok given that it is also used in many similar cases in that module already.

* In `tonic-prost-build`, I removed some unnecessary clones for parameters being passed that were right next to the `tonic_path` parameter.