### PR TITLE
grpc/credentials/rustls: Fix typo in struct names

### DIFF
--- a/examples/src/grpc-gcp/client.rs
+++ b/examples/src/grpc-gcp/client.rs
@@ -36,7 +36,7 @@ use generated::api::publisher_client::PublisherClient;
 use grpc::client::Channel;
 use grpc::credentials::CompositeChannelCredentials;
 use grpc::credentials::rustls::client::ClientTlsConfig;
-use grpc::credentials::rustls::client::RustlsChannelCredendials;
+use grpc::credentials::rustls::client::RustlsChannelCredentials;
 use grpc_google::GcpCallCredentials;
 use protobuf::proto;
 
@@ -50,7 +50,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .ok_or_else(|| "Expected a project name as the first argument.".to_string())?;
 
     let call_creds = GcpCallCredentials::new_application_default()?;
-    let tls = RustlsChannelCredendials::new(ClientTlsConfig::new())?;
+    let tls = RustlsChannelCredentials::new(ClientTlsConfig::new())?;
     let channel_creds = CompositeChannelCredentials::new(tls, Arc::new(call_creds));
 
     let channel = Channel::new(ENDPOINT, Arc::new(channel_creds), Default::default());

--- a/grpc/src/client/transport/tonic/test.rs
+++ b/grpc/src/client/transport/tonic/test.rs
@@ -87,7 +87,7 @@ use crate::credentials::common::Authority;
 use crate::credentials::rustls::RootCertificates;
 use crate::credentials::rustls::StaticProvider;
 use crate::credentials::rustls::client::ClientTlsConfig;
-use crate::credentials::rustls::client::RustlsChannelCredendials;
+use crate::credentials::rustls::client::RustlsChannelCredentials;
 use crate::echo_pb::EchoRequest;
 use crate::echo_pb::EchoResponse;
 use crate::echo_pb::echo_server::Echo;
@@ -463,7 +463,7 @@ async fn grpc_invoke_tonic_unary_tls() {
     let root_certs = RootCertificates::from_pem(ca_cert);
     let root_provider = StaticProvider::new(root_certs);
     let config = ClientTlsConfig::new().with_root_certificates_provider(root_provider);
-    let creds = RustlsChannelCredendials::new(config).unwrap();
+    let creds = RustlsChannelCredentials::new(config).unwrap();
     let call_creds = Arc::new(MockCallCredentials {
         metadata: vec![("x-test-metadata", "test-value")],
         min_security_level: SecurityLevel::PrivacyAndIntegrity,

--- a/grpc/src/credentials/rustls/client/mod.rs
+++ b/grpc/src/credentials/rustls/client/mod.rs
@@ -127,14 +127,17 @@ impl Default for ClientTlsConfig {
 
 /// gRPC TLS [`ChannelCredentials`] based on [`rustls`].
 #[derive(Clone)]
-pub struct RustlsChannelCredendials {
+pub struct RustlsChannelCredentials {
     connector: TlsConnector,
 }
 
-impl RustlsChannelCredendials {
+#[deprecated(since = "0.10.0", note = "typo: use RustlsChannelCredentials instead")]
+pub type RustlsChannelCredendials = RustlsChannelCredentials;
+
+impl RustlsChannelCredentials {
     /// Constructs a new `ClientTlsCredendials` instance from the provided
     /// configuration.
-    pub fn new(config: ClientTlsConfig) -> Result<RustlsChannelCredendials, String> {
+    pub fn new(config: ClientTlsConfig) -> Result<RustlsChannelCredentials, String> {
         let provider = if let Some(p) = CryptoProvider::get_default() {
             p.as_ref().clone()
         } else {
@@ -150,7 +153,7 @@ impl RustlsChannelCredendials {
     fn new_impl(
         mut config: ClientTlsConfig,
         provider: CryptoProvider,
-    ) -> Result<RustlsChannelCredendials, String> {
+    ) -> Result<RustlsChannelCredentials, String> {
         let provider = sanitize_crypto_provider(provider)?;
         let builder = rustls::ClientConfig::builder_with_provider(Arc::new(provider))
             .with_protocol_versions(&[&rustls::version::TLS13, &rustls::version::TLS12])
@@ -189,7 +192,7 @@ impl RustlsChannelCredendials {
             client_config.key_log = Arc::new(KeyLogFile::new(&path))
         }
 
-        Ok(RustlsChannelCredendials {
+        Ok(RustlsChannelCredentials {
             connector: TlsConnector::from(Arc::new(client_config)),
         })
     }
@@ -264,7 +267,7 @@ impl ChannelSecurityContext for ClientTlsSecurityContext {
 }
 
 #[async_trait]
-impl ChannelCredentials for RustlsChannelCredendials {
+impl ChannelCredentials for RustlsChannelCredentials {
     async fn connect(
         &self,
         authority: &Authority,

--- a/grpc/src/credentials/rustls/client/mod.rs
+++ b/grpc/src/credentials/rustls/client/mod.rs
@@ -135,7 +135,7 @@ pub struct RustlsChannelCredentials {
 pub type RustlsChannelCredendials = RustlsChannelCredentials;
 
 impl RustlsChannelCredentials {
-    /// Constructs a new `ClientTlsCredentials` instance from the provided
+    /// Constructs a new [RustlsChannelCredentials] instance from the provided
     /// configuration.
     pub fn new(config: ClientTlsConfig) -> Result<RustlsChannelCredentials, String> {
         let provider = if let Some(p) = CryptoProvider::get_default() {

--- a/grpc/src/credentials/rustls/client/mod.rs
+++ b/grpc/src/credentials/rustls/client/mod.rs
@@ -135,7 +135,7 @@ pub struct RustlsChannelCredentials {
 pub type RustlsChannelCredendials = RustlsChannelCredentials;
 
 impl RustlsChannelCredentials {
-    /// Constructs a new `ClientTlsCredendials` instance from the provided
+    /// Constructs a new `ClientTlsCredentials` instance from the provided
     /// configuration.
     pub fn new(config: ClientTlsConfig) -> Result<RustlsChannelCredentials, String> {
         let provider = if let Some(p) = CryptoProvider::get_default() {

--- a/grpc/src/credentials/rustls/client/test.rs
+++ b/grpc/src/credentials/rustls/client/test.rs
@@ -47,7 +47,7 @@ use crate::credentials::rustls::Identity;
 use crate::credentials::rustls::RootCertificates;
 use crate::credentials::rustls::StaticProvider;
 use crate::credentials::rustls::client::ClientTlsConfig;
-use crate::credentials::rustls::client::RustlsChannelCredendials;
+use crate::credentials::rustls::client::RustlsChannelCredentials;
 use crate::private;
 use crate::rt;
 use crate::rt::AsyncIoAdapter;
@@ -101,7 +101,7 @@ async fn test_tls_cipher_suites_secure() {
         .clone();
 
     // This should succeed as default provider usually has secure suites.
-    let creds = RustlsChannelCredendials::new_impl(config, provider);
+    let creds = RustlsChannelCredentials::new_impl(config, provider);
     assert!(
         creds.is_ok(),
         "Failed to create creds with secure provider: {:?}",
@@ -139,7 +139,7 @@ async fn test_tls_cipher_suites_insecure() {
     // Remove all cipher suites that are considered secure by our policy
     provider.cipher_suites.retain(|suite| !is_secure(suite));
 
-    let creds = RustlsChannelCredendials::new_impl(config, provider);
+    let creds = RustlsChannelCredentials::new_impl(config, provider);
     assert!(creds.err().unwrap().contains("no cipher suites matching"));
 }
 
@@ -160,7 +160,7 @@ async fn test_tls_key_log() {
         .with_root_certificates_provider(root_provider)
         .insecure_with_key_log_path(key_log_file.path());
 
-    let creds = RustlsChannelCredendials::new(config).unwrap();
+    let creds = RustlsChannelCredentials::new(config).unwrap();
 
     let runtime = rt::default_runtime();
     let endpoint = runtime
@@ -210,7 +210,7 @@ async fn test_tls_handshake_wrong_server_name() {
     let root_provider = StaticProvider::new(root_certs);
     let config = ClientTlsConfig::new().with_root_certificates_provider(root_provider);
 
-    let creds = RustlsChannelCredendials::new(config).unwrap();
+    let creds = RustlsChannelCredentials::new(config).unwrap();
 
     let runtime = rt::default_runtime();
     let endpoint = runtime
@@ -267,7 +267,7 @@ async fn test_tls_validate_authority() {
     let root_provider = StaticProvider::new(root_certs);
     let config = ClientTlsConfig::new().with_root_certificates_provider(root_provider);
 
-    let creds = RustlsChannelCredendials::new(config).unwrap();
+    let creds = RustlsChannelCredentials::new(config).unwrap();
 
     let runtime = rt::default_runtime();
     let endpoint = runtime
@@ -311,7 +311,7 @@ async fn test_mtls_handshake_no_identity() {
     let config = ClientTlsConfig::new()
         .with_root_certificates_provider(StaticProvider::new(load_root_certs("ca.pem")));
 
-    let creds = RustlsChannelCredendials::new(config).unwrap();
+    let creds = RustlsChannelCredentials::new(config).unwrap();
     let runtime = rt::default_runtime();
     let endpoint = runtime
         .tcp_stream(addr, TcpOptions::default())
@@ -366,7 +366,7 @@ async fn test_mtls_handshake_with_identitiy() {
         .with_root_certificates_provider(root_provider)
         .with_identity_provider(identity_provider);
 
-    let creds = RustlsChannelCredendials::new(config).unwrap();
+    let creds = RustlsChannelCredentials::new(config).unwrap();
     let runtime = rt::default_runtime();
     let endpoint = runtime
         .tcp_stream(addr, TcpOptions::default())
@@ -421,7 +421,7 @@ async fn check_client_resumption_disabled(
     let root_provider = StaticProvider::new(root_certs);
     let config = ClientTlsConfig::new().with_root_certificates_provider(root_provider);
 
-    let creds = RustlsChannelCredendials::new(config).unwrap();
+    let creds = RustlsChannelCredentials::new(config).unwrap();
 
     for i in 0..2 {
         let runtime = rt::default_runtime();
@@ -588,7 +588,7 @@ async fn run_handshake_test(server_alpn: Vec<Vec<u8>>, expect_success: bool) {
 
     let config = ClientTlsConfig::new().with_root_certificates_provider(root_provider);
 
-    let creds = RustlsChannelCredendials::new(config).unwrap();
+    let creds = RustlsChannelCredentials::new(config).unwrap();
 
     let runtime = rt::default_runtime();
     let endpoint = runtime

--- a/grpc/src/credentials/rustls/server/mod.rs
+++ b/grpc/src/credentials/rustls/server/mod.rs
@@ -98,7 +98,7 @@ impl ResolvesServerCert for SniResolver {
 }
 
 /// Settings for client certificate requests which may be made by
-/// [`RustlsServerCredendials`].
+/// [`RustlsServerCredentials`].
 #[non_exhaustive]
 pub enum TlsClientCertificateRequestType<R = StaticRootCertificatesProvider> {
     /// Server does not request client certificate.
@@ -174,9 +174,12 @@ impl From<TlsClientCertificateRequestType> for InnerClientCertificateRequestType
 
 /// gRPC TLS [`ServerCredentials`] based on [`rustls`].
 #[derive(Clone)]
-pub struct RustlsServerCredendials {
+pub struct RustlsServerCredentials {
     acceptor: TlsAcceptor,
 }
+
+#[deprecated(since = "0.10.0", note = "typo: use RustlsServerCredentials instead")]
+pub type RustlsServerCredendials = RustlsServerCredentials;
 
 /// Configuration for server-side TLS settings.
 pub struct ServerTlsConfig {
@@ -221,10 +224,10 @@ impl ServerTlsConfig {
     }
 }
 
-impl RustlsServerCredendials {
+impl RustlsServerCredentials {
     /// Constructs a new `RustlsServerCredentials` instance from the provided
     /// configuration.
-    pub fn new(config: ServerTlsConfig) -> Result<RustlsServerCredendials, String> {
+    pub fn new(config: ServerTlsConfig) -> Result<RustlsServerCredentials, String> {
         let provider = if let Some(p) = CryptoProvider::get_default() {
             p.as_ref().clone()
         } else {
@@ -240,7 +243,7 @@ impl RustlsServerCredendials {
     fn new_impl(
         mut config: ServerTlsConfig,
         provider: CryptoProvider,
-    ) -> Result<RustlsServerCredendials, String> {
+    ) -> Result<RustlsServerCredentials, String> {
         let provider = sanitize_crypto_provider(provider)?;
         let id_list = config.identities_provider.borrow_and_update().clone();
         if id_list.is_empty() {
@@ -313,7 +316,7 @@ impl RustlsServerCredendials {
         // Install a dummy ticketer that refuses to issue tickets.
         server_config.ticketer = Arc::new(NoTicketer);
 
-        Ok(RustlsServerCredendials {
+        Ok(RustlsServerCredentials {
             acceptor: TlsAcceptor::from(Arc::new(server_config)),
         })
     }
@@ -338,7 +341,7 @@ impl ProducesTickets for NoTicketer {
     }
 }
 
-impl ServerCredentials for RustlsServerCredendials {
+impl ServerCredentials for RustlsServerCredentials {
     type Output<Input> = TlsStream<Input>;
 
     async fn accept<Input: GrpcEndpoint>(

--- a/grpc/src/credentials/rustls/server/test.rs
+++ b/grpc/src/credentials/rustls/server/test.rs
@@ -41,7 +41,7 @@ use crate::credentials::rustls::ALPN_PROTO_STR_H2;
 use crate::credentials::rustls::Identity;
 use crate::credentials::rustls::RootCertificates;
 use crate::credentials::rustls::StaticProvider;
-use crate::credentials::rustls::server::RustlsServerCredendials;
+use crate::credentials::rustls::server::RustlsServerCredentials;
 use crate::credentials::rustls::server::ServerTlsConfig;
 use crate::credentials::rustls::server::TlsClientCertificateRequestType;
 use crate::private;
@@ -65,7 +65,7 @@ async fn test_tls_server_handshake() {
     let identity = load_identity("server.pem", "server.key");
     let identity_provider = StaticProvider::new(vec![identity]);
     let config = ServerTlsConfig::new(identity_provider);
-    let creds = RustlsServerCredendials::new(config).unwrap();
+    let creds = RustlsServerCredentials::new(config).unwrap();
 
     let runtime = rt::default_runtime();
     let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
@@ -121,7 +121,7 @@ async fn test_tls_server_handshake_no_alpn() {
     let identity = load_identity("server.pem", "server.key");
     let identity_provider = StaticProvider::new(vec![identity]);
     let config = ServerTlsConfig::new(identity_provider);
-    let creds = RustlsServerCredendials::new(config).unwrap();
+    let creds = RustlsServerCredentials::new(config).unwrap();
 
     let runtime = rt::default_runtime();
     let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
@@ -164,7 +164,7 @@ async fn test_tls_server_handshake_bad_alpn() {
     let identity = load_identity("server.pem", "server.key");
     let identity_provider = StaticProvider::new(vec![identity]);
     let config = ServerTlsConfig::new(identity_provider);
-    let creds = RustlsServerCredendials::new(config).unwrap();
+    let creds = RustlsServerCredentials::new(config).unwrap();
 
     let runtime = rt::default_runtime();
     let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
@@ -201,7 +201,7 @@ async fn test_tls_handshake_alpn_h1_and_h2() {
     let identity = load_identity("server.pem", "server.key");
     let identity_provider = StaticProvider::new(vec![identity]);
     let config = ServerTlsConfig::new(identity_provider);
-    let creds = RustlsServerCredendials::new(config).unwrap();
+    let creds = RustlsServerCredentials::new(config).unwrap();
 
     let runtime = rt::default_runtime();
     let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
@@ -248,7 +248,7 @@ async fn test_tls_server_mtls_require_fail() {
         },
     );
 
-    let creds = RustlsServerCredendials::new(config).unwrap();
+    let creds = RustlsServerCredentials::new(config).unwrap();
 
     let runtime = rt::default_runtime();
     let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
@@ -299,7 +299,7 @@ async fn test_tls_server_mtls_success() {
         },
     );
 
-    let creds = RustlsServerCredendials::new(config).unwrap();
+    let creds = RustlsServerCredentials::new(config).unwrap();
 
     let runtime = rt::default_runtime();
     let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
@@ -359,7 +359,7 @@ async fn test_tls_server_mtls_optional() {
         },
     );
 
-    let creds = RustlsServerCredendials::new(config).unwrap();
+    let creds = RustlsServerCredentials::new(config).unwrap();
 
     let runtime = rt::default_runtime();
     let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
@@ -409,7 +409,7 @@ async fn test_tls_server_key_log() {
     let config =
         ServerTlsConfig::new(identity_provider).insecure_with_key_log_path(key_log_file.path());
 
-    let creds = RustlsServerCredendials::new(config).unwrap();
+    let creds = RustlsServerCredentials::new(config).unwrap();
 
     let runtime = rt::default_runtime();
     let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
@@ -462,7 +462,7 @@ async fn check_resumption_disabled(versions: Vec<&'static rustls::SupportedProto
     let identity = load_identity("server.pem", "server.key");
     let identity_provider = StaticProvider::new(vec![identity]);
     let config = ServerTlsConfig::new(identity_provider);
-    let creds = RustlsServerCredendials::new(config).unwrap();
+    let creds = RustlsServerCredentials::new(config).unwrap();
 
     let runtime = rt::default_runtime();
     let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
@@ -538,7 +538,7 @@ async fn test_tls_server_sni() {
     // identity2 has *.test.com
     let identity_provider = StaticProvider::new(vec![identity1, identity2]);
     let config = ServerTlsConfig::new(identity_provider);
-    let creds = RustlsServerCredendials::new(config).unwrap();
+    let creds = RustlsServerCredentials::new(config).unwrap();
 
     let runtime = rt::default_runtime();
     let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
@@ -651,7 +651,7 @@ async fn test_tls_server_cipher_suites_insecure() {
     // Remove all cipher suites that are considered secure by gRPC.
     provider.cipher_suites.retain(|suite| !is_secure(suite));
 
-    let creds = RustlsServerCredendials::new_impl(config, provider);
+    let creds = RustlsServerCredentials::new_impl(config, provider);
     assert!(creds.err().unwrap().contains("no cipher suites matching"));
 }
 

--- a/interop/src/bin/client.rs
+++ b/interop/src/bin/client.rs
@@ -7,7 +7,7 @@ use grpc::credentials::LocalChannelCredentials;
 use grpc::credentials::rustls::RootCertificates;
 use grpc::credentials::rustls::StaticProvider;
 use grpc::credentials::rustls::client::ClientTlsConfig as GrpcClientTlsConfig;
-use grpc::credentials::rustls::client::RustlsChannelCredendials;
+use grpc::credentials::rustls::client::RustlsChannelCredentials;
 use interop::client::InteropTest;
 use interop::client::InteropTestUnimplemented;
 use interop::client_prost;
@@ -95,7 +95,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
                 let pem = std::fs::read_to_string("interop/data/ca.pem")?;
                 let root_certs = RootCertificates::from_pem(pem);
-                let creds = RustlsChannelCredendials::new(
+                let creds = RustlsChannelCredentials::new(
                     GrpcClientTlsConfig::new()
                         .with_root_certificates_provider(StaticProvider::new(root_certs)),
                 )?;


### PR DESCRIPTION
Rename 'Credendials' to 'Credentials' in public symbols. Deprecated aliases are provided for the old names to facilitate migration.