### PR TITLE
protoc-gen-rust-grpc: Make only well-known protos available

### DIFF
--- a/protoc-gen-rust-grpc/src/cpp_source/CMakeLists.txt
+++ b/protoc-gen-rust-grpc/src/cpp_source/CMakeLists.txt
@@ -129,7 +129,12 @@ if(BUILD_PROTOC)
 
     install(DIRECTORY ${protobuf_SOURCE_DIR}/src/google/protobuf/
         DESTINATION include/google/protobuf
-        FILES_MATCHING PATTERN "*.proto"
+        FILES_MATCHING
+        PATTERN "protobuf/*.proto"
+        PATTERN "compiler/*.proto"
+        PATTERN "*test*.proto" EXCLUDE
+        PATTERN "*option*.proto" EXCLUDE
+        PATTERN "sample_messages_edition.proto" EXCLUDE
     )
 endif()
 


### PR DESCRIPTION
The testing protos and internal protos are now excluded from include/.