### PR TITLE
tonic-xds/xds-client: client permanently stuck on stale endpoints after backend pod rotation — no keepalives or connect timeouts anywhere in the xDS path

### DIFF
--- a/tonic-xds/src/xds/cluster_discovery.rs
+++ b/tonic-xds/src/xds/cluster_discovery.rs
@@ -14,6 +14,7 @@
 //! connector is kept and a warning is logged.
 
 use std::sync::Arc;
+use std::time::Duration;
 
 use arc_swap::ArcSwap;
 use tokio::sync::mpsc;
@@ -37,6 +38,33 @@ use crate::xds::resource::security::ClusterSecurityConfig;
 /// Buffer capacity for the discovery channel between the spawned task and
 /// Tower's LB layer.
 const DISCOVER_CHANNEL_CAPACITY: usize = 64;
+
+/// Timeout for establishing a connection to an endpoint.
+const ENDPOINT_CONNECT_TIMEOUT: Duration = Duration::from_secs(10);
+
+/// HTTP/2 keepalive PING interval for endpoint connections.
+const ENDPOINT_KEEP_ALIVE_INTERVAL: Duration = Duration::from_secs(30);
+
+/// Time to wait for a keepalive PING ack before closing the connection.
+const ENDPOINT_KEEP_ALIVE_TIMEOUT: Duration = Duration::from_secs(10);
+
+/// Apply connection-liveness settings to a per-endpoint `Endpoint`.
+///
+/// Endpoint channels are created with `connect_lazy`, so a tonic `Channel`
+/// reports readiness independently of TCP connectivity. Without these
+/// settings a request routed to a black-holed address (e.g. a deleted pod IP,
+/// which Kubernetes drops without a RST) hangs on unanswered SYNs, and an
+/// established connection to a dead peer is never torn down — either way the
+/// endpoint stays "ready" to the LB and requests only die by the caller's
+/// deadline. The connect timeout and keepalives turn both cases into prompt
+/// transport errors instead.
+fn with_liveness_settings(endpoint: Endpoint) -> Endpoint {
+    endpoint
+        .connect_timeout(ENDPOINT_CONNECT_TIMEOUT)
+        .http2_keep_alive_interval(ENDPOINT_KEEP_ALIVE_INTERVAL)
+        .keep_alive_timeout(ENDPOINT_KEEP_ALIVE_TIMEOUT)
+        .keep_alive_while_idle(true)
+}
 
 /// xDS-backed cluster discovery.
 ///
@@ -189,9 +217,9 @@ impl Connector for PlaintextConnector {
         // EndpointAddress only holds validated Ipv4/Ipv6/Hostname + u16 port,
         // and its Display impl produces "ip:port" or "hostname:port". Prefixing
         // with "http://" always yields a valid URI, so from_shared cannot fail.
-        let channel = Endpoint::from_shared(format!("http://{addr}"))
-            .expect("EndpointAddress Display guarantees valid URI")
-            .connect_lazy();
+        let endpoint = Endpoint::from_shared(format!("http://{addr}"))
+            .expect("EndpointAddress Display guarantees valid URI");
+        let channel = with_liveness_settings(endpoint).connect_lazy();
         let svc = EndpointChannel::new(channel);
         Box::pin(async move { svc })
     }
@@ -284,8 +312,10 @@ impl Connector for TlsConnector {
         }
 
         let uri = format!("https://{addr}");
-        let endpoint = Endpoint::from_shared(uri.clone())
-            .expect("EndpointAddress Display guarantees valid URI");
+        let endpoint = with_liveness_settings(
+            Endpoint::from_shared(uri.clone())
+                .expect("EndpointAddress Display guarantees valid URI"),
+        );
 
         let channel = match endpoint.tls_config_with_verifier(tls_config, verifier) {
             Ok(ep) => ep.connect_lazy(),
@@ -298,9 +328,11 @@ impl Connector for TlsConnector {
                     error = %e, address = %addr,
                     "tls_config_with_verifier failed; non-TLS lazy fallback",
                 );
-                Endpoint::from_shared(uri)
-                    .expect("EndpointAddress Display guarantees valid URI")
-                    .connect_lazy()
+                with_liveness_settings(
+                    Endpoint::from_shared(uri)
+                        .expect("EndpointAddress Display guarantees valid URI"),
+                )
+                .connect_lazy()
             }
         };
         let svc = EndpointChannel::new(channel);

--- a/xds-client/src/transport/tonic.rs
+++ b/xds-client/src/transport/tonic.rs
@@ -10,6 +10,7 @@ use crate::transport::{Transport, TransportBuilder, TransportStream};
 use bytes::{Buf, BufMut, Bytes};
 use http::uri::PathAndQuery;
 use std::sync::Arc;
+use std::time::Duration;
 use tokio::sync::mpsc;
 use tokio_stream::StreamExt as _;
 use tonic::client::Grpc;
@@ -41,6 +42,23 @@ const ADS_PATH: &str =
     "/envoy.service.discovery.v3.AggregatedDiscoveryService/StreamAggregatedResources";
 
 const ADS_CHANNEL_BUFFER_SIZE: usize = 16;
+
+/// Default timeout for establishing the TCP/TLS connection to the xDS server.
+const DEFAULT_CONNECT_TIMEOUT: Duration = Duration::from_secs(10);
+
+/// Default HTTP/2 keepalive PING interval on the ADS channel.
+///
+/// The ADS stream is mostly idle from the client's perspective (the server
+/// only pushes on resource changes), so without keepalives a half-open
+/// connection — e.g. after an xDS server restart where the RST/GOAWAY was
+/// lost, or a dropped conntrack/NAT entry — is undetectable: `recv()` on the
+/// stream pends forever and the client keeps serving its last known
+/// resources. Keepalives surface such connections as transport errors, which
+/// triggers the worker's reconnect + re-subscribe path.
+const DEFAULT_KEEP_ALIVE_INTERVAL: Duration = Duration::from_secs(30);
+
+/// Default time to wait for a keepalive PING ack before closing the connection.
+const DEFAULT_KEEP_ALIVE_TIMEOUT: Duration = Duration::from_secs(10);
 
 /// A codec that passes bytes through without serialization.
 ///
@@ -169,11 +187,9 @@ impl TonicTransport {
 /// let builder = TonicTransportBuilder::new()
 ///     .with_tls_config(ClientTlsConfig::new().with_enabled_roots());
 /// ```
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone)]
 pub struct TonicTransportBuilder {
     // Future extensions:
-    // - Connection timeout settings
-    // - Keep-alive configuration
     // - Connection pooling settings
     // - Per-server credential overrides (via ServerConfig.extensions)
     #[cfg(any(feature = "tonic-tls-ring", feature = "tonic-tls-aws-lc"))]
@@ -181,12 +197,52 @@ pub struct TonicTransportBuilder {
 
     /// Per-stream call credentials for the ADS stream.
     call_creds: Option<Arc<dyn TonicCallCredentials>>,
+
+    /// Timeout for establishing the connection to the xDS server.
+    connect_timeout: Duration,
+
+    /// HTTP/2 keepalive PING interval; `None` disables keepalives.
+    keep_alive_interval: Option<Duration>,
+
+    /// Time to wait for a keepalive PING ack before closing the connection.
+    keep_alive_timeout: Duration,
+}
+
+impl Default for TonicTransportBuilder {
+    fn default() -> Self {
+        Self {
+            #[cfg(any(feature = "tonic-tls-ring", feature = "tonic-tls-aws-lc"))]
+            tls_config: None,
+            call_creds: None,
+            connect_timeout: DEFAULT_CONNECT_TIMEOUT,
+            keep_alive_interval: Some(DEFAULT_KEEP_ALIVE_INTERVAL),
+            keep_alive_timeout: DEFAULT_KEEP_ALIVE_TIMEOUT,
+        }
+    }
 }
 
 impl TonicTransportBuilder {
     /// Create a new transport builder with default (plaintext) settings.
     pub fn new() -> Self {
         Self::default()
+    }
+
+    /// Set the timeout for establishing the connection to the xDS server.
+    pub fn with_connect_timeout(mut self, timeout: Duration) -> Self {
+        self.connect_timeout = timeout;
+        self
+    }
+
+    /// Configure HTTP/2 keepalives on the ADS channel.
+    ///
+    /// A PING is sent every `interval` (even while the stream is idle); if no
+    /// ack arrives within `timeout` the connection is closed, surfacing a
+    /// transport error that triggers reconnect + re-subscription. Pass
+    /// `interval = None` to disable keepalives.
+    pub fn with_keep_alive(mut self, interval: Option<Duration>, timeout: Duration) -> Self {
+        self.keep_alive_interval = interval;
+        self.keep_alive_timeout = timeout;
+        self
     }
 
     /// Set the TLS configuration for connections to the xDS server.
@@ -208,17 +264,30 @@ impl TonicTransportBuilder {
         self
     }
 
-    /// Prepend `https://` to a scheme-less `server_uri` on the secure path.
+    /// Reconcile the `server_uri` scheme with the channel's security mode.
     ///
-    /// Bootstrap URIs like `trafficdirector.googleapis.com:443` parse with no scheme,
-    /// so `Endpoint` won't negotiate TLS. A scheme lets it, and tonic derive SNI from
-    /// `uri.host()`. Non-`http::Uri` inputs (`unix://`) and plaintext are left as-is.
-    fn ensure_secure_server_uri(raw: &str, secure: bool) -> String {
-        if secure
-            && let Ok(uri) = raw.parse::<http::Uri>()
-            && uri.scheme().is_none()
-        {
-            return format!("https://{raw}");
+    /// Secure path: bootstrap URIs like `trafficdirector.googleapis.com:443`
+    /// parse with no scheme, so `Endpoint` won't negotiate TLS. A `https://`
+    /// scheme lets it, and tonic derive SNI from `uri.host()`.
+    ///
+    /// Insecure path: bootstraps in the wild carry `https://` URIs alongside
+    /// `insecure` channel creds (e.g. `https://istiod.istio-system.svc:15010`,
+    /// istiod's plaintext port). With no TLS configured, passing the `https`
+    /// scheme through hands tonic a contradictory endpoint, so it is rewritten
+    /// to `http://` to match the creds — per xDS bootstrap semantics,
+    /// `channel_creds` decides transport security, not the URI scheme.
+    ///
+    /// Non-`http::Uri` inputs (`unix://`) are left as-is.
+    fn reconcile_server_uri(raw: &str, secure: bool) -> String {
+        if let Ok(uri) = raw.parse::<http::Uri>() {
+            if secure && uri.scheme().is_none() {
+                return format!("https://{raw}");
+            }
+            if !secure && uri.scheme_str() == Some("https") {
+                // Slice by scheme length: `http::Uri` normalizes the scheme's
+                // case, so don't assume the raw string spells it lowercase.
+                return format!("http://{}", &raw["https".len() + "://".len()..]);
+            }
         }
         raw.to_string()
     }
@@ -247,8 +316,16 @@ impl TransportBuilder for TonicTransportBuilder {
 
         // `Endpoint::from_shared` routes `unix://` URIs to tonic's UDS connector.
         // Required for control planes like Istio's grpc-agent that ship `unix:///etc/istio/proxy/XDS`.
-        let endpoint = Endpoint::from_shared(Self::ensure_secure_server_uri(server.uri(), secure))
+        let endpoint = Endpoint::from_shared(Self::reconcile_server_uri(server.uri(), secure))
             .map_err(|e| Error::Connection(e.to_string()))?;
+
+        let mut endpoint = endpoint.connect_timeout(self.connect_timeout);
+        if let Some(interval) = self.keep_alive_interval {
+            endpoint = endpoint
+                .http2_keep_alive_interval(interval)
+                .keep_alive_timeout(self.keep_alive_timeout)
+                .keep_alive_while_idle(true);
+        }
 
         #[cfg(any(feature = "tonic-tls-ring", feature = "tonic-tls-aws-lc"))]
         let endpoint = match &self.tls_config {
@@ -513,25 +590,35 @@ mod tests {
     }
 
     #[test]
-    fn ensure_secure_server_uri_adds_scheme_only_when_needed() {
+    fn reconcile_server_uri_matches_scheme_to_security_mode() {
         assert_eq!(
-            TonicTransportBuilder::ensure_secure_server_uri(
-                "trafficdirector.googleapis.com:443",
-                true
-            ),
+            TonicTransportBuilder::reconcile_server_uri("trafficdirector.googleapis.com:443", true),
             "https://trafficdirector.googleapis.com:443",
         );
         assert_eq!(
-            TonicTransportBuilder::ensure_secure_server_uri("https://xds.example.com:443", true),
+            TonicTransportBuilder::reconcile_server_uri("https://xds.example.com:443", true),
             "https://xds.example.com:443"
         );
         assert_eq!(
-            TonicTransportBuilder::ensure_secure_server_uri("unix:///etc/istio/proxy/XDS", true),
+            TonicTransportBuilder::reconcile_server_uri("unix:///etc/istio/proxy/XDS", true),
             "unix:///etc/istio/proxy/XDS"
         );
         assert_eq!(
-            TonicTransportBuilder::ensure_secure_server_uri("127.0.0.1:18000", false),
+            TonicTransportBuilder::reconcile_server_uri("127.0.0.1:18000", false),
             "127.0.0.1:18000"
+        );
+        // `https://` with insecure creds is rewritten to plaintext: the
+        // channel_creds decide security, not the URI scheme.
+        assert_eq!(
+            TonicTransportBuilder::reconcile_server_uri(
+                "https://istiod.istio-system.svc:15010",
+                false
+            ),
+            "http://istiod.istio-system.svc:15010"
+        );
+        assert_eq!(
+            TonicTransportBuilder::reconcile_server_uri("http://127.0.0.1:18000", false),
+            "http://127.0.0.1:18000"
         );
     }
 


### PR DESCRIPTION
Labels: bug, tonic-xds, xds-client

Environment

- tonic-xds 0.1.0-alpha.2 / xds-client 0.1.0-alpha.2
- Istio istiod as the xDS server (proxyless gRPC), SotW ADS v3
- Bootstrap (file-based, not via istio-agent):
```

{
  "xds_servers": [{
    "server_uri": "https://istiod.istio-system.svc:15010",
    "channel_creds": [{"type": "insecure"}],
    "server_features": ["xds_v3"]
  }],
  "node": {
    "id": "sidecar~10.44.113.2~filtration-67556869bd-2dsxf.default~cluster.local",
    "metadata": {"GENERATOR": "grpc"}
  }
}
```

Symptom

The client works fine until the backend server deployment does a rolling restart. Once the old pods are replaced, the client never routes to the new pods: every request hangs until the caller's deadline and times out. The client never recovers without a restart.

Root cause analysis

The xDS protocol machinery itself looks correct (ACK/NACK, version/nonce, reconnect-with-resubscribe, EDS-not-full-state per gRFC A53, endpoint diffing, health-status filtering). The failure is that dead connections are never detected, in two places:

1. ADS channel to the xDS server has no keepalives, no read deadline, no connect timeout

TonicTransportBuilder::build (xds-client/src/transport/tonic.rs) constructs the channel with just Endpoint::from_shared(...).connect() — no http2_keep_alive_interval, no keep_alive_timeout, no keep_alive_while_idle, no connect_timeout. The worker reads the stream with a bare stream.recv() inside tokio::select! with no timeout arm (xds-client/src/client/worker.rs, run_connected).

The ADS stream is mostly idle from the client's perspective, so if the connection goes half-open during cluster churn (istiod restart where the GOAWAY/RST is lost, dropped conntrack/NAT entry, LB reset) — tonic gets no error and no bytes, recv() pends forever, and the otherwise-correct reconnect + re-subscribe logic never fires. The client then serves its last-known EDS endpoints indefinitely. Combined with (2), that's a permanent outage.

2. Data-plane endpoint channels can never fail

Per-endpoint channels are created with connect_lazy() and no connect timeout or keepalive (PlaintextConnector / TlsConnector in tonic-xds/src/xds/cluster_discovery.rs). The production balancer is raw tower::balance::p2c::Balance (tonic-xds/src/client/cluster.rs), and a lazy tonic channel's poll_ready reflects buffer capacity, not TCP connectivity — so every endpoint is "ready" the moment it's inserted and stays ready forever. Kubernetes black-holes deleted pod IPs (SYNs dropped, no RST), so a request picked onto a dead endpoint hangs until the caller's deadline. Nothing ejects the endpoint.

Notably, tonic-xds/src/client/loadbalance/ contains a full connectivity-aware load balancer with outlier detection (gRFC A50), but the module is #[allow(dead_code)] and never constructed by the production stack.

3. (Secondary) https:// server_uri + insecure creds is passed through unreconciled

With insecure channel creds no TLS is configured, but ensure_secure_server_uri (xds-client/src/transport/tonic.rs) only adds an https:// scheme on the secure path — it never strips one on the insecure path. So the bootstrap above hands tonic an https URI with no TLS backend. Per xDS bootstrap semantics, channel_creds should decide transport security, not the URI scheme.

Failure sequence

Deployment rolls → old pod IPs become black holes → requests picked onto them hang (no connect timeout, no ejection) → the ADS connection is also disturbed by the churn and goes half-open → no EDS update ever arrives to replace the endpoint set (no keepalive to detect the dead stream) → client permanently routes 100% of traffic to dead IPs.

