### PR TITLE
Support --features protoc-gen-rust-grpc everywhere for protoc

### DIFF
--- a/grpc-protobuf-build/Cargo.toml
+++ b/grpc-protobuf-build/Cargo.toml
@@ -20,7 +20,7 @@ which = "8.0"
 protoc-gen-rust-grpc = { version = "0.9.0", path = "../protoc-gen-rust-grpc", optional = true }
 
 [features]
-default = ["protoc-gen-rust-grpc"]
+default = ["build-plugin"]
 # Alias for existing users
 build-plugin = ["protoc-gen-rust-grpc"]
 

--- a/grpc-protobuf-build/Cargo.toml
+++ b/grpc-protobuf-build/Cargo.toml
@@ -20,8 +20,9 @@ which = "8.0"
 protoc-gen-rust-grpc = { version = "0.9.0", path = "../protoc-gen-rust-grpc", optional = true }
 
 [features]
-default = ["build-plugin"]
-build-plugin = ["dep:protoc-gen-rust-grpc"]
+default = ["protoc-gen-rust-grpc"]
+# Alias for existing users
+build-plugin = ["protoc-gen-rust-grpc"]
 
 [build-dependencies]
 cmake = "0.1"

--- a/grpc-protobuf-build/src/lib.rs
+++ b/grpc-protobuf-build/src/lib.rs
@@ -257,8 +257,8 @@ impl CodeGen {
             return Ok((protoc.clone(), plugin.clone()));
         }
 
-        // 2. Compiled via protoc-gen-rust-grpc (build-plugin feature)
-        #[cfg(feature = "build-plugin")]
+        // 2. Compiled via protoc-gen-rust-grpc
+        #[cfg(feature = "protoc-gen-rust-grpc")]
         {
             let compiled_protoc = protoc_gen_rust_grpc::protoc();
             let compiled_plugin = protoc_gen_rust_grpc::protoc_gen_rust_grpc();

--- a/interop/Cargo.toml
+++ b/interop/Cargo.toml
@@ -37,7 +37,7 @@ grpc-protobuf = {path = "../grpc-protobuf"}
 rustls = { version = "0.23", default-features = false, features = ["ring"] }
 
 [features]
-protoc-gen-rust-grpc = ["dep:protoc-gen-rust-grpc", "grpc-protobuf-build/build-plugin"]
+protoc-gen-rust-grpc = ["dep:protoc-gen-rust-grpc", "grpc-protobuf-build/protoc-gen-rust-grpc"]
 
 [build-dependencies]
 tonic-prost-build = {path = "../tonic-prost-build"}

--- a/interop/Cargo.toml
+++ b/interop/Cargo.toml
@@ -36,6 +36,10 @@ tonic-protobuf = {path = "../tonic-protobuf"}
 grpc-protobuf = {path = "../grpc-protobuf"}
 rustls = { version = "0.23", default-features = false, features = ["ring"] }
 
+[features]
+protoc-gen-rust-grpc = ["dep:protoc-gen-rust-grpc", "grpc-protobuf-build/build-plugin"]
+
 [build-dependencies]
 tonic-prost-build = {path = "../tonic-prost-build"}
 grpc-protobuf-build = {path = "../grpc-protobuf-build", default-features = false}
+protoc-gen-rust-grpc = { path = "../protoc-gen-rust-grpc", optional = true }

--- a/interop/build.rs
+++ b/interop/build.rs
@@ -1,5 +1,14 @@
 fn main() {
     println!("cargo:rerun-if-changed=build.rs");
+
+    // Use protoc-gen-rust-grpc for tonic_prost_build when it is available
+    #[cfg(feature = "protoc-gen-rust-grpc")]
+    if protoc_gen_rust_grpc::protoc().exists() {
+        unsafe {
+            std::env::set_var("PROTOC", protoc_gen_rust_grpc::protoc());
+        }
+    }
+
     let proto = "proto/grpc/testing/test.proto";
 
     tonic_prost_build::compile_protos(proto).unwrap();


### PR DESCRIPTION
grpc-protobuf-build had disabled the implicit feature by having a feature with dep:protoc-gen-rust-grpc, so I changed build-plugin to act as an alias and enable the now-implicit feature protoc-gen-rust-grpc.

Since interop/, grpc-protobuf-build/, and examples/ all use the protoc-gen-rust-grpc feature, you can now build everything at the top-level with just `cargo build --features protoc-gen-rust-grpc` without protoc on the PATH.

interop/ is nice in that enabling the protoc-gen-rust-grpc feature cascades to enable the feature on grpc-protobuf-build. Without that, doing `cargo build -p interop --features protoc-gen-rust-grpc` would still require protoc in the PATH. Note that examples doesn't have that, so `GRPC_RUST_REGENERATE_PROTO=1 cargo build -p examples --features protoc-gen-rust-grpc` requires protoc in PATH for the grpc codegen; it still requires --features grpc-protobuf-build/protoc-gen-rust-grpc. Since it is an example, keeping them separate seems the most straight-forward for users, at least for now.

CC @dfawley 