### PR TITLE
fix(tonic-xds): reject a zero cert refresh_interval

### DIFF
--- a/tonic-xds/src/xds/cert_provider/file_watcher.rs
+++ b/tonic-xds/src/xds/cert_provider/file_watcher.rs
@@ -69,12 +69,14 @@ where
     let secs: f64 = num
         .parse()
         .map_err(|_| serde::de::Error::custom(format!("invalid duration number: '{num}'")))?;
-    if secs <= 0.0 {
+    let duration = Duration::try_from_secs_f64(secs)
+        .map_err(|e| serde::de::Error::custom(format!("invalid duration '{s}': {e}")))?;
+    if duration.is_zero() {
         return Err(serde::de::Error::custom(format!(
             "invalid duration '{s}': must be greater than 0"
         )));
     }
-    Ok(Some(Duration::from_secs_f64(secs)))
+    Ok(Some(duration))
 }
 
 /// A certificate provider that reads PEM files from disk.
@@ -400,17 +402,27 @@ mod tests {
 
     #[test]
     fn parse_refresh_interval_must_be_greater_than_zero() {
-        for v in [
+        let err = serde_json::from_value::<FileWatcherConfig>(
             serde_json::json!({"refresh_interval":"0s"}),
+        );
+        assert!(err.is_err());
+        assert!(
+            err.unwrap_err()
+                .to_string()
+                .contains("must be greater than 0")
+        );
+    }
+
+    #[test]
+    fn parse_refresh_interval_rejects_invalid_floats() {
+        // Negative, NaN, and infinite all fail `Duration::try_from_secs_f64`
+        // rather than the "must be greater than 0" zero check.
+        for v in [
             serde_json::json!({"refresh_interval": "-1s"}),
+            serde_json::json!({"refresh_interval": "NaNs"}),
+            serde_json::json!({"refresh_interval": "infs"}),
         ] {
-            let err = serde_json::from_value::<FileWatcherConfig>(v);
-            assert!(err.is_err());
-            assert!(
-                err.unwrap_err()
-                    .to_string()
-                    .contains("must be greater than 0")
-            );
+            assert!(serde_json::from_value::<FileWatcherConfig>(v).is_err());
         }
     }
 

--- a/tonic-xds/src/xds/cert_provider/file_watcher.rs
+++ b/tonic-xds/src/xds/cert_provider/file_watcher.rs
@@ -69,9 +69,9 @@ where
     let secs: f64 = num
         .parse()
         .map_err(|_| serde::de::Error::custom(format!("invalid duration number: '{num}'")))?;
-    if secs < 0.0 {
+    if secs <= 0.0 {
         return Err(serde::de::Error::custom(format!(
-            "invalid duration '{s}': must not be negative"
+            "invalid duration '{s}': must be greater than 0"
         )));
     }
     Ok(Some(Duration::from_secs_f64(secs)))
@@ -399,16 +399,19 @@ mod tests {
     }
 
     #[test]
-    fn parse_refresh_interval_negative() {
-        let err = serde_json::from_value::<FileWatcherConfig>(
+    fn parse_refresh_interval_must_be_greater_than_zero() {
+        for v in [
+            serde_json::json!({"refresh_interval":"0s"}),
             serde_json::json!({"refresh_interval": "-1s"}),
-        );
-        assert!(err.is_err());
-        assert!(
-            err.unwrap_err()
-                .to_string()
-                .contains("must not be negative")
-        );
+        ] {
+            let err = serde_json::from_value::<FileWatcherConfig>(v);
+            assert!(err.is_err());
+            assert!(
+                err.unwrap_err()
+                    .to_string()
+                    .contains("must be greater than 0")
+            );
+        }
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Context
The file-watcher certificate provider's duration deserializer already rejects negative refresh intervals, but a refresh_interval of "0s" was accepted and parsed to `Duration::ZERO`.

`tokio::time::interval(ZERO)` then panics inside the spawned refresh task, silently killing certificate rotation while provider construction still succeeds.

## Motivation

Improve runtime error message when user miss-configured the refresh duration. 
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? If a new feature is being added, describe the intended
use case that feature fulfills.
-->

## Solution
Extend the existing guard to reject zero as well as negative durations, so the misconfiguration surfaces as a clear bootstrap error (matching grpc-java's `refreshInterval > 0` [check](https://github.com/grpc/grpc-java/blob/v1.83.x/xds/src/main/java/io/grpc/xds/internal/security/certprovider/FileWatcherCertificateProviderProvider.java#L127)).

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
