### PR TITLE
feat(xds): expose CertificateProvider for custom certificate sources

### DIFF
--- a/tonic-xds/Cargo.toml
+++ b/tonic-xds/Cargo.toml
@@ -110,6 +110,9 @@ allowed_external_types = [
     "http::*",
     "http_body::*",
 
+    # Public `CertificateData` surfaces CA roots as a rustls `RootCertStore`.
+    "rustls::*",
+
     # not major released
     "prost::*",
     "opentelemetry::*",

--- a/tonic-xds/Cargo.toml
+++ b/tonic-xds/Cargo.toml
@@ -110,9 +110,6 @@ allowed_external_types = [
     "http::*",
     "http_body::*",
 
-    # Public `CertificateData` surfaces CA roots as a rustls `RootCertStore`.
-    "rustls::*",
-
     # not major released
     "prost::*",
     "opentelemetry::*",

--- a/tonic-xds/src/client/channel.rs
+++ b/tonic-xds/src/client/channel.rs
@@ -274,14 +274,10 @@ impl XdsChannelBuilder {
         }
 
         #[cfg(feature = "_tls-any")]
-        let cert_provider_registry = Arc::new(if self.cert_providers.is_empty() {
-            CertProviderRegistry::from_bootstrap(&bootstrap.certificate_providers)?
-        } else {
-            CertProviderRegistry::from_bootstrap_with_providers(
-                &bootstrap.certificate_providers,
-                self.cert_providers.clone(),
-            )?
-        });
+        let cert_provider_registry = Arc::new(CertProviderRegistry::from_bootstrap(
+            &bootstrap.certificate_providers,
+            self.cert_providers.clone(),
+        )?);
 
         let node = Node::try_from(bootstrap.node)?;
         let client_config =
@@ -715,8 +711,10 @@ mod tests {
             dyn ClusterDiscovery<EndpointAddress, EndpointChannel<Channel>>,
         > = {
             use crate::xds::cert_provider::CertProviderRegistry;
-            let registry =
-                Arc::new(CertProviderRegistry::from_bootstrap(&Default::default()).unwrap());
+            let registry = Arc::new(
+                CertProviderRegistry::from_bootstrap(&Default::default(), Default::default())
+                    .unwrap(),
+            );
             Arc::new(XdsClusterDiscovery::new(cache, registry))
         };
         #[cfg(not(feature = "_tls-any"))]
@@ -848,8 +846,10 @@ mod tests {
         #[cfg(feature = "_tls-any")]
         let _channel = {
             use crate::xds::cert_provider::CertProviderRegistry;
-            let registry =
-                Arc::new(CertProviderRegistry::from_bootstrap(&Default::default()).unwrap());
+            let registry = Arc::new(
+                CertProviderRegistry::from_bootstrap(&Default::default(), Default::default())
+                    .unwrap(),
+            );
             builder.build_from_cache(cache, registry, xds_client, resource_manager)
         };
         #[cfg(not(feature = "_tls-any"))]

--- a/tonic-xds/src/client/channel.rs
+++ b/tonic-xds/src/client/channel.rs
@@ -176,16 +176,20 @@ pub struct XdsChannelBuilder {
 
 impl Debug for XdsChannelBuilder {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("XdsChannelBuilder")
-            .field("config", &self.config)
-            .field(
-                "recorder",
-                &self
-                    .recorder
-                    .as_deref()
-                    .map_or("None", |r| std::any::type_name_of_val(r)),
-            )
-            .finish()
+        let mut s = f.debug_struct("XdsChannelBuilder");
+        s.field("config", &self.config).field(
+            "recorder",
+            &self
+                .recorder
+                .as_deref()
+                .map_or("None", |r| std::any::type_name_of_val(r)),
+        );
+        #[cfg(feature = "_tls-any")]
+        s.field(
+            "cert_providers",
+            &self.cert_providers.keys().collect::<Vec<_>>(),
+        );
+        s.finish()
     }
 }
 

--- a/tonic-xds/src/client/channel.rs
+++ b/tonic-xds/src/client/channel.rs
@@ -5,12 +5,14 @@ use crate::client::route::{Router, XdsRoutingLayer};
 use crate::xds::bootstrap::{BootstrapConfig, BootstrapError};
 use crate::xds::cache::XdsCache;
 #[cfg(feature = "_tls-any")]
-use crate::xds::cert_provider::{CertProviderError, CertProviderRegistry};
+use crate::xds::cert_provider::{CertProviderError, CertProviderRegistry, CertificateProvider};
 use crate::xds::cluster_discovery::XdsClusterDiscovery;
 use crate::xds::resource_manager::XdsResourceManager;
 use crate::xds::routing::XdsRouter;
 use crate::{TonicCallCredentials, XdsUri};
 use http::Request;
+#[cfg(feature = "_tls-any")]
+use std::collections::HashMap;
 use std::fmt::Debug;
 use std::sync::Arc;
 use std::task::{Context, Poll};
@@ -168,6 +170,8 @@ const _: fn() = || {
 pub struct XdsChannelBuilder {
     config: Arc<XdsChannelConfig>,
     recorder: Option<Arc<dyn MetricsRecorder>>,
+    #[cfg(feature = "_tls-any")]
+    cert_providers: HashMap<String, Arc<dyn CertificateProvider>>,
 }
 
 impl Debug for XdsChannelBuilder {
@@ -192,6 +196,8 @@ impl XdsChannelBuilder {
         Self {
             config: Arc::new(config),
             recorder: None,
+            #[cfg(feature = "_tls-any")]
+            cert_providers: HashMap::new(),
         }
     }
 
@@ -204,6 +210,22 @@ impl XdsChannelBuilder {
     #[must_use]
     pub fn with_metrics_recorder(mut self, recorder: Arc<dyn MetricsRecorder>) -> Self {
         self.recorder = Some(recorder);
+        self
+    }
+
+    /// Registers a custom [`CertificateProvider`] under an xDS certificate
+    /// provider instance name, resolved by CDS `UpstreamTlsContext` references.
+    /// Shadows a bootstrap `file_watcher` instance of the same name.
+    ///
+    /// [`CertificateProvider`]: crate::CertificateProvider
+    #[cfg(feature = "_tls-any")]
+    #[must_use]
+    pub fn with_certificate_provider(
+        mut self,
+        instance_name: impl Into<String>,
+        provider: Arc<dyn CertificateProvider>,
+    ) -> Self {
+        self.cert_providers.insert(instance_name.into(), provider);
         self
     }
 
@@ -252,9 +274,14 @@ impl XdsChannelBuilder {
         }
 
         #[cfg(feature = "_tls-any")]
-        let cert_provider_registry = Arc::new(CertProviderRegistry::from_bootstrap(
-            &bootstrap.certificate_providers,
-        )?);
+        let cert_provider_registry = Arc::new(if self.cert_providers.is_empty() {
+            CertProviderRegistry::from_bootstrap(&bootstrap.certificate_providers)?
+        } else {
+            CertProviderRegistry::from_bootstrap_with_providers(
+                &bootstrap.certificate_providers,
+                self.cert_providers.clone(),
+            )?
+        });
 
         let node = Node::try_from(bootstrap.node)?;
         let client_config =

--- a/tonic-xds/src/lib.rs
+++ b/tonic-xds/src/lib.rs
@@ -151,6 +151,9 @@ pub use xds::bootstrap::{BootstrapConfig, BootstrapError};
 pub use xds::uri::{XdsUri, XdsUriError};
 pub use xds_client::TonicCallCredentials;
 
+#[cfg(feature = "_tls-any")]
+pub use xds::cert_provider::{CertProviderError, CertificateData, CertificateProvider, Identity};
+
 pub use xds_client::{Instrument, InstrumentKind, KeyValue, MetricsRecorder, StringValue, Value};
 
 #[cfg(any(test, feature = "testutil"))]

--- a/tonic-xds/src/xds/cert_provider/file_watcher.rs
+++ b/tonic-xds/src/xds/cert_provider/file_watcher.rs
@@ -22,8 +22,6 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use arc_swap::ArcSwap;
-use rustls::RootCertStore;
-use rustls::pki_types::CertificateDer;
 use serde::Deserialize;
 
 use crate::common::async_util::AbortOnDrop;
@@ -135,13 +133,9 @@ impl CertificateProvider for FileWatcherProvider {
 
 /// Read certificate data from the files specified in the config.
 ///
-/// CA roots are parsed into [`Arc<RootCertStore>`] in this function — once per
-/// refresh — so the verifier can use them directly on every TLS handshake
-/// without re-parsing. Identity bytes are kept as PEM because
-/// [`tonic::transport::Identity::from_pem`] is bytes-only on the consumer side.
-///
-/// This function is the single validation boundary between the permissive
-/// JSON-parsed [`FileWatcherConfig`] and the invariant-enforcing
+/// CA roots and identity material are read as raw PEM bytes; parsing is left to
+/// the consumer. This function is the single validation boundary between the
+/// permissive JSON-parsed [`FileWatcherConfig`] and the invariant-enforcing
 /// [`CertificateData`]. It checks both A65 rules:
 /// - cert/key pairing (first match)
 /// - at least one of identity/roots is set (second match)
@@ -149,14 +143,13 @@ fn read_certificate_data(config: &FileWatcherConfig) -> Result<CertificateData, 
     let roots = config
         .ca_certificate_file
         .as_deref()
-        .map(read_and_parse_roots)
+        .map(read_file)
         .transpose()?;
 
     let identity = match (&config.certificate_file, &config.private_key_file) {
-        (Some(cert_path), Some(key_path)) => Some(Identity {
-            cert_chain: read_file(cert_path)?,
-            key: read_file(key_path)?,
-        }),
+        (Some(cert_path), Some(key_path)) => {
+            Some(Identity::new(read_file(cert_path)?, read_file(key_path)?))
+        }
         (None, None) => None,
         (Some(_), None) | (None, Some(_)) => return Err(CertProviderError::UnpairedCertKey),
     };
@@ -174,26 +167,6 @@ fn read_file(path: &Path) -> Result<Vec<u8>, CertProviderError> {
         path: path.display().to_string(),
         source: e,
     })
-}
-
-fn read_and_parse_roots(path: &Path) -> Result<Arc<RootCertStore>, CertProviderError> {
-    let pem = read_file(path)?;
-    let mut reader = std::io::Cursor::new(&pem);
-    let certs: Vec<CertificateDer<'static>> = rustls_pemfile::certs(&mut reader)
-        .collect::<Result<_, _>>()
-        .map_err(|e| CertProviderError::PemParse {
-            path: path.display().to_string(),
-            reason: e.to_string(),
-        })?;
-    let mut store = RootCertStore::empty();
-    let (added, _) = store.add_parsable_certificates(certs);
-    if added == 0 {
-        return Err(CertProviderError::PemParse {
-            path: path.display().to_string(),
-            reason: "no usable certificates in PEM".into(),
-        });
-    }
-    Ok(Arc::new(store))
 }
 
 #[cfg(test)]
@@ -229,15 +202,15 @@ mod tests {
 
     #[tokio::test]
     async fn reads_ca_certificate() {
-        let ca_file = write_temp_file(&gen_ca_pem());
+        let ca_pem = gen_ca_pem();
+        let ca_file = write_temp_file(&ca_pem);
 
         let provider =
             FileWatcherProvider::new(make_config(ca_file.path().to_str(), None, None)).unwrap();
         let data = provider.fetch().unwrap();
 
         assert!(matches!(*data, CertificateData::RootsOnly { .. }));
-        let roots = data.roots().unwrap();
-        assert_eq!(roots.len(), 1);
+        assert_eq!(data.roots().unwrap(), ca_pem.as_slice());
         assert!(data.identity().is_none());
     }
 
@@ -256,14 +229,15 @@ mod tests {
 
         assert!(matches!(*data, CertificateData::IdentityOnly { .. }));
         let identity = data.identity().unwrap();
-        assert_eq!(identity.cert_chain.as_slice(), b"cert-chain-pem");
-        assert_eq!(identity.key.as_slice(), b"private-key-pem");
+        assert_eq!(identity.cert_chain(), b"cert-chain-pem");
+        assert_eq!(identity.key(), b"private-key-pem");
         assert!(data.roots().is_none());
     }
 
     #[tokio::test]
     async fn reads_all_files() {
-        let ca_file = write_temp_file(&gen_ca_pem());
+        let ca_pem = gen_ca_pem();
+        let ca_file = write_temp_file(&ca_pem);
         let cert_file = write_temp_file(b"cert-pem");
         let key_file = write_temp_file(b"key-pem");
 
@@ -276,10 +250,10 @@ mod tests {
         let data = provider.fetch().unwrap();
 
         assert!(matches!(*data, CertificateData::Both { .. }));
-        assert_eq!(data.roots().unwrap().len(), 1);
+        assert_eq!(data.roots().unwrap(), ca_pem.as_slice());
         let identity = data.identity().unwrap();
-        assert_eq!(identity.cert_chain.as_slice(), b"cert-pem");
-        assert_eq!(identity.key.as_slice(), b"key-pem");
+        assert_eq!(identity.cert_chain(), b"cert-pem");
+        assert_eq!(identity.key(), b"key-pem");
     }
 
     #[test]
@@ -417,7 +391,8 @@ mod tests {
         use crate::xds::cert_provider::CertProviderRegistry;
         use std::collections::HashMap;
 
-        let ca_file = write_temp_file(&gen_ca_pem());
+        let ca_pem = gen_ca_pem();
+        let ca_file = write_temp_file(&ca_pem);
 
         let mut configs = HashMap::new();
         configs.insert(
@@ -430,12 +405,12 @@ mod tests {
             },
         );
 
-        let registry = CertProviderRegistry::from_bootstrap(&configs).unwrap();
+        let registry = CertProviderRegistry::from_bootstrap(&configs, HashMap::new()).unwrap();
         assert!(registry.get("my_certs").is_some());
         assert!(registry.get("other").is_none());
 
         let provider = registry.get("my_certs").unwrap();
         let data = provider.fetch().unwrap();
-        assert_eq!(data.roots().unwrap().len(), 1);
+        assert_eq!(data.roots().unwrap(), ca_pem.as_slice());
     }
 }

--- a/tonic-xds/src/xds/cert_provider/mod.rs
+++ b/tonic-xds/src/xds/cert_provider/mod.rs
@@ -21,9 +21,11 @@ use crate::xds::bootstrap::CertProviderPluginConfig;
 
 /// PEM-encoded identity (a cert chain paired with its private key).
 #[derive(Debug, Clone)]
-pub(crate) struct Identity {
-    pub(crate) cert_chain: Vec<u8>,
-    pub(crate) key: Vec<u8>,
+pub struct Identity {
+    /// PEM-encoded certificate chain.
+    pub cert_chain: Vec<u8>,
+    /// PEM-encoded private key.
+    pub key: Vec<u8>,
 }
 
 /// Certificate material returned by a [`CertificateProvider`] plugin.
@@ -47,17 +49,25 @@ pub(crate) struct Identity {
 ///   ("in the file-watcher certificate provider, at least one of the
 ///   `certificate_file` or `ca_certificate_file` fields must be specified")
 #[derive(Debug, Clone)]
-pub(crate) enum CertificateData {
+pub enum CertificateData {
     /// CA trust bundle only — used by TLS clients that don't present an
     /// identity.
-    RootsOnly { roots: Arc<RootCertStore> },
+    RootsOnly {
+        /// CA trust anchors.
+        roots: Arc<RootCertStore>,
+    },
     /// Identity only — used by TLS servers that don't validate peers
     /// (non-mTLS). Peer validation falls back to system roots at the
     /// consumer layer if needed.
-    IdentityOnly { identity: Identity },
+    IdentityOnly {
+        /// Local certificate chain and private key.
+        identity: Identity,
+    },
     /// Both roots and identity — used for mTLS on either end.
     Both {
+        /// CA trust anchors.
         roots: Arc<RootCertStore>,
+        /// Local certificate chain and private key.
         identity: Identity,
     },
 }
@@ -83,30 +93,48 @@ impl CertificateData {
 /// Errors from certificate provider operations.
 #[derive(Debug, thiserror::Error)]
 pub enum CertProviderError {
+    /// A certificate file could not be read.
     #[error("failed to read certificate file '{path}': {source}")]
     FileRead {
+        /// Path that failed to read.
         path: String,
+        /// Underlying I/O error.
         source: std::io::Error,
     },
+    /// A certificate file was not valid PEM.
     #[error("failed to parse PEM in '{path}': {reason}")]
-    PemParse { path: String, reason: String },
+    PemParse {
+        /// Path that failed to parse.
+        path: String,
+        /// Parse failure reason.
+        reason: String,
+    },
+    /// The bootstrap named a plugin that is not built in.
     #[error("unknown certificate provider plugin: {0}")]
     UnknownPlugin(String),
+    /// A plugin's bootstrap config failed to deserialize.
     #[error("invalid config for plugin '{plugin}': {source}")]
     InvalidPluginConfig {
+        /// Plugin name.
         plugin: String,
+        /// Underlying deserialization error.
         source: serde_json::Error,
     },
+    /// `certificate_file` and `private_key_file` must both be set or unset.
     #[error(
         "invalid file_watcher config: 'certificate_file' and 'private_key_file' must both be \
          set or both be unset"
     )]
     UnpairedCertKey,
+    /// Neither an identity nor a CA bundle was configured.
     #[error(
         "invalid file_watcher config: at least one of 'certificate_file' or \
          'ca_certificate_file' must be specified"
     )]
     EmptyConfig,
+    /// Catch-all for errors raised by out-of-crate provider implementations.
+    #[error("certificate provider error: {0}")]
+    Other(Box<dyn std::error::Error + Send + Sync + 'static>),
 }
 
 /// A certificate provider plugin.
@@ -114,7 +142,7 @@ pub enum CertProviderError {
 /// Implementations obtain certificates from some source (local files, remote CA,
 /// etc.) and deliver them to consumers. Providers cache their last successful
 /// result and may refresh periodically.
-pub(crate) trait CertificateProvider: Send + Sync {
+pub trait CertificateProvider: Send + Sync {
     /// Fetch the current certificate data.
     ///
     /// Returns the most recently cached certificate material. This is called
@@ -149,13 +177,29 @@ impl CertProviderRegistry {
     pub(crate) fn from_bootstrap(
         configs: &HashMap<String, CertProviderPluginConfig>,
     ) -> Result<Self, CertProviderError> {
+        Self::from_bootstrap_with_providers(configs, HashMap::new())
+    }
+
+    /// Like [`from_bootstrap`](Self::from_bootstrap), but merges in externally
+    /// supplied provider instances that shadow bootstrap instances of the same
+    /// name.
+    pub(crate) fn from_bootstrap_with_providers(
+        configs: &HashMap<String, CertProviderPluginConfig>,
+        injected: HashMap<String, Arc<dyn CertificateProvider>>,
+    ) -> Result<Self, CertProviderError> {
         let mut providers: HashMap<String, Arc<dyn CertificateProvider>> =
-            HashMap::with_capacity(configs.len());
+            HashMap::with_capacity(configs.len() + injected.len());
 
         for (instance_name, entry) in configs {
+            // Injected providers shadow bootstrap instances of the same name.
+            if injected.contains_key(instance_name) {
+                continue;
+            }
             let provider = Self::create_provider(entry)?;
             providers.insert(instance_name.clone(), provider);
         }
+
+        providers.extend(injected);
 
         Ok(Self { providers })
     }
@@ -215,5 +259,66 @@ mod tests {
     fn get_returns_none_for_missing_instance() {
         let registry = CertProviderRegistry::from_bootstrap(&HashMap::new()).unwrap();
         assert!(registry.get("nonexistent").is_none());
+    }
+
+    struct StaticProvider(Arc<CertificateData>);
+
+    impl CertificateProvider for StaticProvider {
+        fn fetch(&self) -> Result<Arc<CertificateData>, CertProviderError> {
+            Ok(self.0.clone())
+        }
+    }
+
+    #[test]
+    fn injected_provider_is_resolvable_by_instance_name() {
+        let provider: Arc<dyn CertificateProvider> =
+            Arc::new(StaticProvider(Arc::new(CertificateData::RootsOnly {
+                roots: Arc::new(RootCertStore::empty()),
+            })));
+        let mut injected: HashMap<String, Arc<dyn CertificateProvider>> = HashMap::new();
+        injected.insert("dv".to_string(), provider);
+
+        let registry =
+            CertProviderRegistry::from_bootstrap_with_providers(&HashMap::new(), injected).unwrap();
+
+        assert!(registry.get("dv").is_some());
+        assert!(registry.get("missing").is_none());
+    }
+
+    #[test]
+    fn injected_provider_overrides_bootstrap_instance_of_same_name() {
+        // The bootstrap "shared" instance points at a missing file, so it would
+        // fail to build; the injected "shared" must shadow it entirely.
+        let mut configs = HashMap::new();
+        configs.insert(
+            "shared".to_string(),
+            CertProviderPluginConfig {
+                plugin_name: file_watcher::PLUGIN_NAME.to_string(),
+                config: serde_json::json!({
+                    "ca_certificate_file": "/nonexistent/ca.pem",
+                }),
+            },
+        );
+
+        let injected_data = Arc::new(CertificateData::IdentityOnly {
+            identity: Identity {
+                cert_chain: b"injected-cert".to_vec(),
+                key: b"injected-key".to_vec(),
+            },
+        });
+        let mut injected: HashMap<String, Arc<dyn CertificateProvider>> = HashMap::new();
+        injected.insert(
+            "shared".to_string(),
+            Arc::new(StaticProvider(injected_data)),
+        );
+
+        let registry =
+            CertProviderRegistry::from_bootstrap_with_providers(&configs, injected).unwrap();
+
+        let data = registry.get("shared").unwrap().fetch().unwrap();
+        assert!(
+            matches!(*data, CertificateData::IdentityOnly { .. }),
+            "expected the injected provider to win over the bootstrap instance",
+        );
     }
 }

--- a/tonic-xds/src/xds/cert_provider/mod.rs
+++ b/tonic-xds/src/xds/cert_provider/mod.rs
@@ -161,7 +161,7 @@ pub enum CertProviderError {
     EmptyConfig,
     /// Catch-all for errors raised by out-of-crate provider implementations.
     #[error("certificate provider error: {0}")]
-    Other(Box<dyn std::error::Error + Send + Sync + 'static>),
+    Other(#[source] Box<dyn std::error::Error + Send + Sync + 'static>),
 }
 
 /// A certificate provider plugin.

--- a/tonic-xds/src/xds/cert_provider/mod.rs
+++ b/tonic-xds/src/xds/cert_provider/mod.rs
@@ -14,26 +14,52 @@ pub(crate) mod verifier;
 use std::collections::HashMap;
 use std::sync::Arc;
 
-use rustls::RootCertStore;
 use serde::Deserialize;
 
 use crate::xds::bootstrap::CertProviderPluginConfig;
 
 /// PEM-encoded identity (a cert chain paired with its private key).
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct Identity {
+    cert_chain: Vec<u8>,
+    key: Vec<u8>,
+}
+
+impl Identity {
+    /// Creates an identity from a PEM certificate chain and PEM private key.
+    pub fn new(cert_chain: Vec<u8>, key: Vec<u8>) -> Self {
+        Self { cert_chain, key }
+    }
+
     /// PEM-encoded certificate chain.
-    pub cert_chain: Vec<u8>,
+    pub fn cert_chain(&self) -> &[u8] {
+        &self.cert_chain
+    }
+
     /// PEM-encoded private key.
-    pub key: Vec<u8>,
+    pub fn key(&self) -> &[u8] {
+        &self.key
+    }
+}
+
+// Manual `Debug` keeps the private key out of logs.
+impl std::fmt::Debug for Identity {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Identity")
+            .field(
+                "cert_chain",
+                &format_args!("{} bytes", self.cert_chain.len()),
+            )
+            .field("key", &format_args!("<redacted>"))
+            .finish()
+    }
 }
 
 /// Certificate material returned by a [`CertificateProvider`] plugin.
 ///
-/// CA roots are pre-parsed into an [`Arc<RootCertStore>`] so consumers reach
-/// for it on every TLS handshake without paying parse cost. Identity material
-/// stays as PEM bytes since [`tonic::transport::Identity::from_pem`] is
-/// itself bytes-only.
+/// Both the CA trust bundle and the identity are carried as PEM bytes; the
+/// consumer parses them (e.g. into a rustls `RootCertStore`) at the point of
+/// use.
 ///
 /// The variants encode two invariants from gRFC A29 and A65 at the type level:
 ///
@@ -53,8 +79,8 @@ pub enum CertificateData {
     /// CA trust bundle only — used by TLS clients that don't present an
     /// identity.
     RootsOnly {
-        /// CA trust anchors.
-        roots: Arc<RootCertStore>,
+        /// PEM-encoded CA trust anchors.
+        roots: Vec<u8>,
     },
     /// Identity only — used by TLS servers that don't validate peers
     /// (non-mTLS). Peer validation falls back to system roots at the
@@ -65,18 +91,18 @@ pub enum CertificateData {
     },
     /// Both roots and identity — used for mTLS on either end.
     Both {
-        /// CA trust anchors.
-        roots: Arc<RootCertStore>,
+        /// PEM-encoded CA trust anchors.
+        roots: Vec<u8>,
         /// Local certificate chain and private key.
         identity: Identity,
     },
 }
 
 impl CertificateData {
-    /// Parsed CA trust bundle, if present.
-    pub(crate) fn roots(&self) -> Option<&Arc<RootCertStore>> {
+    /// PEM-encoded CA trust bundle, if present.
+    pub(crate) fn roots(&self) -> Option<&[u8]> {
         match self {
-            Self::RootsOnly { roots } | Self::Both { roots, .. } => Some(roots),
+            Self::RootsOnly { roots } | Self::Both { roots, .. } => Some(roots.as_slice()),
             Self::IdentityOnly { .. } => None,
         }
     }
@@ -92,6 +118,7 @@ impl CertificateData {
 
 /// Errors from certificate provider operations.
 #[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
 pub enum CertProviderError {
     /// A certificate file could not be read.
     #[error("failed to read certificate file '{path}': {source}")]
@@ -169,21 +196,10 @@ impl std::fmt::Debug for CertProviderRegistry {
 }
 
 impl CertProviderRegistry {
-    /// Build a registry from the bootstrap `certificate_providers` map.
-    ///
-    /// Dispatches on `plugin_name` and deserializes the opaque `config`
-    /// into the appropriate plugin-specific type. Unknown plugin names
-    /// are rejected here.
+    /// Builds a registry from the bootstrap `certificate_providers` map,
+    /// dispatching on `plugin_name`, and merges in externally supplied provider
+    /// instances that shadow bootstrap instances of the same name.
     pub(crate) fn from_bootstrap(
-        configs: &HashMap<String, CertProviderPluginConfig>,
-    ) -> Result<Self, CertProviderError> {
-        Self::from_bootstrap_with_providers(configs, HashMap::new())
-    }
-
-    /// Like [`from_bootstrap`](Self::from_bootstrap), but merges in externally
-    /// supplied provider instances that shadow bootstrap instances of the same
-    /// name.
-    pub(crate) fn from_bootstrap_with_providers(
         configs: &HashMap<String, CertProviderPluginConfig>,
         injected: HashMap<String, Arc<dyn CertificateProvider>>,
     ) -> Result<Self, CertProviderError> {
@@ -234,7 +250,7 @@ mod tests {
     #[test]
     fn empty_bootstrap_creates_empty_registry() {
         let configs = HashMap::new();
-        let registry = CertProviderRegistry::from_bootstrap(&configs).unwrap();
+        let registry = CertProviderRegistry::from_bootstrap(&configs, HashMap::new()).unwrap();
         assert!(registry.get("anything").is_none());
     }
 
@@ -250,14 +266,16 @@ mod tests {
             }
         }"#;
         let config = crate::xds::bootstrap::BootstrapConfig::from_json(json).unwrap();
-        let err = CertProviderRegistry::from_bootstrap(&config.certificate_providers);
+        let err =
+            CertProviderRegistry::from_bootstrap(&config.certificate_providers, HashMap::new());
         assert!(err.is_err());
         assert!(err.unwrap_err().to_string().contains("unknown_plugin"));
     }
 
     #[test]
     fn get_returns_none_for_missing_instance() {
-        let registry = CertProviderRegistry::from_bootstrap(&HashMap::new()).unwrap();
+        let registry =
+            CertProviderRegistry::from_bootstrap(&HashMap::new(), HashMap::new()).unwrap();
         assert!(registry.get("nonexistent").is_none());
     }
 
@@ -273,13 +291,12 @@ mod tests {
     fn injected_provider_is_resolvable_by_instance_name() {
         let provider: Arc<dyn CertificateProvider> =
             Arc::new(StaticProvider(Arc::new(CertificateData::RootsOnly {
-                roots: Arc::new(RootCertStore::empty()),
+                roots: Vec::new(),
             })));
         let mut injected: HashMap<String, Arc<dyn CertificateProvider>> = HashMap::new();
         injected.insert("dv".to_string(), provider);
 
-        let registry =
-            CertProviderRegistry::from_bootstrap_with_providers(&HashMap::new(), injected).unwrap();
+        let registry = CertProviderRegistry::from_bootstrap(&HashMap::new(), injected).unwrap();
 
         assert!(registry.get("dv").is_some());
         assert!(registry.get("missing").is_none());
@@ -301,10 +318,7 @@ mod tests {
         );
 
         let injected_data = Arc::new(CertificateData::IdentityOnly {
-            identity: Identity {
-                cert_chain: b"injected-cert".to_vec(),
-                key: b"injected-key".to_vec(),
-            },
+            identity: Identity::new(b"injected-cert".to_vec(), b"injected-key".to_vec()),
         });
         let mut injected: HashMap<String, Arc<dyn CertificateProvider>> = HashMap::new();
         injected.insert(
@@ -312,8 +326,7 @@ mod tests {
             Arc::new(StaticProvider(injected_data)),
         );
 
-        let registry =
-            CertProviderRegistry::from_bootstrap_with_providers(&configs, injected).unwrap();
+        let registry = CertProviderRegistry::from_bootstrap(&configs, injected).unwrap();
 
         let data = registry.get("shared").unwrap().fetch().unwrap();
         assert!(

--- a/tonic-xds/src/xds/cert_provider/verifier.rs
+++ b/tonic-xds/src/xds/cert_provider/verifier.rs
@@ -12,6 +12,8 @@
 use std::net::IpAddr;
 use std::sync::Arc;
 
+use arc_swap::ArcSwapOption;
+
 use rustls::client::danger::{HandshakeSignatureValid, ServerCertVerified, ServerCertVerifier};
 use rustls::client::verify_server_cert_signed_by_trust_anchor;
 use rustls::crypto::{WebPkiSupportedAlgorithms, verify_tls12_signature, verify_tls13_signature};
@@ -24,8 +26,16 @@ use x509_parser::extensions::{GeneralName, ParsedExtension};
 use x509_parser::oid_registry::OID_X509_EXT_SUBJECT_ALT_NAME;
 use x509_parser::prelude::FromDer;
 
-use crate::xds::cert_provider::CertificateProvider;
+use crate::xds::cert_provider::{CertificateData, CertificateProvider};
 use crate::xds::resource::san_matcher::{SanEntry, SanMatcher};
+
+/// Parsed CA roots cached against the [`CertificateData`] they were parsed
+/// from. A provider returns the same `Arc` until it rotates, so an
+/// `Arc::ptr_eq` check lets us skip re-parsing the PEM on every handshake.
+struct CachedRoots {
+    data: Arc<CertificateData>,
+    store: Arc<RootCertStore>,
+}
 
 /// Verifier that chain-validates the peer cert and enforces gRFC A29 SAN
 /// matching. Sources CA roots from a [`CertificateProvider`] per handshake
@@ -34,6 +44,7 @@ pub(crate) struct XdsServerCertVerifier {
     ca_provider: Arc<dyn CertificateProvider>,
     supported_algs: WebPkiSupportedAlgorithms,
     san_matchers: Vec<SanMatcher>,
+    roots_cache: ArcSwapOption<CachedRoots>,
 }
 
 impl std::fmt::Debug for XdsServerCertVerifier {
@@ -54,7 +65,32 @@ impl XdsServerCertVerifier {
             ca_provider,
             supported_algs: provider.signature_verification_algorithms,
             san_matchers,
+            roots_cache: ArcSwapOption::empty(),
         }
+    }
+
+    /// Return the parsed CA [`RootCertStore`] for `data`, reusing the cached
+    /// parse unless the provider has rotated to a new `Arc`.
+    fn root_store(&self, data: &Arc<CertificateData>) -> Result<Arc<RootCertStore>, RustlsError> {
+        let cached = self.roots_cache.load();
+        if let Some(cached) = cached.as_ref() {
+            if Arc::ptr_eq(&cached.data, data) {
+                return Ok(Arc::clone(&cached.store));
+            }
+        }
+
+        let roots_pem = data
+            .roots()
+            .ok_or_else(|| RustlsError::General("CA provider has no roots".into()))?;
+        let store = Arc::new(
+            parse_root_store(roots_pem)
+                .map_err(|e| RustlsError::General(format!("failed to parse CA roots: {e}")))?,
+        );
+        self.roots_cache.store(Some(Arc::new(CachedRoots {
+            data: Arc::clone(data),
+            store: Arc::clone(&store),
+        })));
+        Ok(store)
     }
 }
 
@@ -87,11 +123,7 @@ impl ServerCertVerifier for XdsServerCertVerifier {
             .ca_provider
             .fetch()
             .map_err(|e| RustlsError::General(format!("CA provider fetch failed: {e}")))?;
-        let roots_pem = data
-            .roots()
-            .ok_or_else(|| RustlsError::General("CA provider has no roots".into()))?;
-        let roots = parse_root_store(roots_pem)
-            .map_err(|e| RustlsError::General(format!("failed to parse CA roots: {e}")))?;
+        let roots = self.root_store(&data)?;
 
         let cert = ParsedCertificate::try_from(end_entity)?;
         verify_server_cert_signed_by_trust_anchor(
@@ -420,6 +452,55 @@ mod tests {
         assert!(
             matches!(err, RustlsError::General(ref msg) if msg.contains("no roots")),
             "expected General(\"...no roots...\"), got {err:?}",
+        );
+    }
+
+    /// Test shim whose snapshot can be swapped at runtime, to exercise the
+    /// verifier's root-store cache across a provider rotation.
+    struct SwappableProvider(arc_swap::ArcSwap<CertificateData>);
+
+    impl CertificateProvider for SwappableProvider {
+        fn fetch(&self) -> Result<Arc<CertificateData>, CertProviderError> {
+            Ok(self.0.load_full())
+        }
+    }
+
+    #[test]
+    fn cached_roots_reused_then_invalidated_on_rotation() {
+        // `leaf_der` is signed by CA1; CA2 is an unrelated root.
+        let (ca1_pem, leaf_der) = build_chain_with_spiffe_leaf("spiffe://td/ns/prod/sa/api");
+        let (ca2_pem, _) = build_chain_with_spiffe_leaf("spiffe://td/ns/prod/sa/api");
+
+        let provider = Arc::new(SwappableProvider(arc_swap::ArcSwap::from_pointee(
+            CertificateData::RootsOnly { roots: ca1_pem },
+        )));
+        let verifier = XdsServerCertVerifier::new(
+            provider.clone(),
+            vec![uri_matcher("spiffe://td/ns/prod/sa/api")],
+        );
+        let server_name = ServerName::try_from("any.connect.hostname").unwrap();
+
+        // First call parses and caches CA1; the second hits the cache (same
+        // `Arc`). Both pass.
+        for _ in 0..2 {
+            assert!(
+                verifier
+                    .verify_server_cert(&leaf_der, &[], &server_name, &[], UnixTime::now())
+                    .is_ok()
+            );
+        }
+
+        // Rotate to an unrelated CA (a new `Arc`): the cache must invalidate and
+        // re-parse, so the leaf no longer chains to a trusted root.
+        provider
+            .0
+            .store(Arc::new(CertificateData::RootsOnly { roots: ca2_pem }));
+        let err = verifier
+            .verify_server_cert(&leaf_der, &[], &server_name, &[], UnixTime::now())
+            .unwrap_err();
+        assert!(
+            matches!(err, RustlsError::InvalidCertificate(_)),
+            "expected chain validation failure after rotation, got {err:?}",
         );
     }
 }

--- a/tonic-xds/src/xds/cert_provider/verifier.rs
+++ b/tonic-xds/src/xds/cert_provider/verifier.rs
@@ -17,7 +17,9 @@ use rustls::client::verify_server_cert_signed_by_trust_anchor;
 use rustls::crypto::{WebPkiSupportedAlgorithms, verify_tls12_signature, verify_tls13_signature};
 use rustls::pki_types::{CertificateDer, ServerName, UnixTime};
 use rustls::server::ParsedCertificate;
-use rustls::{CertificateError, DigitallySignedStruct, Error as RustlsError, SignatureScheme};
+use rustls::{
+    CertificateError, DigitallySignedStruct, Error as RustlsError, RootCertStore, SignatureScheme,
+};
 use x509_parser::extensions::{GeneralName, ParsedExtension};
 use x509_parser::oid_registry::OID_X509_EXT_SUBJECT_ALT_NAME;
 use x509_parser::prelude::FromDer;
@@ -85,14 +87,16 @@ impl ServerCertVerifier for XdsServerCertVerifier {
             .ca_provider
             .fetch()
             .map_err(|e| RustlsError::General(format!("CA provider fetch failed: {e}")))?;
-        let roots = data
+        let roots_pem = data
             .roots()
             .ok_or_else(|| RustlsError::General("CA provider has no roots".into()))?;
+        let roots = parse_root_store(roots_pem)
+            .map_err(|e| RustlsError::General(format!("failed to parse CA roots: {e}")))?;
 
         let cert = ParsedCertificate::try_from(end_entity)?;
         verify_server_cert_signed_by_trust_anchor(
             &cert,
-            roots,
+            &roots,
             intermediates,
             now,
             self.supported_algs.all,
@@ -134,6 +138,20 @@ impl ServerCertVerifier for XdsServerCertVerifier {
     fn supported_verify_schemes(&self) -> Vec<SignatureScheme> {
         self.supported_algs.supported_schemes()
     }
+}
+
+/// Parse a PEM CA trust bundle into a rustls [`RootCertStore`].
+fn parse_root_store(pem: &[u8]) -> Result<RootCertStore, String> {
+    let mut reader = std::io::Cursor::new(pem);
+    let certs: Vec<CertificateDer<'static>> = rustls_pemfile::certs(&mut reader)
+        .collect::<Result<_, _>>()
+        .map_err(|e| e.to_string())?;
+    let mut store = RootCertStore::empty();
+    let (added, _) = store.add_parsable_certificates(certs);
+    if added == 0 {
+        return Err("no usable certificates in CA PEM".into());
+    }
+    Ok(store)
 }
 
 /// Extract SAN entries from an X.509 cert's subjectAltName extension.
@@ -196,7 +214,6 @@ mod tests {
     use super::*;
     use crate::xds::cert_provider::{CertProviderError, CertificateData, Identity};
     use rcgen::{CertificateParams, SanType as RcgenSanType};
-    use rustls::RootCertStore;
 
     /// Generate a self-signed DER cert carrying the given SANs.
     fn gen_cert_with_sans(sans: Vec<RcgenSanType>) -> CertificateDer<'static> {
@@ -290,10 +307,8 @@ mod tests {
     }
 
     /// Build a small chain: a self-signed CA and a leaf signed by it that
-    /// carries only a `URI` SAN (SPIFFE-style). Returns `(ca_der, leaf_der)`.
-    fn build_chain_with_spiffe_leaf(
-        spiffe_uri: &str,
-    ) -> (CertificateDer<'static>, CertificateDer<'static>) {
+    /// carries only a `URI` SAN (SPIFFE-style). Returns `(ca_pem, leaf_der)`.
+    fn build_chain_with_spiffe_leaf(spiffe_uri: &str) -> (Vec<u8>, CertificateDer<'static>) {
         use rcgen::{BasicConstraints, IsCa, Issuer, KeyPair, KeyUsagePurpose};
 
         let ca_key = KeyPair::generate().unwrap();
@@ -301,7 +316,7 @@ mod tests {
         ca_params.is_ca = IsCa::Ca(BasicConstraints::Unconstrained);
         ca_params.key_usages = vec![KeyUsagePurpose::KeyCertSign, KeyUsagePurpose::CrlSign];
         let ca_cert = ca_params.self_signed(&ca_key).unwrap();
-        let ca_der = ca_cert.der().clone();
+        let ca_pem = ca_cert.pem().into_bytes();
 
         let leaf_key = KeyPair::generate().unwrap();
         let mut leaf_params = CertificateParams::new(Vec::<String>::new()).unwrap();
@@ -310,13 +325,7 @@ mod tests {
         let leaf_cert = leaf_params.signed_by(&leaf_key, &issuer).unwrap();
         let leaf_der = leaf_cert.der().clone();
 
-        (ca_der, leaf_der)
-    }
-
-    fn root_store_with(ca_der: CertificateDer<'static>) -> RootCertStore {
-        let mut store = RootCertStore::empty();
-        store.add(ca_der).unwrap();
-        store
+        (ca_pem, leaf_der)
     }
 
     /// Test shim: a [`CertificateProvider`] that returns a fixed snapshot.
@@ -328,9 +337,9 @@ mod tests {
         }
     }
 
-    fn provider_with_roots(store: RootCertStore) -> Arc<dyn CertificateProvider> {
+    fn provider_with_roots(roots_pem: Vec<u8>) -> Arc<dyn CertificateProvider> {
         Arc::new(StaticProvider(Arc::new(CertificateData::RootsOnly {
-            roots: Arc::new(store),
+            roots: roots_pem,
         })))
     }
 
@@ -353,9 +362,9 @@ mod tests {
 
     #[test]
     fn spiffe_uri_only_cert_with_matching_uri_matcher_passes() {
-        let (ca_der, leaf_der) = build_chain_with_spiffe_leaf("spiffe://td/ns/prod/sa/api");
+        let (ca_pem, leaf_der) = build_chain_with_spiffe_leaf("spiffe://td/ns/prod/sa/api");
         let verifier = XdsServerCertVerifier::new(
-            provider_with_roots(root_store_with(ca_der)),
+            provider_with_roots(ca_pem),
             vec![uri_matcher("spiffe://td/ns/prod/sa/api")],
         );
 
@@ -367,9 +376,9 @@ mod tests {
 
     #[test]
     fn spiffe_uri_only_cert_with_non_matching_matcher_fails() {
-        let (ca_der, leaf_der) = build_chain_with_spiffe_leaf("spiffe://td/ns/prod/sa/api");
+        let (ca_pem, leaf_der) = build_chain_with_spiffe_leaf("spiffe://td/ns/prod/sa/api");
         let verifier = XdsServerCertVerifier::new(
-            provider_with_roots(root_store_with(ca_der)),
+            provider_with_roots(ca_pem),
             vec![uri_matcher("spiffe://td/ns/prod/sa/other")],
         );
 
@@ -386,9 +395,8 @@ mod tests {
     #[test]
     fn spiffe_uri_only_cert_with_empty_matchers_passes_ca_only() {
         // per gRFC A29 §'Server Authorization': an empty matcher list passes
-        let (ca_der, leaf_der) = build_chain_with_spiffe_leaf("spiffe://td/ns/prod/sa/api");
-        let verifier =
-            XdsServerCertVerifier::new(provider_with_roots(root_store_with(ca_der)), vec![]);
+        let (ca_pem, leaf_der) = build_chain_with_spiffe_leaf("spiffe://td/ns/prod/sa/api");
+        let verifier = XdsServerCertVerifier::new(provider_with_roots(ca_pem), vec![]);
 
         let server_name = ServerName::try_from("any.connect.hostname").unwrap();
         let result =
@@ -398,13 +406,10 @@ mod tests {
 
     #[test]
     fn verify_fails_when_provider_has_no_roots() {
-        let (_ca_der, leaf_der) = build_chain_with_spiffe_leaf("spiffe://td/ns/prod/sa/api");
+        let (_ca_pem, leaf_der) = build_chain_with_spiffe_leaf("spiffe://td/ns/prod/sa/api");
         let provider: Arc<dyn CertificateProvider> =
             Arc::new(StaticProvider(Arc::new(CertificateData::IdentityOnly {
-                identity: Identity {
-                    cert_chain: b"chain".to_vec(),
-                    key: b"key".to_vec(),
-                },
+                identity: Identity::new(b"chain".to_vec(), b"key".to_vec()),
             })));
         let verifier = XdsServerCertVerifier::new(provider, vec![]);
 

--- a/tonic-xds/src/xds/cluster_discovery.rs
+++ b/tonic-xds/src/xds/cluster_discovery.rs
@@ -268,7 +268,7 @@ impl Connector for TlsConnector {
             .and_then(|p| match p.fetch() {
                 Ok(data) => data
                     .identity()
-                    .map(|id| tonic::transport::Identity::from_pem(&id.cert_chain, &id.key)),
+                    .map(|id| tonic::transport::Identity::from_pem(id.cert_chain(), id.key())),
                 Err(e) => {
                     tracing::error!(
                         error = %e,
@@ -325,7 +325,7 @@ mod tests {
     #[cfg(feature = "_tls-any")]
     fn empty_registry() -> CertProviderRegistry {
         use std::collections::HashMap;
-        CertProviderRegistry::from_bootstrap(&HashMap::new()).unwrap()
+        CertProviderRegistry::from_bootstrap(&HashMap::new(), HashMap::new()).unwrap()
     }
 
     /// Plaintext dispatch under TLS feature.
@@ -374,7 +374,6 @@ mod tests {
         use crate::xds::cert_provider::{
             CertProviderError, CertificateData, CertificateProvider, Identity,
         };
-        use rustls::RootCertStore;
         use std::sync::atomic::{AtomicUsize, Ordering};
 
         struct CountingIdentity {
@@ -397,15 +396,12 @@ mod tests {
 
         let ca_provider: Arc<dyn CertificateProvider> =
             Arc::new(StaticCa(Arc::new(CertificateData::RootsOnly {
-                roots: Arc::new(RootCertStore::empty()),
+                roots: Vec::new(),
             })));
         let verifier = Arc::new(XdsServerCertVerifier::new(ca_provider, vec![]));
 
         let identity_data = Arc::new(CertificateData::IdentityOnly {
-            identity: Identity {
-                cert_chain: b"cert".to_vec(),
-                key: b"key".to_vec(),
-            },
+            identity: Identity::new(b"cert".to_vec(), b"key".to_vec()),
         });
         let counter = Arc::new(CountingIdentity {
             count: AtomicUsize::new(0),


### PR DESCRIPTION
## Motivation

`tonic-xds` currently sources data-plane (upstream) TLS certificates only from the built-in `file_watcher` plugin, configured through the bootstrap `certificate_providers` map (gRFC A29). Applications that obtain certificates from a different system have no way to plug in.

This mirrors the pluggable certificate-provider registries in grpc-go / grpc-java: applications can register their own provider implementation and have CDS-referenced instances resolve to it.

## Changes

- Promote `CertificateProvider`, `CertificateData`, and `Identity` to public API and re-export them from the crate root (gated on a TLS feature).
- Add `XdsChannelBuilder::with_certificate_provider(instance_name, provider)` to register custom provider instances. 
- Add a general `CertProviderError::Other` variant so out-of-crate providers can surface their own failures.
- Allow `rustls::*` in the `cargo-check-external-types` allowlist: `CertificateData` surfaces CA roots as a parsed `rustls::RootCertStore`.

## Testing

- `cargo test -p tonic-xds --features tls-ring` — all
- `cargo clippy -p tonic-xds --features tls-ring` and default (no-TLS feature).
- `cargo doc` with `-D rustdoc::broken_intra_doc_links`.
