### PR TITLE
grpc: expose unstable APIs behind __unstable feature

### DIFF
--- a/grpc/Cargo.toml
+++ b/grpc/Cargo.toml
@@ -48,6 +48,7 @@ tls-rustls = [
     "dep:rustls-platform-verifier",
     "dep:rustls-webpki",
 ]
+__unstable = []
 
 [dependencies]
 base64 = "0.22"

--- a/grpc/src/client/load_balancing/child_manager.rs
+++ b/grpc/src/client/load_balancing/child_manager.rs
@@ -50,7 +50,7 @@ use crate::rt::GrpcRuntime;
 
 // An LbPolicy implementation that manages multiple children.
 #[derive(Debug)]
-pub(crate) struct ChildManager<T: Debug> {
+pub struct ChildManager<T: Debug> {
     subchannel_to_child_idx: HashMap<WeakSubchannel, usize>,
     handle_to_child_idx: HashMap<ChildHandle, usize>,
     children: Vec<Child<T>>,
@@ -61,7 +61,7 @@ pub(crate) struct ChildManager<T: Debug> {
 
 #[non_exhaustive]
 #[derive(Debug)]
-pub(crate) struct Child<T> {
+pub struct Child<T> {
     pub identifier: T,
     pub builder: Arc<DynLbPolicyBuilder>,
     pub state: LbState,
@@ -70,7 +70,7 @@ pub(crate) struct Child<T> {
 }
 
 /// A collection of data sent to a child of the ChildManager.
-pub(crate) struct ChildUpdate<'a, T> {
+pub struct ChildUpdate<'a, T> {
     /// The identifier the ChildManager should use for this child.
     pub child_identifier: T,
     /// The builder the ChildManager should use to create this child if it does

--- a/grpc/src/client/load_balancing/graceful_switch.rs
+++ b/grpc/src/client/load_balancing/graceful_switch.rs
@@ -43,7 +43,7 @@ use crate::client::name_resolution::ResolverUpdate;
 use crate::rt::GrpcRuntime;
 
 #[derive(Debug)]
-pub(crate) struct GracefulSwitchLbConfig {
+pub struct GracefulSwitchLbConfig {
     child_builder: Arc<DynLbPolicyBuilder>,
     child_config: Option<DynLbConfig>,
 }
@@ -56,7 +56,7 @@ pub(crate) struct GracefulSwitchLbConfig {
 /// active policy is not READY, graceful switch will promote the pending policy
 /// to active and tear down the previously active policy.
 #[derive(Debug)]
-pub(crate) struct GracefulSwitchPolicy {
+pub struct GracefulSwitchPolicy {
     child_manager: ChildManager<()>, // Child ID empty - only the name of the child LB policy matters.
     last_update: Option<LbState>, // Saves the last output LbState to determine if an update is needed.
     active_child_builder: Option<Arc<DynLbPolicyBuilder>>,

--- a/grpc/src/client/load_balancing/lazy.rs
+++ b/grpc/src/client/load_balancing/lazy.rs
@@ -49,7 +49,7 @@ use crate::core::RequestHeaders;
 /// Note that Lazy can only properly wrap a policy whose config is Clone, as it
 /// needs to store the config until the child is built.
 #[derive(Debug)]
-pub(crate) struct Lazy<T: LbPolicyBuilder> {
+pub struct Lazy<T: LbPolicyBuilder> {
     inner: Inner<T>,
 }
 

--- a/grpc/src/client/load_balancing/mod.rs
+++ b/grpc/src/client/load_balancing/mod.rs
@@ -40,23 +40,23 @@ use crate::core::RequestHeaders;
 use crate::metadata::MetadataMap;
 use crate::rt::GrpcRuntime;
 
-pub(crate) mod child_manager;
-pub(crate) mod graceful_switch;
-pub(crate) mod lazy;
-pub(crate) mod pick_first;
-pub(crate) mod round_robin;
-pub(crate) mod subchannel;
 pub(crate) mod subchannel_sharing;
+
+pub mod child_manager;
+pub mod graceful_switch;
+pub mod lazy;
+pub mod pick_first;
+pub mod registry;
+pub mod round_robin;
+pub mod subchannel;
+pub use registry::GLOBAL_LB_REGISTRY;
 
 #[cfg(test)]
 pub(crate) mod test_utils;
 
-pub(crate) mod registry;
-pub(crate) use registry::GLOBAL_LB_REGISTRY;
-
 /// An LB policy factory that produces LbPolicy instances used by the channel
 /// to manage connections and pick connections for RPCs.
-pub(crate) trait LbPolicyBuilder: Send + Sync + Debug + 'static {
+pub trait LbPolicyBuilder: Send + Sync + Debug + 'static {
     type LbPolicy: LbPolicy;
 
     /// Builds and returns a new LB policy instance.
@@ -88,7 +88,7 @@ pub(crate) trait LbPolicyBuilder: Send + Sync + Debug + 'static {
 /// LB policies are responsible for creating connections (modeled as
 /// Subchannels) and producing Picker instances for picking connections for
 /// RPCs.
-pub(crate) trait LbPolicy: Send + Sync + Debug + 'static {
+pub trait LbPolicy: Send + Sync + Debug + 'static {
     type LbConfig: Any + Send + Sync + Debug + 'static;
 
     /// Called by the channel when the name resolver produces a new set of
@@ -121,7 +121,7 @@ pub(crate) trait LbPolicy: Send + Sync + Debug + 'static {
 /// A collection of data configured on the channel that is constructing this
 /// LbPolicy.
 #[derive(Debug)]
-pub(crate) struct LbPolicyOptions {
+pub struct LbPolicyOptions {
     /// A hook into the channel's work scheduler that allows the LbPolicy to
     /// request the ability to perform operations on the ChannelController.
     pub work_scheduler: Arc<dyn WorkScheduler>,
@@ -132,13 +132,13 @@ pub(crate) struct LbPolicyOptions {
 /// to be printed more readily.  Blanket implemented on all types that are Any +
 /// Send + Debug.  `dyn WorkDataTrait` also implements downcast methods like
 /// [`Any`] for convenience.
-pub(crate) trait WorkDataTrait: Any + Send + Debug {}
+pub trait WorkDataTrait: Any + Send + Debug {}
 
 impl<T: Any + Send + Debug> WorkDataTrait for T {}
 
 impl dyn WorkDataTrait {
     /// Like [`Box<dyn Any>::downcast`] but for this wrapper trait.
-    pub(crate) fn downcast<T: Any>(self: Box<Self>) -> Result<Box<T>, Box<Self>> {
+    pub fn downcast<T: Any>(self: Box<Self>) -> Result<Box<T>, Box<Self>> {
         // If we directly call downcast then we can't return `Self` anymore
         // (only a Box<dyn Any + Send>), so we first have to check `is` and only
         // downcast when we know it will succeed.
@@ -152,26 +152,26 @@ impl dyn WorkDataTrait {
     /// Like
     /// [`downcast_ref`](https://doc.rust-lang.org/std/any/trait.Any.html#method.downcast_ref)
     /// implemented on [`dyn Any`](Any), but for this wrapper trait.
-    pub(crate) fn downcast_ref<T: Any>(&self) -> Option<&T> {
+    pub fn downcast_ref<T: Any>(&self) -> Option<&T> {
         (self as &(dyn Any + Send)).downcast_ref::<T>()
     }
 
     /// Like
     /// [`downcast_mut`](https://doc.rust-lang.org/std/any/trait.Any.html#method.downcast_mut)
     /// implemented on [`dyn Any`](Any), but for this wrapper trait.
-    pub(crate) fn downcast_mut<T: Any>(&mut self) -> Option<&mut T> {
+    pub fn downcast_mut<T: Any>(&mut self) -> Option<&mut T> {
         (self as &mut (dyn Any + Send)).downcast_mut::<T>()
     }
 }
 
 /// A dynamic payload passed between [`WorkScheduler::schedule_work`] and its
 /// associated policy's [`work`](LbPolicy::work) method.
-pub(crate) type WorkData = Box<dyn WorkDataTrait>;
+pub type WorkData = Box<dyn WorkDataTrait>;
 
 /// Used to asynchronously request a call into the LbPolicy's work method if
 /// the LbPolicy needs to provide an update without waiting for an update
 /// from the channel first.
-pub(crate) trait WorkScheduler: Send + Sync + Debug {
+pub trait WorkScheduler: Send + Sync + Debug {
     // Schedules a call into the LbPolicy's work method.  If there is already a
     // pending work call that has not yet started, this may not schedule another
     // call.
@@ -182,7 +182,7 @@ pub(crate) trait WorkScheduler: Send + Sync + Debug {
 /// JSON.  Hides internal storage details and includes a method to deserialize
 /// the JSON into a concrete policy struct.
 #[derive(Debug)]
-pub(crate) struct ParsedJsonLbConfig {
+pub struct ParsedJsonLbConfig {
     value: serde_json::Value,
 }
 
@@ -195,7 +195,7 @@ impl ParsedJsonLbConfig {
         }
     }
 
-    pub(crate) fn from_value(value: serde_json::Value) -> Self {
+    pub fn from_value(value: serde_json::Value) -> Self {
         Self { value }
     }
 
@@ -218,7 +218,7 @@ impl ParsedJsonLbConfig {
 }
 
 /// Controls channel behaviors.
-pub(crate) trait ChannelController: Send + Sync {
+pub trait ChannelController: Send + Sync {
     /// Creates a new subchannel and returns its current state.
     fn new_subchannel(&mut self, address: &Address) -> (Arc<dyn Subchannel>, SubchannelState);
 
@@ -252,7 +252,7 @@ pub(crate) trait ChannelController: Send + Sync {
 ///
 /// If the ConnectivityState is TransientFailure, the Picker should return an
 /// Err with an error that describes why connections are failing.
-pub(crate) trait Picker: Send + Sync + Debug {
+pub trait Picker: Send + Sync + Debug {
     /// Picks a connection to use for the request.
     ///
     /// This function should not block.  If the Picker needs to do blocking or
@@ -263,7 +263,7 @@ pub(crate) trait Picker: Send + Sync + Debug {
 }
 
 #[derive(Debug)]
-pub(crate) enum PickResult {
+pub enum PickResult {
     /// Indicates the Subchannel in the Pick should be used for the request.
     Pick(Pick),
     /// Indicates the LbPolicy is attempting to connect to a server to use for
@@ -326,7 +326,7 @@ impl Display for PickResult {
 
 /// State provided by the LB policy to the channel.
 #[derive(Clone, Debug)]
-pub(crate) struct LbState {
+pub struct LbState {
     pub connectivity_state: super::ConnectivityState,
     pub picker: Arc<dyn Picker>,
 }
@@ -358,10 +358,10 @@ impl LbState {
 }
 
 /// Type alias for the completion callback function.
-pub(crate) type CompletionCallback = Box<dyn Fn() + Send + Sync>;
+pub type CompletionCallback = Box<dyn Fn() + Send + Sync>;
 
 /// A collection of data used by the channel for routing a request.
-pub(crate) struct Pick {
+pub struct Pick {
     /// The Subchannel for the request.
     pub subchannel: Arc<dyn Subchannel>,
     // Metadata to be added to existing outgoing metadata.

--- a/grpc/src/client/load_balancing/pick_first.rs
+++ b/grpc/src/client/load_balancing/pick_first.rs
@@ -55,18 +55,18 @@ use crate::metadata::MetadataMap;
 use crate::rt::BoxedTaskHandle;
 use crate::rt::GrpcRuntime;
 
-pub(crate) static POLICY_NAME: &str = "pick_first";
+pub static POLICY_NAME: &str = "pick_first";
 
 type ShufflerFn = dyn Fn(&mut [Endpoint]) + Send + Sync + 'static;
 
 #[derive(Debug, serde::Deserialize, Clone)]
-pub(crate) struct PickFirstConfig {
+pub struct PickFirstConfig {
     #[serde(rename = "shuffleAddressList")]
     pub shuffle_address_list: bool,
 }
 
 #[derive(Debug)]
-struct PickFirstBuilder {}
+pub struct PickFirstBuilder {}
 
 impl LbPolicyBuilder for PickFirstBuilder {
     type LbPolicy = PickFirstPolicy;
@@ -101,7 +101,7 @@ pub(crate) fn reg() {
     super::GLOBAL_LB_REGISTRY.add_builder(PickFirstBuilder {})
 }
 
-pub(crate) struct PickFirstPolicy {
+pub struct PickFirstPolicy {
     work_scheduler: Arc<dyn WorkScheduler>,
     runtime: GrpcRuntime,
     connectivity_state: ConnectivityState,

--- a/grpc/src/client/load_balancing/registry.rs
+++ b/grpc/src/client/load_balancing/registry.rs
@@ -43,7 +43,7 @@ use crate::client::name_resolution::ResolverUpdate;
 
 /// A registry to store and retrieve LB policies.  LB policies are indexed by
 /// their names.
-pub(crate) struct LbPolicyRegistry {
+pub struct LbPolicyRegistry {
     m: Arc<Mutex<HashMap<String, Arc<DynLbPolicyBuilder>>>>,
 }
 
@@ -54,7 +54,7 @@ impl LbPolicyRegistry {
     }
 
     /// Adds a LB policy into the registry.
-    pub(crate) fn add_builder<B: LbPolicyBuilder>(&self, builder: B) {
+    pub fn add_builder<B: LbPolicyBuilder>(&self, builder: B) {
         self.m
             .lock()
             .unwrap()
@@ -62,7 +62,7 @@ impl LbPolicyRegistry {
     }
 
     /// Adds a dynamic LB policy into the registry.
-    pub(crate) fn add_dyn_builder(&self, builder: Arc<DynLbPolicyBuilder>) {
+    pub fn add_dyn_builder(&self, builder: Arc<DynLbPolicyBuilder>) {
         self.m
             .lock()
             .unwrap()
@@ -70,7 +70,7 @@ impl LbPolicyRegistry {
     }
 
     /// Retrieves a LB policy from the registry, or None if not found.
-    pub(crate) fn get_policy(&self, name: &str) -> Option<Arc<DynLbPolicyBuilder>> {
+    pub fn get_policy(&self, name: &str) -> Option<Arc<DynLbPolicyBuilder>> {
         self.m.lock().unwrap().get(name).cloned()
     }
 }
@@ -83,8 +83,7 @@ impl Default for LbPolicyRegistry {
 
 /// The registry used if a local registry is not provided to a channel or if it
 /// does not exist in the local registry.
-pub(crate) static GLOBAL_LB_REGISTRY: LazyLock<LbPolicyRegistry> =
-    LazyLock::new(LbPolicyRegistry::new);
+pub static GLOBAL_LB_REGISTRY: LazyLock<LbPolicyRegistry> = LazyLock::new(LbPolicyRegistry::new);
 
 /// Implements DynLbPolicy and DynLbPolicyBuilder around the enclosed LbPolicy
 /// or LbPolicyBuilder, respectively.

--- a/grpc/src/client/load_balancing/round_robin.rs
+++ b/grpc/src/client/load_balancing/round_robin.rs
@@ -49,11 +49,11 @@ use crate::client::name_resolution::Endpoint;
 use crate::client::name_resolution::ResolverUpdate;
 use crate::core::RequestHeaders;
 
-pub(crate) static POLICY_NAME: &str = "round_robin";
+pub static POLICY_NAME: &str = "round_robin";
 static START: Once = Once::new();
 
 #[derive(Debug)]
-pub(crate) struct RoundRobinBuilder {}
+pub struct RoundRobinBuilder {}
 
 impl LbPolicyBuilder for RoundRobinBuilder {
     type LbPolicy = RoundRobinPolicy;
@@ -78,7 +78,7 @@ impl LbPolicyBuilder for RoundRobinBuilder {
 }
 
 #[derive(Debug)]
-pub(crate) struct RoundRobinPolicy {
+pub struct RoundRobinPolicy {
     child_manager: ChildManager<Endpoint>,
     pick_first_builder: Arc<DynLbPolicyBuilder>,
 }

--- a/grpc/src/client/load_balancing/subchannel.rs
+++ b/grpc/src/client/load_balancing/subchannel.rs
@@ -37,38 +37,38 @@ use crate::client::name_resolution::Address;
 
 /// Represents the current state of a Subchannel.
 #[derive(Debug, Clone)]
-pub(crate) struct SubchannelState {
+pub struct SubchannelState {
     /// The connectivity state of the subchannel.  See SubChannel for a
     /// description of the various states and their valid transitions.
-    pub(crate) connectivity_state: ConnectivityState,
+    pub connectivity_state: ConnectivityState,
     // Set if connectivity state is TransientFailure to describe the most recent
     // connection error.  None for any other connectivity_state value.
     pub last_connection_error: Option<String>,
 }
 
 impl SubchannelState {
-    pub(crate) fn idle() -> Self {
+    pub fn idle() -> Self {
         Self {
             connectivity_state: ConnectivityState::Idle,
             last_connection_error: None,
         }
     }
 
-    pub(crate) fn ready() -> Self {
+    pub fn ready() -> Self {
         Self {
             connectivity_state: ConnectivityState::Ready,
             last_connection_error: None,
         }
     }
 
-    pub(crate) fn connecting() -> Self {
+    pub fn connecting() -> Self {
         Self {
             connectivity_state: ConnectivityState::Connecting,
             last_connection_error: None,
         }
     }
 
-    pub(crate) fn transient_failure(last_connection_error: impl Into<String>) -> Self {
+    pub fn transient_failure(last_connection_error: impl Into<String>) -> Self {
         Self {
             connectivity_state: ConnectivityState::TransientFailure,
             last_connection_error: Some(last_connection_error.into()),
@@ -86,7 +86,7 @@ impl Display for SubchannelState {
     }
 }
 
-pub(crate) trait DynHash {
+pub trait DynHash {
     #[allow(clippy::redundant_allocation)]
     fn dyn_hash(&self, state: &mut Box<&mut dyn Hasher>);
 }
@@ -97,7 +97,7 @@ impl<T: Hash> DynHash for T {
     }
 }
 
-pub(crate) trait DynPartialEq {
+pub trait DynPartialEq {
     fn dyn_eq(&self, other: &&dyn Any) -> bool;
 }
 
@@ -131,9 +131,7 @@ pub(crate) mod private {
 ///
 /// When a Subchannel is dropped, it is disconnected automatically, and no
 /// subsequent state updates will be provided for it to the LB policy.
-pub(crate) trait Subchannel:
-    private::Sealed + DynHash + DynPartialEq + Any + Send + Sync
-{
+pub trait Subchannel: private::Sealed + DynHash + DynPartialEq + Any + Send + Sync {
     /// Returns the address of the Subchannel.
     /// TODO: Consider whether this should really be public.
     fn address(&self) -> Address;
@@ -192,7 +190,7 @@ impl Display for dyn Subchannel {
 }
 
 #[derive(Debug)]
-pub(crate) struct WeakSubchannel(Weak<dyn Subchannel>);
+pub struct WeakSubchannel(Weak<dyn Subchannel>);
 
 impl From<&Arc<dyn Subchannel>> for WeakSubchannel {
     fn from(subchannel: &Arc<dyn Subchannel>) -> Self {
@@ -228,7 +226,7 @@ impl PartialEq for WeakSubchannel {
 
 impl Eq for WeakSubchannel {}
 
-pub(crate) trait ForwardingSubchannel: DynHash + DynPartialEq + Any + Send + Sync {
+pub trait ForwardingSubchannel: DynHash + DynPartialEq + Any + Send + Sync {
     fn delegate(&self) -> &Arc<dyn Subchannel>;
 
     fn address(&self) -> Address {

--- a/grpc/src/client/mod.rs
+++ b/grpc/src/client/mod.rs
@@ -56,17 +56,18 @@ use crate::core::SendMessage;
 use crate::core::Trailers;
 
 mod channel;
-pub mod interceptor;
-pub mod metadata_utils;
-pub(crate) mod service_config;
-pub mod stream_util;
-
 pub use channel::Channel;
 pub use channel::ChannelOptions;
 
+mod subchannel;
+
+pub mod interceptor;
+pub mod metadata_utils;
+pub mod stream_util;
+
 pub(crate) mod load_balancing;
 pub(crate) mod name_resolution;
-mod subchannel;
+pub(crate) mod service_config;
 pub(crate) mod transport;
 
 #[cfg(test)]

--- a/grpc/src/client/name_resolution/mod.rs
+++ b/grpc/src/client/name_resolution/mod.rs
@@ -46,18 +46,20 @@ use crate::client::service_config::ServiceConfig;
 use crate::rt::GrpcRuntime;
 
 mod backoff;
-mod registry;
-
-#[cfg(test)]
-pub(crate) mod test_utils;
+pub mod registry;
 
 pub(crate) mod dns;
+pub(crate) use registry::global_registry;
+
+#[cfg(test)]
+mod test_utils;
+
+pub(crate) mod proxy_resolver;
+
 #[cfg(unix)]
 pub(crate) mod unix;
 #[cfg(target_os = "linux")]
 pub(crate) mod unix_abstract;
-pub(crate) use registry::global_registry;
-pub(crate) mod proxy_resolver;
 
 /// Target represents a target for gRPC, as specified in:
 /// https://github.com/grpc/grpc/blob/master/doc/naming.md.
@@ -70,7 +72,7 @@ pub(crate) mod proxy_resolver;
 /// (i.e. no corresponding resolver available to resolve the endpoint), we will
 /// apply the default scheme, and will attempt to reparse it.
 #[derive(Debug, Clone)]
-pub(crate) struct Target {
+pub struct Target {
     url: Url,
     decoded_path: String,
 }
@@ -145,7 +147,7 @@ impl Display for Target {
 
 /// A name resolver factory that produces Resolver instances used by the channel
 /// to resolve network addresses for the target URI.
-pub(crate) trait ResolverBuilder: Send + Sync {
+pub trait ResolverBuilder: Send + Sync {
     /// Builds a name resolver instance.
     ///
     /// Note that build must not fail.  Instead, an erroring Resolver may be
@@ -202,7 +204,7 @@ pub(crate) trait ResolverBuilder: Send + Sync {
 /// A collection of data configured on the channel that is constructing this
 /// name resolver.
 #[non_exhaustive]
-pub(crate) struct ResolverOptions {
+pub struct ResolverOptions {
     /// The authority that will be used for the channel by default. This refers
     /// to the `:authority` value sent in HTTP/2 requests — the dataplane
     /// authority — and not the authority portion of the target URI, which is
@@ -222,7 +224,7 @@ pub(crate) struct ResolverOptions {
 }
 
 /// Used to asynchronously request a call into the Resolver's work method.
-pub(crate) trait WorkScheduler: Send + Sync {
+pub trait WorkScheduler: Send + Sync {
     // Schedules a call into the Resolver's work method.  If there is already a
     // pending work call that has not yet started, this may not schedule another
     // call.
@@ -234,7 +236,7 @@ pub(crate) trait WorkScheduler: Send + Sync {
 // This trait may not need the Sync sub-trait if the channel implementation can
 // ensure that the resolver is accessed serially. The sub-trait can be removed
 // in that case.
-pub(crate) trait Resolver: Send + Sync {
+pub trait Resolver: Send + Sync {
     /// Asks the resolver to obtain an updated resolver result, if applicable.
     ///
     /// This is useful for polling resolvers to decide when to re-resolve.
@@ -253,7 +255,7 @@ pub(crate) trait Resolver: Send + Sync {
 
 /// The `ChannelController` trait provides the resolver with functionality
 /// to interact with the channel.
-pub(crate) trait ChannelController: Send + Sync {
+pub trait ChannelController: Send + Sync {
     /// Notifies the channel about the current state of the name resolver.  If
     /// an error value is returned, the name resolver should attempt to
     /// re-resolve, if possible.  The resolver is responsible for applying an
@@ -270,7 +272,7 @@ pub(crate) trait ChannelController: Send + Sync {
 #[non_exhaustive]
 /// ResolverUpdate contains the current Resolver state relevant to the
 /// channel.
-pub(crate) struct ResolverUpdate {
+pub struct ResolverUpdate {
     /// Attributes contains arbitrary data about the resolver intended for
     /// consumption by the load balancing policy.
     pub attributes: Attributes,
@@ -309,7 +311,7 @@ impl Default for ResolverUpdate {
 /// which the server can be reached, e.g. via IPv4 and IPv6 addresses.
 #[derive(Debug, Default, Clone, PartialEq, Eq)]
 #[non_exhaustive]
-pub(crate) struct Endpoint {
+pub struct Endpoint {
     /// Addresses contains a list of addresses used to access this endpoint.
     pub addresses: Vec<Address>,
 
@@ -327,7 +329,7 @@ impl Hash for Endpoint {
 /// An Address is an identifier that indicates how to connect to a server.
 #[non_exhaustive]
 #[derive(Debug, Clone, Default, PartialEq, Eq, Ord, PartialOrd)]
-pub(crate) struct Address {
+pub struct Address {
     /// The network type is used to identify what kind of transport to create
     /// when connecting to this address.  Typically TCP_IP_ADDRESS_TYPE.
     pub network_type: &'static str,
@@ -357,11 +359,11 @@ impl Display for Address {
 
 /// Indicates the address is an IPv4 or IPv6 address that should be connected to
 /// via TCP/IP.
-pub(crate) static TCP_IP_NETWORK_TYPE: &str = "tcp";
+pub static TCP_IP_NETWORK_TYPE: &str = "tcp";
 
 /// Indicates the address is a local filesystem path or abstract name that
 /// should be connected to via a UNIX domain socket.
-pub(crate) static UNIX_NETWORK_TYPE: &str = "unix";
+pub static UNIX_NETWORK_TYPE: &str = "unix";
 
 // A resolver that returns the same result every time its work method is called.
 // It can be used to return an error to the channel when a resolver fails to

--- a/grpc/src/client/name_resolution/registry.rs
+++ b/grpc/src/client/name_resolution/registry.rs
@@ -34,7 +34,7 @@ static GLOBAL_RESOLVER_REGISTRY: OnceLock<ResolverRegistry> = OnceLock::new();
 /// A registry to store and retrieve name resolvers.  Resolvers are indexed by
 /// the URI scheme they are intended to handle.
 #[derive(Default)]
-pub(crate) struct ResolverRegistry {
+pub struct ResolverRegistry {
     inner: Arc<Mutex<HashMap<String, Arc<dyn ResolverBuilder>>>>,
 }
 
@@ -90,6 +90,6 @@ impl ResolverRegistry {
 }
 
 /// Global registry for resolver builders.
-pub(crate) fn global_registry() -> &'static ResolverRegistry {
+pub fn global_registry() -> &'static ResolverRegistry {
     GLOBAL_RESOLVER_REGISTRY.get_or_init(ResolverRegistry::new)
 }

--- a/grpc/src/client/service_config.rs
+++ b/grpc/src/client/service_config.rs
@@ -26,7 +26,7 @@
 /// a JSON object.
 // TODO: this shouldn't be public; users should set with JSON instead.
 #[derive(Debug, Default, Clone)]
-pub(crate) struct ServiceConfig {
+pub struct ServiceConfig {
     pub load_balancing_policy: Option<LbPolicyType>,
 }
 

--- a/grpc/src/client/service_config.rs
+++ b/grpc/src/client/service_config.rs
@@ -24,10 +24,10 @@
 
 /// An in-memory representation of a service config, usually provided to gRPC as
 /// a JSON object.
-// TODO: this shouldn't be public; users should set with JSON instead.
+// TODO: complete this and ensure it meets all our requirements.
 #[derive(Debug, Default, Clone)]
 pub struct ServiceConfig {
-    pub load_balancing_policy: Option<LbPolicyType>,
+    pub(crate) load_balancing_policy: Option<LbPolicyType>,
 }
 
 #[derive(Debug, Default, Clone, PartialEq, Eq)]

--- a/grpc/src/lib.rs
+++ b/grpc/src/lib.rs
@@ -55,10 +55,12 @@ pub mod core;
 pub mod credentials;
 pub mod metadata;
 
-pub(crate) mod inmemory;
-pub(crate) mod server;
-
+mod byte_str;
+mod inmemory;
 mod macros;
+mod rt;
+mod send_future;
+mod server;
 mod status;
 
 pub use status::Status;
@@ -66,9 +68,24 @@ pub use status::StatusCodeError;
 pub use status::StatusError;
 pub use status::StatusOr;
 
-mod byte_str;
-mod rt;
-mod send_future;
+#[cfg(feature = "__unstable")]
+#[doc(hidden)]
+pub mod __unstable {
+    pub mod rt {
+        pub use crate::rt::*;
+    }
+    pub mod client {
+        pub mod load_balancing {
+            pub use crate::client::load_balancing::*;
+        }
+        pub mod name_resolution {
+            pub use crate::client::name_resolution::*;
+        }
+        pub mod service_config {
+            pub use crate::client::service_config::*;
+        }
+    }
+}
 
 mod private {
     /// A zero-sized type used to seal methods on a public trait.


### PR DESCRIPTION
We'd like to implement our own features outside of the grpc crate that require unstable APIs in the grpc crate.  If we don't implement them in foreign crates, then the situation quickly devolves into "all things must be inside the grpc crate behind feature flags".

This PR introduces an `__unstable` feature flag that publicly re-exports the runtime, LB policy, name resolver, and service config modules, but under a top-level `__unstable` module path to make it as obvious as possible that these features are unstable and should not be relied upon by end users.  It also doc-hides them for two purposes:

1. to prevent them from rendering on docs.rs.
2. to allow for some unstable things to use foreign external types, at least for now (mainly: serde symbols for LB policy config).  (The `check-external-types` checker we run automatically ignores doc-hidden symbols.)

This PR then makes public many symbols that were previously private or pub(crate), so that they can be exported via the `__unstable` module.

cc @gu0keno0 - I think your xds protos change (#2723) should just go ahead and put the protos into a new `grpc-xds` crate which will subsequently be free to use these unstable APIs.