### PR TITLE
protoc-gen-rust-grpc: Have cmake install to a separate directory

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -56,8 +56,8 @@ jobs:
         shell: bash
         run: |
           cp -r target/debug/build/protoc-gen-rust-grpc-*/out/install protoc-cache/
-          echo "Cached binaries (the biggest files):"
-          ls -la protoc-cache/bin/
+          echo "Cached files:"
+          find protoc-cache/ -type f -exec ls -lh {} +
 
   clippy:
     runs-on: ubuntu-latest

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -55,16 +55,9 @@ jobs:
         if: steps.protoc-binaries-cache.outputs.cache-hit != 'true'
         shell: bash
         run: |
-          mkdir -p protoc-cache
-          # Find where cmake built the binaries and any companion DLLs.
-          find target/ -name "protoc" -o -name "protoc.exe" -o -name "protoc-gen-rust-grpc" -o -name "protoc-gen-rust-grpc.exe" -o -name "*.dll" | while read -r file; do
-            # Verify it's in the build output directory to avoid copying source or unrelated files.
-            if [[ "$file" == *"/out/bin/"* ]] || [[ "$file" == *"/out/build/bin/"* ]]; then
-              cp "$file" protoc-cache/
-            fi
-          done
-          echo "Cached files:"
-          ls -la protoc-cache/
+          cp -r target/debug/build/protoc-gen-rust-grpc-*/out/install protoc-cache/
+          echo "Cached binaries (the biggest files):"
+          ls -la protoc-cache/bin/
 
   clippy:
     runs-on: ubuntu-latest
@@ -81,7 +74,7 @@ jobs:
         key: protoc-binaries-${{ runner.os }}-${{ hashFiles('protoc-gen-rust-grpc/src/cpp_source/**', 'protoc-gen-rust-grpc/build.rs') }}
     - name: Add cached binaries to PATH
       shell: bash
-      run: echo "${{ github.workspace }}/protoc-cache" >> $GITHUB_PATH
+      run: echo "${{ github.workspace }}/protoc-cache/bin" >> $GITHUB_PATH
     - uses: Swatinem/rust-cache@v2
     - run: cargo clippy --workspace --all-features --all-targets
 
@@ -97,7 +90,7 @@ jobs:
         key: protoc-binaries-${{ runner.os }}-${{ hashFiles('protoc-gen-rust-grpc/src/cpp_source/**', 'protoc-gen-rust-grpc/build.rs') }}
     - name: Add cached binaries to PATH
       shell: bash
-      run: echo "${{ github.workspace }}/protoc-cache" >> $GITHUB_PATH
+      run: echo "${{ github.workspace }}/protoc-cache/bin" >> $GITHUB_PATH
     - uses: Swatinem/rust-cache@v2
     - run: cargo run --package codegen
     - run: git diff --exit-code
@@ -119,7 +112,7 @@ jobs:
         key: protoc-binaries-${{ runner.os }}-${{ hashFiles('protoc-gen-rust-grpc/src/cpp_source/**', 'protoc-gen-rust-grpc/build.rs') }}
     - name: Add cached binaries to PATH
       shell: bash
-      run: echo "${{ github.workspace }}/protoc-cache" >> $GITHUB_PATH
+      run: echo "${{ github.workspace }}/protoc-cache/bin" >> $GITHUB_PATH
     - uses: Swatinem/rust-cache@v2
     - run: cargo hack udeps --workspace --exclude-features=_tls-any,tls,tls-aws-lc,tls-ring,tls-connect-info --each-feature
     - run: cargo udeps --package tonic --features tls-ring,transport
@@ -149,7 +142,7 @@ jobs:
         key: protoc-binaries-${{ runner.os }}-${{ hashFiles('protoc-gen-rust-grpc/src/cpp_source/**', 'protoc-gen-rust-grpc/build.rs') }}
     - name: Add cached binaries to PATH
       shell: bash
-      run: echo "${{ github.workspace }}/protoc-cache" >> $GITHUB_PATH
+      run: echo "${{ github.workspace }}/protoc-cache/bin" >> $GITHUB_PATH
     - uses: Swatinem/rust-cache@v2
     - name: Check features
       run: cargo hack check --workspace --no-private --each-feature --no-dev-deps
@@ -180,7 +173,7 @@ jobs:
         key: protoc-binaries-${{ runner.os }}-${{ hashFiles('protoc-gen-rust-grpc/src/cpp_source/**', 'protoc-gen-rust-grpc/build.rs') }}
     - name: Add cached binaries to PATH
       shell: bash
-      run: echo "${{ github.workspace }}/protoc-cache" >> $GITHUB_PATH
+      run: echo "${{ github.workspace }}/protoc-cache/bin" >> $GITHUB_PATH
     - uses: Swatinem/rust-cache@v2
     - run: cargo no-dev-deps --no-private check --all-features --workspace
 
@@ -197,7 +190,7 @@ jobs:
         key: protoc-binaries-${{ runner.os }}-${{ hashFiles('protoc-gen-rust-grpc/src/cpp_source/**', 'protoc-gen-rust-grpc/build.rs') }}
     - name: Add cached binaries to PATH
       shell: bash
-      run: echo "${{ github.workspace }}/protoc-cache" >> $GITHUB_PATH
+      run: echo "${{ github.workspace }}/protoc-cache/bin" >> $GITHUB_PATH
     - uses: Swatinem/rust-cache@v2
     - run: cargo +nightly hack --no-private docs-rs
       env:
@@ -221,7 +214,7 @@ jobs:
         key: protoc-binaries-${{ runner.os }}-${{ hashFiles('protoc-gen-rust-grpc/src/cpp_source/**', 'protoc-gen-rust-grpc/build.rs') }}
     - name: Add cached binaries to PATH
       shell: bash
-      run: echo "${{ github.workspace }}/protoc-cache" >> $GITHUB_PATH
+      run: echo "${{ github.workspace }}/protoc-cache/bin" >> $GITHUB_PATH
     - uses: Swatinem/rust-cache@v2
     - run: cargo nextest run --workspace --all-features
       env:
@@ -239,7 +232,7 @@ jobs:
         key: protoc-binaries-${{ runner.os }}-${{ hashFiles('protoc-gen-rust-grpc/src/cpp_source/**', 'protoc-gen-rust-grpc/build.rs') }}
     - name: Add cached binaries to PATH
       shell: bash
-      run: echo "${{ github.workspace }}/protoc-cache" >> $GITHUB_PATH
+      run: echo "${{ github.workspace }}/protoc-cache/bin" >> $GITHUB_PATH
     - uses: Swatinem/rust-cache@v2
     - run: cargo hack --no-private test --doc --all-features
 
@@ -260,7 +253,7 @@ jobs:
         key: protoc-binaries-${{ runner.os }}-${{ hashFiles('protoc-gen-rust-grpc/src/cpp_source/**', 'protoc-gen-rust-grpc/build.rs') }}
     - name: Add cached binaries to PATH
       shell: bash
-      run: echo "${{ github.workspace }}/protoc-cache" >> $GITHUB_PATH
+      run: echo "${{ github.workspace }}/protoc-cache/bin" >> $GITHUB_PATH
     - uses: Swatinem/rust-cache@v2
     - run: cargo build -p interop
     - name: Run interop tests
@@ -296,7 +289,7 @@ jobs:
         key: protoc-binaries-${{ runner.os }}-${{ hashFiles('protoc-gen-rust-grpc/src/cpp_source/**', 'protoc-gen-rust-grpc/build.rs') }}
     - name: Add cached binaries to PATH
       shell: bash
-      run: echo "${{ github.workspace }}/protoc-cache" >> $GITHUB_PATH
+      run: echo "${{ github.workspace }}/protoc-cache/bin" >> $GITHUB_PATH
     - uses: Swatinem/rust-cache@v2
     - run: cargo hack --no-private check-external-types --all-features
       env:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -67,7 +67,6 @@ jobs:
     - uses: hecrj/setup-rust-action@v2
       with:
         components: clippy
-    - uses: taiki-e/install-action@protoc
     - uses: actions/cache@v4
       with:
         path: protoc-cache
@@ -105,7 +104,6 @@ jobs:
         toolchain: nightly-2026-02-22
     - uses: taiki-e/install-action@cargo-hack
     - uses: taiki-e/install-action@cargo-udeps
-    - uses: taiki-e/install-action@protoc
     - uses: actions/cache@v4
       with:
         path: protoc-cache
@@ -135,7 +133,6 @@ jobs:
     - uses: actions/checkout@v6
     - uses: hecrj/setup-rust-action@v2
     - uses: taiki-e/install-action@cargo-hack
-    - uses: taiki-e/install-action@protoc
     - uses: actions/cache@v4
       with:
         path: protoc-cache
@@ -207,7 +204,6 @@ jobs:
     - uses: hecrj/setup-rust-action@v2
     - uses: taiki-e/install-action@cargo-hack
     - uses: taiki-e/install-action@cargo-nextest
-    - uses: taiki-e/install-action@protoc
     - uses: actions/cache@v4
       with:
         path: protoc-cache
@@ -246,7 +242,6 @@ jobs:
     steps:
     - uses: actions/checkout@v6
     - uses: hecrj/setup-rust-action@v2
-    - uses: taiki-e/install-action@protoc
     - uses: actions/cache@v4
       with:
         path: protoc-cache

--- a/protoc-gen-rust-grpc/build.rs
+++ b/protoc-gen-rust-grpc/build.rs
@@ -1,3 +1,5 @@
+use std::path::PathBuf;
+
 fn main() {
     println!("cargo:rerun-if-changed=build.rs");
 
@@ -22,8 +24,16 @@ fn main() {
     // Avoid rebuilding if the C++ source files (and this file) didn't change.
     println!("cargo:rerun-if-changed=src/cpp_source");
 
+    let out_dir = PathBuf::from(std::env::var("OUT_DIR").expect("OUT_DIR env var is defined"));
+    let install_dir = out_dir.join("install");
+    if install_dir.exists() {
+        std::fs::remove_dir_all(&install_dir)
+            .expect("All files in install/ directory should be deletable");
+    }
+
     let mut cmake_config = cmake::Config::new("src/cpp_source");
     cmake_config.define("BUILD_PROTOC", "ON");
     cmake_config.define("BUILD_PLUGIN", "ON");
+    cmake_config.define("CMAKE_INSTALL_PREFIX", &install_dir);
     cmake_config.build();
 }

--- a/protoc-gen-rust-grpc/src/lib.rs
+++ b/protoc-gen-rust-grpc/src/lib.rs
@@ -50,5 +50,5 @@ pub fn protoc_gen_rust_grpc() -> PathBuf {
 /// The path to the `bin` directory containing the C++ binaries this package
 /// builds.
 pub fn bin() -> PathBuf {
-    PathBuf::from(env!("OUT_DIR")).join("bin")
+    PathBuf::from(env!("OUT_DIR")).join("install/bin")
 }


### PR DESCRIPTION
This allows cleaning up the install directory before builds, so no left-over artifacts are around from a previous build. Also, it makes it easier to include the well-known protos in CI.yml's protoc-cache.