### PR TITLE
fix(tonic-xds): consume immediate first tick in OD housekeeping actor

### DIFF
--- a/tonic-xds/src/client/loadbalance/outlier_detection.rs
+++ b/tonic-xds/src/client/loadbalance/outlier_detection.rs
@@ -282,6 +282,14 @@ pub(crate) fn spawn_actor(registry: Arc<OutlierStatsRegistry>) -> AbortOnDrop {
     let task = tokio::spawn(async move {
         let mut ticker = tokio::time::interval(interval);
         ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+        // `interval` fires its first tick immediately; consume it so the
+        // first `run_housekeeping` happens one full period after spawn,
+        // not at t=0. Without this, counters that the data path is
+        // accumulating between `OutlierDetector::new` and the first
+        // recorded outcome can be snapshot_and_reset to zero, causing
+        // flakiness in tests and dropping the first interval's worth of
+        // outcomes in production.
+        ticker.tick().await;
         loop {
             ticker.tick().await;
             registry.run_housekeeping();

--- a/tonic-xds/src/client/loadbalance/outlier_detection.rs
+++ b/tonic-xds/src/client/loadbalance/outlier_detection.rs
@@ -282,13 +282,6 @@ pub(crate) fn spawn_actor(registry: Arc<OutlierStatsRegistry>) -> AbortOnDrop {
     let task = tokio::spawn(async move {
         let mut ticker = tokio::time::interval(interval);
         ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
-        // `interval` fires its first tick immediately; consume it so the
-        // first `run_housekeeping` happens one full period after spawn,
-        // not at t=0. Without this, counters that the data path is
-        // accumulating between `OutlierDetector::new` and the first
-        // recorded outcome can be snapshot_and_reset to zero, causing
-        // flakiness in tests and dropping the first interval's worth of
-        // outcomes in production.
         ticker.tick().await;
         loop {
             ticker.tick().await;


### PR DESCRIPTION
## Summary

A flaky test was reported ([link](https://github.com/grpc/grpc-rust/pull/2619#issuecomment-4711913222)) after #2619 was merged.

The root cause is: `tokio::time::interval(period)` fires immediately on its first poll, so the outlier-detection housekeeping actor was running `run_housekeeping` at t≈0 — before the data path had recorded anything. That early sweep calls `snapshot_and_reset` and zeros whatever counters have landed. Therefore, `test_outlier_detection_reinsert_preserves_state` flakes with `(0, 0) != (3, 0)` when the actor's first tick races the assertion read.

Fix: consume the immediate tick before entering the loop so the first real sweep fires one full `interval` after spawn, matching the gRFC A50 semantics.

## Testing

\`cargo test -p tonic-xds --lib test_outlier_detection_reinsert_preserves_state\` — 10/10 pass under stress.