### PR TITLE
grpc/client: fix trait bounds on channel credentials to avoid double Arcing

### DIFF
--- a/grpc/src/client/channel.rs
+++ b/grpc/src/client/channel.rs
@@ -80,12 +80,10 @@ use crate::client::transport::TransportRegistry;
 #[cfg(feature = "_runtime-tokio")]
 use crate::client::transport::tonic as tonic_transport;
 use crate::core::RequestHeaders;
-use crate::credentials::ChannelCredentials;
+use crate::credentials::SharedChannelCredentials;
 use crate::credentials::client::ClientHandshakeInfo;
 use crate::credentials::common::Authority;
-use crate::credentials::dyn_wrapper::DynChannelCredentials;
 use crate::rt;
-use crate::rt::GrpcEndpoint;
 use crate::rt::GrpcRuntime;
 use crate::rt::default_runtime;
 
@@ -167,11 +165,11 @@ impl Channel {
     /// Constructs a new gRPC channel.  Channel creation cannot fail, but if the
     /// target string is invalid, the returned channel will never connect, and
     /// will fail all RPCs.
-    pub fn new<C>(target: impl Into<String>, credentials: Arc<C>, options: ChannelOptions) -> Self
-    where
-        C: ChannelCredentials,
-        C::Output<Box<dyn GrpcEndpoint>>: GrpcEndpoint + 'static,
-    {
+    pub fn new(
+        target: impl Into<String>,
+        credentials: impl Into<SharedChannelCredentials>,
+        options: ChannelOptions,
+    ) -> Self {
         pick_first::reg();
         round_robin::reg();
         dns::reg();
@@ -186,7 +184,7 @@ impl Channel {
                 target,
                 default_runtime(),
                 options,
-                credentials as Arc<dyn DynChannelCredentials>,
+                credentials.into(),
             )),
         }
     }
@@ -246,7 +244,7 @@ impl PersistentChannel {
         target: impl Into<String>,
         runtime: GrpcRuntime,
         options: ChannelOptions,
-        credentials: Arc<dyn DynChannelCredentials>,
+        credentials: SharedChannelCredentials,
     ) -> Self {
         // TODO(arjan-bal): Return errors here instead of panicking.
         let target = Url::from_str(&target.into()).unwrap();

--- a/grpc/src/client/subchannel.rs
+++ b/grpc/src/client/subchannel.rs
@@ -55,11 +55,13 @@ use crate::client::transport::DynTransport;
 use crate::client::transport::SecurityOpts;
 use crate::client::transport::TransportOptions;
 use crate::core::RequestHeaders;
+use crate::credentials::ChannelCredentials;
 use crate::credentials::call::CallDetails;
 use crate::credentials::call::ClientConnectionSecurityInfo as CallClientConnectionSecurityInfo;
 use crate::credentials::client::ClientConnectionSecurityContext;
 use crate::credentials::client::ClientConnectionSecurityInfo;
 use crate::credentials::common::Authority;
+use crate::private;
 use crate::rt::GrpcRuntime;
 
 type SharedInvoke = Arc<dyn DynInvoke>;
@@ -186,7 +188,7 @@ impl DynInvoke for InternalSubchannel {
             let creds = data
                 .security_opts
                 .credentials
-                .get_call_credentials()
+                .get_call_credentials(private::Internal)
                 .cloned();
 
             (state, creds)

--- a/grpc/src/client/transport/mod.rs
+++ b/grpc/src/client/transport/mod.rs
@@ -22,16 +22,15 @@
  *
  */
 
-use std::sync::Arc;
 use std::time::Duration;
 use std::time::Instant;
 
 use crate::client::DynInvoke;
 use crate::client::Invoke;
+use crate::credentials::SharedChannelCredentials;
 use crate::credentials::client::ClientHandshakeInfo;
 use crate::credentials::client::DynClientConnectionSecurityInfo;
 use crate::credentials::common::Authority;
-use crate::credentials::dyn_wrapper::DynChannelCredentials;
 use crate::rt::GrpcRuntime;
 
 mod registry;
@@ -126,7 +125,7 @@ impl<T: Transport> DynTransport for T {
 
 #[derive(Clone)]
 pub(crate) struct SecurityOpts {
-    pub(crate) credentials: Arc<dyn DynChannelCredentials>,
+    pub(crate) credentials: SharedChannelCredentials,
     pub(crate) authority: Authority,
     pub(crate) handshake_info: ClientHandshakeInfo,
 }

--- a/grpc/src/client/transport/tonic/test.rs
+++ b/grpc/src/client/transport/tonic/test.rs
@@ -151,7 +151,7 @@ pub(crate) async fn tonic_transport_rpc() {
         .unwrap();
     let config = Arc::new(TransportOptions::default());
     let securty_opts = SecurityOpts {
-        credentials: LocalChannelCredentials::new_arc(),
+        credentials: LocalChannelCredentials::new_arc().into(),
         authority: Authority::new("localhost".to_string(), None),
         handshake_info: ClientHandshakeInfo::default(),
     };
@@ -668,7 +668,7 @@ async fn tonic_transport_invalid_base64_headers() {
         .unwrap();
     let config = Arc::new(TransportOptions::default());
     let securty_opts = SecurityOpts {
-        credentials: LocalChannelCredentials::new_arc(),
+        credentials: LocalChannelCredentials::new_arc().into(),
         authority: Authority::new("localhost".to_string(), None),
         handshake_info: ClientHandshakeInfo::default(),
     };
@@ -743,7 +743,7 @@ async fn tonic_transport_recv_drop_cancels_send() {
         .unwrap();
     let config = Arc::new(TransportOptions::default());
     let securty_opts = SecurityOpts {
-        credentials: LocalChannelCredentials::new_arc(),
+        credentials: LocalChannelCredentials::new_arc().into(),
         authority: Authority::new("localhost".to_string(), None),
         handshake_info: ClientHandshakeInfo::default(),
     };

--- a/grpc/src/credentials/dyn_wrapper.rs
+++ b/grpc/src/credentials/dyn_wrapper.rs
@@ -29,6 +29,7 @@ use tonic::async_trait;
 use crate::credentials::ChannelCredentials;
 use crate::credentials::ProtocolInfo;
 use crate::credentials::ServerCredentials;
+use crate::credentials::SharedChannelCredentials;
 use crate::credentials::call::CallCredentials;
 use crate::credentials::client::ClientConnectionSecurityContext;
 use crate::credentials::client::ClientHandshakeInfo;
@@ -95,7 +96,7 @@ where
     }
 }
 
-impl ChannelCredentials for Arc<dyn DynChannelCredentials> {
+impl ChannelCredentials for SharedChannelCredentials {
     type ContextType = Box<dyn ClientConnectionSecurityContext>;
     type Output<I> = BoxEndpoint;
 
@@ -107,17 +108,17 @@ impl ChannelCredentials for Arc<dyn DynChannelCredentials> {
         runtime: &GrpcRuntime,
         _token: private::Internal,
     ) -> Result<HandshakeOutput<Self::Output<Input>, Self::ContextType>, String> {
-        (**self)
+        self.inner
             .dyn_connect(authority, Box::new(source), info, runtime)
             .await
     }
 
     fn get_call_credentials(&self, _: private::Internal) -> Option<&Arc<dyn CallCredentials>> {
-        (**self).get_call_credentials()
+        self.inner.get_call_credentials()
     }
 
     fn info(&self) -> &ProtocolInfo {
-        (**self).info()
+        self.inner.info()
     }
 }
 
@@ -164,6 +165,7 @@ mod tests {
     use tokio::net::TcpStream;
 
     use super::*;
+    use crate::client::Channel;
     use crate::credentials::LocalChannelCredentials;
     use crate::credentials::LocalServerCredentials;
     use crate::credentials::SecurityLevel;
@@ -272,5 +274,13 @@ mod tests {
         assert_eq!(&buf[..], b"hello dynamic grpc server");
 
         client_handle.abort();
+    }
+
+    #[test]
+    fn test_passing_sharable_to_channel() {
+        // Test verifies that type erased credentials can be passed to a new
+        // channel without wrapping them in a second Arc.
+        let dyn_creds: SharedChannelCredentials = LocalChannelCredentials::new_arc().into();
+        let _ = Channel::new("dns:///localhost:8080", dyn_creds, Default::default());
     }
 }

--- a/grpc/src/credentials/mod.rs
+++ b/grpc/src/credentials/mod.rs
@@ -54,6 +54,7 @@ use crate::credentials::client::ClientConnectionSecurityContext;
 use crate::credentials::client::ClientHandshakeInfo;
 use crate::credentials::client::HandshakeOutput;
 use crate::credentials::common::Authority;
+use crate::credentials::dyn_wrapper::DynChannelCredentials;
 use crate::private;
 use crate::rt::GrpcEndpoint;
 use crate::rt::GrpcRuntime;
@@ -197,6 +198,25 @@ impl ProtocolInfo {
     /// Returns the security protocol name currently in use, e.g. "tls".
     pub fn security_protocol(&self) -> &'static str {
         self.security_protocol
+    }
+}
+
+/// A type-erased, reference-counted container for [`ChannelCredentials`].
+///
+/// Any type implementing [`ChannelCredentials`] that is wrapped in an [`Arc`]
+/// can be converted into `SharedChannelCredentials` via [`From`]/[`Into`].
+#[derive(Clone)]
+pub struct SharedChannelCredentials {
+    inner: Arc<dyn DynChannelCredentials>,
+}
+
+impl<C> From<Arc<C>> for SharedChannelCredentials
+where
+    C: ChannelCredentials + 'static,
+    C::Output<Box<dyn GrpcEndpoint>>: GrpcEndpoint,
+{
+    fn from(credentials: Arc<C>) -> Self {
+        SharedChannelCredentials { inner: credentials }
     }
 }
 


### PR DESCRIPTION
## Background

The channel constructor currently accepts an `Arc<C>` because the credentials might be reused to create "out of band" (OOB) channels (e.g., to an RLS server). If we accepted raw credentials and wrapped them inside the constructor instead, creating an OOB channel would result in a second, redundant `Arc` wrapper, leading to unnecessary pointer indirection and reference counting.

## Problem

Passing an `Arc<dyn DynChannelCredentials>` to `Channel::new` currently fails to compile, even if we add an `impl ChannelCredentials for dyn DynChannelCredentials`.

```rust
error[E0277]: the size for values of type `dyn dyn_wrapper::DynChannelCredentials` cannot be known at compilation time
   --> grpc/src/credentials/dyn_wrapper.rs:307:38
    |
307 |         let ch = Channel::new("abc", creds, ChannelOptions::default());
    |                  ------------        ^^^^^ doesn't have a size known at compile-time
    |                  |
    |                  required by a bound introduced by this call
    |
    = help: the trait `Sized` is not implemented for `dyn dyn_wrapper::DynChannelCredentials`
note: required by an implicit `Sized` bound in `channel::Channel::new`
   --> grpc/src/client/channel.rs:170:16
    |
170 |     pub fn new<C>(target: impl Into<String>, credentials: Arc<C>, options: ChannelOptions) -> Self
    |                ^ required by the implicit `Sized` requirement on this type parameter in `Channel::new`
help: consider relaxing the implicit `Sized` restriction
   --> grpc/src/client/channel.rs:172:30
    |
172 |         C: ChannelCredentials + ?Sized,
    |                               ++++++++

For more information about this error, try `rustc --explain E0277`.

```

This happens because the generic type parameter `C` in `Channel::new` has an implicit `Sized` bound, which trait objects like `dyn DynChannelCredentials` do not satisfy.

## Fix

This PR introduces an opaque wrapper struct, `SharedChannelCredentials`, and updates the channel constructor to accept `impl Into<SharedChannelCredentials>`.

Specifically, this change:

* Adds a `From<Arc<C>>` implementation to convert any valid `Arc<C: ChannelCredentials>` into `SharedChannelCredentials`.
* Implements the `ChannelCredentials` trait directly on `SharedChannelCredentials` so it can be used seamlessly.

This resolves the compilation error while preserving the optimization against double-`Arc`ing. An existing `SharedChannelCredentials` object can be passed directly to an OOB channel; calling `.into()` on it is essentially a no-op, securely reusing the existing reference count.