### PR TITLE
examples: gRPC Google credentials example

### DIFF
--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -108,6 +108,11 @@ path = "src/gcp/client.rs"
 required-features = ["gcp"]
 
 [[bin]]
+name = "grpc-gcp-client"
+path = "src/grpc-gcp/client.rs"
+required-features = ["grpc-gcp"]
+
+[[bin]]
 name = "tracing-client"
 path = "src/tracing/client.rs"
 required-features = ["tracing"]
@@ -282,9 +287,14 @@ types = ["dep:tonic-types"]
 h2c = ["dep:hyper", "dep:tower", "dep:http", "dep:hyper-util"]
 cancellation = ["dep:tokio-util"]
 tower = ["dep:tower", "dep:http"]
+grpc-gcp = [ "dep:protobuf", "dep:grpc-protobuf", "dep:grpc", "dep:grpc-google",
+"dep:rustls", "dep:protobuf-well-known-types" ]
 grpc-routeguide = ["dep:grpc", "dep:grpc-protobuf", "dep:protobuf", "dep:rand"]
 grpc-helloworld = ["dep:grpc", "dep:grpc-protobuf", "dep:protobuf"]
-full = ["gcp", "routeguide", "reflection", "autoreload", "health", "grpc-web", "tracing", "uds", "streaming", "mock", "json-codec", "compression", "tls", "tls-rustls", "tls-client-auth", "types", "cancellation", "h2c", "grpc-routeguide", "grpc-helloworld"]
+full = ["gcp", "routeguide", "reflection", "autoreload", "health", "grpc-web",
+"tracing", "uds", "streaming", "mock", "json-codec", "compression", "tls",
+"tls-rustls", "tls-client-auth", "types", "cancellation", "h2c",
+"grpc-routeguide", "grpc-helloworld", "grpc-gcp"]
 default = ["full"]
 
 [dependencies]
@@ -317,11 +327,15 @@ h2 = { version = "0.4", optional = true }
 tokio-rustls = { version = "0.26.1", optional = true, features = ["ring", "tls12"], default-features = false }
 hyper-rustls = { version = "0.27.0", features = ["http2", "ring", "tls12"], optional = true, default-features = false }
 tower-http = { version = "0.6", optional = true }
+grpc-google = { path = "../grpc-google", optional = true}
 grpc-protobuf = { path = "../grpc-protobuf", optional = true }
 protobuf = { version = "4.34.0-release", optional = true }
 grpc = { path = "../grpc", optional = true }
+rustls = { version = "0.23", default-features = false, features = ["ring"], optional = true}
+protobuf-well-known-types = { version = "4.34.0-release", optional = true }
 
 [build-dependencies]
 tonic-prost-build = { path = "../tonic-prost-build" }
 grpc-protobuf-build = { path = "../grpc-protobuf-build", default-features = false }
 protoc-gen-rust-grpc = { path = "../protoc-gen-rust-grpc", optional = true }
+protobuf-well-known-types = { version = "4.34.0-release" }

--- a/examples/README.md
+++ b/examples/README.md
@@ -86,6 +86,25 @@ server instead:
 $ cargo run --bin routeguide-server
 ```
 
+## Google Cloud Pub/Sub Example
+This example demonstrates fetching a list of topics from the Cloud Pub/Sub API. 
+The request is secured using an OAuth token and TLS.
+
+### Client
+
+Ensure your environment has [Application Default Credentials] configured.
+You can do this by setting the `GOOGLE_APPLICATION_CREDENTIALS` environment
+variable, or by running the `gcloud auth application-default login` command.
+
+Once your credentials are set up, you will need your GCP Project ID, which can
+be found on the main dashboard of the Google Cloud Console. With both of these
+ready, you can run the example like so:
+```bash
+$ cargo run --bin grpc-gcp-client -- <project-id>
+```
+
+[Application Default Credentials]: https://docs.cloud.google.com/docs/authentication/application-default-credentials
+
 ## Helloworld
 
 ### Client

--- a/examples/build.rs
+++ b/examples/build.rs
@@ -1,4 +1,5 @@
-use std::{env, path::PathBuf};
+use std::env;
+use std::path::PathBuf;
 
 fn main() {
     println!("cargo:rerun-if-changed=build.rs");
@@ -78,6 +79,31 @@ fn main() {
             .output_dir(generated_dir.join("routeguide"))
             .input("route_guide.proto")
             .include(manifest_dir.join("proto/routeguide"))
+            .client_only()
+            .compile()
+            .unwrap();
+    }
+
+    if env::var_os("CARGO_FEATURE_GRPC_GCP").is_some() {
+        let manifest_dir = PathBuf::from(env::var_os("CARGO_MANIFEST_DIR").unwrap());
+        let dependencies = protobuf_well_known_types::get_dependency("protobuf_well_known_types")
+            .into_iter()
+            .map(|d| d.into())
+            .collect();
+
+        grpc_protobuf_build::CodeGen::new()
+            .include(manifest_dir.join("proto/googleapis"))
+            .inputs([
+                "google/pubsub/v1/pubsub.proto",
+                "google/pubsub/v1/schema.proto",
+                "google/api/annotations.proto",
+                "google/api/resource.proto",
+                "google/api/http.proto",
+                "google/api/field_behavior.proto",
+                "google/api/client.proto",
+                "google/protobuf/descriptor.proto", // bundled with protoc.
+            ])
+            .dependencies(dependencies)
             .client_only()
             .compile()
             .unwrap();

--- a/examples/src/grpc-gcp/client.rs
+++ b/examples/src/grpc-gcp/client.rs
@@ -1,0 +1,69 @@
+/*
+ *
+ * Copyright 2026 gRPC authors.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to
+ * deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ *
+ */
+
+#[allow(unused)]
+mod generated {
+    pub mod api {
+        grpc::include_proto!("google/pubsub/v1", "pubsub");
+    }
+}
+
+use std::sync::Arc;
+
+use generated::api::ListTopicsRequest;
+use generated::api::publisher_client::PublisherClient;
+use grpc::client::Channel;
+use grpc::credentials::CompositeChannelCredentials;
+use grpc::credentials::rustls::client::ClientTlsConfig;
+use grpc::credentials::rustls::client::RustlsChannelCredendials;
+use grpc_google::GcpCallCredentials;
+use protobuf::proto;
+
+const ENDPOINT: &str = "dns:///pubsub.googleapis.com";
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    _ = rustls::crypto::ring::default_provider().install_default();
+    let project = std::env::args()
+        .nth(1)
+        .ok_or_else(|| "Expected a project name as the first argument.".to_string())?;
+
+    let call_creds = GcpCallCredentials::new_application_default()?;
+    let tls = RustlsChannelCredendials::new(ClientTlsConfig::new())?;
+    let channel_creds = CompositeChannelCredentials::new(tls, Arc::new(call_creds));
+
+    let channel = Channel::new(ENDPOINT, Arc::new(channel_creds), Default::default());
+
+    let client = PublisherClient::new(channel);
+
+    let response = client
+        .list_topics(proto!(ListTopicsRequest {
+            project: format!("projects/{project}"),
+        }))
+        .await;
+
+    println!("RESPONSE={response:?}");
+
+    Ok(())
+}

--- a/grpc-protobuf-build/Cargo.toml
+++ b/grpc-protobuf-build/Cargo.toml
@@ -12,6 +12,9 @@ categories = ["web-programming", "network-programming", "asynchronous"]
 rust-version = { workspace = true }
 edition = "2024"
 
+[package.metadata.cargo_check_external_types]
+allowed_external_types = ["protobuf_codegen::Dependency"]
+
 [dependencies]
 prettyplease = "0.2.35"
 protobuf-codegen = { version = "4.34.0-release" }

--- a/grpc-protobuf-build/src/lib.rs
+++ b/grpc-protobuf-build/src/lib.rs
@@ -110,6 +110,16 @@ impl From<&Dependency> for protobuf_codegen::Dependency {
     }
 }
 
+impl From<protobuf_codegen::Dependency> for Dependency {
+    fn from(val: protobuf_codegen::Dependency) -> Self {
+        Dependency {
+            crate_name: val.crate_name,
+            proto_import_paths: val.proto_import_paths,
+            proto_files: val.proto_files,
+        }
+    }
+}
+
 fn check_runnable(binary: &Path) -> Result<(), String> {
     let out = Command::new(binary)
         .arg("--version")


### PR DESCRIPTION
This PR adds an example demonstrating how to call the Cloud Pub/Sub API using Google call credentials and TLS with system root certificates, similar to the [tonic GCP](https://github.com/grpc/grpc-rust/tree/master/examples/src/gcp) example.

The example utilizes protobuf well-known types (WKT) crates. I've also added `From<protobuf_codegen::Dependency> for Dependency` to easily convert dependency types returned by WKT/codegen crates into the format  expected by `grpc_protobuf_build`.

Unlike other gRPC examples, the generated code is not checked-in as it's approximately 60k lines https://github.com/grpc/grpc-rust/commit/15b7f7f97a386a601ea0602c481fc0c24db149df.