### PR TITLE
protoc-gen-rust-grpc: Always reconfigure, --fresh

### DIFF
--- a/protoc-gen-rust-grpc/build.rs
+++ b/protoc-gen-rust-grpc/build.rs
@@ -38,5 +38,9 @@ fn main() {
     cmake_config.define("BUILD_PROTOC", "ON");
     cmake_config.define("BUILD_PLUGIN", "ON");
     cmake_config.define("CMAKE_INSTALL_PREFIX", &install_dir);
+    // Make sure to not use stale configuration from a previous devel build, lest we get a bunch of
+    // linker errors when building at various points in the tree without cargo clean-ing between.
+    cmake_config.always_configure(true);
+    cmake_config.configure_arg("--fresh");
     cmake_config.build();
 }


### PR DESCRIPTION
002ac6d0b changed cmake's outdir to be different for each protobuf version. However, this was not sufficient to avoid linking errors because cmake's own files aren't rebuilt and it uses a horrible mix of old and new settings.

always_reconfigure causes the rust cmake library to always run cmake to configure itself, and then we need --fresh so that cmake ignores its previous caches and actually reconfigures.