### PR TITLE
grpc/credentials/client: Make ChannelCredentials object safe

### DIFF
--- a/grpc-protobuf-build/Cargo.toml
+++ b/grpc-protobuf-build/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grpc-protobuf-build"
-version = "0.9.0"
+version = "0.10.0"
 authors = ["gRPC Authors"]
 license = "MIT"
 homepage = "https://grpc.io"
@@ -20,7 +20,7 @@ prettyplease = "0.2.35"
 protobuf-codegen = { version = "4.34.0-release" }
 syn = "2.0.104"
 which = "8.0"
-protoc-gen-rust-grpc = { version = "0.9.0", path = "../protoc-gen-rust-grpc", optional = true }
+protoc-gen-rust-grpc = { version = "0.10.0", path = "../protoc-gen-rust-grpc", optional = true }
 
 [features]
 default = ["build-plugin"]

--- a/grpc-protobuf/Cargo.toml
+++ b/grpc-protobuf/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grpc-protobuf"
-version = "0.9.0"
+version = "0.10.0"
 authors = ["gRPC Authors"]
 license = "MIT"
 homepage = "https://grpc.io"
@@ -22,7 +22,7 @@ allowed_external_types = [
 
 [dependencies]
 bytes = "1.11.1"
-grpc = { version = "0.9.0", path = "../grpc" }
+grpc = { version = "0.10.0", path = "../grpc" }
 protobuf = "4.34.0-release"
 
 [dev-dependencies]

--- a/grpc/Cargo.toml
+++ b/grpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grpc"
-version = "0.9.0"
+version = "0.10.0"
 authors = ["gRPC Authors"]
 license = "MIT"
 homepage = "https://grpc.io"

--- a/grpc/src/client/channel.rs
+++ b/grpc/src/client/channel.rs
@@ -82,9 +82,7 @@ use crate::core::RequestHeaders;
 use crate::credentials::ChannelCredentials;
 use crate::credentials::client::ClientHandshakeInfo;
 use crate::credentials::common::Authority;
-use crate::credentials::dyn_wrapper::DynChannelCredentials;
 use crate::rt;
-use crate::rt::GrpcEndpoint;
 use crate::rt::GrpcRuntime;
 use crate::rt::default_runtime;
 
@@ -166,11 +164,11 @@ impl Channel {
     /// Constructs a new gRPC channel.  Channel creation cannot fail, but if the
     /// target string is invalid, the returned channel will never connect, and
     /// will fail all RPCs.
-    pub fn new<C>(target: impl Into<String>, credentials: Arc<C>, options: ChannelOptions) -> Self
-    where
-        C: ChannelCredentials,
-        C::Output<Box<dyn GrpcEndpoint>>: GrpcEndpoint + 'static,
-    {
+    pub fn new(
+        target: impl Into<String>,
+        credentials: Arc<dyn ChannelCredentials>,
+        options: ChannelOptions,
+    ) -> Self {
         pick_first::reg();
         round_robin::reg();
         dns::reg();
@@ -185,7 +183,7 @@ impl Channel {
                 target,
                 default_runtime(),
                 options,
-                credentials as Arc<dyn DynChannelCredentials>,
+                credentials,
             )),
         }
     }
@@ -245,7 +243,7 @@ impl PersistentChannel {
         target: impl Into<String>,
         runtime: GrpcRuntime,
         options: ChannelOptions,
-        credentials: Arc<dyn DynChannelCredentials>,
+        credentials: Arc<dyn ChannelCredentials>,
     ) -> Self {
         // TODO(nathanielford): Return errors here instead of panicking.
         let target = Target::from_str(&target.into()).unwrap();

--- a/grpc/src/client/subchannel.rs
+++ b/grpc/src/client/subchannel.rs
@@ -57,8 +57,7 @@ use crate::client::transport::TransportOptions;
 use crate::core::RequestHeaders;
 use crate::credentials::call::CallDetails;
 use crate::credentials::call::ClientConnectionSecurityInfo as CallClientConnectionSecurityInfo;
-use crate::credentials::client::ClientConnectionSecurityContext;
-use crate::credentials::client::ClientConnectionSecurityInfo;
+use crate::credentials::client::ChannelSecurityInfo;
 use crate::credentials::common::Authority;
 use crate::rt::GrpcRuntime;
 
@@ -84,7 +83,7 @@ impl Backoff for NopBackoff {
 
 struct ReadyState {
     service: Box<dyn DynInvoke>,
-    security_info: ClientConnectionSecurityInfo<Box<dyn ClientConnectionSecurityContext>>,
+    security_info: ChannelSecurityInfo,
     authority: Authority,
 }
 

--- a/grpc/src/client/subchannel.rs
+++ b/grpc/src/client/subchannel.rs
@@ -59,6 +59,7 @@ use crate::credentials::call::CallDetails;
 use crate::credentials::call::ClientConnectionSecurityInfo as CallClientConnectionSecurityInfo;
 use crate::credentials::client::ChannelSecurityInfo;
 use crate::credentials::common::Authority;
+use crate::private;
 use crate::rt::GrpcRuntime;
 
 type SharedInvoke = Arc<dyn DynInvoke>;
@@ -185,7 +186,7 @@ impl DynInvoke for InternalSubchannel {
             let creds = data
                 .security_opts
                 .credentials
-                .get_call_credentials()
+                .get_call_credentials(private::Internal)
                 .cloned();
 
             (state, creds)

--- a/grpc/src/client/transport/mod.rs
+++ b/grpc/src/client/transport/mod.rs
@@ -27,10 +27,10 @@ use std::time::Duration;
 
 use crate::client::DynInvoke;
 use crate::client::Invoke;
+use crate::credentials::ChannelCredentials;
 use crate::credentials::client::ChannelSecurityInfo;
 use crate::credentials::client::ClientHandshakeInfo;
 use crate::credentials::common::Authority;
-use crate::credentials::dyn_wrapper::DynChannelCredentials;
 use crate::rt::GrpcRuntime;
 
 mod registry;
@@ -124,7 +124,7 @@ impl<T: Transport> DynTransport for T {
 
 #[derive(Clone)]
 pub(crate) struct SecurityOpts {
-    pub(crate) credentials: Arc<dyn DynChannelCredentials>,
+    pub(crate) credentials: Arc<dyn ChannelCredentials>,
     pub(crate) authority: Authority,
     pub(crate) handshake_info: ClientHandshakeInfo,
 }

--- a/grpc/src/client/transport/mod.rs
+++ b/grpc/src/client/transport/mod.rs
@@ -27,8 +27,8 @@ use std::time::Duration;
 
 use crate::client::DynInvoke;
 use crate::client::Invoke;
+use crate::credentials::client::ChannelSecurityInfo;
 use crate::credentials::client::ClientHandshakeInfo;
-use crate::credentials::client::DynClientConnectionSecurityInfo;
 use crate::credentials::common::Authority;
 use crate::credentials::dyn_wrapper::DynChannelCredentials;
 use crate::rt::GrpcRuntime;
@@ -76,7 +76,7 @@ pub(crate) trait Transport: Sync {
     ) -> Result<
         (
             Self::Service,
-            DynClientConnectionSecurityInfo,
+            ChannelSecurityInfo,
             oneshot::Receiver<Result<(), String>>,
         ),
         String,
@@ -94,7 +94,7 @@ pub(crate) trait DynTransport: Send + Sync {
     ) -> Result<
         (
             Box<dyn DynInvoke>,
-            DynClientConnectionSecurityInfo,
+            ChannelSecurityInfo,
             oneshot::Receiver<Result<(), String>>,
         ),
         String,
@@ -112,7 +112,7 @@ impl<T: Transport> DynTransport for T {
     ) -> Result<
         (
             Box<dyn DynInvoke>,
-            DynClientConnectionSecurityInfo,
+            ChannelSecurityInfo,
             oneshot::Receiver<Result<(), String>>,
         ),
         String,

--- a/grpc/src/client/transport/tonic/mod.rs
+++ b/grpc/src/client/transport/tonic/mod.rs
@@ -87,7 +87,7 @@ use crate::core::ResponseHeaders;
 use crate::core::SendMessage;
 use crate::core::Trailers;
 use crate::credentials::client::ChannelSecurityInfo;
-use crate::credentials::dyn_wrapper::DynChannelCredentials;
+use crate::private;
 use crate::rt::BoxedTaskHandle;
 use crate::rt::GrpcRuntime;
 use crate::rt::TcpOptions;
@@ -425,11 +425,12 @@ impl Transport for TransportBuilder {
         let transport = transport_fut.await?;
         let credentials = &security_info.credentials;
         let handshake_ouput = credentials
-            .dyn_connect(
+            .connect(
                 &security_info.authority,
                 transport,
                 &security_info.handshake_info,
                 &runtime,
+                private::Internal,
             )
             .await?;
 

--- a/grpc/src/client/transport/tonic/mod.rs
+++ b/grpc/src/client/transport/tonic/mod.rs
@@ -86,7 +86,7 @@ use crate::core::RequestHeaders;
 use crate::core::ResponseHeaders;
 use crate::core::SendMessage;
 use crate::core::Trailers;
-use crate::credentials::client::DynClientConnectionSecurityInfo;
+use crate::credentials::client::ChannelSecurityInfo;
 use crate::credentials::dyn_wrapper::DynChannelCredentials;
 use crate::rt::BoxedTaskHandle;
 use crate::rt::GrpcRuntime;
@@ -373,7 +373,7 @@ impl Transport for TransportBuilder {
     ) -> Result<
         (
             Self::Service,
-            DynClientConnectionSecurityInfo,
+            ChannelSecurityInfo,
             oneshot::Receiver<Result<(), String>>,
         ),
         String,

--- a/grpc/src/client/transport/tonic/test.rs
+++ b/grpc/src/client/transport/tonic/test.rs
@@ -95,7 +95,7 @@ use crate::echo_pb::echo_server::EchoServer;
 use crate::metadata::AsciiMetadataKey;
 use crate::metadata::MetadataMap;
 use crate::private;
-use crate::rt::GrpcEndpoint;
+use crate::rt::BoxEndpoint;
 use crate::rt::GrpcRuntime;
 use crate::rt::tokio::TokioRuntime;
 
@@ -833,17 +833,16 @@ impl SlowChannelCredentials {
     }
 }
 
+#[async_trait]
 impl ChannelCredentials for SlowChannelCredentials {
-    type Output<I> = I;
-
-    async fn connect<Input: GrpcEndpoint>(
+    async fn connect(
         &self,
         _authority: &Authority,
-        source: Input,
+        source: BoxEndpoint,
         _info: &ClientHandshakeInfo,
         runtime: &GrpcRuntime,
         _token: private::Internal,
-    ) -> Result<HandshakeOutput<Self::Output<Input>>, String> {
+    ) -> Result<HandshakeOutput, String> {
         runtime.sleep(self.sleep_duration).await;
         Ok(HandshakeOutput {
             endpoint: source,

--- a/grpc/src/client/transport/tonic/test.rs
+++ b/grpc/src/client/transport/tonic/test.rs
@@ -80,7 +80,7 @@ use crate::credentials::call::CallCredentials;
 use crate::credentials::call::CallDetails;
 use crate::credentials::call::ClientConnectionSecurityInfo;
 use crate::credentials::client::ChannelSecurityContext;
-use crate::credentials::client::ChannelSecurityInfo as ClientSecurityInfo;
+use crate::credentials::client::ChannelSecurityInfo;
 use crate::credentials::client::ClientHandshakeInfo;
 use crate::credentials::client::HandshakeOutput;
 use crate::credentials::common::Authority;
@@ -846,7 +846,7 @@ impl ChannelCredentials for SlowChannelCredentials {
         runtime.sleep(self.sleep_duration).await;
         Ok(HandshakeOutput {
             endpoint: source,
-            security: ClientSecurityInfo::new(
+            security: ChannelSecurityInfo::new(
                 "mock",
                 SecurityLevel::NoSecurity,
                 Box::new(MockConnectionSecurityContext),

--- a/grpc/src/client/transport/tonic/test.rs
+++ b/grpc/src/client/transport/tonic/test.rs
@@ -79,8 +79,8 @@ use crate::credentials::SecurityLevel;
 use crate::credentials::call::CallCredentials;
 use crate::credentials::call::CallDetails;
 use crate::credentials::call::ClientConnectionSecurityInfo;
-use crate::credentials::client::ClientConnectionSecurityContext;
-use crate::credentials::client::ClientConnectionSecurityInfo as ClientSecurityInfo;
+use crate::credentials::client::ChannelSecurityContext;
+use crate::credentials::client::ChannelSecurityInfo as ClientSecurityInfo;
 use crate::credentials::client::ClientHandshakeInfo;
 use crate::credentials::client::HandshakeOutput;
 use crate::credentials::common::Authority;
@@ -816,7 +816,7 @@ async fn tonic_transport_recv_drop_cancels_send() {
 
 #[derive(Debug, Clone)]
 struct MockConnectionSecurityContext;
-impl ClientConnectionSecurityContext for MockConnectionSecurityContext {
+impl ChannelSecurityContext for MockConnectionSecurityContext {
     fn validate_authority(&self, _authority: &Authority) -> bool {
         true
     }
@@ -834,7 +834,6 @@ impl SlowChannelCredentials {
 }
 
 impl ChannelCredentials for SlowChannelCredentials {
-    type ContextType = MockConnectionSecurityContext;
     type Output<I> = I;
 
     async fn connect<Input: GrpcEndpoint>(
@@ -844,14 +843,14 @@ impl ChannelCredentials for SlowChannelCredentials {
         _info: &ClientHandshakeInfo,
         runtime: &GrpcRuntime,
         _token: private::Internal,
-    ) -> Result<HandshakeOutput<Self::Output<Input>, Self::ContextType>, String> {
+    ) -> Result<HandshakeOutput<Self::Output<Input>>, String> {
         runtime.sleep(self.sleep_duration).await;
         Ok(HandshakeOutput {
             endpoint: source,
             security: ClientSecurityInfo::new(
                 "mock",
                 SecurityLevel::NoSecurity,
-                MockConnectionSecurityContext,
+                Box::new(MockConnectionSecurityContext),
                 Attributes::new(),
             ),
         })

--- a/grpc/src/credentials/client.rs
+++ b/grpc/src/credentials/client.rs
@@ -35,12 +35,12 @@ use crate::private;
 use crate::rt::GrpcEndpoint;
 use crate::rt::GrpcRuntime;
 
-pub struct HandshakeOutput<T, C: ClientConnectionSecurityContext> {
+pub struct HandshakeOutput<T> {
     pub endpoint: T,
-    pub security: ClientConnectionSecurityInfo<C>,
+    pub security: ChannelSecurityInfo,
 }
 
-pub trait ClientConnectionSecurityContext: Send + Sync + 'static {
+pub trait ChannelSecurityContext: Send + Sync + 'static {
     /// Checks if the established connection is authorized to send requests to
     /// the given authority.
     ///
@@ -57,29 +57,26 @@ pub trait ClientConnectionSecurityContext: Send + Sync + 'static {
     }
 }
 
-impl ClientConnectionSecurityContext for Box<dyn ClientConnectionSecurityContext> {
+impl ChannelSecurityContext for Box<dyn ChannelSecurityContext> {
     fn validate_authority(&self, authority: &Authority) -> bool {
         (**self).validate_authority(authority)
     }
 }
 
 /// Represents the security state of an established client-side connection.
-pub struct ClientConnectionSecurityInfo<C> {
+pub struct ChannelSecurityInfo {
     security_protocol: &'static str,
     security_level: SecurityLevel,
-    security_context: C,
+    security_context: Box<dyn ChannelSecurityContext>,
     /// Stores extra data derived from the underlying protocol.
     attributes: Attributes,
 }
 
-pub type DynClientConnectionSecurityInfo =
-    ClientConnectionSecurityInfo<Box<dyn ClientConnectionSecurityContext>>;
-
-impl<C> ClientConnectionSecurityInfo<C> {
+impl ChannelSecurityInfo {
     pub fn new(
         security_protocol: &'static str,
         security_level: SecurityLevel,
-        security_context: C,
+        security_context: Box<dyn ChannelSecurityContext>,
         attributes: Attributes,
     ) -> Self {
         Self {
@@ -98,24 +95,12 @@ impl<C> ClientConnectionSecurityInfo<C> {
         self.security_level
     }
 
-    pub fn security_context(&self) -> &C {
+    pub fn security_context(&self) -> &dyn ChannelSecurityContext {
         &self.security_context
     }
 
     pub fn attributes(&self) -> &Attributes {
         &self.attributes
-    }
-
-    pub fn into_boxed(self) -> DynClientConnectionSecurityInfo
-    where
-        C: ClientConnectionSecurityContext + 'static,
-    {
-        ClientConnectionSecurityInfo {
-            security_protocol: self.security_protocol,
-            security_level: self.security_level,
-            security_context: Box::new(self.security_context),
-            attributes: self.attributes,
-        }
     }
 }
 
@@ -171,7 +156,6 @@ impl<T: ChannelCredentials> CompositeChannelCredentials<T> {
 }
 
 impl<T: ChannelCredentials> ChannelCredentials for CompositeChannelCredentials<T> {
-    type ContextType = T::ContextType;
     type Output<I> = T::Output<I>;
 
     async fn connect<Input: GrpcEndpoint>(
@@ -181,7 +165,7 @@ impl<T: ChannelCredentials> ChannelCredentials for CompositeChannelCredentials<T
         info: &ClientHandshakeInfo,
         runtime: &GrpcRuntime,
         token: private::Internal,
-    ) -> Result<HandshakeOutput<Self::Output<Input>, Self::ContextType>, String> {
+    ) -> Result<HandshakeOutput<Self::Output<Input>>, String> {
         self.channel_creds
             .connect(authority, source, info, runtime, token)
             .await

--- a/grpc/src/credentials/client.rs
+++ b/grpc/src/credentials/client.rs
@@ -24,6 +24,8 @@
 
 use std::sync::Arc;
 
+use tonic::async_trait;
+
 use crate::attributes::Attributes;
 use crate::credentials::ChannelCredentials;
 use crate::credentials::ProtocolInfo;
@@ -32,11 +34,11 @@ use crate::credentials::call::CallCredentials;
 use crate::credentials::call::CompositeCallCredentials;
 use crate::credentials::common::Authority;
 use crate::private;
-use crate::rt::GrpcEndpoint;
+use crate::rt::BoxEndpoint;
 use crate::rt::GrpcRuntime;
 
-pub struct HandshakeOutput<T> {
-    pub endpoint: T,
+pub struct HandshakeOutput {
+    pub endpoint: BoxEndpoint,
     pub security: ChannelSecurityInfo,
 }
 
@@ -155,17 +157,16 @@ impl<T: ChannelCredentials> CompositeChannelCredentials<T> {
     }
 }
 
+#[async_trait]
 impl<T: ChannelCredentials> ChannelCredentials for CompositeChannelCredentials<T> {
-    type Output<I> = T::Output<I>;
-
-    async fn connect<Input: GrpcEndpoint>(
+    async fn connect(
         &self,
         authority: &Authority,
-        source: Input,
+        source: BoxEndpoint,
         info: &ClientHandshakeInfo,
         runtime: &GrpcRuntime,
         token: private::Internal,
-    ) -> Result<HandshakeOutput<Self::Output<Input>>, String> {
+    ) -> Result<HandshakeOutput, String> {
         self.channel_creds
             .connect(authority, source, info, runtime, token)
             .await

--- a/grpc/src/credentials/dyn_wrapper.rs
+++ b/grpc/src/credentials/dyn_wrapper.rs
@@ -22,101 +22,16 @@
  *
  */
 
-use std::sync::Arc;
-
 use tonic::async_trait;
 
-use crate::credentials::ChannelCredentials;
 use crate::credentials::ProtocolInfo;
 use crate::credentials::ServerCredentials;
-use crate::credentials::call::CallCredentials;
-use crate::credentials::client::ClientHandshakeInfo;
-use crate::credentials::client::HandshakeOutput;
-use crate::credentials::common::Authority;
 use crate::credentials::server::HandshakeOutput as ServerHandshakeOutput;
 use crate::private;
+use crate::rt::BoxEndpoint;
 use crate::rt::GrpcEndpoint;
 use crate::rt::GrpcRuntime;
 use crate::send_future::SendFuture;
-
-type BoxEndpoint = Box<dyn GrpcEndpoint>;
-
-// Bridge trait for type erasure.
-#[async_trait]
-pub(crate) trait DynChannelCredentials: Send + Sync {
-    async fn dyn_connect(
-        &self,
-        authority: &Authority,
-        source: BoxEndpoint,
-        info: &ClientHandshakeInfo,
-        runtime: &GrpcRuntime,
-    ) -> Result<HandshakeOutput<BoxEndpoint>, String>;
-
-    fn info(&self) -> &ProtocolInfo;
-
-    fn get_call_credentials(&self) -> Option<&Arc<dyn CallCredentials>>;
-}
-
-#[async_trait]
-impl<T> DynChannelCredentials for T
-where
-    T: ChannelCredentials,
-    T::Output<BoxEndpoint>: GrpcEndpoint,
-{
-    async fn dyn_connect(
-        &self,
-        authority: &Authority,
-        source: BoxEndpoint,
-        info: &ClientHandshakeInfo,
-        runtime: &GrpcRuntime,
-    ) -> Result<HandshakeOutput<BoxEndpoint>, String> {
-        let output = self
-            .connect(authority, source, info, runtime, private::Internal)
-            .make_send()
-            .await?;
-
-        let stream = output.endpoint;
-        let sec_info = output.security;
-
-        Ok(HandshakeOutput {
-            endpoint: Box::new(stream),
-            security: sec_info,
-        })
-    }
-
-    fn info(&self) -> &ProtocolInfo {
-        self.info()
-    }
-
-    fn get_call_credentials(&self) -> Option<&Arc<dyn CallCredentials>> {
-        self.get_call_credentials(private::Internal)
-    }
-}
-
-impl ChannelCredentials for Arc<dyn DynChannelCredentials> {
-    type Output<I> = BoxEndpoint;
-
-    async fn connect<Input: GrpcEndpoint>(
-        &self,
-        authority: &Authority,
-        source: Input,
-        info: &ClientHandshakeInfo,
-        runtime: &GrpcRuntime,
-        _token: private::Internal,
-    ) -> Result<HandshakeOutput<Self::Output<Input>>, String> {
-        (**self)
-            .dyn_connect(authority, Box::new(source), info, runtime)
-            .await
-    }
-
-    fn get_call_credentials(&self, _: private::Internal) -> Option<&Arc<dyn CallCredentials>> {
-        (**self).get_call_credentials()
-    }
-
-    fn info(&self) -> &ProtocolInfo {
-        (**self).info()
-    }
-}
 
 // Bridge trait for type erasure.
 #[async_trait]
@@ -161,67 +76,11 @@ mod tests {
     use tokio::net::TcpStream;
 
     use super::*;
-    use crate::credentials::LocalChannelCredentials;
     use crate::credentials::LocalServerCredentials;
     use crate::credentials::SecurityLevel;
-    use crate::credentials::client::ClientHandshakeInfo;
+    use crate::rt;
     use crate::rt::AsyncIoAdapter;
-    use crate::rt::TcpOptions;
     use crate::rt::tokio::TokioIoStream;
-    use crate::rt::{self};
-
-    #[tokio::test]
-    async fn test_dyn_client_credential_dispatch() {
-        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
-        let addr = listener.local_addr().unwrap();
-
-        let dyn_creds = LocalChannelCredentials::new_arc() as Arc<dyn DynChannelCredentials>;
-
-        let authority = Authority::new("localhost".to_string(), Some(addr.port()));
-
-        let runtime = crate::rt::default_runtime();
-        let source = runtime
-            .tcp_stream(addr, TcpOptions::default())
-            .await
-            .unwrap();
-        let info = ClientHandshakeInfo::default();
-
-        let result = dyn_creds
-            .dyn_connect(&authority, source, &info, &runtime)
-            .await;
-
-        assert!(result.is_ok());
-        let output = result.unwrap();
-        let endpoint = output.endpoint;
-        let security_info = output.security;
-
-        assert!(!endpoint.get_local_address().is_empty());
-        assert_eq!(security_info.security_protocol(), "local");
-        assert_eq!(security_info.security_level(), SecurityLevel::NoSecurity);
-
-        // Verify data transfer.
-        let (mut server_stream, _) = listener.accept().await.unwrap();
-        assert_eq!(
-            endpoint.get_local_address(),
-            &server_stream.peer_addr().unwrap().to_string()
-        );
-        let test_data = b"hello dynamic grpc";
-        server_stream.write_all(test_data).await.unwrap();
-
-        let mut buf = vec![0u8; test_data.len()];
-        AsyncIoAdapter::new(endpoint)
-            .read_exact(&mut buf)
-            .await
-            .unwrap();
-        assert_eq!(buf, test_data);
-
-        // Validate arbitrary authority.
-        assert!(
-            security_info
-                .security_context()
-                .validate_authority(&authority)
-        );
-    }
 
     #[tokio::test]
     async fn test_dyn_server_credential_dispatch() {

--- a/grpc/src/credentials/dyn_wrapper.rs
+++ b/grpc/src/credentials/dyn_wrapper.rs
@@ -30,7 +30,6 @@ use crate::credentials::ChannelCredentials;
 use crate::credentials::ProtocolInfo;
 use crate::credentials::ServerCredentials;
 use crate::credentials::call::CallCredentials;
-use crate::credentials::client::ClientConnectionSecurityContext;
 use crate::credentials::client::ClientHandshakeInfo;
 use crate::credentials::client::HandshakeOutput;
 use crate::credentials::common::Authority;
@@ -51,7 +50,7 @@ pub(crate) trait DynChannelCredentials: Send + Sync {
         source: BoxEndpoint,
         info: &ClientHandshakeInfo,
         runtime: &GrpcRuntime,
-    ) -> Result<HandshakeOutput<BoxEndpoint, Box<dyn ClientConnectionSecurityContext>>, String>;
+    ) -> Result<HandshakeOutput<BoxEndpoint>, String>;
 
     fn info(&self) -> &ProtocolInfo;
 
@@ -70,8 +69,7 @@ where
         source: BoxEndpoint,
         info: &ClientHandshakeInfo,
         runtime: &GrpcRuntime,
-    ) -> Result<HandshakeOutput<BoxEndpoint, Box<dyn ClientConnectionSecurityContext>>, String>
-    {
+    ) -> Result<HandshakeOutput<BoxEndpoint>, String> {
         let output = self
             .connect(authority, source, info, runtime, private::Internal)
             .make_send()
@@ -82,7 +80,7 @@ where
 
         Ok(HandshakeOutput {
             endpoint: Box::new(stream),
-            security: sec_info.into_boxed(),
+            security: sec_info,
         })
     }
 
@@ -96,7 +94,6 @@ where
 }
 
 impl ChannelCredentials for Arc<dyn DynChannelCredentials> {
-    type ContextType = Box<dyn ClientConnectionSecurityContext>;
     type Output<I> = BoxEndpoint;
 
     async fn connect<Input: GrpcEndpoint>(
@@ -106,7 +103,7 @@ impl ChannelCredentials for Arc<dyn DynChannelCredentials> {
         info: &ClientHandshakeInfo,
         runtime: &GrpcRuntime,
         _token: private::Internal,
-    ) -> Result<HandshakeOutput<Self::Output<Input>, Self::ContextType>, String> {
+    ) -> Result<HandshakeOutput<Self::Output<Input>>, String> {
         (**self)
             .dyn_connect(authority, Box::new(source), info, runtime)
             .await

--- a/grpc/src/credentials/local.rs
+++ b/grpc/src/credentials/local.rs
@@ -34,8 +34,8 @@ use crate::credentials::ProtocolInfo;
 use crate::credentials::SecurityLevel;
 use crate::credentials::ServerCredentials;
 use crate::credentials::call::CallCredentials;
-use crate::credentials::client::ClientConnectionSecurityContext;
-use crate::credentials::client::ClientConnectionSecurityInfo;
+use crate::credentials::client::ChannelSecurityContext;
+use crate::credentials::client::ChannelSecurityInfo;
 use crate::credentials::client::ClientHandshakeInfo;
 use crate::credentials::client::HandshakeOutput;
 use crate::credentials::common::Authority;
@@ -74,7 +74,7 @@ impl LocalChannelCredentials {
 #[derive(Debug, Clone)]
 pub struct LocalConnectionSecurityContext;
 
-impl ClientConnectionSecurityContext for LocalConnectionSecurityContext {
+impl ChannelSecurityContext for LocalConnectionSecurityContext {
     fn validate_authority(&self, _authority: &Authority) -> bool {
         true
     }
@@ -113,7 +113,6 @@ fn security_level_for_endpoint(
 }
 
 impl ChannelCredentials for LocalChannelCredentials {
-    type ContextType = LocalConnectionSecurityContext;
     type Output<I> = I;
 
     async fn connect<Input: GrpcEndpoint>(
@@ -123,15 +122,15 @@ impl ChannelCredentials for LocalChannelCredentials {
         _info: &ClientHandshakeInfo,
         _runtime: &GrpcRuntime,
         _token: private::Internal,
-    ) -> Result<HandshakeOutput<Self::Output<Input>, Self::ContextType>, String> {
+    ) -> Result<HandshakeOutput<Self::Output<Input>>, String> {
         let security_level =
             security_level_for_endpoint(source.get_peer_address(), source.get_network_type())?;
         Ok(HandshakeOutput {
             endpoint: source,
-            security: ClientConnectionSecurityInfo::new(
+            security: ChannelSecurityInfo::new(
                 PROTOCOL_NAME,
                 security_level,
-                LocalConnectionSecurityContext,
+                Box::new(LocalConnectionSecurityContext),
                 Attributes::new(),
             ),
         })
@@ -199,7 +198,6 @@ mod test {
     use crate::credentials::ChannelCredentials;
     use crate::credentials::SecurityLevel;
     use crate::credentials::ServerCredentials;
-    use crate::credentials::client::ClientConnectionSecurityContext;
     use crate::credentials::client::ClientHandshakeInfo;
     use crate::credentials::common::Authority;
     use crate::rt;

--- a/grpc/src/credentials/local.rs
+++ b/grpc/src/credentials/local.rs
@@ -26,6 +26,8 @@ use std::net::SocketAddr;
 use std::str::FromStr;
 use std::sync::Arc;
 
+use tonic::async_trait;
+
 use crate::attributes::Attributes;
 use crate::client::name_resolution::TCP_IP_NETWORK_TYPE;
 use crate::client::name_resolution::UNIX_NETWORK_TYPE;
@@ -42,6 +44,7 @@ use crate::credentials::common::Authority;
 use crate::credentials::server;
 use crate::credentials::server::ServerConnectionSecurityInfo;
 use crate::private;
+use crate::rt::BoxEndpoint;
 use crate::rt::GrpcEndpoint;
 use crate::rt::GrpcRuntime;
 
@@ -112,17 +115,16 @@ fn security_level_for_endpoint(
     ))
 }
 
+#[async_trait]
 impl ChannelCredentials for LocalChannelCredentials {
-    type Output<I> = I;
-
-    async fn connect<Input: GrpcEndpoint>(
+    async fn connect(
         &self,
         _authority: &Authority,
-        source: Input,
+        source: BoxEndpoint,
         _info: &ClientHandshakeInfo,
         _runtime: &GrpcRuntime,
         _token: private::Internal,
-    ) -> Result<HandshakeOutput<Self::Output<Input>>, String> {
+    ) -> Result<HandshakeOutput, String> {
         let security_level =
             security_level_for_endpoint(source.get_peer_address(), source.get_network_type())?;
         Ok(HandshakeOutput {

--- a/grpc/src/credentials/mod.rs
+++ b/grpc/src/credentials/mod.rs
@@ -50,7 +50,6 @@ pub use local::LocalChannelCredentials;
 pub use local::LocalServerCredentials;
 
 use crate::credentials::call::CallCredentials;
-use crate::credentials::client::ClientConnectionSecurityContext;
 use crate::credentials::client::ClientHandshakeInfo;
 use crate::credentials::client::HandshakeOutput;
 use crate::credentials::common::Authority;
@@ -65,8 +64,6 @@ use crate::rt::GrpcRuntime;
 /// [`CompositeChannelCredentials`].
 #[trait_variant::make(Send)]
 pub trait ChannelCredentials: Sync + 'static {
-    #[doc(hidden)]
-    type ContextType: ClientConnectionSecurityContext;
     #[doc(hidden)]
     type Output<I>;
 
@@ -99,7 +96,7 @@ pub trait ChannelCredentials: Sync + 'static {
         info: &ClientHandshakeInfo,
         runtime: &GrpcRuntime,
         token: private::Internal,
-    ) -> Result<HandshakeOutput<Self::Output<Input>, Self::ContextType>, String>;
+    ) -> Result<HandshakeOutput<Self::Output<Input>>, String>;
 }
 
 /// Server-side trait for all live gRPC wire protocols and supported

--- a/grpc/src/credentials/mod.rs
+++ b/grpc/src/credentials/mod.rs
@@ -48,12 +48,14 @@ use std::sync::Arc;
 pub use client::CompositeChannelCredentials;
 pub use local::LocalChannelCredentials;
 pub use local::LocalServerCredentials;
+use tonic::async_trait;
 
 use crate::credentials::call::CallCredentials;
 use crate::credentials::client::ClientHandshakeInfo;
 use crate::credentials::client::HandshakeOutput;
 use crate::credentials::common::Authority;
 use crate::private;
+use crate::rt::BoxEndpoint;
 use crate::rt::GrpcEndpoint;
 use crate::rt::GrpcRuntime;
 
@@ -62,11 +64,8 @@ use crate::rt::GrpcRuntime;
 ///
 /// Also includes the ability to attach [`CallCredentials`] when used with the
 /// [`CompositeChannelCredentials`].
-#[trait_variant::make(Send)]
-pub trait ChannelCredentials: Sync + 'static {
-    #[doc(hidden)]
-    type Output<I>;
-
+#[async_trait]
+pub trait ChannelCredentials: Send + Sync + 'static {
     /// Provides the ProtocolInfo of these credentials.
     fn info(&self) -> &ProtocolInfo;
 
@@ -89,14 +88,14 @@ pub trait ChannelCredentials: Sync + 'static {
     /// * `source` - The raw connection handle.
     /// * `info` - Additional context passed from the resolver or load balancer.
     #[doc(hidden)]
-    async fn connect<Input: GrpcEndpoint>(
+    async fn connect(
         &self,
         authority: &Authority,
-        source: Input,
+        source: BoxEndpoint,
         info: &ClientHandshakeInfo,
         runtime: &GrpcRuntime,
         token: private::Internal,
-    ) -> Result<HandshakeOutput<Self::Output<Input>>, String>;
+    ) -> Result<HandshakeOutput, String>;
 }
 
 /// Server-side trait for all live gRPC wire protocols and supported

--- a/grpc/src/credentials/rustls/client/mod.rs
+++ b/grpc/src/credentials/rustls/client/mod.rs
@@ -40,8 +40,8 @@ use crate::credentials::ChannelCredentials;
 use crate::credentials::ProtocolInfo;
 use crate::credentials::SecurityLevel;
 use crate::credentials::call::CallCredentials;
-use crate::credentials::client::ClientConnectionSecurityContext;
-use crate::credentials::client::ClientConnectionSecurityInfo;
+use crate::credentials::client::ChannelSecurityContext;
+use crate::credentials::client::ChannelSecurityInfo;
 use crate::credentials::client::ClientHandshakeInfo;
 use crate::credentials::client::HandshakeOutput;
 use crate::credentials::common::Authority;
@@ -199,7 +199,7 @@ pub struct ClientTlsSecurityContext {
     verified_peer_cert: Option<CertificateDer<'static>>,
 }
 
-impl ClientConnectionSecurityContext for ClientTlsSecurityContext {
+impl ChannelSecurityContext for ClientTlsSecurityContext {
     fn validate_authority(&self, authority: &Authority) -> bool {
         let server_name = match ServerName::try_from(authority.host()) {
             Ok(n) => n,
@@ -221,7 +221,6 @@ impl ClientConnectionSecurityContext for ClientTlsSecurityContext {
 }
 
 impl ChannelCredentials for RustlsChannelCredendials {
-    type ContextType = ClientTlsSecurityContext;
     type Output<I> = TlsStream<I>;
 
     async fn connect<Input: GrpcEndpoint>(
@@ -231,7 +230,7 @@ impl ChannelCredentials for RustlsChannelCredendials {
         _info: &ClientHandshakeInfo,
         _rt: &GrpcRuntime,
         _token: private::Internal,
-    ) -> Result<HandshakeOutput<TlsStream<Input>, ClientTlsSecurityContext>, String> {
+    ) -> Result<HandshakeOutput<TlsStream<Input>>, String> {
         let server_name = ServerName::try_from(authority.host())
             .map_err(|e| format!("invalid authority: {}", e))?
             .to_owned();
@@ -257,12 +256,12 @@ impl ChannelCredentials for RustlsChannelCredendials {
             .and_then(|certs| certs.first())
             .map(|c| c.clone().into_owned());
 
-        let cs_info = ClientConnectionSecurityInfo::new(
+        let cs_info = ChannelSecurityInfo::new(
             "tls",
             SecurityLevel::PrivacyAndIntegrity,
-            ClientTlsSecurityContext {
+            Box::new(ClientTlsSecurityContext {
                 verified_peer_cert: peer_cert,
-            },
+            }),
             Attributes::new(),
         );
         let ep = TlsStream::new(RustlsStream::Client(tls_stream));

--- a/grpc/src/credentials/rustls/client/mod.rs
+++ b/grpc/src/credentials/rustls/client/mod.rs
@@ -34,6 +34,7 @@ use rustls_platform_verifier::BuilderVerifierExt;
 use tokio::sync::watch::Receiver;
 use tokio_rustls::TlsConnector;
 use tokio_rustls::TlsStream as RustlsStream;
+use tonic::async_trait;
 
 use crate::attributes::Attributes;
 use crate::credentials::ChannelCredentials;
@@ -57,7 +58,7 @@ use crate::credentials::rustls::sanitize_crypto_provider;
 use crate::credentials::rustls::tls_stream::TlsStream;
 use crate::private;
 use crate::rt::AsyncIoAdapter;
-use crate::rt::GrpcEndpoint;
+use crate::rt::BoxEndpoint;
 use crate::rt::GrpcRuntime;
 
 #[cfg(test)]
@@ -192,45 +193,12 @@ impl RustlsChannelCredendials {
             connector: TlsConnector::from(Arc::new(client_config)),
         })
     }
-}
 
-/// Security context for [`rustls`]-based gRPC [`ChannelCredentials`].
-pub struct ClientTlsSecurityContext {
-    verified_peer_cert: Option<CertificateDer<'static>>,
-}
-
-impl ChannelSecurityContext for ClientTlsSecurityContext {
-    fn validate_authority(&self, authority: &Authority) -> bool {
-        let server_name = match ServerName::try_from(authority.host()) {
-            Ok(n) => n,
-            Err(_) => return false,
-        };
-
-        let cert_der = match &self.verified_peer_cert {
-            Some(c) => c,
-            None => return false,
-        };
-
-        let cert = match webpki::EndEntityCert::try_from(cert_der) {
-            Ok(c) => c,
-            Err(_) => return false,
-        };
-
-        cert.verify_is_valid_for_subject_name(&server_name).is_ok()
-    }
-}
-
-impl ChannelCredentials for RustlsChannelCredendials {
-    type Output<I> = TlsStream<I>;
-
-    async fn connect<Input: GrpcEndpoint>(
+    pub(crate) async fn connect_tls(
         &self,
         authority: &Authority,
-        source: Input,
-        _info: &ClientHandshakeInfo,
-        _rt: &GrpcRuntime,
-        _token: private::Internal,
-    ) -> Result<HandshakeOutput<TlsStream<Input>>, String> {
+        source: BoxEndpoint,
+    ) -> Result<(TlsStream<BoxEndpoint>, ChannelSecurityInfo), String> {
         let server_name = ServerName::try_from(authority.host())
             .map_err(|e| format!("invalid authority: {}", e))?
             .to_owned();
@@ -265,8 +233,49 @@ impl ChannelCredentials for RustlsChannelCredendials {
             Attributes::new(),
         );
         let ep = TlsStream::new(RustlsStream::Client(tls_stream));
+        Ok((ep, cs_info))
+    }
+}
+
+/// Security context for [`rustls`]-based gRPC [`ChannelCredentials`].
+pub struct ClientTlsSecurityContext {
+    verified_peer_cert: Option<CertificateDer<'static>>,
+}
+
+impl ChannelSecurityContext for ClientTlsSecurityContext {
+    fn validate_authority(&self, authority: &Authority) -> bool {
+        let server_name = match ServerName::try_from(authority.host()) {
+            Ok(n) => n,
+            Err(_) => return false,
+        };
+
+        let cert_der = match &self.verified_peer_cert {
+            Some(c) => c,
+            None => return false,
+        };
+
+        let cert = match webpki::EndEntityCert::try_from(cert_der) {
+            Ok(c) => c,
+            Err(_) => return false,
+        };
+
+        cert.verify_is_valid_for_subject_name(&server_name).is_ok()
+    }
+}
+
+#[async_trait]
+impl ChannelCredentials for RustlsChannelCredendials {
+    async fn connect(
+        &self,
+        authority: &Authority,
+        source: BoxEndpoint,
+        _info: &ClientHandshakeInfo,
+        _rt: &GrpcRuntime,
+        _token: private::Internal,
+    ) -> Result<HandshakeOutput, String> {
+        let (ep, cs_info) = self.connect_tls(authority, source).await?;
         Ok(HandshakeOutput {
-            endpoint: ep,
+            endpoint: Box::new(ep),
             security: cs_info,
         })
     }

--- a/grpc/src/credentials/rustls/client/test.rs
+++ b/grpc/src/credentials/rustls/client/test.rs
@@ -40,7 +40,6 @@ use tokio::task::JoinHandle;
 use tokio_rustls::TlsAcceptor;
 
 use crate::credentials::ChannelCredentials;
-use crate::credentials::client::ClientConnectionSecurityContext;
 use crate::credentials::client::ClientHandshakeInfo;
 use crate::credentials::common::Authority;
 use crate::credentials::rustls::ALPN_PROTO_STR_H2;

--- a/grpc/src/credentials/rustls/client/test.rs
+++ b/grpc/src/credentials/rustls/client/test.rs
@@ -431,18 +431,10 @@ async fn check_client_resumption_disabled(
             .unwrap();
         let authority = Authority::new("localhost".to_string(), Some(addr.port()));
 
-        let result = creds
-            .connect(
-                &authority,
-                endpoint,
-                &ClientHandshakeInfo::default(),
-                &runtime,
-                private::Internal,
-            )
+        let (tls_stream, _security) = creds
+            .connect_tls(&authority, endpoint)
             .await
             .expect("Handshake failed");
-
-        let tls_stream = result.endpoint;
 
         let connection = match tls_stream.inner() {
             tokio_rustls::TlsStream::Client(conn) => conn.get_ref().1,

--- a/grpc/src/inmemory/mod.rs
+++ b/grpc/src/inmemory/mod.rs
@@ -66,9 +66,8 @@ use crate::core::ResponseHeaders;
 use crate::core::SendMessage;
 use crate::core::Trailers;
 use crate::credentials::SecurityLevel;
-use crate::credentials::client::ClientConnectionSecurityContext;
-use crate::credentials::client::ClientConnectionSecurityInfo;
-use crate::credentials::client::DynClientConnectionSecurityInfo;
+use crate::credentials::client::ChannelSecurityContext;
+use crate::credentials::client::ChannelSecurityInfo;
 use crate::credentials::common::Authority;
 use crate::rt::GrpcRuntime;
 use crate::server::Call as ServerCall;
@@ -350,7 +349,7 @@ impl Transport for InMemoryTransport {
     ) -> Result<
         (
             Self::Service,
-            DynClientConnectionSecurityInfo,
+            ChannelSecurityInfo,
             oneshot::Receiver<Result<(), String>>,
         ),
         String,
@@ -365,13 +364,12 @@ impl Transport for InMemoryTransport {
             s: s.clone(),
             closed_tx: Some(closed_tx),
         };
-        let sec_info = ClientConnectionSecurityInfo::new(
+        let sec_info = ChannelSecurityInfo::new(
             "inmemory",
             SecurityLevel::PrivacyAndIntegrity,
-            InMemoryChannelecurityContext {},
+            Box::new(InMemoryChannelecurityContext {}),
             Attributes::new(),
-        )
-        .into_boxed();
+        );
 
         Ok((conn, sec_info, closed_rx))
     }
@@ -381,7 +379,7 @@ impl Transport for InMemoryTransport {
 #[derive(Debug, Clone)]
 struct InMemoryChannelecurityContext;
 
-impl ClientConnectionSecurityContext for InMemoryChannelecurityContext {
+impl ChannelSecurityContext for InMemoryChannelecurityContext {
     fn validate_authority(&self, _authority: &Authority) -> bool {
         true
     }

--- a/protoc-gen-rust-grpc/Cargo.toml
+++ b/protoc-gen-rust-grpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "protoc-gen-rust-grpc"
-version = "0.9.0"
+version = "0.10.0"
 authors = ["gRPC Authors"]
 license = "MIT"
 homepage = "https://grpc.io"


### PR DESCRIPTION
This update makes the `ChannelCredentials` trait object-safe and removes the `DynChannelCredentials` trait, which simplifies the channel constructor by dropping its generic parameters. It also renames `ClientConnectionSecurityInfo` to `ChannelSecurityInfo`.