### PR TITLE
fix(reflection): preserve custom options in served descriptors

### DIFF
--- a/tonic-reflection/src/server/mod.rs
+++ b/tonic-reflection/src/server/mod.rs
@@ -137,22 +137,35 @@ impl ReflectionServiceState {
             symbols: HashMap::new(),
         };
 
-        // Sets provided already-decoded have no original bytes to preserve, so
-        // re-encode each file (custom options may already have been dropped when
-        // the caller decoded the set into `prost_types`).
-        for fds in file_descriptor_sets {
-            for fd in fds.file {
-                let raw = fd.encode_to_vec();
+        // The builder accepts descriptor sets in two forms: raw bytes (via
+        // `register_encoded_file_descriptor_set`) and already-decoded
+        // `prost_types::FileDescriptorSet`s (via `register_file_descriptor_set`).
+        //
+        // The encoded sets are registered first, on purpose: `register_file`
+        // keeps the first entry seen for a given file name (see below), and the
+        // encoded form is the one that faithfully preserves custom options. So
+        // if the same file arrives in both forms, the lossless bytes win.
+        //
+        // Each encoded set is split into its per-file byte ranges without
+        // decoding the inner message, so the original bytes (including custom
+        // options such as `google.api.http`) are retained and served unchanged.
+        for encoded in encoded_file_descriptor_sets {
+            for raw in split_file_descriptor_set(encoded)? {
+                let fd = FileDescriptorProto::decode(raw.as_slice())?;
                 state.register_file(&fd, Arc::from(raw), use_all_service_names)?;
             }
         }
 
-        // Encoded sets are split into their per-file byte ranges without
-        // decoding the inner message, so the original bytes (including custom
-        // options) are retained and served unchanged.
-        for encoded in encoded_file_descriptor_sets {
-            for raw in split_file_descriptor_set(encoded)? {
-                let fd = FileDescriptorProto::decode(raw.as_slice())?;
+        // Already-decoded sets carry no original bytes, so each file has to be
+        // re-encoded. This is lossy for custom options, but unavoidable: those
+        // options were already dropped when the caller decoded the set into
+        // `prost_types` (which has no field to hold them). Callers that need
+        // custom options preserved should use `register_encoded_file_descriptor_set`
+        // instead. Registered second, as a fallback for files not already
+        // supplied in encoded form above.
+        for fds in file_descriptor_sets {
+            for fd in fds.file {
+                let raw = fd.encode_to_vec();
                 state.register_file(&fd, Arc::from(raw), use_all_service_names)?;
             }
         }
@@ -173,6 +186,9 @@ impl ReflectionServiceState {
             Some(n) => n,
         };
 
+        // First registration for a file name wins; later duplicates are ignored.
+        // `new` registers the option-preserving encoded sets before the
+        // re-encoded ones, so a file present in both keeps its original bytes.
         if self.files.contains_key(&name) {
             return Ok(());
         }

--- a/tonic-reflection/src/server/mod.rs
+++ b/tonic-reflection/src/server/mod.rs
@@ -2,6 +2,7 @@ use std::collections::HashMap;
 use std::fmt::{Display, Formatter};
 use std::sync::Arc;
 
+use prost::encoding::{WireType, decode_key, decode_varint};
 use prost::{DecodeError, Message};
 use prost_types::{
     DescriptorProto, EnumDescriptorProto, FieldDescriptorProto, FileDescriptorProto,
@@ -114,62 +115,86 @@ impl<'b> Builder<'b> {
 #[derive(Debug)]
 struct ReflectionServiceState {
     service_names: Vec<String>,
-    files: HashMap<String, Arc<FileDescriptorProto>>,
-    symbols: HashMap<String, Arc<FileDescriptorProto>>,
+    // The original, encoded bytes of each `FileDescriptorProto` are stored (and
+    // served) verbatim rather than a decoded `prost_types::FileDescriptorProto`.
+    // prost silently drops unknown fields on decode, so a decode/re-encode
+    // round-trip strips custom options / extensions (e.g. `google.api.http`);
+    // keeping the raw bytes preserves them for reflection consumers.
+    files: HashMap<String, Arc<[u8]>>,
+    symbols: HashMap<String, Arc<[u8]>>,
 }
 
 impl ReflectionServiceState {
     fn new(
         service_names: Vec<String>,
         encoded_file_descriptor_sets: Vec<&[u8]>,
-        mut file_descriptor_sets: Vec<FileDescriptorSet>,
+        file_descriptor_sets: Vec<FileDescriptorSet>,
         use_all_service_names: bool,
     ) -> Result<Self, Error> {
-        for encoded in encoded_file_descriptor_sets {
-            file_descriptor_sets.push(FileDescriptorSet::decode(encoded)?);
-        }
-
         let mut state = ReflectionServiceState {
             service_names,
             files: HashMap::new(),
             symbols: HashMap::new(),
         };
 
+        // Sets provided already-decoded have no original bytes to preserve, so
+        // re-encode each file (custom options may already have been dropped when
+        // the caller decoded the set into `prost_types`).
         for fds in file_descriptor_sets {
             for fd in fds.file {
-                let name = match fd.name.clone() {
-                    None => {
-                        return Err(Error::InvalidFileDescriptorSet("missing name".to_string()));
-                    }
-                    Some(n) => n,
-                };
+                let raw = fd.encode_to_vec();
+                state.register_file(&fd, Arc::from(raw), use_all_service_names)?;
+            }
+        }
 
-                if state.files.contains_key(&name) {
-                    continue;
-                }
-
-                let fd = Arc::new(fd);
-                state.files.insert(name, fd.clone());
-                state.process_file(fd, use_all_service_names)?;
+        // Encoded sets are split into their per-file byte ranges without
+        // decoding the inner message, so the original bytes (including custom
+        // options) are retained and served unchanged.
+        for encoded in encoded_file_descriptor_sets {
+            for raw in split_file_descriptor_set(encoded)? {
+                let fd = FileDescriptorProto::decode(raw.as_slice())?;
+                state.register_file(&fd, Arc::from(raw), use_all_service_names)?;
             }
         }
 
         Ok(state)
     }
 
+    fn register_file(
+        &mut self,
+        fd: &FileDescriptorProto,
+        raw: Arc<[u8]>,
+        use_all_service_names: bool,
+    ) -> Result<(), Error> {
+        let name = match fd.name.clone() {
+            None => {
+                return Err(Error::InvalidFileDescriptorSet("missing name".to_string()));
+            }
+            Some(n) => n,
+        };
+
+        if self.files.contains_key(&name) {
+            return Ok(());
+        }
+
+        self.files.insert(name, raw.clone());
+        self.process_file(fd, &raw, use_all_service_names)
+    }
+
     fn process_file(
         &mut self,
-        fd: Arc<FileDescriptorProto>,
+        fd: &FileDescriptorProto,
+        raw: &Arc<[u8]>,
         use_all_service_names: bool,
     ) -> Result<(), Error> {
         let prefix = &fd.package.clone().unwrap_or_default();
 
         for msg in &fd.message_type {
-            self.process_message(fd.clone(), prefix, msg)?;
+            self.process_message(raw, prefix, msg)?;
         }
 
         for en in &fd.enum_type {
-            self.process_enum(fd.clone(), prefix, en)?;
+            self.process_enum(raw, prefix, en)?;
         }
 
         for service in &fd.service {
@@ -177,11 +202,11 @@ impl ReflectionServiceState {
             if use_all_service_names {
                 self.service_names.push(service_name.clone());
             }
-            self.symbols.insert(service_name.clone(), fd.clone());
+            self.symbols.insert(service_name.clone(), raw.clone());
 
             for method in &service.method {
                 let method_name = extract_name(&service_name, "method", method.name.as_ref())?;
-                self.symbols.insert(method_name, fd.clone());
+                self.symbols.insert(method_name, raw.clone());
             }
         }
 
@@ -190,28 +215,28 @@ impl ReflectionServiceState {
 
     fn process_message(
         &mut self,
-        fd: Arc<FileDescriptorProto>,
+        raw: &Arc<[u8]>,
         prefix: &str,
         msg: &DescriptorProto,
     ) -> Result<(), Error> {
         let message_name = extract_name(prefix, "message", msg.name.as_ref())?;
-        self.symbols.insert(message_name.clone(), fd.clone());
+        self.symbols.insert(message_name.clone(), raw.clone());
 
         for nested in &msg.nested_type {
-            self.process_message(fd.clone(), &message_name, nested)?;
+            self.process_message(raw, &message_name, nested)?;
         }
 
         for en in &msg.enum_type {
-            self.process_enum(fd.clone(), &message_name, en)?;
+            self.process_enum(raw, &message_name, en)?;
         }
 
         for field in &msg.field {
-            self.process_field(fd.clone(), &message_name, field)?;
+            self.process_field(raw, &message_name, field)?;
         }
 
         for oneof in &msg.oneof_decl {
             let oneof_name = extract_name(&message_name, "oneof", oneof.name.as_ref())?;
-            self.symbols.insert(oneof_name, fd.clone());
+            self.symbols.insert(oneof_name, raw.clone());
         }
 
         Ok(())
@@ -219,16 +244,16 @@ impl ReflectionServiceState {
 
     fn process_enum(
         &mut self,
-        fd: Arc<FileDescriptorProto>,
+        raw: &Arc<[u8]>,
         prefix: &str,
         en: &EnumDescriptorProto,
     ) -> Result<(), Error> {
         let enum_name = extract_name(prefix, "enum", en.name.as_ref())?;
-        self.symbols.insert(enum_name.clone(), fd.clone());
+        self.symbols.insert(enum_name.clone(), raw.clone());
 
         for value in &en.value {
             let value_name = extract_name(&enum_name, "enum value", value.name.as_ref())?;
-            self.symbols.insert(value_name, fd.clone());
+            self.symbols.insert(value_name, raw.clone());
         }
 
         Ok(())
@@ -236,12 +261,12 @@ impl ReflectionServiceState {
 
     fn process_field(
         &mut self,
-        fd: Arc<FileDescriptorProto>,
+        raw: &Arc<[u8]>,
         prefix: &str,
         field: &FieldDescriptorProto,
     ) -> Result<(), Error> {
         let field_name = extract_name(prefix, "field", field.name.as_ref())?;
-        self.symbols.insert(field_name, fd);
+        self.symbols.insert(field_name, raw.clone());
         Ok(())
     }
 
@@ -252,30 +277,72 @@ impl ReflectionServiceState {
     fn symbol_by_name(&self, symbol: &str) -> Result<Vec<u8>, Status> {
         match self.symbols.get(symbol) {
             None => Err(Status::not_found(format!("symbol '{symbol}' not found"))),
-            Some(fd) => {
-                let mut encoded_fd = Vec::new();
-                if fd.clone().encode(&mut encoded_fd).is_err() {
-                    return Err(Status::internal("encoding error"));
-                };
-
-                Ok(encoded_fd)
-            }
+            Some(raw) => Ok(raw.to_vec()),
         }
     }
 
     fn file_by_filename(&self, filename: &str) -> Result<Vec<u8>, Status> {
         match self.files.get(filename) {
             None => Err(Status::not_found(format!("file '{filename}' not found"))),
-            Some(fd) => {
-                let mut encoded_fd = Vec::new();
-                if fd.clone().encode(&mut encoded_fd).is_err() {
-                    return Err(Status::internal("encoding error"));
-                }
+            Some(raw) => Ok(raw.to_vec()),
+        }
+    }
+}
 
-                Ok(encoded_fd)
+/// Splits an encoded `FileDescriptorSet` into the raw, unmodified bytes of each
+/// contained `FileDescriptorProto` (wire field 1), without decoding the inner
+/// messages.
+///
+/// Serving these original bytes preserves custom options / extensions (e.g.
+/// `google.api.http`) that prost silently drops when a `FileDescriptorProto` is
+/// decoded and re-encoded.
+fn split_file_descriptor_set(mut buf: &[u8]) -> Result<Vec<Vec<u8>>, Error> {
+    // Field number of `repeated FileDescriptorProto file = 1;`.
+    const FILE_FIELD_TAG: u32 = 1;
+
+    let truncated = || {
+        Error::InvalidFileDescriptorSet("unexpected end of FileDescriptorSet buffer".to_string())
+    };
+
+    let mut files = Vec::new();
+    while !buf.is_empty() {
+        let (tag, wire_type) = decode_key(&mut buf)?;
+        match wire_type {
+            WireType::LengthDelimited => {
+                let len = decode_varint(&mut buf)? as usize;
+                if len > buf.len() {
+                    return Err(truncated());
+                }
+                let (field, rest) = buf.split_at(len);
+                if tag == FILE_FIELD_TAG {
+                    files.push(field.to_vec());
+                }
+                buf = rest;
+            }
+            WireType::Varint => {
+                decode_varint(&mut buf)?;
+            }
+            WireType::ThirtyTwoBit => {
+                if buf.len() < 4 {
+                    return Err(truncated());
+                }
+                buf = &buf[4..];
+            }
+            WireType::SixtyFourBit => {
+                if buf.len() < 8 {
+                    return Err(truncated());
+                }
+                buf = &buf[8..];
+            }
+            WireType::StartGroup | WireType::EndGroup => {
+                return Err(Error::InvalidFileDescriptorSet(
+                    "unexpected group wire type in FileDescriptorSet".to_string(),
+                ));
             }
         }
     }
+
+    Ok(files)
 }
 
 fn extract_name(

--- a/tonic-reflection/tests/server.rs
+++ b/tonic-reflection/tests/server.rs
@@ -92,7 +92,98 @@ async fn test_file_containing_symbol() {
     }
 }
 
+/// Builds the raw bytes of a `FileDescriptorProto` that carries a field prost
+/// does not know about, standing in for a custom option / extension such as
+/// `google.api.http` (field `72295728`). prost drops unknown fields on decode,
+/// so a decode/re-encode round-trip strips these bytes.
+fn file_descriptor_with_custom_option() -> Vec<u8> {
+    use prost::encoding::{WireType, encode_key, encode_varint};
+
+    let fd = prost_types::FileDescriptorProto {
+        name: Some("custom_option.proto".to_string()),
+        package: Some("test.custom".to_string()),
+        message_type: vec![prost_types::DescriptorProto {
+            name: Some("Msg".to_string()),
+            ..Default::default()
+        }],
+        ..Default::default()
+    };
+    let mut raw = fd.encode_to_vec();
+
+    // Append an extension-range field number that `prost_types` has no field for.
+    encode_key(72295728, WireType::LengthDelimited, &mut raw);
+    let payload = b"custom-option-value";
+    encode_varint(payload.len() as u64, &mut raw);
+    raw.extend_from_slice(payload);
+
+    raw
+}
+
+/// Wraps encoded `FileDescriptorProto` bytes into an encoded `FileDescriptorSet`
+/// (`repeated FileDescriptorProto file = 1`) verbatim, without a prost round-trip.
+fn wrap_in_file_descriptor_set(file_bytes: &[u8]) -> Vec<u8> {
+    use prost::encoding::{WireType, encode_key, encode_varint};
+
+    let mut set = Vec::new();
+    encode_key(1, WireType::LengthDelimited, &mut set);
+    encode_varint(file_bytes.len() as u64, &mut set);
+    set.extend_from_slice(file_bytes);
+    set
+}
+
+#[tokio::test]
+async fn test_custom_options_are_preserved() {
+    let raw_file = file_descriptor_with_custom_option();
+
+    // Sanity check the fixture: a naive prost decode/re-encode round-trip (the
+    // behaviour this test guards against) strips the unknown field.
+    let round_tripped = prost_types::FileDescriptorProto::decode(raw_file.as_slice())
+        .expect("decode file descriptor")
+        .encode_to_vec();
+    assert_ne!(
+        round_tripped, raw_file,
+        "fixture invalid: the unknown field should be dropped by a prost round-trip"
+    );
+
+    let encoded_set = wrap_in_file_descriptor_set(&raw_file);
+
+    // The bytes served for both a file lookup and a symbol lookup must be the
+    // original bytes, with the custom option intact.
+    for message_request in [
+        MessageRequest::FileByFilename("custom_option.proto".to_string()),
+        MessageRequest::FileContainingSymbol("test.custom.Msg".to_string()),
+    ] {
+        let response = make_test_reflection_request_for(
+            encoded_set.clone(),
+            ServerReflectionRequest {
+                host: "".to_string(),
+                message_request: Some(message_request),
+            },
+        )
+        .await;
+
+        let MessageResponse::FileDescriptorResponse(descriptor) = response else {
+            panic!("Expected a FileDescriptorResponse variant");
+        };
+        let served = descriptor
+            .file_descriptor_proto
+            .first()
+            .expect("descriptor");
+        assert_eq!(
+            served, &raw_file,
+            "reflection must serve the original bytes, preserving custom options"
+        );
+    }
+}
+
 async fn make_test_reflection_request(request: ServerReflectionRequest) -> MessageResponse {
+    make_test_reflection_request_for(FILE_DESCRIPTOR_SET.to_vec(), request).await
+}
+
+async fn make_test_reflection_request_for(
+    encoded_fds: Vec<u8>,
+    request: ServerReflectionRequest,
+) -> MessageResponse {
     // Run a test server
     let (shutdown_tx, shutdown_rx) = oneshot::channel();
 
@@ -101,7 +192,7 @@ async fn make_test_reflection_request(request: ServerReflectionRequest) -> Messa
     let local_addr = format!("http://{}", listener.local_addr().expect("local address"));
     let jh = tokio::spawn(async move {
         let service = Builder::configure()
-            .register_encoded_file_descriptor_set(FILE_DESCRIPTOR_SET)
+            .register_encoded_file_descriptor_set(&encoded_fds)
             .build_v1()
             .unwrap();
 

--- a/tonic-reflection/tests/server.rs
+++ b/tonic-reflection/tests/server.rs
@@ -155,6 +155,7 @@ async fn test_custom_options_are_preserved() {
     ] {
         let response = make_test_reflection_request_for(
             encoded_set.clone(),
+            None,
             ServerReflectionRequest {
                 host: "".to_string(),
                 message_request: Some(message_request),
@@ -176,12 +177,53 @@ async fn test_custom_options_are_preserved() {
     }
 }
 
+#[tokio::test]
+async fn test_encoded_bytes_win_over_decoded_duplicate() {
+    // The same file is registered in both forms: as raw bytes carrying a custom
+    // option, and as an already-decoded `FileDescriptorSet` (which cannot carry
+    // the option). The lossless raw bytes must take precedence.
+    let raw_file = file_descriptor_with_custom_option();
+    let encoded_set = wrap_in_file_descriptor_set(&raw_file);
+
+    let decoded_dup = prost_types::FileDescriptorSet {
+        file: vec![
+            prost_types::FileDescriptorProto::decode(raw_file.as_slice())
+                .expect("decode file descriptor"),
+        ],
+    };
+
+    let response = make_test_reflection_request_for(
+        encoded_set,
+        Some(decoded_dup),
+        ServerReflectionRequest {
+            host: "".to_string(),
+            message_request: Some(MessageRequest::FileByFilename(
+                "custom_option.proto".to_string(),
+            )),
+        },
+    )
+    .await;
+
+    let MessageResponse::FileDescriptorResponse(descriptor) = response else {
+        panic!("Expected a FileDescriptorResponse variant");
+    };
+    let served = descriptor
+        .file_descriptor_proto
+        .first()
+        .expect("descriptor");
+    assert_eq!(
+        served, &raw_file,
+        "the option-preserving encoded bytes must win over a decoded duplicate"
+    );
+}
+
 async fn make_test_reflection_request(request: ServerReflectionRequest) -> MessageResponse {
-    make_test_reflection_request_for(FILE_DESCRIPTOR_SET.to_vec(), request).await
+    make_test_reflection_request_for(FILE_DESCRIPTOR_SET.to_vec(), None, request).await
 }
 
 async fn make_test_reflection_request_for(
     encoded_fds: Vec<u8>,
+    decoded_fds: Option<prost_types::FileDescriptorSet>,
     request: ServerReflectionRequest,
 ) -> MessageResponse {
     // Run a test server
@@ -191,10 +233,11 @@ async fn make_test_reflection_request_for(
     let listener = tokio::net::TcpListener::bind(addr).await.expect("bind");
     let local_addr = format!("http://{}", listener.local_addr().expect("local address"));
     let jh = tokio::spawn(async move {
-        let service = Builder::configure()
-            .register_encoded_file_descriptor_set(&encoded_fds)
-            .build_v1()
-            .unwrap();
+        let mut builder = Builder::configure().register_encoded_file_descriptor_set(&encoded_fds);
+        if let Some(decoded) = decoded_fds {
+            builder = builder.register_file_descriptor_set(decoded);
+        }
+        let service = builder.build_v1().unwrap();
 
         Server::builder()
             .add_service(service)


### PR DESCRIPTION
Fixes #2719

## Motivation

`tonic-reflection` silently dropped **custom options** — extensions on `MethodOptions` / `FieldOptions` / etc., e.g. `google.api.http` — from the descriptors it served. `ReflectionServiceState` stored each file as a decoded `prost_types::FileDescriptorProto` and re-encoded it on every response, so the round-trip was `raw bytes → decode → encode`. prost drops unknown fields on decode, so any extension in the `>= 1000` range was lost right at registration.

This breaks every reflection consumer that reads custom options: `google.api.http` REST transcoding, `google.api.method_signature`, `buf.validate` / protoc-gen-validate rules, etc. The Go / C++ / Java reflection servers preserve these because they serve the original descriptor bytes.

## Solution

Serve the **original per-file bytes** instead of re-encoding the decoded form.

- For encoded descriptor sets (`register_encoded_file_descriptor_set`), split the set into its per-file byte ranges at the wire level (field 1) **without** decoding the inner message, and store those raw bytes. The `FileDescriptorProto` is still decoded — but only to build the symbol index; the decoded value is discarded and the original bytes are what gets served.
- Sets registered already-decoded (`register_file_descriptor_set`) have no original bytes, so they are re-encoded as before (unavoidable for that entry point).

The internal representation for both `files` and `symbols` becomes `Arc<[u8]>` (per-file encoded bytes). No public API change; the processing order (and therefore dedup precedence and `service_names` ordering) is preserved. The only behavior change is faithfully preserving options.

## Tests

Adds `test_custom_options_are_preserved`, which registers a `FileDescriptorProto` carrying an extension-range field (`72295728`, standing in for `google.api.http`) and asserts the served bytes equal the original for **both** `FileByFilename` and `FileContainingSymbol` lookups. It includes a sanity check (`assert_ne!`) proving a naive prost decode/re-encode round-trip would strip the field — so the test genuinely guards the regression rather than being a tautology. All existing reflection tests continue to pass.