### PR TITLE
ci: Compile and cache --release protoc binaries

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -52,12 +52,12 @@ jobs:
           cache-targets: "false"
       - name: Build protoc-gen-rust-grpc
         if: steps.protoc-binaries-cache.outputs.cache-hit != 'true'
-        run: cargo build -p protoc-gen-rust-grpc
+        run: cargo build -p protoc-gen-rust-grpc --release
       - name: Populate cache directory if needed
         if: steps.protoc-binaries-cache.outputs.cache-hit != 'true'
         shell: bash
         run: |
-          cp -r target/debug/build/protoc-gen-rust-grpc-*/out/install protoc-cache/
+          cp -r target/release/build/protoc-gen-rust-grpc-*/out/install protoc-cache/
           echo "Cached files:"
           find protoc-cache/ -type f -exec ls -lh {} +
 


### PR DESCRIPTION
On Linux, for ~10% additional CPU time the resulting binaries are ~93% smaller. Windows sees similar large savings, albeit at a ~30% increase in compilation time. This reduces the compressed cache size from 68/82 MB to 3 MB.