### PR TITLE
tonic/xds: update versions of tonic-xds and xds-client

### DIFF
--- a/tonic-xds/Cargo.toml
+++ b/tonic-xds/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tonic-xds"
-version = "0.1.0-alpha.1"
+version = "0.1.0-alpha.2"
 edition = "2024"
 rust-version.workspace = true
 homepage = "https://github.com/hyperium/tonic"

--- a/tonic-xds/Cargo.toml
+++ b/tonic-xds/Cargo.toml
@@ -33,7 +33,7 @@ url = "2.5.8"
 futures-core = "0.3.31"
 futures-util = "0.3"
 bytes = "1"
-xds-client = { version = "0.1.0-alpha.1", path = "../xds-client" }
+xds-client = { version = "0.1.0-alpha.2", path = "../xds-client" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 envoy-types = "0.7"

--- a/xds-client/Cargo.toml
+++ b/xds-client/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "xds-client"
 description = "An xDS client implementation in Rust"
-version = "0.1.0-alpha.1"
+version = "0.1.0-alpha.2"
 edition = "2024"
 homepage = "https://github.com/hyperium/tonic"
 repository = "https://github.com/hyperium/tonic"


### PR DESCRIPTION
Bump version to prepare for a crate.io update

## Motivation

Need to do a version bump to facilitate consumptions direcly from crates.io.

## Solution

Version bump

