### PR TITLE
ci: Exclude targets from rust-cache

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -160,6 +160,7 @@ jobs:
       run: echo "${{ github.workspace }}/protoc-cache" >> $GITHUB_PATH
     - uses: Swatinem/rust-cache@v2
       with:
+        # Windows is the long pole of a build. Caching it avoids adding ~5 minutes of build time
         cache-targets: ${{ matrix.os == 'windows-latest' }}
     - name: Check features
       run: cargo hack check --workspace --no-private --each-feature --no-dev-deps
@@ -238,6 +239,7 @@ jobs:
       run: echo "${{ github.workspace }}/protoc-cache" >> $GITHUB_PATH
     - uses: Swatinem/rust-cache@v2
       with:
+        # Windows is the long pole of a build. Caching it avoids adding ~4 minutes of build time
         cache-targets: ${{ matrix.os == 'windows-latest' }}
     - run: cargo nextest run --workspace --all-features
       env:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -48,6 +48,8 @@ jobs:
         if: steps.protoc-binaries-cache.outputs.cache-hit != 'true'
       - uses: Swatinem/rust-cache@v2
         if: steps.protoc-binaries-cache.outputs.cache-hit != 'true'
+        with:
+          cache-targets: "false"
       - name: Build protoc-gen-rust-grpc
         if: steps.protoc-binaries-cache.outputs.cache-hit != 'true'
         run: cargo build -p protoc-gen-rust-grpc
@@ -83,6 +85,8 @@ jobs:
       shell: bash
       run: echo "${{ github.workspace }}/protoc-cache" >> $GITHUB_PATH
     - uses: Swatinem/rust-cache@v2
+      with:
+        cache-targets: "false"
     - run: cargo clippy --workspace --all-features --all-targets
 
   codegen:
@@ -99,6 +103,8 @@ jobs:
       shell: bash
       run: echo "${{ github.workspace }}/protoc-cache" >> $GITHUB_PATH
     - uses: Swatinem/rust-cache@v2
+      with:
+        cache-targets: "false"
     - run: cargo run --package codegen
     - run: git diff --exit-code
 
@@ -121,6 +127,8 @@ jobs:
       shell: bash
       run: echo "${{ github.workspace }}/protoc-cache" >> $GITHUB_PATH
     - uses: Swatinem/rust-cache@v2
+      with:
+        cache-targets: "false"
     - run: cargo hack udeps --workspace --exclude-features=_tls-any,tls,tls-aws-lc,tls-ring,tls-connect-info --each-feature
     - run: cargo udeps --package tonic --features tls-ring,transport
     - run: cargo udeps --package tonic --features tls-ring,server
@@ -151,6 +159,8 @@ jobs:
       shell: bash
       run: echo "${{ github.workspace }}/protoc-cache" >> $GITHUB_PATH
     - uses: Swatinem/rust-cache@v2
+      with:
+        cache-targets: ${{ matrix.os == 'windows-latest' }}
     - name: Check features
       run: cargo hack check --workspace --no-private --each-feature --no-dev-deps
     - name: Check tonic feature powerset
@@ -182,6 +192,8 @@ jobs:
       shell: bash
       run: echo "${{ github.workspace }}/protoc-cache" >> $GITHUB_PATH
     - uses: Swatinem/rust-cache@v2
+      with:
+        cache-targets: "false"
     - run: cargo no-dev-deps --no-private check --all-features --workspace
 
   doc:
@@ -199,6 +211,8 @@ jobs:
       shell: bash
       run: echo "${{ github.workspace }}/protoc-cache" >> $GITHUB_PATH
     - uses: Swatinem/rust-cache@v2
+      with:
+        cache-targets: "false"
     - run: cargo +nightly hack --no-private docs-rs
       env:
         RUSTDOCFLAGS: "-D warnings"
@@ -223,6 +237,8 @@ jobs:
       shell: bash
       run: echo "${{ github.workspace }}/protoc-cache" >> $GITHUB_PATH
     - uses: Swatinem/rust-cache@v2
+      with:
+        cache-targets: ${{ matrix.os == 'windows-latest' }}
     - run: cargo nextest run --workspace --all-features
       env:
         QUICKCHECK_TESTS: 1000  # run a lot of quickcheck iterations
@@ -241,6 +257,8 @@ jobs:
       shell: bash
       run: echo "${{ github.workspace }}/protoc-cache" >> $GITHUB_PATH
     - uses: Swatinem/rust-cache@v2
+      with:
+        cache-targets: "false"
     - run: cargo hack --no-private test --doc --all-features
 
   interop:
@@ -262,6 +280,8 @@ jobs:
       shell: bash
       run: echo "${{ github.workspace }}/protoc-cache" >> $GITHUB_PATH
     - uses: Swatinem/rust-cache@v2
+      with:
+        cache-targets: "false"
     - run: cargo build -p interop
     - name: Run interop tests
       run: ./interop/test.sh
@@ -298,6 +318,8 @@ jobs:
       shell: bash
       run: echo "${{ github.workspace }}/protoc-cache" >> $GITHUB_PATH
     - uses: Swatinem/rust-cache@v2
+      with:
+        cache-targets: "false"
     - run: cargo hack --no-private check-external-types --all-features
       env:
         RUSTFLAGS: "-D warnings"


### PR DESCRIPTION
target/ is quite large so this substantially reduces the size of caches, at the cost of additional CPU to recompile dependencies. Pretty much all the caches become ~85 MB as they download approximately the same deps. That might also allow future cache reduction by sharing caches between jobs.

v0-rust-test-Linux is a cache that shrinks quite a bit, from 710 MB. v0-rust-codegen-Linux shrinks less, from 170 MB. The sum of caches from rust-cache would reduce from 6410 MB to 1355 MB, except I opt to continue caching slower Windows jobs so it reduces down to 2425 MB instead. We're now able to fit 3 completely unique build caches within the 10 GB limit (protoc-binaries is too big to fit 4).

To see the speed reductions, here are the wall times for a build, if we disabled targets everywhere:

Job         | Cached | Less Cache
----------- | ------ | ----------
rustfmt     |     6s |     6s
msrv        |    37s | 1m 22s
doc         | 1m 51s | 1m 46s
doc-test    |    42s | 2m 22s
semver      | 1m 38s | 1m 36s
external-types | 42s | 1m 45s
clippy      |    46s | 1m 56s
codegen     |    18s |    30s
udeps       | 5m 59s | 5m 35s
check mac   | 3m 47s | 5m 50s
check lin   | 2m 12s | 4m 59s
check win   | 6m  4s | 11m 2s
interop mac | 1m  6s | 1m 23s
interop lin |    56s | 1m 22s
interop win | 4m  7s | 5m 40s
test mac    | 2m  6s | 3m 38s
test lin    | 1m 58s | 3m 45s
test win    | 5m 25s | 9m 37s