### PR TITLE
CI: Use best practices in release-protoc-gen-rust-grpc

### DIFF
--- a/.github/workflows/release-protoc-gen-rust-grpc.yml
+++ b/.github/workflows/release-protoc-gen-rust-grpc.yml
@@ -24,7 +24,7 @@ on:
   pull_request:
 
 permissions:
-  contents: write
+  contents: read
 
 jobs:
   # Determines whether the plugin needs to be built (i.e. a plugin release is
@@ -148,9 +148,11 @@ jobs:
 
       - name: Configure CMake
         shell: bash
+        env:
+          TAG_NAME: ${{ github.event.release.tag_name }}
         run: |
           # Extract version from release tag (e.g. protoc-gen-rust-grpc-v0.9.0 -> 0.9.0)
-          VERSION_FROM_TAG="${{ github.event.release.tag_name }}"
+          VERSION_FROM_TAG="$TAG_NAME"
           if [ -z "$VERSION_FROM_TAG" ]; then
             VERSION_FROM_TAG="test-version"
           else
@@ -182,15 +184,14 @@ jobs:
         if: runner.os != 'Windows'
         run: |
           cd install
-          zip -r ../${{ env.ASSET_FILENAME }} bin/
+          zip -r "../$ASSET_FILENAME" bin/
 
       - name: Prepare and Zip Asset (Windows)
         if: runner.os == 'Windows'
         shell: bash
         run: |
           cd install
-          7z a ../${{ env.ASSET_FILENAME }} bin/
-
+          7z a "../$ASSET_FILENAME" bin/
 
       - name: Upload build artifact
         if: github.event_name == 'release'
@@ -206,6 +207,8 @@ jobs:
     needs: [detect-changes, build-plugin]
     if: needs.detect-changes.outputs.should_run == 'true' && github.event_name == 'release'
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Download all artifacts
         uses: actions/download-artifact@v4
@@ -237,10 +240,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check build status
+        env:
+          DETECT_RESULT: ${{ needs.detect-changes.result }}
+          BUILD_RESULT: ${{ needs.build-plugin.result }}
         run: |
-          DETECT_RESULT="${{ needs.detect-changes.result }}"
-          BUILD_RESULT="${{ needs.build-plugin.result }}"
-
           echo "Detect changes result: $DETECT_RESULT"
           echo "Build result: $BUILD_RESULT"
 


### PR DESCRIPTION
Reducing the scope of write permissions is nice and makes it more obvious where the permissions are used. ${{}} in inline shell scripts is just a textual replacement, so it is better to be in the habit of using environment variables and letting the shell handle the replacement. I left ${{ matrix }} cases, since several of those are intended as textual replacements.