### PR TITLE
chore(xds): enable manual publishing for xds crates

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -153,7 +153,10 @@ jobs:
         # Windows is the long pole of a build. Caching it avoids adding ~5 minutes of build time
         cache-targets: ${{ matrix.os == 'windows-latest' }}
     - name: Check features
-      run: cargo hack check --workspace --no-private --each-feature --no-dev-deps
+      # `_tls-any` is an internal feature that only compiles together with a
+      # crypto backend (tls-ring / tls-aws-lc); exclude it from the per-feature
+      # check so it isn't built in isolation.
+      run: cargo hack check --workspace --no-private --each-feature --no-dev-deps --exclude-features _tls-any
     - name: Check tonic feature powerset
       run: cargo hack check --package tonic --feature-powerset --depth 2
     - name: Check all targets

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -41,14 +41,18 @@ version_group = "tonic"
 name = "tonic-web"
 version_group = "tonic"
 
-# xds group (shared version)
-#[[package]]
-#name = "xds-client"
-#version_group = "xds"
+# xds crates: published manually for now
+[[package]]
+name = "xds-client"
+release = false
 
-#[[package]]
-#name = "tonic-xds"
-#version_group = "xds"
+[[package]]
+name = "tonic-xds"
+release = false
+
+[[package]]
+name = "xds-client-opentelemetry"
+release = false
 
 # grpc group (single crate)
 #[[package]]

--- a/tonic-xds/Cargo.toml
+++ b/tonic-xds/Cargo.toml
@@ -99,3 +99,25 @@ required-features = ["testutil"]
 
 [[example]]
 name = "xds_server"
+
+[package.metadata.cargo_check_external_types]
+allowed_external_types = [
+    "tonic::*",
+    "xds_client::*",
+
+    # major released
+    "bytes::*",
+    "http::*",
+    "http_body::*",
+
+    # not major released
+    "prost::*",
+    "opentelemetry::*",
+
+    "tower_service::Service",
+    "tower::BoxError",
+    "tower::util::boxed_clone_sync::BoxCloneSyncService",
+    "url::parser::ParseError",
+    "serde_core::de::Deserialize",
+    "serde_json::error::Error",
+]

--- a/tonic-xds/Cargo.toml
+++ b/tonic-xds/Cargo.toml
@@ -17,7 +17,7 @@ xDS routing and load balancing implementation for Tonic and Tower services
 """
 keywords = ["grpc", "xds"]
 license = "MIT"
-publish = false
+publish = true
 exclude = ["proto/test/*"]
 
 [dependencies]
@@ -56,13 +56,13 @@ rustls = { version = "0.23", default-features = false, features = ["std", "tls12
 rustls-pemfile = { version = "2", optional = true }
 x509-parser = { version = "0.17", optional = true }
 opentelemetry = { version = "0.32", optional = true, default-features = false, features = ["metrics"] }
-xds-client-opentelemetry = { version = "0.1.0-alpha.1", path = "../xds-client-opentelemetry", optional = true }
+xds-client-opentelemetry = { version = "0.1.0-alpha.2", path = "../xds-client-opentelemetry", optional = true }
 
 [lints]
 workspace = true
 
 [dev-dependencies]
-xds-client = { version = "0.1.0-alpha.1", path = "../xds-client", features = ["test-util"] }
+xds-client = { version = "0.1.0-alpha.2", path = "../xds-client", features = ["test-util"] }
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "net", "test-util"] }
 tonic = { version = "0.14", features = [ "server", "channel", "tls-ring" ] }
 tonic-prost = "0.14"

--- a/tonic-xds/src/client/loadbalance/keyed_futures.rs
+++ b/tonic-xds/src/client/loadbalance/keyed_futures.rs
@@ -26,7 +26,7 @@ pub(crate) enum KeyedFuturesError<K: std::fmt::Debug> {
 /// A cancellable, keyed set of futures.
 ///
 /// Each future is associated with a key `K` and produces a value `T`.
-/// Futures can be cancelled individually by key. [`poll_next`] drives all
+/// Futures can be cancelled individually by key. `poll_next` drives all
 /// futures concurrently and yields `(K, T)` when one completes; cancelled
 /// futures are silently skipped.
 ///

--- a/tonic-xds/src/client/loadbalance/loadbalancer.rs
+++ b/tonic-xds/src/client/loadbalance/loadbalancer.rs
@@ -13,7 +13,7 @@
 //! `watch` channel each time the set changes; the LB consumes the
 //! latest snapshot, consumes the matching [`ReadyChannel`] via
 //! [`ReadyChannel::eject`], and tracks the resulting
-//! [`EjectedChannel`] in [`Self::ejected`]. When the timer fires, the
+//! [`EjectedChannel`] in `ejected`. When the timer fires, the
 //! resolved [`UnejectedChannel`] is routed back into `ready` or
 //! `connecting`.
 //!
@@ -93,7 +93,7 @@ pub(crate) struct LoadBalancer<D, C: Connector, Req> {
     /// ring stays stable across connection flaps and ejections.
     members: IndexSet<EndpointAddress>,
     /// Currently-ejected channels. Each entry is an
-    /// [`EjectedChannel`] whose `Sleep` fires when the ejection
+    /// `EjectedChannel` whose `Sleep` fires when the ejection
     /// window expires.
     ejected: KeyedFutures<EndpointAddress, UnejectedChannel<C::Service>>,
     /// Per-LB outlier-detection plumbing. Always present; the

--- a/tonic-xds/src/client/loadbalance/outlier_detection.rs
+++ b/tonic-xds/src/client/loadbalance/outlier_detection.rs
@@ -2,7 +2,7 @@
 //!
 //! Work is split across three sites:
 //!
-//! - **Data path** ([`ReadyChannel::record_outcome`]): runs inline per
+//! - **Data path** (`ReadyChannel::record_outcome`): runs inline per
 //!   RPC. Updates per-channel counters only; ejection decisions are
 //!   deferred to the sweep.
 //! - **Load balancer**: drains the ejected-set snapshot broadcast by

--- a/tonic-xds/src/xds/cluster_discovery.rs
+++ b/tonic-xds/src/xds/cluster_discovery.rs
@@ -203,7 +203,7 @@ impl Connector for PlaintextConnector {
 /// - a verifier that reads CA roots from its [`CertificateProvider`] on
 ///   each handshake (so `file_watcher`-driven CA rotation is picked up
 ///   automatically), and
-/// - an optional identity provider for mTLS — fetched per [`connect`] call
+/// - an optional identity provider for mTLS — fetched per `connect` call
 ///   so identity rotation is picked up on each new connection.
 ///
 /// The connector is rebuilt by [`build_connector`] on every CDS update, so

--- a/tonic-xds/src/xds/endpoint_manager.rs
+++ b/tonic-xds/src/xds/endpoint_manager.rs
@@ -2,7 +2,7 @@
 //! [`Change`] streams for Tower's load balancing infrastructure.
 //!
 //! The resource manager writes [`EndpointsResource`] snapshots into the
-//! [`XdsCache`]; this module diffs consecutive snapshots and produces
+//! `XdsCache`; this module diffs consecutive snapshots and produces
 //! `Change::Insert` / `Change::Remove` events that Tower's P2C balancer
 //! (or any other `Discover`-based balancer) can consume.
 

--- a/tonic-xds/src/xds/resource/string_matcher.rs
+++ b/tonic-xds/src/xds/resource/string_matcher.rs
@@ -1,6 +1,6 @@
 //! Generic string matcher for xDS configuration.
 //!
-//! Mirrors [`envoy.type.matcher.v3.StringMatcher`]: a small set of string
+//! Mirrors `envoy.type.matcher.v3.StringMatcher`: a small set of string
 //! comparison modes (`exact` / `prefix` / `suffix` / `contains` / `safe_regex`)
 //! with optional ASCII case-insensitive matching on the string-literal variants.
 //!
@@ -12,7 +12,7 @@ use envoy_types::pb::envoy::r#type::matcher::v3::string_matcher::MatchPattern;
 use regex::Regex;
 use xds_client::Error;
 
-/// Validated [`envoy.type.matcher.v3.StringMatcher`].
+/// Validated `envoy.type.matcher.v3.StringMatcher`.
 #[derive(Debug, Clone)]
 pub(crate) enum StringMatcher {
     Exact { value: String, ignore_case: bool },

--- a/tonic-xds/src/xds/resource_manager.rs
+++ b/tonic-xds/src/xds/resource_manager.rs
@@ -1,7 +1,7 @@
 //! xDS resource manager: LDS -> RDS -> CDS -> EDS cascade.
 //!
 //! The [`XdsResourceManager`] bridges the xDS client (ADS protocol layer) to the
-//! [`XdsCache`](super::cache::XdsCache). It watches resources via
+//! [`XdsCache`]. It watches resources via
 //! [`XdsClient::watch()`] and writes validated resources into the cache for
 //! downstream consumers (routing layer, endpoint manager).
 //!

--- a/xds-client-opentelemetry/Cargo.toml
+++ b/xds-client-opentelemetry/Cargo.toml
@@ -1,19 +1,19 @@
 [package]
 name = "xds-client-opentelemetry"
 description = "OpenTelemetry metrics recorder for xds-client (gRFC A78 XdsClient metrics)"
-version = "0.1.0-alpha.1"
+version = "0.1.0-alpha.2"
 edition = "2024"
 homepage = "https://github.com/grpc/grpc-rust"
 repository = "https://github.com/grpc/grpc-rust"
 license = "MIT"
 rust-version = { workspace = true }
-publish = false
+publish = true
 
 [lints]
 workspace = true
 
 [dependencies]
-xds-client = { version = "0.1.0-alpha.1", path = "../xds-client" }
+xds-client = { version = "0.1.0-alpha.2", path = "../xds-client" }
 opentelemetry = { version = "0.32", default-features = false, features = ["metrics"] }
 
 [dev-dependencies]

--- a/xds-client/Cargo.toml
+++ b/xds-client/Cargo.toml
@@ -7,7 +7,7 @@ homepage = "https://github.com/hyperium/tonic"
 repository = "https://github.com/hyperium/tonic"
 license = "MIT"
 rust-version = { workspace = true }
-publish = false
+publish = true
 
 [lints]
 workspace = true

--- a/xds-client/Cargo.toml
+++ b/xds-client/Cargo.toml
@@ -61,4 +61,7 @@ required-features = ["tonic-tls-ring"]
 allowed_external_types = [
     # major released
     "bytes::*",
+    # Re-exported in the public API behind the transport-tonic / codegen-prost features.
+    "tonic::*",
+    "prost::*",
 ]

--- a/xds-client/src/transport/tonic.rs
+++ b/xds-client/src/transport/tonic.rs
@@ -160,7 +160,7 @@ impl TonicTransport {
 ///
 /// # TLS
 ///
-/// Enable the `tls-ring` or `tls-aws-lc` feature and call [`with_tls_config`](Self::with_tls_config):
+/// Enable the `tls-ring` or `tls-aws-lc` feature and call `with_tls_config`:
 ///
 /// ```ignore
 /// use tonic::transport::ClientTlsConfig;


### PR DESCRIPTION
## Motivation

Currently `tonic-xds`, `xds-client`, and `xds-client-opentelemetry` are all marked as `publish = false`, blocking manual publication.

## Solution

Flipped all to `publish = true`. Also added `release = false` to the `release-plz` config so no automated release for now.


