### PR TITLE
feat(transport): expose http2_max_local_error_reset_streams on Endpoint

### DIFF
--- a/tonic/src/transport/channel/endpoint.rs
+++ b/tonic/src/transport/channel/endpoint.rs
@@ -52,6 +52,7 @@ pub struct Endpoint {
     pub(crate) http2_keep_alive_while_idle: Option<bool>,
     pub(crate) http2_header_table_size: Option<u32>,
     pub(crate) http2_max_header_list_size: Option<u32>,
+    pub(crate) http2_max_local_error_reset_streams: Option<Option<usize>>,
     pub(crate) connect_timeout: Option<Duration>,
     pub(crate) http2_adaptive_window: Option<bool>,
     pub(crate) local_address: Option<IpAddr>,
@@ -101,6 +102,7 @@ impl Endpoint {
             http2_keep_alive_while_idle: None,
             http2_header_table_size: None,
             http2_max_header_list_size: None,
+            http2_max_local_error_reset_streams: None,
             connect_timeout: None,
             http2_adaptive_window: None,
             executor: SharedExec::tokio(),
@@ -132,6 +134,7 @@ impl Endpoint {
             http2_keep_alive_while_idle: None,
             http2_header_table_size: None,
             http2_max_header_list_size: None,
+            http2_max_local_error_reset_streams: None,
             connect_timeout: None,
             http2_adaptive_window: None,
             executor: SharedExec::tokio(),
@@ -483,6 +486,21 @@ impl Endpoint {
     pub fn http2_max_header_list_size(self, size: u32) -> Self {
         Endpoint {
             http2_max_header_list_size: Some(size),
+            ..self
+        }
+    }
+
+    /// Sets the maximum number of local error resets h2 will perform before
+    /// closing the connection with a `GOAWAY(ENHANCE_YOUR_CALM)`.
+    ///
+    /// This is the client-side counterpart to the server-side
+    /// `Server::http2_max_local_error_reset_streams`. When left unset, hyper's
+    /// default (currently 1024) is used. Pass `None` to disable the limit
+    /// entirely — this removes h2's excessive-reset protection, so only do so
+    /// when connecting to trusted peers.
+    pub fn http2_max_local_error_reset_streams(self, max: Option<usize>) -> Self {
+        Endpoint {
+            http2_max_local_error_reset_streams: Some(max),
             ..self
         }
     }

--- a/tonic/src/transport/channel/service/connection.rs
+++ b/tonic/src/transport/channel/service/connection.rs
@@ -63,6 +63,10 @@ impl Connection {
             settings.max_header_list_size(val);
         }
 
+        if let Some(val) = endpoint.http2_max_local_error_reset_streams {
+            settings.max_local_error_reset_streams(val);
+        }
+
         let stack = ServiceBuilder::new()
             .layer_fn(|s| {
                 let origin = endpoint.origin.as_ref().unwrap_or(endpoint.uri()).clone();


### PR DESCRIPTION
Adds `Endpoint::http2_max_local_error_reset_streams`, the client-side counterpart to the existing `Server::http2_max_local_error_reset_streams`.

**Why this is needed.** h2 caps the number of local error resets a connection may accumulate over its lifetime (`max_local_error_reset_streams`, default 1024); once past it, h2 closes the connection with `GOAWAY(ENHANCE_YOUR_CALM, "too_many_internal_resets")`, failing every in-flight RPC on it. A long-lived client `Channel` that legitimately cancels many server-streaming RPCs — e.g. dropping the response stream on client disconnect or timeout — steadily accrues these resets: an abandoned stream yields a *counted* `STREAM_CLOSED` reset once h2 has forgotten the stream and the peer's in-flight DATA arrives. Under sustained load this trips the limit and tears the connection down.

`Server` already exposes this knob (for the symmetric server-side case), but `Endpoint` does not — so today there is no way to raise or disable the limit on an outbound connection without patching tonic.

**Behavior.** Mirrors the server method's `Option<usize>` signature. Non-breaking: when unset, hyper's default (currently 1024) is unchanged; only an explicit call overrides it, and `None` disables the limit (advisable only for trusted peers, e.g. internal services).

Opening as a draft for maintainer feedback on the approach.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
