### PR TITLE
protoc-gen-rust-grpc: Include exe inside rlib

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -55,16 +55,9 @@ jobs:
         if: steps.protoc-binaries-cache.outputs.cache-hit != 'true'
         shell: bash
         run: |
-          mkdir -p protoc-cache
-          # Find where cmake built the binaries and any companion DLLs.
-          find target/ -name "protoc" -o -name "protoc.exe" -o -name "protoc-gen-rust-grpc" -o -name "protoc-gen-rust-grpc.exe" -o -name "*.dll" | while read -r file; do
-            # Verify it's in the build output directory to avoid copying source or unrelated files.
-            if [[ "$file" == *"/out/bin/"* ]] || [[ "$file" == *"/out/build/bin/"* ]]; then
-              cp "$file" protoc-cache/
-            fi
-          done
-          echo "Cached files:"
-          ls -la protoc-cache/
+          cp -r target/debug/build/protoc-gen-rust-grpc-*/out/install protoc-cache/
+          echo "Cached binaries (the biggest files):"
+          ls -la protoc-cache/bin/
 
   clippy:
     runs-on: ubuntu-latest
@@ -81,7 +74,7 @@ jobs:
         key: protoc-binaries-${{ runner.os }}-${{ hashFiles('protoc-gen-rust-grpc/src/cpp_source/**', 'protoc-gen-rust-grpc/build.rs') }}
     - name: Add cached binaries to PATH
       shell: bash
-      run: echo "${{ github.workspace }}/protoc-cache" >> $GITHUB_PATH
+      run: echo "${{ github.workspace }}/protoc-cache/bin" >> $GITHUB_PATH
     - uses: Swatinem/rust-cache@v2
     - run: cargo clippy --workspace --all-features --all-targets
 
@@ -97,7 +90,7 @@ jobs:
         key: protoc-binaries-${{ runner.os }}-${{ hashFiles('protoc-gen-rust-grpc/src/cpp_source/**', 'protoc-gen-rust-grpc/build.rs') }}
     - name: Add cached binaries to PATH
       shell: bash
-      run: echo "${{ github.workspace }}/protoc-cache" >> $GITHUB_PATH
+      run: echo "${{ github.workspace }}/protoc-cache/bin" >> $GITHUB_PATH
     - uses: Swatinem/rust-cache@v2
     - run: cargo run --package codegen
     - run: git diff --exit-code
@@ -119,7 +112,7 @@ jobs:
         key: protoc-binaries-${{ runner.os }}-${{ hashFiles('protoc-gen-rust-grpc/src/cpp_source/**', 'protoc-gen-rust-grpc/build.rs') }}
     - name: Add cached binaries to PATH
       shell: bash
-      run: echo "${{ github.workspace }}/protoc-cache" >> $GITHUB_PATH
+      run: echo "${{ github.workspace }}/protoc-cache/bin" >> $GITHUB_PATH
     - uses: Swatinem/rust-cache@v2
     - run: cargo hack udeps --workspace --exclude-features=_tls-any,tls,tls-aws-lc,tls-ring,tls-connect-info --each-feature
     - run: cargo udeps --package tonic --features tls-ring,transport
@@ -149,7 +142,7 @@ jobs:
         key: protoc-binaries-${{ runner.os }}-${{ hashFiles('protoc-gen-rust-grpc/src/cpp_source/**', 'protoc-gen-rust-grpc/build.rs') }}
     - name: Add cached binaries to PATH
       shell: bash
-      run: echo "${{ github.workspace }}/protoc-cache" >> $GITHUB_PATH
+      run: echo "${{ github.workspace }}/protoc-cache/bin" >> $GITHUB_PATH
     - uses: Swatinem/rust-cache@v2
     - name: Check features
       run: cargo hack check --workspace --no-private --each-feature --no-dev-deps
@@ -180,7 +173,7 @@ jobs:
         key: protoc-binaries-${{ runner.os }}-${{ hashFiles('protoc-gen-rust-grpc/src/cpp_source/**', 'protoc-gen-rust-grpc/build.rs') }}
     - name: Add cached binaries to PATH
       shell: bash
-      run: echo "${{ github.workspace }}/protoc-cache" >> $GITHUB_PATH
+      run: echo "${{ github.workspace }}/protoc-cache/bin" >> $GITHUB_PATH
     - uses: Swatinem/rust-cache@v2
     - run: cargo no-dev-deps --no-private check --all-features --workspace
 
@@ -197,7 +190,7 @@ jobs:
         key: protoc-binaries-${{ runner.os }}-${{ hashFiles('protoc-gen-rust-grpc/src/cpp_source/**', 'protoc-gen-rust-grpc/build.rs') }}
     - name: Add cached binaries to PATH
       shell: bash
-      run: echo "${{ github.workspace }}/protoc-cache" >> $GITHUB_PATH
+      run: echo "${{ github.workspace }}/protoc-cache/bin" >> $GITHUB_PATH
     - uses: Swatinem/rust-cache@v2
     - run: cargo +nightly hack --no-private docs-rs
       env:
@@ -221,7 +214,7 @@ jobs:
         key: protoc-binaries-${{ runner.os }}-${{ hashFiles('protoc-gen-rust-grpc/src/cpp_source/**', 'protoc-gen-rust-grpc/build.rs') }}
     - name: Add cached binaries to PATH
       shell: bash
-      run: echo "${{ github.workspace }}/protoc-cache" >> $GITHUB_PATH
+      run: echo "${{ github.workspace }}/protoc-cache/bin" >> $GITHUB_PATH
     - uses: Swatinem/rust-cache@v2
     - run: cargo nextest run --workspace --all-features
       env:
@@ -239,7 +232,7 @@ jobs:
         key: protoc-binaries-${{ runner.os }}-${{ hashFiles('protoc-gen-rust-grpc/src/cpp_source/**', 'protoc-gen-rust-grpc/build.rs') }}
     - name: Add cached binaries to PATH
       shell: bash
-      run: echo "${{ github.workspace }}/protoc-cache" >> $GITHUB_PATH
+      run: echo "${{ github.workspace }}/protoc-cache/bin" >> $GITHUB_PATH
     - uses: Swatinem/rust-cache@v2
     - run: cargo hack --no-private test --doc --all-features
 
@@ -260,7 +253,7 @@ jobs:
         key: protoc-binaries-${{ runner.os }}-${{ hashFiles('protoc-gen-rust-grpc/src/cpp_source/**', 'protoc-gen-rust-grpc/build.rs') }}
     - name: Add cached binaries to PATH
       shell: bash
-      run: echo "${{ github.workspace }}/protoc-cache" >> $GITHUB_PATH
+      run: echo "${{ github.workspace }}/protoc-cache/bin" >> $GITHUB_PATH
     - uses: Swatinem/rust-cache@v2
     - run: cargo build -p interop
     - name: Run interop tests
@@ -296,7 +289,7 @@ jobs:
         key: protoc-binaries-${{ runner.os }}-${{ hashFiles('protoc-gen-rust-grpc/src/cpp_source/**', 'protoc-gen-rust-grpc/build.rs') }}
     - name: Add cached binaries to PATH
       shell: bash
-      run: echo "${{ github.workspace }}/protoc-cache" >> $GITHUB_PATH
+      run: echo "${{ github.workspace }}/protoc-cache/bin" >> $GITHUB_PATH
     - uses: Swatinem/rust-cache@v2
     - run: cargo hack --no-private check-external-types --all-features
       env:

--- a/examples/build.rs
+++ b/examples/build.rs
@@ -7,9 +7,9 @@ fn main() {
     // build when PROTOC_GEN_RUST_GRPC_NO_BUILD=1 (used in gRPC's CI), so we check that the binary
     // exists.
     #[cfg(feature = "protoc-gen-rust-grpc")]
-    if protoc_gen_rust_grpc::protoc().exists() {
+    if let Ok(protoc) = protoc_gen_rust_grpc::protoc() {
         unsafe {
-            env::set_var("PROTOC", protoc_gen_rust_grpc::protoc());
+            env::set_var("PROTOC", protoc);
         }
     }
 

--- a/grpc-protobuf-build/src/lib.rs
+++ b/grpc-protobuf-build/src/lib.rs
@@ -260,11 +260,11 @@ impl CodeGen {
         // 2. Compiled via protoc-gen-rust-grpc (build-plugin feature)
         #[cfg(feature = "build-plugin")]
         {
-            let compiled_protoc = protoc_gen_rust_grpc::protoc();
-            let compiled_plugin = protoc_gen_rust_grpc::protoc_gen_rust_grpc();
-            if compiled_protoc.exists() && compiled_plugin.exists() {
-                // The files may not exist if a build setting instructed protoc-gen-rust-grpc to
-                // skip the C++ build (DOCS_RS / our CI setting).
+            // protoc_gen_rust_grpc may fail if a build setting instructed it to skip the C++ build
+            if let (Ok(compiled_protoc), Ok(compiled_plugin)) = (
+                protoc_gen_rust_grpc::protoc(),
+                protoc_gen_rust_grpc::protoc_gen_rust_grpc(),
+            ) {
                 return Ok((compiled_protoc, compiled_plugin));
             }
         }

--- a/protoc-gen-rust-grpc/build.rs
+++ b/protoc-gen-rust-grpc/build.rs
@@ -1,6 +1,25 @@
+use std::fs;
+use std::io::Write;
+use std::path::{Path, PathBuf};
+
 fn main() {
     println!("cargo:rerun-if-changed=build.rs");
 
+    let out_dir = PathBuf::from(std::env::var("OUT_DIR").expect("OUT_DIR env var is defined"));
+
+    let install_dir = out_dir.join("install");
+    if install_dir.exists() {
+        fs::remove_dir_all(&install_dir)
+            .expect("All files in install/ directory should be deletable");
+    }
+
+    populate_install_dir(&install_dir);
+
+    generate_code(&out_dir.join("embedded_assets.rs"), &install_dir);
+}
+
+/// Compiles if appropriate, leaving the install directory untouched otherwise.
+fn populate_install_dir(install_dir: &Path) {
     // docs.rs won't let us download sources, so skip the C++ compile.
     if std::env::var("DOCS_RS").is_ok() {
         return;
@@ -25,5 +44,75 @@ fn main() {
     let mut cmake_config = cmake::Config::new("src/cpp_source");
     cmake_config.define("BUILD_PROTOC", "ON");
     cmake_config.define("BUILD_PLUGIN", "ON");
+    cmake_config.define("CMAKE_INSTALL_PREFIX", &install_dir);
+    // There may be many copies of the files, so we don't want large debug information. Debug
+    // information increases the binary size by 20x.
+    cmake_config.profile("MinSizeRel");
     cmake_config.build();
+}
+
+fn visit_dirs(dir: &Path, cb: &mut dyn FnMut(&Path)) -> Result<(), String> {
+    if dir.is_dir() {
+        let entries = fs::read_dir(dir)
+            .map_err(|e| format!("Failed to read directory {}: {}", dir.display(), e))?;
+        for entry in entries {
+            let entry =
+                entry.map_err(|e| format!("Failed reading entry in {}: {}", dir.display(), e))?;
+            let ft = entry.file_type().map_err(|e| {
+                format!(
+                    "Failed getting file type for entry {}: {}",
+                    entry.path().display(),
+                    e
+                )
+            })?;
+            let path = entry.path();
+            if ft.is_dir() {
+                visit_dirs(&path, cb)?;
+            } else {
+                cb(&path);
+            }
+        }
+    }
+    Ok(())
+}
+
+fn to_literal(s: &str) -> String {
+    assert!(
+        !s.contains("\"##"),
+        "Strings containing \"## are not supported"
+    );
+    format!("r##\"{}\"##", s)
+}
+
+fn generate_code(dest_file: &Path, install_dir: &Path) {
+    let mut f = fs::File::create(&dest_file).expect("Create generated code file");
+
+    let mut files_to_embed = Vec::new();
+    visit_dirs(&install_dir, &mut |path| {
+        files_to_embed.push(path.to_owned());
+    })
+    .expect("Install directory is fully traversable");
+    files_to_embed.sort();
+
+    writeln!(f, "static EMBEDDED_FILES: &[(&str, &[u8])] = &[")
+        .expect("Generated code write should succeed");
+    for path in files_to_embed {
+        let rel_path = path
+            .strip_prefix(&install_dir)
+            .expect("File path starts with install dir");
+        // lib.rs expects forward slashes.
+        let rel_path_str = rel_path
+            .to_str()
+            .expect("File name can be in a str")
+            .replace("\\", "/");
+        let path_str = path.to_str().expect("File name can be in a str");
+        writeln!(
+            f,
+            "    ({}, include_bytes!({})),",
+            to_literal(&rel_path_str),
+            to_literal(&path_str)
+        )
+        .expect("Generated code write should succeed");
+    }
+    writeln!(f, "];").expect("Generated code write should succeed");
 }

--- a/protoc-gen-rust-grpc/src/cpp_source/CMakeLists.txt
+++ b/protoc-gen-rust-grpc/src/cpp_source/CMakeLists.txt
@@ -129,7 +129,13 @@ if(BUILD_PROTOC)
 
     install(DIRECTORY ${protobuf_SOURCE_DIR}/src/google/protobuf/
         DESTINATION include/google/protobuf
-        FILES_MATCHING PATTERN "*.proto"
+        FILES_MATCHING
+        PATTERN "*.proto"
+        PATTERN "*test*.proto" EXCLUDE
+        PATTERN "*unittest*.proto" EXCLUDE
+        PATTERN "compiler/cpp/*" EXCLUDE
+        PATTERN "compiler/java/*" EXCLUDE
+        PATTERN "compiler/ruby/*" EXCLUDE
     )
 endif()
 

--- a/protoc-gen-rust-grpc/src/lib.rs
+++ b/protoc-gen-rust-grpc/src/lib.rs
@@ -27,28 +27,151 @@
 //! [`protoc`]: https://protobuf.dev/installation/
 //! [`gRPC-Rust`]: https://crates.io/crates/grpc
 
+include!(concat!(env!("OUT_DIR"), "/embedded_assets.rs"));
+
+use std::fs;
 use std::path::PathBuf;
 
-fn bin_file(file: &str) -> PathBuf {
-    let mut path = bin().join(file);
-    if cfg!(target_os = "windows") {
-        path.set_extension("exe");
-    }
-    path
-}
+const PROTOC_NAME: &str = if cfg!(target_os = "windows") {
+    "protoc.exe"
+} else {
+    "protoc"
+};
+const PLUGIN_NAME: &str = if cfg!(target_os = "windows") {
+    "protoc-gen-rust-grpc.exe"
+} else {
+    "protoc-gen-rust-grpc"
+};
 
 /// The full path to the `protoc` executable.
-pub fn protoc() -> PathBuf {
-    bin_file("protoc")
+pub fn protoc() -> Result<PathBuf, String> {
+    let path = bin()?.join(PROTOC_NAME);
+    Ok(path)
 }
 
 /// The full path to the gRPC `protoc` plugin, `protoc-gen-rust-grpc`.
-pub fn protoc_gen_rust_grpc() -> PathBuf {
-    bin_file("protoc-gen-rust-grpc")
+pub fn protoc_gen_rust_grpc() -> Result<PathBuf, String> {
+    let path = bin()?.join(PLUGIN_NAME);
+    Ok(path)
 }
 
 /// The path to the `bin` directory containing the C++ binaries this package
-/// builds.
-pub fn bin() -> PathBuf {
-    PathBuf::from(env!("OUT_DIR")).join("bin")
+/// builds. It extracts protobuf into a subdirectory of the calling crate's `OUT_DIR`.
+pub fn bin() -> Result<PathBuf, String> {
+    let out_dir =
+        extract_assets_impl().map_err(|e| format!("Failed to write protobuf assets: {}", e))?;
+    Ok(out_dir.join("bin"))
+}
+
+fn extract_assets_impl() -> Result<PathBuf, String> {
+    let out = std::env::var("OUT_DIR").map_err(|e| {
+        format!("Could not get OUT_DIR environment variable. protoc-gen-rust-grpc may only be called from within a build script: {}", e)
+    })?;
+    let target_dir =
+        PathBuf::from(out).join(format!("grpc-rust-bin-{}", env!("CARGO_PKG_VERSION")));
+
+    if EMBEDDED_FILES.is_empty() {
+        return Err("No embedded assets are available (build was skipped).".to_string());
+    }
+
+    for (rel_path, bytes) in EMBEDDED_FILES {
+        let target_path = target_dir.join(rel_path);
+
+        if target_path.exists() {
+            let metadata = target_path.metadata().map_err(|e| {
+                format!(
+                    "Failed to read metadata for existing file {}: {}",
+                    target_path.display(),
+                    e
+                )
+            })?;
+            if metadata.len() == bytes.len() as u64 {
+                // The file is still present from a previous execution.
+                continue;
+            }
+        }
+
+        let parent = target_path
+            .parent()
+            .expect("The file has a parent directory");
+        fs::create_dir_all(parent).map_err(|e| {
+            format!(
+                "Failed to create parent directory {}: {}",
+                parent.display(),
+                e
+            )
+        })?;
+
+        let temp_path = parent.join(format!(
+            ".tmp-{}-{:?}",
+            std::process::id(),
+            std::thread::current().id()
+        ));
+        fs::write(&temp_path, bytes).map_err(|e| {
+            format!(
+                "Failed to write embedded asset {} to temporary file: {}",
+                target_path.display(),
+                e
+            )
+        })?;
+
+        // Assume all files in bin/ should be executable
+        #[cfg(unix)]
+        if rel_path.starts_with("bin/") {
+            use std::os::unix::fs::PermissionsExt;
+            fs::set_permissions(&temp_path, fs::Permissions::from_mode(0o755)).map_err(|e| {
+                format!(
+                    "Failed to set executable permissions on {}: {}",
+                    temp_path.display(),
+                    e
+                )
+            })?;
+        }
+
+        if let Err(e) = fs::rename(&temp_path, &target_path) {
+            let _ = fs::remove_file(&temp_path);
+            if !target_path.exists() {
+                return Err(format!(
+                    "Failed to rename temporary file {} to target path {}: {}",
+                    temp_path.display(),
+                    target_path.display(),
+                    e
+                ));
+            }
+        }
+    }
+
+    Ok(target_dir)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_expected_embedded_files() {
+        if EMBEDDED_FILES.is_empty() {
+            // Build was skipped via PROTOC_GEN_RUST_GRPC_NO_BUILD=1 or DOCS_RS
+            return;
+        }
+
+        assert!(
+            EMBEDDED_FILES
+                .iter()
+                .any(|(p, _)| *p == format!("bin/{}", PROTOC_NAME)),
+            "protoc binary missing from embedded files"
+        );
+        assert!(
+            EMBEDDED_FILES
+                .iter()
+                .any(|(p, _)| *p == format!("bin/{}", PLUGIN_NAME)),
+            "protoc-gen-rust-grpc binary missing from embedded files"
+        );
+        assert!(
+            EMBEDDED_FILES
+                .iter()
+                .any(|(p, _)| *p == "include/google/protobuf/empty.proto"),
+            "empty.proto missing from embedded files"
+        );
+    }
 }


### PR DESCRIPTION
OUT_DIR is a good temporary directory, but downstream users interested in caching won't have OUT_DIR available. The caching systems only preserve rlib, so we should include the important data in our library directly.

Since we're now writing out files during execution, the various methods were changed to return errors. That is then re-used if protobuf compilation was skipped during building.

CC @dfawley 