### PR TITLE
feat(tonic-xds): pre-route header-mutation interceptor

### DIFF
--- a/tonic-xds/src/client/channel.rs
+++ b/tonic-xds/src/client/channel.rs
@@ -1,14 +1,16 @@
 use crate::client::cluster::ClusterClientRegistryGrpc;
 use crate::client::endpoint::{EndpointAddress, EndpointChannel};
 use crate::client::lb::{ClusterDiscovery, XdsLbService};
-use crate::client::route::{Router, XdsRoutingLayer};
+use crate::client::route::{
+    PreRouteInterceptor, PreRouteLayer, RouteConfigSelectorLayer, Router, XdsRoutingLayer,
+};
 use crate::xds::bootstrap::{BootstrapConfig, BootstrapError};
 use crate::xds::cache::XdsCache;
 #[cfg(feature = "_tls-any")]
 use crate::xds::cert_provider::{CertProviderError, CertProviderRegistry, CertificateProvider};
 use crate::xds::cluster_discovery::XdsClusterDiscovery;
 use crate::xds::resource_manager::XdsResourceManager;
-use crate::xds::routing::XdsRouter;
+use crate::xds::routing::{RouteConfigWatcher, XdsRouter};
 use crate::{TonicCallCredentials, XdsUri};
 use http::Request;
 #[cfg(feature = "_tls-any")]
@@ -170,6 +172,7 @@ const _: fn() = || {
 pub struct XdsChannelBuilder {
     config: Arc<XdsChannelConfig>,
     recorder: Option<Arc<dyn MetricsRecorder>>,
+    pre_route: Option<Arc<dyn PreRouteInterceptor>>,
     #[cfg(feature = "_tls-any")]
     cert_providers: HashMap<String, Arc<dyn CertificateProvider>>,
 }
@@ -177,13 +180,21 @@ pub struct XdsChannelBuilder {
 impl Debug for XdsChannelBuilder {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut s = f.debug_struct("XdsChannelBuilder");
-        s.field("config", &self.config).field(
-            "recorder",
-            &self
-                .recorder
-                .as_deref()
-                .map_or("None", |r| std::any::type_name_of_val(r)),
-        );
+        s.field("config", &self.config)
+            .field(
+                "recorder",
+                &self
+                    .recorder
+                    .as_deref()
+                    .map_or("None", |r| std::any::type_name_of_val(r)),
+            )
+            .field(
+                "pre_route",
+                &self
+                    .pre_route
+                    .as_deref()
+                    .map_or("None", |i| std::any::type_name_of_val(i)),
+            );
         #[cfg(feature = "_tls-any")]
         s.field(
             "cert_providers",
@@ -200,6 +211,7 @@ impl XdsChannelBuilder {
         Self {
             config: Arc::new(config),
             recorder: None,
+            pre_route: None,
             #[cfg(feature = "_tls-any")]
             cert_providers: HashMap::new(),
         }
@@ -214,6 +226,22 @@ impl XdsChannelBuilder {
     #[must_use]
     pub fn with_metrics_recorder(mut self, recorder: Arc<dyn MetricsRecorder>) -> Self {
         self.recorder = Some(recorder);
+        self
+    }
+
+    /// Registers a [`PreRouteInterceptor`] that runs before route selection.
+    ///
+    /// The channel binds the active `RouteConfiguration` to each request
+    /// in the route-config selector stage. When an interceptor is registered, it
+    /// runs between that selector stage and the router: it may mutate request
+    /// headers (using the config's
+    /// [`RouteConfigMetadata`](crate::RouteConfigMetadata)) before the router
+    /// matches on them, against that same config snapshot. This enables
+    /// config-driven request transformation such as computing a partition/shard
+    /// key and injecting a routing header.
+    #[must_use]
+    pub fn with_pre_route_interceptor(mut self, interceptor: Arc<dyn PreRouteInterceptor>) -> Self {
+        self.pre_route = Some(interceptor);
         self
     }
 
@@ -317,15 +345,17 @@ impl XdsChannelBuilder {
         xds_client: XdsClient,
         resource_manager: XdsResourceManager,
     ) -> XdsChannelGrpc {
-        let router: Arc<dyn Router> = Arc::new(XdsRouter::new(&cache));
         #[cfg(feature = "_tls-any")]
         let discovery: Arc<
             dyn ClusterDiscovery<EndpointAddress, EndpointChannel<Channel>>,
-        > = Arc::new(XdsClusterDiscovery::new(cache, cert_provider_registry));
+        > = Arc::new(XdsClusterDiscovery::new(
+            cache.clone(),
+            cert_provider_registry,
+        ));
         #[cfg(not(feature = "_tls-any"))]
         let discovery: Arc<
             dyn ClusterDiscovery<EndpointAddress, EndpointChannel<Channel>>,
-        > = Arc::new(XdsClusterDiscovery::new(cache));
+        > = Arc::new(XdsClusterDiscovery::new(cache.clone()));
         let retry_policy = GrpcRetryPolicy::new(GrpcRetryPolicyConfig::default());
 
         let resources = Arc::new(XdsChannelResources {
@@ -333,18 +363,21 @@ impl XdsChannelBuilder {
             _xds_client: xds_client,
         });
 
-        let routing_layer = XdsRoutingLayer::new(router, self.authority());
         let retry_layer = RetryLayer::new(retry_policy);
         let cluster_registry = Arc::new(ClusterClientRegistryGrpc::new());
         let lb_service = XdsLbService::new(cluster_registry, discovery);
+
+        let watcher = Arc::new(RouteConfigWatcher::new(&cache));
+        let router: Arc<dyn Router> = Arc::new(XdsRouter);
         let inner = ServiceBuilder::new()
-            .layer(routing_layer)
+            .layer(RouteConfigSelectorLayer::new(watcher))
+            .option_layer(self.pre_route.clone().map(PreRouteLayer::new))
+            .layer(XdsRoutingLayer::new(router, self.authority()))
             .layer(retry_layer)
             .map_request(|req: Request<shared_http_body::SharedBody<TonicBody>>| {
                 req.map(TonicBody::new)
             })
             .service(lb_service);
-
         BoxCloneSyncService::new(XdsChannel {
             config: self.config.clone(),
             inner,
@@ -359,20 +392,24 @@ impl XdsChannelBuilder {
         self.build_tonic_grpc_channel()
     }
 
-    /// Builds an `XdsChannelGrpc` from the given router, cluster discovery, and retry policy.
+    /// Builds an `XdsChannelGrpc` from the given parts, mirroring the production
+    /// stack, used for tests.
     #[cfg(test)]
     pub(crate) fn build_grpc_channel_from_parts(
         &self,
+        watcher: Arc<RouteConfigWatcher>,
         router: Arc<dyn Router>,
         discovery: Arc<dyn ClusterDiscovery<EndpointAddress, EndpointChannel<Channel>>>,
         retry_policy: GrpcRetryPolicy,
+        interceptor: Option<Arc<dyn PreRouteInterceptor>>,
     ) -> XdsChannelGrpc {
-        let routing_layer = XdsRoutingLayer::new(router, self.authority());
         let retry_layer = RetryLayer::new(retry_policy);
         let cluster_registry = Arc::new(ClusterClientRegistryGrpc::new());
         let lb_service = XdsLbService::new(cluster_registry, discovery);
         let inner = ServiceBuilder::new()
-            .layer(routing_layer)
+            .layer(RouteConfigSelectorLayer::new(watcher))
+            .option_layer(interceptor.map(PreRouteLayer::new))
+            .layer(XdsRoutingLayer::new(router, self.authority()))
             .layer(retry_layer)
             .map_request(|req: Request<shared_http_body::SharedBody<TonicBody>>| {
                 req.map(TonicBody::new)
@@ -415,6 +452,7 @@ mod tests {
     use crate::xds::cache::XdsCache;
     use crate::xds::resource::EndpointsResource;
     use crate::xds::resource::route_config::RouteConfigResource;
+    use crate::xds::routing::RouteConfigWatcher;
     use std::sync::Arc;
     use tokio::sync::mpsc;
     use tonic::transport::Channel;
@@ -549,11 +587,14 @@ mod tests {
         // Create a mock XdsManager with the test servers
         let xds_manager = Arc::new(MockXdsManager::from_test_servers(&servers));
 
+        let (_cache, watcher) = mock_ready_watcher();
         let xds_channel_builder = XdsChannelBuilder::new(test_config());
         let xds_channel = xds_channel_builder.build_grpc_channel_from_parts(
+            watcher,
             xds_manager.clone(),
             xds_manager.clone(),
             GrpcRetryPolicy::default(),
+            None,
         );
 
         let client = GreeterClient::new(xds_channel);
@@ -627,10 +668,13 @@ mod tests {
                 .num_retries(1),
         );
 
+        let (_cache, watcher) = mock_ready_watcher();
         let xds_channel = XdsChannelBuilder::new(test_config()).build_grpc_channel_from_parts(
+            watcher,
             xds_manager.clone(),
             xds_manager.clone(),
             retry_policy,
+            None,
         );
 
         let mut client = GreeterClient::new(xds_channel);
@@ -677,7 +721,19 @@ mod tests {
                     action: RouteConfigAction::Cluster(cluster_name.to_string()),
                 }],
             }],
+            metadata: Default::default(),
         })
+    }
+
+    /// Helper: a [`RouteConfigWatcher`] fed by a cache with a published route
+    /// config, so the selector layer becomes ready. Returns the cache
+    /// too so callers can keep it alive for the duration of the test. Used by
+    /// mock-router tests whose router ignores the bound config.
+    fn mock_ready_watcher() -> (Arc<XdsCache>, Arc<RouteConfigWatcher>) {
+        let cache = Arc::new(XdsCache::new());
+        cache.update_route_config(make_test_route_config("test-cluster"));
+        let watcher = Arc::new(RouteConfigWatcher::new(&cache));
+        (cache, watcher)
     }
 
     /// Helper: creates an `EndpointsResource` from test server addresses.
@@ -708,7 +764,8 @@ mod tests {
         use crate::xds::cluster_discovery::XdsClusterDiscovery;
         use crate::xds::routing::XdsRouter;
 
-        let router: Arc<dyn Router> = Arc::new(XdsRouter::new(&cache));
+        let router: Arc<dyn Router> = Arc::new(XdsRouter);
+        let watcher = Arc::new(RouteConfigWatcher::new(&cache));
 
         #[cfg(feature = "_tls-any")]
         let discovery: Arc<
@@ -727,7 +784,13 @@ mod tests {
         > = Arc::new(XdsClusterDiscovery::new(cache));
 
         let builder = XdsChannelBuilder::new(test_config());
-        builder.build_grpc_channel_from_parts(router, discovery, GrpcRetryPolicy::default())
+        builder.build_grpc_channel_from_parts(
+            watcher,
+            router,
+            discovery,
+            GrpcRetryPolicy::default(),
+            None,
+        )
     }
 
     /// Tests the full xDS stack (XdsRouter + XdsClusterDiscovery) with a

--- a/tonic-xds/src/client/channel.rs
+++ b/tonic-xds/src/client/channel.rs
@@ -1,16 +1,14 @@
 use crate::client::cluster::ClusterClientRegistryGrpc;
 use crate::client::endpoint::{EndpointAddress, EndpointChannel};
 use crate::client::lb::{ClusterDiscovery, XdsLbService};
-use crate::client::route::{
-    PreRouteInterceptor, PreRouteLayer, RouteConfigSelectorLayer, Router, XdsRoutingLayer,
-};
+use crate::client::route::{PreRouteInterceptor, Router, XdsRoutingLayer};
 use crate::xds::bootstrap::{BootstrapConfig, BootstrapError};
 use crate::xds::cache::XdsCache;
 #[cfg(feature = "_tls-any")]
 use crate::xds::cert_provider::{CertProviderError, CertProviderRegistry, CertificateProvider};
 use crate::xds::cluster_discovery::XdsClusterDiscovery;
 use crate::xds::resource_manager::XdsResourceManager;
-use crate::xds::routing::{RouteConfigWatcher, XdsRouter};
+use crate::xds::routing::XdsRouter;
 use crate::{TonicCallCredentials, XdsUri};
 use http::Request;
 #[cfg(feature = "_tls-any")]
@@ -231,14 +229,13 @@ impl XdsChannelBuilder {
 
     /// Registers a [`PreRouteInterceptor`] that runs before route selection.
     ///
-    /// The channel binds the active `RouteConfiguration` to each request
-    /// in the route-config selector stage. When an interceptor is registered, it
-    /// runs between that selector stage and the router: it may mutate request
-    /// headers (using the config's
-    /// [`RouteConfigMetadata`](crate::RouteConfigMetadata)) before the router
-    /// matches on them, against that same config snapshot. This enables
-    /// config-driven request transformation such as computing a partition/shard
-    /// key and injecting a routing header.
+    /// The routing layer takes a `RouteConfiguration` snapshot for each request;
+    /// when an interceptor is registered, it is invoked inline against that
+    /// snapshot before matching, and may mutate request headers (using the
+    /// config's [`RouteConfigMetadata`](crate::RouteConfigMetadata)) so the
+    /// router matches on the result. This enables config-driven request
+    /// transformation such as computing a partition/shard key and injecting a
+    /// routing header. The interceptor and the router observe the same snapshot.
     #[must_use]
     pub fn with_pre_route_interceptor(mut self, interceptor: Arc<dyn PreRouteInterceptor>) -> Self {
         self.pre_route = Some(interceptor);
@@ -345,17 +342,15 @@ impl XdsChannelBuilder {
         xds_client: XdsClient,
         resource_manager: XdsResourceManager,
     ) -> XdsChannelGrpc {
+        let router: Arc<dyn Router> = Arc::new(XdsRouter::new(&cache));
         #[cfg(feature = "_tls-any")]
         let discovery: Arc<
             dyn ClusterDiscovery<EndpointAddress, EndpointChannel<Channel>>,
-        > = Arc::new(XdsClusterDiscovery::new(
-            cache.clone(),
-            cert_provider_registry,
-        ));
+        > = Arc::new(XdsClusterDiscovery::new(cache, cert_provider_registry));
         #[cfg(not(feature = "_tls-any"))]
         let discovery: Arc<
             dyn ClusterDiscovery<EndpointAddress, EndpointChannel<Channel>>,
-        > = Arc::new(XdsClusterDiscovery::new(cache.clone()));
+        > = Arc::new(XdsClusterDiscovery::new(cache));
         let retry_policy = GrpcRetryPolicy::new(GrpcRetryPolicyConfig::default());
 
         let resources = Arc::new(XdsChannelResources {
@@ -363,21 +358,18 @@ impl XdsChannelBuilder {
             _xds_client: xds_client,
         });
 
+        let routing_layer = XdsRoutingLayer::new(router, self.pre_route.clone(), self.authority());
         let retry_layer = RetryLayer::new(retry_policy);
         let cluster_registry = Arc::new(ClusterClientRegistryGrpc::new());
         let lb_service = XdsLbService::new(cluster_registry, discovery);
-
-        let watcher = Arc::new(RouteConfigWatcher::new(&cache));
-        let router: Arc<dyn Router> = Arc::new(XdsRouter);
         let inner = ServiceBuilder::new()
-            .layer(RouteConfigSelectorLayer::new(watcher))
-            .option_layer(self.pre_route.clone().map(PreRouteLayer::new))
-            .layer(XdsRoutingLayer::new(router, self.authority()))
+            .layer(routing_layer)
             .layer(retry_layer)
             .map_request(|req: Request<shared_http_body::SharedBody<TonicBody>>| {
                 req.map(TonicBody::new)
             })
             .service(lb_service);
+
         BoxCloneSyncService::new(XdsChannel {
             config: self.config.clone(),
             inner,
@@ -392,24 +384,22 @@ impl XdsChannelBuilder {
         self.build_tonic_grpc_channel()
     }
 
-    /// Builds an `XdsChannelGrpc` from the given parts, mirroring the production
-    /// stack, used for tests.
+    /// Builds an `XdsChannelGrpc` from the given router, cluster discovery, retry
+    /// policy, and optional pre-route interceptor.
     #[cfg(test)]
     pub(crate) fn build_grpc_channel_from_parts(
         &self,
-        watcher: Arc<RouteConfigWatcher>,
         router: Arc<dyn Router>,
         discovery: Arc<dyn ClusterDiscovery<EndpointAddress, EndpointChannel<Channel>>>,
         retry_policy: GrpcRetryPolicy,
         interceptor: Option<Arc<dyn PreRouteInterceptor>>,
     ) -> XdsChannelGrpc {
+        let routing_layer = XdsRoutingLayer::new(router, interceptor, self.authority());
         let retry_layer = RetryLayer::new(retry_policy);
         let cluster_registry = Arc::new(ClusterClientRegistryGrpc::new());
         let lb_service = XdsLbService::new(cluster_registry, discovery);
         let inner = ServiceBuilder::new()
-            .layer(RouteConfigSelectorLayer::new(watcher))
-            .option_layer(interceptor.map(PreRouteLayer::new))
-            .layer(XdsRoutingLayer::new(router, self.authority()))
+            .layer(routing_layer)
             .layer(retry_layer)
             .map_request(|req: Request<shared_http_body::SharedBody<TonicBody>>| {
                 req.map(TonicBody::new)
@@ -452,7 +442,6 @@ mod tests {
     use crate::xds::cache::XdsCache;
     use crate::xds::resource::EndpointsResource;
     use crate::xds::resource::route_config::RouteConfigResource;
-    use crate::xds::routing::RouteConfigWatcher;
     use std::sync::Arc;
     use tokio::sync::mpsc;
     use tonic::transport::Channel;
@@ -587,10 +576,8 @@ mod tests {
         // Create a mock XdsManager with the test servers
         let xds_manager = Arc::new(MockXdsManager::from_test_servers(&servers));
 
-        let (_cache, watcher) = mock_ready_watcher();
         let xds_channel_builder = XdsChannelBuilder::new(test_config());
         let xds_channel = xds_channel_builder.build_grpc_channel_from_parts(
-            watcher,
             xds_manager.clone(),
             xds_manager.clone(),
             GrpcRetryPolicy::default(),
@@ -668,9 +655,7 @@ mod tests {
                 .num_retries(1),
         );
 
-        let (_cache, watcher) = mock_ready_watcher();
         let xds_channel = XdsChannelBuilder::new(test_config()).build_grpc_channel_from_parts(
-            watcher,
             xds_manager.clone(),
             xds_manager.clone(),
             retry_policy,
@@ -725,17 +710,6 @@ mod tests {
         })
     }
 
-    /// Helper: a [`RouteConfigWatcher`] fed by a cache with a published route
-    /// config, so the selector layer becomes ready. Returns the cache
-    /// too so callers can keep it alive for the duration of the test. Used by
-    /// mock-router tests whose router ignores the bound config.
-    fn mock_ready_watcher() -> (Arc<XdsCache>, Arc<RouteConfigWatcher>) {
-        let cache = Arc::new(XdsCache::new());
-        cache.update_route_config(make_test_route_config("test-cluster"));
-        let watcher = Arc::new(RouteConfigWatcher::new(&cache));
-        (cache, watcher)
-    }
-
     /// Helper: creates an `EndpointsResource` from test server addresses.
     fn make_test_endpoints(cluster_name: &str, servers: &[TestServer]) -> Arc<EndpointsResource> {
         use crate::xds::resource::endpoints::{HealthStatus, LocalityEndpoints, ResolvedEndpoint};
@@ -764,8 +738,7 @@ mod tests {
         use crate::xds::cluster_discovery::XdsClusterDiscovery;
         use crate::xds::routing::XdsRouter;
 
-        let router: Arc<dyn Router> = Arc::new(XdsRouter);
-        let watcher = Arc::new(RouteConfigWatcher::new(&cache));
+        let router: Arc<dyn Router> = Arc::new(XdsRouter::new(&cache));
 
         #[cfg(feature = "_tls-any")]
         let discovery: Arc<
@@ -784,13 +757,7 @@ mod tests {
         > = Arc::new(XdsClusterDiscovery::new(cache));
 
         let builder = XdsChannelBuilder::new(test_config());
-        builder.build_grpc_channel_from_parts(
-            watcher,
-            router,
-            discovery,
-            GrpcRetryPolicy::default(),
-            None,
-        )
+        builder.build_grpc_channel_from_parts(router, discovery, GrpcRetryPolicy::default(), None)
     }
 
     /// Tests the full xDS stack (XdsRouter + XdsClusterDiscovery) with a

--- a/tonic-xds/src/client/route.rs
+++ b/tonic-xds/src/client/route.rs
@@ -369,11 +369,10 @@ mod tests {
         // Config carries filter_metadata that the interceptor is expected to see.
         let mut filter_metadata = std::collections::HashMap::new();
         filter_metadata.insert("partitioning".to_string(), Struct::default());
-        let metadata = Metadata {
+        let metadata = RouteConfigMetadata::from_proto(Metadata {
             filter_metadata,
             ..Default::default()
-        }
-        .into();
+        });
 
         let rc = Arc::new(RouteConfigResource {
             name: "rc".into(),

--- a/tonic-xds/src/client/route.rs
+++ b/tonic-xds/src/client/route.rs
@@ -1,5 +1,6 @@
 use crate::common::async_util::BoxFuture;
-use crate::xds::routing::RoutingError;
+use crate::xds::resource::route_config::{RouteConfigMetadata, RouteConfigResource};
+use crate::xds::routing::{RouteConfigWatcher, RoutingError};
 use http::Request;
 use std::sync::Arc;
 use std::task::{Context, Poll};
@@ -12,6 +13,12 @@ pub(crate) struct RouteInput<'a> {
     pub authority: &'a str,
     /// The HTTP headers of the request. These can be used for header-based routing decisions.
     pub headers: &'a http::HeaderMap,
+    /// Route configuration already bound to this request by an upstream
+    /// [`RouteConfigSelectorService`]. When `Some`, the router matches against
+    /// it directly (the single-pass path shared with a pre-route interceptor);
+    /// when `None`, routing fails with `RoutingError::NotReady` (the selector
+    /// layer always sets it in the assembled channel stack).
+    pub config: Option<&'a RouteConfigResource>,
 }
 
 /// Represents the routing decision made by the routing layer.
@@ -25,6 +32,33 @@ pub(crate) struct RouteDecision {
     // Populated by the routing layer; consumed by the ring-hash picker (later PR).
     #[allow(dead_code)]
     pub request_hash: Option<u64>,
+}
+
+/// Marker stored in request extensions carrying the [`RouteConfigResource`]
+/// bound to a request by [`RouteConfigSelectorService`].
+///
+/// Binding the config once and sharing it via extensions guarantees that a
+/// [`PreRouteInterceptor`] and the router observe the *same* route-config
+/// version for a given request, even if an xDS update lands mid-request.
+#[derive(Clone)]
+pub(crate) struct ActiveRouteConfig(pub(crate) Arc<RouteConfigResource>);
+
+/// A hook that runs **before** xDS route selection.
+///
+/// The interceptor may inspect and mutate the request headers using the
+/// [`RouteConfigMetadata`] attached to the active `RouteConfiguration`. Because
+/// it runs before routing, any header mutation it makes is visible to route
+/// matching — enabling config-driven request transformation, such as computing
+/// a partition/shard key and injecting a routing header that the standard
+/// header-match router then selects on.
+///
+/// The hook deliberately cannot return a routing decision: it influences routing
+/// only by mutating the request, after which the standard xDS router runs once.
+/// This keeps the routing model itself unchanged and single-pass.
+pub trait PreRouteInterceptor: Send + Sync + 'static {
+    /// Inspects and optionally mutates `headers` using the active route-config
+    /// `metadata`. Runs before route selection.
+    fn on_request(&self, headers: &mut http::HeaderMap, metadata: &RouteConfigMetadata);
 }
 
 /// Trait for routing requests to clusters.
@@ -69,12 +103,16 @@ where
         let authority = self.authority.clone();
         let mut inner_service = self.inner.clone();
         Box::pin(async move {
-            let headers = &request.headers();
-            let route_input = RouteInput {
-                authority: &authority,
-                headers,
+            let active = request.extensions().get::<ActiveRouteConfig>().cloned();
+            let route_future = {
+                let route_input = RouteInput {
+                    authority: &authority,
+                    headers: request.headers(),
+                    config: active.as_ref().map(|a| a.0.as_ref()),
+                };
+                router.route(&route_input)
             };
-            let route_decision = router.route(&route_input).await?;
+            let route_decision = route_future.await?;
             request.extensions_mut().insert(route_decision);
             inner_service.call(request).await.map_err(Into::into)
         })
@@ -108,6 +146,125 @@ impl<S> Layer<S> for XdsRoutingLayer {
             inner: service,
             router: self.router.clone(),
             authority: self.authority.clone(),
+        }
+    }
+}
+
+/// Tower service that snapshots the active route configuration once and binds it
+/// to the request as [`ActiveRouteConfig`], before any pre-route interceptor or
+/// the router runs.
+///
+/// It also owns A57 initial-resource readiness: the first request blocks here
+/// until route config is available, after which the stateless router and
+/// any interceptor share this single snapshot.
+#[derive(Clone)]
+pub(crate) struct RouteConfigSelectorService<S> {
+    inner: S,
+    watcher: Arc<RouteConfigWatcher>,
+}
+
+impl<S, B> Service<Request<B>> for RouteConfigSelectorService<S>
+where
+    S: Service<Request<B>, Error: Into<BoxError>> + Clone + Send + 'static,
+    B: Send + 'static,
+    S::Future: Send + 'static,
+{
+    type Response = S::Response;
+    type Error = BoxError;
+    type Future = BoxFuture<Result<Self::Response, Self::Error>>;
+
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.inner.poll_ready(cx).map_err(Into::into)
+    }
+
+    fn call(&mut self, mut request: Request<B>) -> Self::Future {
+        let watcher = self.watcher.clone();
+        let mut inner = self.inner.clone();
+        Box::pin(async move {
+            let config = watcher.snapshot().await?;
+            request.extensions_mut().insert(ActiveRouteConfig(config));
+            inner.call(request).await.map_err(Into::into)
+        })
+    }
+}
+
+/// Layer producing a [`RouteConfigSelectorService`].
+#[derive(Clone)]
+pub(crate) struct RouteConfigSelectorLayer {
+    watcher: Arc<RouteConfigWatcher>,
+}
+
+impl RouteConfigSelectorLayer {
+    pub(crate) fn new(watcher: Arc<RouteConfigWatcher>) -> Self {
+        Self { watcher }
+    }
+}
+
+impl<S> Layer<S> for RouteConfigSelectorLayer {
+    type Service = RouteConfigSelectorService<S>;
+
+    fn layer(&self, service: S) -> Self::Service {
+        RouteConfigSelectorService {
+            inner: service,
+            watcher: self.watcher.clone(),
+        }
+    }
+}
+
+/// Tower service that runs a [`PreRouteInterceptor`] before routing.
+///
+/// Reads the [`ActiveRouteConfig`] bound upstream and lets the interceptor
+/// mutate request headers using its metadata; the mutated headers are then seen
+/// by the router in the same pass.
+#[derive(Clone)]
+pub(crate) struct PreRouteService<S> {
+    inner: S,
+    interceptor: Arc<dyn PreRouteInterceptor>,
+}
+
+impl<S, B> Service<Request<B>> for PreRouteService<S>
+where
+    S: Service<Request<B>, Error: Into<BoxError>> + Clone + Send + 'static,
+    B: Send + 'static,
+    S::Future: Send + 'static,
+{
+    type Response = S::Response;
+    type Error = BoxError;
+    type Future = BoxFuture<Result<Self::Response, Self::Error>>;
+
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.inner.poll_ready(cx).map_err(Into::into)
+    }
+
+    fn call(&mut self, mut request: Request<B>) -> Self::Future {
+        if let Some(active) = request.extensions().get::<ActiveRouteConfig>().cloned() {
+            self.interceptor
+                .on_request(request.headers_mut(), &active.0.metadata);
+        }
+        let mut inner = self.inner.clone();
+        Box::pin(async move { inner.call(request).await.map_err(Into::into) })
+    }
+}
+
+/// Layer producing a [`PreRouteService`].
+#[derive(Clone)]
+pub(crate) struct PreRouteLayer {
+    interceptor: Arc<dyn PreRouteInterceptor>,
+}
+
+impl PreRouteLayer {
+    pub(crate) fn new(interceptor: Arc<dyn PreRouteInterceptor>) -> Self {
+        Self { interceptor }
+    }
+}
+
+impl<S> Layer<S> for PreRouteLayer {
+    type Service = PreRouteService<S>;
+
+    fn layer(&self, service: S) -> Self::Service {
+        PreRouteService {
+            inner: service,
+            interceptor: self.interceptor.clone(),
         }
     }
 }
@@ -176,5 +333,114 @@ mod tests {
             captured.lock().unwrap().as_deref(),
             Some("greeter.svc:50051"),
         );
+    }
+
+    #[tokio::test]
+    async fn pre_route_interceptor_drives_partition_selection() {
+        use crate::xds::cache::XdsCache;
+        use crate::xds::resource::route_config::{
+            HeaderMatchSpecifierConfig, HeaderMatcherConfig, PathSpecifierConfig, RouteConfig,
+            RouteConfigAction, RouteConfigMatch, RouteConfigResource, VirtualHostConfig,
+        };
+        use crate::xds::routing::XdsRouter;
+        use envoy_types::pb::envoy::config::core::v3::Metadata;
+        use envoy_types::pb::google::protobuf::Struct;
+
+        // Route table: x-partition N -> cluster-pN, matched via integer range.
+        fn partition_route(partition: i64, cluster: &str) -> RouteConfig {
+            RouteConfig {
+                match_criteria: RouteConfigMatch {
+                    path_specifier: PathSpecifierConfig::Prefix("/".into()),
+                    headers: vec![HeaderMatcherConfig {
+                        name: "x-partition".into(),
+                        match_specifier: HeaderMatchSpecifierConfig::Range {
+                            start: partition,
+                            end: partition + 1,
+                        },
+                        invert_match: false,
+                    }],
+                    case_sensitive: true,
+                    match_fraction: None,
+                },
+                action: RouteConfigAction::Cluster(cluster.into()),
+            }
+        }
+
+        // Config carries filter_metadata that the interceptor is expected to see.
+        let mut filter_metadata = std::collections::HashMap::new();
+        filter_metadata.insert("partitioning".to_string(), Struct::default());
+        let metadata = Metadata {
+            filter_metadata,
+            ..Default::default()
+        }
+        .into();
+
+        let rc = Arc::new(RouteConfigResource {
+            name: "rc".into(),
+            virtual_hosts: vec![VirtualHostConfig {
+                name: "vh".into(),
+                domains: vec!["*".into()],
+                routes: vec![
+                    partition_route(1, "cluster-p1"),
+                    partition_route(2, "cluster-p2"),
+                ],
+            }],
+            metadata,
+        });
+
+        let cache = XdsCache::new();
+        cache.update_route_config(rc);
+        tokio::task::yield_now().await;
+
+        /// Reads the `hint` header, verifies metadata is delivered, and injects
+        /// the partition header the router selects on.
+        struct PartitionInterceptor;
+        impl PreRouteInterceptor for PartitionInterceptor {
+            fn on_request(&self, headers: &mut http::HeaderMap, metadata: &RouteConfigMetadata) {
+                assert!(
+                    metadata.filter_metadata("partitioning").is_some(),
+                    "interceptor must see the RouteConfiguration metadata",
+                );
+                let partition = match headers.get("hint").and_then(|v| v.to_str().ok()) {
+                    Some("a") => "1",
+                    _ => "2",
+                };
+                headers.insert("x-partition", partition.parse().unwrap());
+            }
+        }
+
+        let captured: Arc<Mutex<Option<String>>> = Arc::new(Mutex::new(None));
+        let terminal = {
+            let captured = captured.clone();
+            service_fn(move |req: Request<()>| {
+                let captured = captured.clone();
+                async move {
+                    let cluster = req
+                        .extensions()
+                        .get::<RouteDecision>()
+                        .map(|d| d.cluster.clone());
+                    *captured.lock().unwrap() = cluster;
+                    Ok::<_, BoxError>(http::Response::new(()))
+                }
+            })
+        };
+
+        let watcher = Arc::new(RouteConfigWatcher::new(&cache));
+        let router: Arc<dyn Router> = Arc::new(XdsRouter);
+        let interceptor: Arc<dyn PreRouteInterceptor> = Arc::new(PartitionInterceptor);
+        let svc = RouteConfigSelectorLayer::new(watcher).layer(
+            PreRouteLayer::new(interceptor)
+                .layer(XdsRoutingLayer::new(router, Arc::from("svc")).layer(terminal)),
+        );
+
+        // hint "a" -> partition 1 -> cluster-p1
+        let req = Request::builder().header("hint", "a").body(()).unwrap();
+        svc.clone().oneshot(req).await.unwrap();
+        assert_eq!(captured.lock().unwrap().as_deref(), Some("cluster-p1"));
+
+        // hint "b" -> partition 2 -> cluster-p2
+        let req = Request::builder().header("hint", "b").body(()).unwrap();
+        svc.oneshot(req).await.unwrap();
+        assert_eq!(captured.lock().unwrap().as_deref(), Some("cluster-p2"));
     }
 }

--- a/tonic-xds/src/client/route.rs
+++ b/tonic-xds/src/client/route.rs
@@ -1,6 +1,6 @@
 use crate::common::async_util::BoxFuture;
-use crate::xds::resource::route_config::{RouteConfigMetadata, RouteConfigResource};
-use crate::xds::routing::{RouteConfigWatcher, RoutingError};
+use crate::xds::resource::route_config::RouteConfigMetadata;
+use crate::xds::routing::RoutingError;
 use http::Request;
 use std::sync::Arc;
 use std::task::{Context, Poll};
@@ -13,12 +13,6 @@ pub(crate) struct RouteInput<'a> {
     pub authority: &'a str,
     /// The HTTP headers of the request. These can be used for header-based routing decisions.
     pub headers: &'a http::HeaderMap,
-    /// Route configuration already bound to this request by an upstream
-    /// [`RouteConfigSelectorService`]. When `Some`, the router matches against
-    /// it directly (the single-pass path shared with a pre-route interceptor);
-    /// when `None`, routing fails with `RoutingError::NotReady` (the selector
-    /// layer always sets it in the assembled channel stack).
-    pub config: Option<&'a RouteConfigResource>,
 }
 
 /// Represents the routing decision made by the routing layer.
@@ -34,30 +28,15 @@ pub(crate) struct RouteDecision {
     pub request_hash: Option<u64>,
 }
 
-/// Marker stored in request extensions carrying the [`RouteConfigResource`]
-/// bound to a request by [`RouteConfigSelectorService`].
+/// A hook that runs before xDS route selection.
 ///
-/// Binding the config once and sharing it via extensions guarantees that a
-/// [`PreRouteInterceptor`] and the router observe the *same* route-config
-/// version for a given request, even if an xDS update lands mid-request.
-#[derive(Clone)]
-pub(crate) struct ActiveRouteConfig(pub(crate) Arc<RouteConfigResource>);
-
-/// A hook that runs **before** xDS route selection.
-///
-/// The interceptor may inspect and mutate the request headers using the
-/// [`RouteConfigMetadata`] attached to the active `RouteConfiguration`. Because
-/// it runs before routing, any header mutation it makes is visible to route
-/// matching — enabling config-driven request transformation, such as computing
-/// a partition/shard key and injecting a routing header that the standard
-/// header-match router then selects on.
-///
-/// The hook deliberately cannot return a routing decision: it influences routing
-/// only by mutating the request, after which the standard xDS router runs once.
-/// This keeps the routing model itself unchanged and single-pass.
+/// The interceptor may mutate the request headers using the route
+/// configuration's [`RouteConfigMetadata`]. Because it runs before routing, its
+/// mutations are visible to route matching — enabling config-driven request
+/// transformation (e.g. computing a partition/shard key and injecting a routing
+/// header the router then matches on). It cannot otherwise influence routing.
 pub trait PreRouteInterceptor: Send + Sync + 'static {
-    /// Inspects and optionally mutates `headers` using the active route-config
-    /// `metadata`. Runs before route selection.
+    /// Inspects and optionally mutates `headers` using the route-config `metadata`.
     fn on_request(&self, headers: &mut http::HeaderMap, metadata: &RouteConfigMetadata);
 }
 
@@ -68,6 +47,12 @@ pub trait PreRouteInterceptor: Send + Sync + 'static {
 /// [`XdsRouter`](crate::xds::routing::XdsRouter).
 pub(crate) trait Router: Send + Sync + 'static {
     fn route(&self, input: &RouteInput<'_>) -> BoxFuture<Result<RouteDecision, RoutingError>>;
+
+    /// Current route-config metadata, if available, used to feed a
+    /// [`PreRouteInterceptor`]. Defaults to `None` (e.g. for mock routers).
+    fn metadata(&self) -> Option<RouteConfigMetadata> {
+        None
+    }
 }
 
 /// Tower service for routing requests to the appropriate cluster.
@@ -80,6 +65,8 @@ pub(crate) struct XdsRoutingService<S> {
     inner: S,
     /// The router used to make routing decisions based on the request.
     router: Arc<dyn Router>,
+    /// Optional hook run before routing; may mutate request headers.
+    interceptor: Option<Arc<dyn PreRouteInterceptor>>,
     /// Channel-level authority used as the routing key.
     authority: Arc<str>,
 }
@@ -100,19 +87,21 @@ where
 
     fn call(&mut self, mut request: Request<B>) -> Self::Future {
         let router = self.router.clone();
+        let interceptor = self.interceptor.clone();
         let authority = self.authority.clone();
         let mut inner_service = self.inner.clone();
         Box::pin(async move {
-            let active = request.extensions().get::<ActiveRouteConfig>().cloned();
-            let route_future = {
-                let route_input = RouteInput {
-                    authority: &authority,
-                    headers: request.headers(),
-                    config: active.as_ref().map(|a| a.0.as_ref()),
-                };
-                router.route(&route_input)
+            if let Some(interceptor) = interceptor.as_ref()
+                && let Some(metadata) = router.metadata()
+            {
+                interceptor.on_request(request.headers_mut(), &metadata);
+            }
+            let headers = &request.headers();
+            let route_input = RouteInput {
+                authority: &authority,
+                headers,
             };
-            let route_decision = route_future.await?;
+            let route_decision = router.route(&route_input).await?;
             request.extensions_mut().insert(route_decision);
             inner_service.call(request).await.map_err(Into::into)
         })
@@ -124,17 +113,27 @@ where
 #[allow(dead_code)]
 pub(crate) struct XdsRoutingLayer {
     router: Arc<dyn Router>,
+    interceptor: Option<Arc<dyn PreRouteInterceptor>>,
     authority: Arc<str>,
 }
 
 impl XdsRoutingLayer {
-    /// Creates a new `XdsRoutingLayer` with the given [`Router`] and authority.
+    /// Creates a new `XdsRoutingLayer` with the given [`Router`], optional
+    /// pre-route interceptor, and authority.
     ///
     /// `authority` is the routing key matched against `VirtualHost.domains`
     /// in RDS. It should be the endpoint portion of the xDS target.
     #[allow(dead_code)]
-    pub(crate) fn new(router: Arc<dyn Router>, authority: Arc<str>) -> Self {
-        Self { router, authority }
+    pub(crate) fn new(
+        router: Arc<dyn Router>,
+        interceptor: Option<Arc<dyn PreRouteInterceptor>>,
+        authority: Arc<str>,
+    ) -> Self {
+        Self {
+            router,
+            interceptor,
+            authority,
+        }
     }
 }
 
@@ -145,126 +144,8 @@ impl<S> Layer<S> for XdsRoutingLayer {
         XdsRoutingService {
             inner: service,
             router: self.router.clone(),
-            authority: self.authority.clone(),
-        }
-    }
-}
-
-/// Tower service that snapshots the active route configuration once and binds it
-/// to the request as [`ActiveRouteConfig`], before any pre-route interceptor or
-/// the router runs.
-///
-/// It also owns A57 initial-resource readiness: the first request blocks here
-/// until route config is available, after which the stateless router and
-/// any interceptor share this single snapshot.
-#[derive(Clone)]
-pub(crate) struct RouteConfigSelectorService<S> {
-    inner: S,
-    watcher: Arc<RouteConfigWatcher>,
-}
-
-impl<S, B> Service<Request<B>> for RouteConfigSelectorService<S>
-where
-    S: Service<Request<B>, Error: Into<BoxError>> + Clone + Send + 'static,
-    B: Send + 'static,
-    S::Future: Send + 'static,
-{
-    type Response = S::Response;
-    type Error = BoxError;
-    type Future = BoxFuture<Result<Self::Response, Self::Error>>;
-
-    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
-        self.inner.poll_ready(cx).map_err(Into::into)
-    }
-
-    fn call(&mut self, mut request: Request<B>) -> Self::Future {
-        let watcher = self.watcher.clone();
-        let mut inner = self.inner.clone();
-        Box::pin(async move {
-            let config = watcher.snapshot().await?;
-            request.extensions_mut().insert(ActiveRouteConfig(config));
-            inner.call(request).await.map_err(Into::into)
-        })
-    }
-}
-
-/// Layer producing a [`RouteConfigSelectorService`].
-#[derive(Clone)]
-pub(crate) struct RouteConfigSelectorLayer {
-    watcher: Arc<RouteConfigWatcher>,
-}
-
-impl RouteConfigSelectorLayer {
-    pub(crate) fn new(watcher: Arc<RouteConfigWatcher>) -> Self {
-        Self { watcher }
-    }
-}
-
-impl<S> Layer<S> for RouteConfigSelectorLayer {
-    type Service = RouteConfigSelectorService<S>;
-
-    fn layer(&self, service: S) -> Self::Service {
-        RouteConfigSelectorService {
-            inner: service,
-            watcher: self.watcher.clone(),
-        }
-    }
-}
-
-/// Tower service that runs a [`PreRouteInterceptor`] before routing.
-///
-/// Reads the [`ActiveRouteConfig`] bound upstream and lets the interceptor
-/// mutate request headers using its metadata; the mutated headers are then seen
-/// by the router in the same pass.
-#[derive(Clone)]
-pub(crate) struct PreRouteService<S> {
-    inner: S,
-    interceptor: Arc<dyn PreRouteInterceptor>,
-}
-
-impl<S, B> Service<Request<B>> for PreRouteService<S>
-where
-    S: Service<Request<B>, Error: Into<BoxError>> + Clone + Send + 'static,
-    B: Send + 'static,
-    S::Future: Send + 'static,
-{
-    type Response = S::Response;
-    type Error = BoxError;
-    type Future = BoxFuture<Result<Self::Response, Self::Error>>;
-
-    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
-        self.inner.poll_ready(cx).map_err(Into::into)
-    }
-
-    fn call(&mut self, mut request: Request<B>) -> Self::Future {
-        if let Some(active) = request.extensions().get::<ActiveRouteConfig>().cloned() {
-            self.interceptor
-                .on_request(request.headers_mut(), &active.0.metadata);
-        }
-        let mut inner = self.inner.clone();
-        Box::pin(async move { inner.call(request).await.map_err(Into::into) })
-    }
-}
-
-/// Layer producing a [`PreRouteService`].
-#[derive(Clone)]
-pub(crate) struct PreRouteLayer {
-    interceptor: Arc<dyn PreRouteInterceptor>,
-}
-
-impl PreRouteLayer {
-    pub(crate) fn new(interceptor: Arc<dyn PreRouteInterceptor>) -> Self {
-        Self { interceptor }
-    }
-}
-
-impl<S> Layer<S> for PreRouteLayer {
-    type Service = PreRouteService<S>;
-
-    fn layer(&self, service: S) -> Self::Service {
-        PreRouteService {
-            inner: service,
             interceptor: self.interceptor.clone(),
+            authority: self.authority.clone(),
         }
     }
 }
@@ -301,7 +182,7 @@ mod tests {
         let router: Arc<dyn Router> = Arc::new(CaptureAuthorityRouter {
             captured: captured.clone(),
         });
-        let layer = XdsRoutingLayer::new(router, Arc::from("greeter.svc:50051"));
+        let layer = XdsRoutingLayer::new(router, None, Arc::from("greeter.svc:50051"));
 
         let inner =
             service_fn(
@@ -335,6 +216,8 @@ mod tests {
         );
     }
 
+    /// End-to-end check of the pre-route seam: the interceptor reads route-config
+    /// metadata and injects a partition header, which the router then matches.
     #[tokio::test]
     async fn pre_route_interceptor_drives_partition_selection() {
         use crate::xds::cache::XdsCache;
@@ -344,9 +227,8 @@ mod tests {
         };
         use crate::xds::routing::XdsRouter;
         use envoy_types::pb::envoy::config::core::v3::Metadata;
-        use envoy_types::pb::google::protobuf::Struct;
+        use envoy_types::pb::google::protobuf::{Any, Struct};
 
-        // Route table: x-partition N -> cluster-pN, matched via integer range.
         fn partition_route(partition: i64, cluster: &str) -> RouteConfig {
             RouteConfig {
                 match_criteria: RouteConfigMatch {
@@ -366,15 +248,24 @@ mod tests {
             }
         }
 
-        // Config carries filter_metadata that the interceptor is expected to see.
+        // Config carries both untyped and typed metadata the interceptor sees.
         let mut filter_metadata = std::collections::HashMap::new();
         filter_metadata.insert("partitioning".to_string(), Struct::default());
+        let mut typed_filter_metadata = std::collections::HashMap::new();
+        typed_filter_metadata.insert(
+            "partitioning-typed".to_string(),
+            Any {
+                type_url: "type.example/Partitioning".to_string(),
+                value: vec![1, 2, 3],
+            },
+        );
         let metadata = RouteConfigMetadata::from_proto(Metadata {
             filter_metadata,
-            ..Default::default()
+            typed_filter_metadata,
         });
 
-        let rc = Arc::new(RouteConfigResource {
+        let cache = XdsCache::new();
+        cache.update_route_config(Arc::new(RouteConfigResource {
             name: "rc".into(),
             virtual_hosts: vec![VirtualHostConfig {
                 name: "vh".into(),
@@ -385,21 +276,24 @@ mod tests {
                 ],
             }],
             metadata,
-        });
-
-        let cache = XdsCache::new();
-        cache.update_route_config(rc);
+        }));
+        let router: Arc<dyn Router> = Arc::new(XdsRouter::new(&cache));
         tokio::task::yield_now().await;
 
-        /// Reads the `hint` header, verifies metadata is delivered, and injects
-        /// the partition header the router selects on.
+        /// Reads the `hint` header, verifies metadata delivery, and injects the
+        /// partition header the router selects on.
         struct PartitionInterceptor;
         impl PreRouteInterceptor for PartitionInterceptor {
             fn on_request(&self, headers: &mut http::HeaderMap, metadata: &RouteConfigMetadata) {
                 assert!(
                     metadata.filter_metadata("partitioning").is_some(),
-                    "interceptor must see the RouteConfiguration metadata",
+                    "interceptor must see the untyped metadata",
                 );
+                let typed = metadata
+                    .typed_filter_metadata("partitioning-typed")
+                    .expect("interceptor must see the typed metadata");
+                assert_eq!(typed.type_url, "type.example/Partitioning");
+                assert_eq!(typed.value.as_ref(), [1, 2, 3]);
                 let partition = match headers.get("hint").and_then(|v| v.to_str().ok()) {
                     Some("a") => "1",
                     _ => "2",
@@ -424,13 +318,8 @@ mod tests {
             })
         };
 
-        let watcher = Arc::new(RouteConfigWatcher::new(&cache));
-        let router: Arc<dyn Router> = Arc::new(XdsRouter);
         let interceptor: Arc<dyn PreRouteInterceptor> = Arc::new(PartitionInterceptor);
-        let svc = RouteConfigSelectorLayer::new(watcher).layer(
-            PreRouteLayer::new(interceptor)
-                .layer(XdsRoutingLayer::new(router, Arc::from("svc")).layer(terminal)),
-        );
+        let svc = XdsRoutingLayer::new(router, Some(interceptor), Arc::from("svc")).layer(terminal);
 
         // hint "a" -> partition 1 -> cluster-p1
         let req = Request::builder().header("hint", "a").body(()).unwrap();

--- a/tonic-xds/src/lib.rs
+++ b/tonic-xds/src/lib.rs
@@ -147,7 +147,9 @@ pub(crate) mod xds;
 pub use client::channel::{
     BuildError, XdsChannel, XdsChannelBuilder, XdsChannelConfig, XdsChannelGrpc,
 };
+pub use client::route::PreRouteInterceptor;
 pub use xds::bootstrap::{BootstrapConfig, BootstrapError};
+pub use xds::resource::route_config::RouteConfigMetadata;
 pub use xds::uri::{XdsUri, XdsUriError};
 pub use xds_client::TonicCallCredentials;
 

--- a/tonic-xds/src/lib.rs
+++ b/tonic-xds/src/lib.rs
@@ -149,7 +149,7 @@ pub use client::channel::{
 };
 pub use client::route::PreRouteInterceptor;
 pub use xds::bootstrap::{BootstrapConfig, BootstrapError};
-pub use xds::resource::route_config::RouteConfigMetadata;
+pub use xds::resource::route_config::{RouteConfigMetadata, TypedMetadata};
 pub use xds::uri::{XdsUri, XdsUriError};
 pub use xds_client::TonicCallCredentials;
 

--- a/tonic-xds/src/xds/cache.rs
+++ b/tonic-xds/src/xds/cache.rs
@@ -186,6 +186,7 @@ mod tests {
                     action: RouteConfigAction::Cluster("cluster-1".to_string()),
                 }],
             }],
+            metadata: Default::default(),
         })
     }
 

--- a/tonic-xds/src/xds/resource/route_config.rs
+++ b/tonic-xds/src/xds/resource/route_config.rs
@@ -1,11 +1,13 @@
 //! Validated RouteConfiguration resource (RDS).
 
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 
 use bytes::Bytes;
+use envoy_types::pb::envoy::config::core::v3::Metadata;
 use envoy_types::pb::envoy::config::route::v3::{
     RouteConfiguration, RouteMatch, route, route_action, route_match,
 };
+use envoy_types::pb::google::protobuf::Struct;
 use prost::Message;
 use regex::Regex;
 use xds_client::resource::TypeUrl;
@@ -13,11 +15,51 @@ use xds_client::{Error, Resource};
 
 use super::string_matcher::StringMatcher;
 
+/// Read-only view over an xDS resource's `metadata.filter_metadata`
+/// (see [`envoy.config.core.v3.Metadata`]).
+///
+/// Exposes the untyped `google.protobuf.Struct` config keyed by
+/// `filter_metadata` namespace.
+/// This is the spec-native carrier for extensions that ride on standard xDS
+/// `metadata`, surfaced so that a pre-route interceptor (or other consumer)
+/// can read config that was attached to the `RouteConfiguration`.
+///
+/// [`envoy.config.core.v3.Metadata`]: https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/core/v3/base.proto#envoy-v3-api-msg-config-core-v3-metadata
+#[derive(Debug, Clone, Default)]
+pub struct RouteConfigMetadata {
+    filter_metadata: HashMap<String, Struct>,
+}
+
+impl RouteConfigMetadata {
+    /// Returns the untyped `filter_metadata` [`Struct`] for `namespace`, if present.
+    #[must_use]
+    pub fn filter_metadata(&self, namespace: &str) -> Option<&Struct> {
+        self.filter_metadata.get(namespace)
+    }
+
+    /// Returns `true` when no `filter_metadata` namespaces are present.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.filter_metadata.is_empty()
+    }
+}
+
+impl From<Metadata> for RouteConfigMetadata {
+    fn from(metadata: Metadata) -> Self {
+        Self {
+            filter_metadata: metadata.filter_metadata,
+        }
+    }
+}
+
 /// Validated RouteConfiguration.
 #[derive(Debug, Clone)]
 pub(crate) struct RouteConfigResource {
     pub name: String,
     pub virtual_hosts: Vec<VirtualHostConfig>,
+    /// Resource-level `metadata` (`filter_metadata`), surfaced for pre-route
+    /// interceptors. Empty when the `RouteConfiguration` carried no metadata.
+    pub metadata: RouteConfigMetadata,
 }
 
 /// Validated virtual host with domain matching and routes.
@@ -114,6 +156,10 @@ impl Resource for RouteConfigResource {
 
     fn validate(message: Self::Message) -> xds_client::Result<Self> {
         let name = message.name;
+        let metadata = message
+            .metadata
+            .map(RouteConfigMetadata::from)
+            .unwrap_or_default();
 
         if message.virtual_hosts.is_empty() {
             return Err(Error::Validation(format!(
@@ -148,6 +194,7 @@ impl Resource for RouteConfigResource {
         Ok(RouteConfigResource {
             name,
             virtual_hosts,
+            metadata,
         })
     }
 }

--- a/tonic-xds/src/xds/resource/route_config.rs
+++ b/tonic-xds/src/xds/resource/route_config.rs
@@ -7,7 +7,6 @@ use envoy_types::pb::envoy::config::core::v3::Metadata;
 use envoy_types::pb::envoy::config::route::v3::{
     RouteConfiguration, RouteMatch, route, route_action, route_match,
 };
-use envoy_types::pb::google::protobuf::Struct;
 use prost::Message;
 use regex::Regex;
 use xds_client::resource::TypeUrl;
@@ -18,23 +17,29 @@ use super::string_matcher::StringMatcher;
 /// Read-only view over an xDS resource's `metadata.filter_metadata`
 /// (see [`envoy.config.core.v3.Metadata`]).
 ///
-/// Exposes the untyped `google.protobuf.Struct` config keyed by
-/// `filter_metadata` namespace.
+/// Each `filter_metadata` namespace carries a `google.protobuf.Struct`; this
+/// exposes it as the **encoded protobuf bytes** (keyed by namespace) so
+/// consumers can decode it with their own prost message — for example a
+/// `Struct`, or a typed config proto that shares its wire format.
+///
 /// This is the spec-native carrier for extensions that ride on standard xDS
-/// `metadata`, surfaced so that a pre-route interceptor (or other consumer)
-/// can read config that was attached to the `RouteConfiguration`.
+/// `metadata`, surfaced so that a pre-route interceptor (or other consumer) can
+/// read config attached to the `RouteConfiguration`.
 ///
 /// [`envoy.config.core.v3.Metadata`]: https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/core/v3/base.proto#envoy-v3-api-msg-config-core-v3-metadata
 #[derive(Debug, Clone, Default)]
 pub struct RouteConfigMetadata {
-    filter_metadata: HashMap<String, Struct>,
+    /// Encoded `google.protobuf.Struct` bytes, keyed by `filter_metadata` namespace.
+    filter_metadata: HashMap<String, Bytes>,
 }
 
 impl RouteConfigMetadata {
-    /// Returns the untyped `filter_metadata` [`Struct`] for `namespace`, if present.
+    /// Returns the encoded `google.protobuf.Struct` for the `filter_metadata`
+    /// `namespace`, if present. Decode it with a prost message (for example a
+    /// `Struct`, or a typed config proto sharing its wire format).
     #[must_use]
-    pub fn filter_metadata(&self, namespace: &str) -> Option<&Struct> {
-        self.filter_metadata.get(namespace)
+    pub fn filter_metadata(&self, namespace: &str) -> Option<Bytes> {
+        self.filter_metadata.get(namespace).cloned()
     }
 
     /// Returns `true` when no `filter_metadata` namespaces are present.
@@ -42,13 +47,16 @@ impl RouteConfigMetadata {
     pub fn is_empty(&self) -> bool {
         self.filter_metadata.is_empty()
     }
-}
 
-impl From<Metadata> for RouteConfigMetadata {
-    fn from(metadata: Metadata) -> Self {
-        Self {
-            filter_metadata: metadata.filter_metadata,
-        }
+    /// Builds the view from an xDS `Metadata`, pre-encoding each namespace's
+    /// `Struct` to bytes.
+    pub(crate) fn from_proto(metadata: Metadata) -> Self {
+        let filter_metadata = metadata
+            .filter_metadata
+            .into_iter()
+            .map(|(namespace, value)| (namespace, Bytes::from(value.encode_to_vec())))
+            .collect();
+        Self { filter_metadata }
     }
 }
 
@@ -158,7 +166,7 @@ impl Resource for RouteConfigResource {
         let name = message.name;
         let metadata = message
             .metadata
-            .map(RouteConfigMetadata::from)
+            .map(RouteConfigMetadata::from_proto)
             .unwrap_or_default();
 
         if message.virtual_hosts.is_empty() {

--- a/tonic-xds/src/xds/resource/route_config.rs
+++ b/tonic-xds/src/xds/resource/route_config.rs
@@ -14,13 +14,23 @@ use xds_client::{Error, Resource};
 
 use super::string_matcher::StringMatcher;
 
-/// Read-only view over an xDS resource's `metadata.filter_metadata`
-/// (see [`envoy.config.core.v3.Metadata`]).
+/// A `typed_filter_metadata` entry — a `google.protobuf.Any` (a type URL plus an
+/// encoded message value).
+#[derive(Debug, Clone)]
+pub struct TypedMetadata {
+    /// Type URL identifying the message encoded in `value`.
+    pub type_url: String,
+    /// The encoded message; decode it according to `type_url`.
+    pub value: Bytes,
+}
+
+/// Read-only view over an xDS resource's `metadata` (see
+/// [`envoy.config.core.v3.Metadata`]).
 ///
-/// Each `filter_metadata` namespace carries a `google.protobuf.Struct`; this
-/// exposes it as the **encoded protobuf bytes** (keyed by namespace) so
-/// consumers can decode it with their own prost message — for example a
-/// `Struct`, or a typed config proto that shares its wire format.
+/// Exposes both metadata maps — untyped `filter_metadata`
+/// (`google.protobuf.Struct`) and typed `typed_filter_metadata`
+/// (`google.protobuf.Any`) — as encoded bytes, so consumers can decode them with
+/// their own prost messages.
 ///
 /// This is the spec-native carrier for extensions that ride on standard xDS
 /// `metadata`, surfaced so that a pre-route interceptor (or other consumer) can
@@ -31,10 +41,12 @@ use super::string_matcher::StringMatcher;
 pub struct RouteConfigMetadata {
     /// Encoded `google.protobuf.Struct` bytes, keyed by `filter_metadata` namespace.
     filter_metadata: HashMap<String, Bytes>,
+    /// Typed `google.protobuf.Any` entries, keyed by `typed_filter_metadata` namespace.
+    typed_filter_metadata: HashMap<String, TypedMetadata>,
 }
 
 impl RouteConfigMetadata {
-    /// Returns the encoded `google.protobuf.Struct` for the `filter_metadata`
+    /// Returns the encoded untyped `filter_metadata` `google.protobuf.Struct` for
     /// `namespace`, if present. Decode it with a prost message (for example a
     /// `Struct`, or a typed config proto sharing its wire format).
     #[must_use]
@@ -42,21 +54,44 @@ impl RouteConfigMetadata {
         self.filter_metadata.get(namespace).cloned()
     }
 
-    /// Returns `true` when no `filter_metadata` namespaces are present.
+    /// Returns the typed `typed_filter_metadata` `google.protobuf.Any` for
+    /// `namespace`, if present.
+    #[must_use]
+    pub fn typed_filter_metadata(&self, namespace: &str) -> Option<TypedMetadata> {
+        self.typed_filter_metadata.get(namespace).cloned()
+    }
+
+    /// Returns `true` when both metadata maps are empty.
     #[must_use]
     pub fn is_empty(&self) -> bool {
-        self.filter_metadata.is_empty()
+        self.filter_metadata.is_empty() && self.typed_filter_metadata.is_empty()
     }
 
     /// Builds the view from an xDS `Metadata`, pre-encoding each namespace's
-    /// `Struct` to bytes.
+    /// `Struct`/`Any` to bytes.
     pub(crate) fn from_proto(metadata: Metadata) -> Self {
         let filter_metadata = metadata
             .filter_metadata
             .into_iter()
             .map(|(namespace, value)| (namespace, Bytes::from(value.encode_to_vec())))
             .collect();
-        Self { filter_metadata }
+        let typed_filter_metadata = metadata
+            .typed_filter_metadata
+            .into_iter()
+            .map(|(namespace, any)| {
+                (
+                    namespace,
+                    TypedMetadata {
+                        type_url: any.type_url,
+                        value: Bytes::from(any.value),
+                    },
+                )
+            })
+            .collect();
+        Self {
+            filter_metadata,
+            typed_filter_metadata,
+        }
     }
 }
 

--- a/tonic-xds/src/xds/resource_manager.rs
+++ b/tonic-xds/src/xds/resource_manager.rs
@@ -320,6 +320,7 @@ mod tests {
                     })
                     .collect(),
             }],
+            metadata: Default::default(),
         })
     }
 
@@ -344,6 +345,7 @@ mod tests {
                         })
                         .collect(),
                 }],
+                metadata: Default::default(),
             }),
         })
     }

--- a/tonic-xds/src/xds/routing.rs
+++ b/tonic-xds/src/xds/routing.rs
@@ -25,34 +25,34 @@ use crate::xds::cache::XdsCache;
 use crate::xds::resource::hash_policy::HashPolicyConfig;
 use crate::xds::resource::route_config::{
     HeaderMatchSpecifierConfig, HeaderMatcherConfig, PathSpecifierConfig, RouteConfig,
-    RouteConfigAction, RouteConfigMatch, RouteConfigResource, VirtualHostConfig, WeightedCluster,
+    RouteConfigAction, RouteConfigMatch, RouteConfigMetadata, RouteConfigResource,
+    VirtualHostConfig, WeightedCluster,
 };
 
 /// Default timeout for waiting for the initial route config (matches gRFC A57
 /// resource initial timeout).
 const DEFAULT_READY_TIMEOUT: Duration = Duration::from_secs(30);
 
-/// Watches route configuration from the [`XdsCache`] and hands out point-in-time
-/// snapshots.
+/// xDS-backed [`Router`] that resolves requests to cluster names.
 ///
-/// This is the stateful half of routing: it spawns a background task that keeps a
-/// lock-free [`ArcSwapOption`] up to date and tracks A57 initial-resource
-/// readiness. A snapshot taken here can be *bound to a request* (see
-/// [`ActiveRouteConfig`](crate::client::route::ActiveRouteConfig)) so that a
-/// pre-route interceptor and the [`XdsRouter`] both observe the same config
-/// version for a given request. The watch task is aborted when the watcher is
-/// dropped.
-pub(crate) struct RouteConfigWatcher {
+/// Subscribes to route config changes from [`XdsCache`] via a background watch task
+/// and maintains a shared [`ArcSwapOption`] for lock-free reads on the hot path.
+/// The watch task is aborted when the router is dropped.
+///
+/// The first RPC blocks (up to [`DEFAULT_READY_TIMEOUT`]) until the initial route
+/// config is available, matching standard gRPC behavior where RPCs wait for the
+/// resolver's first update. Subsequent RPCs read the config lock-free.
+pub(crate) struct XdsRouter {
     route_config: Arc<ArcSwapOption<RouteConfigResource>>,
     ready_rx: watch::Receiver<bool>,
     _watch_task: AbortOnDrop,
 }
 
-impl RouteConfigWatcher {
-    /// Creates a watcher that tracks route config from the given cache.
+impl XdsRouter {
+    /// Creates a new `XdsRouter` that watches route config from the given cache.
     ///
     /// Spawns a background task that updates the local route config whenever
-    /// the cache publishes a new one. The task is aborted when this watcher
+    /// the cache publishes a new one. The task is aborted when this router
     /// is dropped.
     pub(crate) fn new(cache: &XdsCache) -> Self {
         let route_config = Arc::new(ArcSwapOption::empty());
@@ -75,47 +75,35 @@ impl RouteConfigWatcher {
             _watch_task: AbortOnDrop(handle),
         }
     }
-
-    /// Returns the active route configuration, waiting up to
-    /// [`DEFAULT_READY_TIMEOUT`] for the first one if none has arrived yet.
-    ///
-    /// This mirrors standard gRPC behavior where RPCs block until the watcher
-    /// provides its first update.
-    pub(crate) async fn snapshot(&self) -> Result<Arc<RouteConfigResource>, RoutingError> {
-        // Fast path: config already available.
-        if let Some(rc) = self.route_config.load_full() {
-            return Ok(rc);
-        }
-        // Slow path: wait for the initial route config.
-        let mut ready_rx = self.ready_rx.clone();
-        tokio::time::timeout(DEFAULT_READY_TIMEOUT, ready_rx.wait_for(|ready| *ready))
-            .await
-            .map_err(|_| RoutingError::NotReady)?
-            .map_err(|_| RoutingError::NotReady)?;
-        self.route_config.load_full().ok_or(RoutingError::NotReady)
-    }
 }
-
-/// xDS-backed [`Router`] that resolves requests to cluster names.
-///
-/// A pure matcher: it operates on the [`RouteConfigResource`] bound to the
-/// request by the upstream route-config selector stage (via [`RouteInput::config`]).
-/// It holds no state and performs no I/O — route matching is a pure function of
-/// the bound config, authority, and headers.
-///
-/// In the assembled channel the route-config selector stage always runs first, so
-/// config is always bound; if it is somehow missing, the router returns
-/// [`RoutingError::NotReady`].
-pub(crate) struct XdsRouter;
 
 impl Router for XdsRouter {
     fn route(&self, input: &RouteInput<'_>) -> BoxFuture<Result<RouteDecision, RoutingError>> {
-        // Pure, synchronous match against the config bound to this request.
-        let decision = match input.config {
-            Some(config) => resolve_route(config, input.authority, input.headers),
-            None => Err(RoutingError::NotReady),
-        };
-        Box::pin(async move { decision })
+        let authority = input.authority.to_string();
+        let headers = input.headers.clone();
+
+        // Fast path: config already available, no cloning needed.
+        if let Some(rc) = self.route_config.load_full() {
+            return Box::pin(async move { resolve_route(&rc, &authority, &headers) });
+        }
+
+        // Slow path: wait for the initial route config, matching standard
+        // gRPC behavior where RPCs block until the resolver provides the
+        // first update.
+        let route_config_ref = self.route_config.clone();
+        let mut ready_rx = self.ready_rx.clone();
+        Box::pin(async move {
+            tokio::time::timeout(DEFAULT_READY_TIMEOUT, ready_rx.wait_for(|ready| *ready))
+                .await
+                .map_err(|_| RoutingError::NotReady)?
+                .map_err(|_| RoutingError::NotReady)?;
+            let rc = route_config_ref.load_full().ok_or(RoutingError::NotReady)?;
+            resolve_route(&rc, &authority, &headers)
+        })
+    }
+
+    fn metadata(&self) -> Option<RouteConfigMetadata> {
+        self.route_config.load_full().map(|rc| rc.metadata.clone())
     }
 }
 
@@ -365,7 +353,7 @@ mod tests {
     use super::*;
     use crate::xds::cache::XdsCache;
     use crate::xds::resource::route_config::{
-        RouteConfig, RouteConfigAction, RouteConfigMatch, RouteConfigMetadata, VirtualHostConfig,
+        RouteConfig, RouteConfigAction, RouteConfigMatch, VirtualHostConfig,
     };
     use crate::xds::resource::string_matcher::StringMatcher;
 
@@ -385,7 +373,7 @@ mod tests {
         RouteConfigResource {
             name: "test-rc".into(),
             virtual_hosts,
-            metadata: RouteConfigMetadata::default(),
+            metadata: Default::default(),
         }
     }
 
@@ -1065,60 +1053,66 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn watcher_reflects_config_updates() {
+    async fn xds_router_routes_to_correct_cluster() {
         let cache = XdsCache::new();
-        let watcher = RouteConfigWatcher::new(&cache);
-        let router = XdsRouter;
-        let headers = http::HeaderMap::new();
+        cache.update_route_config(make_route_config("my-cluster"));
 
+        let router = XdsRouter::new(&cache);
+        tokio::task::yield_now().await; // let watch task propagate
+
+        let headers = http::HeaderMap::new();
+        let input = RouteInput {
+            authority: "my-service",
+            headers: &headers,
+        };
+        let decision = router.route(&input).await.unwrap();
+        assert_eq!(decision.cluster, "my-cluster");
+    }
+
+    #[tokio::test]
+    async fn xds_router_updates_on_config_change() {
+        let cache = XdsCache::new();
         cache.update_route_config(make_route_config("cluster-a"));
+
+        let router = XdsRouter::new(&cache);
         tokio::task::yield_now().await;
-        let rc = watcher.snapshot().await.unwrap();
+
+        let headers = http::HeaderMap::new();
         let input = RouteInput {
             authority: "svc",
             headers: &headers,
-            config: Some(&rc),
         };
-        assert_eq!(router.route(&input).await.unwrap().cluster, "cluster-a");
+
+        let decision = router.route(&input).await.unwrap();
+        assert_eq!(decision.cluster, "cluster-a");
 
         cache.update_route_config(make_route_config("cluster-b"));
         tokio::task::yield_now().await;
-        let rc = watcher.snapshot().await.unwrap();
-        let input = RouteInput {
-            authority: "svc",
-            headers: &headers,
-            config: Some(&rc),
-        };
-        assert_eq!(router.route(&input).await.unwrap().cluster, "cluster-b");
-    }
 
-    #[tokio::test]
-    async fn router_matches_bound_config() {
-        let rc = make_route_config("bound-cluster");
-        let router = XdsRouter;
-
-        let headers = http::HeaderMap::new();
-        let input = RouteInput {
-            authority: "svc",
-            headers: &headers,
-            config: Some(&rc),
-        };
         let decision = router.route(&input).await.unwrap();
-        assert_eq!(decision.cluster, "bound-cluster");
+        assert_eq!(decision.cluster, "cluster-b");
     }
 
     #[tokio::test]
-    async fn router_without_bound_config_is_not_ready() {
-        let router = XdsRouter;
+    async fn xds_router_returns_not_ready_without_config() {
+        let cache = XdsCache::new();
+        let router = XdsRouter::new(&cache);
+
         let headers = http::HeaderMap::new();
         let input = RouteInput {
             authority: "svc",
             headers: &headers,
-            config: None,
         };
-        assert!(matches!(
-            router.route(&input).await,
-            Err(RoutingError::NotReady)
-        ));
+        // The router now blocks waiting for config; verify it returns
+        // NotReady after the timeout elapses.
+        let result =
+            tokio::time::timeout(std::time::Duration::from_millis(100), router.route(&input)).await;
+        // Either the inner timeout fires (NotReady) or the outer timeout
+        // fires (config never arrived) — both are correct.
+        match result {
+            Ok(Err(RoutingError::NotReady)) => {}
+            Err(_elapsed) => {}
+            other => panic!("expected NotReady or timeout, got {other:?}"),
+        }
     }
 }

--- a/tonic-xds/src/xds/routing.rs
+++ b/tonic-xds/src/xds/routing.rs
@@ -32,26 +32,27 @@ use crate::xds::resource::route_config::{
 /// resource initial timeout).
 const DEFAULT_READY_TIMEOUT: Duration = Duration::from_secs(30);
 
-/// xDS-backed [`Router`] that resolves requests to cluster names.
+/// Watches route configuration from the [`XdsCache`] and hands out point-in-time
+/// snapshots.
 ///
-/// Subscribes to route config changes from [`XdsCache`] via a background watch task
-/// and maintains a shared [`ArcSwapOption`] for lock-free reads on the hot path.
-/// The watch task is aborted when the router is dropped.
-///
-/// The first RPC blocks (up to [`DEFAULT_READY_TIMEOUT`]) until the initial route
-/// config is available, matching standard gRPC behavior where RPCs wait for the
-/// resolver's first update. Subsequent RPCs read the config lock-free.
-pub(crate) struct XdsRouter {
+/// This is the stateful half of routing: it spawns a background task that keeps a
+/// lock-free [`ArcSwapOption`] up to date and tracks A57 initial-resource
+/// readiness. A snapshot taken here can be *bound to a request* (see
+/// [`ActiveRouteConfig`](crate::client::route::ActiveRouteConfig)) so that a
+/// pre-route interceptor and the [`XdsRouter`] both observe the same config
+/// version for a given request. The watch task is aborted when the watcher is
+/// dropped.
+pub(crate) struct RouteConfigWatcher {
     route_config: Arc<ArcSwapOption<RouteConfigResource>>,
     ready_rx: watch::Receiver<bool>,
     _watch_task: AbortOnDrop,
 }
 
-impl XdsRouter {
-    /// Creates a new `XdsRouter` that watches route config from the given cache.
+impl RouteConfigWatcher {
+    /// Creates a watcher that tracks route config from the given cache.
     ///
     /// Spawns a background task that updates the local route config whenever
-    /// the cache publishes a new one. The task is aborted when this router
+    /// the cache publishes a new one. The task is aborted when this watcher
     /// is dropped.
     pub(crate) fn new(cache: &XdsCache) -> Self {
         let route_config = Arc::new(ArcSwapOption::empty());
@@ -74,31 +75,47 @@ impl XdsRouter {
             _watch_task: AbortOnDrop(handle),
         }
     }
+
+    /// Returns the active route configuration, waiting up to
+    /// [`DEFAULT_READY_TIMEOUT`] for the first one if none has arrived yet.
+    ///
+    /// This mirrors standard gRPC behavior where RPCs block until the watcher
+    /// provides its first update.
+    pub(crate) async fn snapshot(&self) -> Result<Arc<RouteConfigResource>, RoutingError> {
+        // Fast path: config already available.
+        if let Some(rc) = self.route_config.load_full() {
+            return Ok(rc);
+        }
+        // Slow path: wait for the initial route config.
+        let mut ready_rx = self.ready_rx.clone();
+        tokio::time::timeout(DEFAULT_READY_TIMEOUT, ready_rx.wait_for(|ready| *ready))
+            .await
+            .map_err(|_| RoutingError::NotReady)?
+            .map_err(|_| RoutingError::NotReady)?;
+        self.route_config.load_full().ok_or(RoutingError::NotReady)
+    }
 }
+
+/// xDS-backed [`Router`] that resolves requests to cluster names.
+///
+/// A pure matcher: it operates on the [`RouteConfigResource`] bound to the
+/// request by the upstream route-config selector stage (via [`RouteInput::config`]).
+/// It holds no state and performs no I/O — route matching is a pure function of
+/// the bound config, authority, and headers.
+///
+/// In the assembled channel the route-config selector stage always runs first, so
+/// config is always bound; if it is somehow missing, the router returns
+/// [`RoutingError::NotReady`].
+pub(crate) struct XdsRouter;
 
 impl Router for XdsRouter {
     fn route(&self, input: &RouteInput<'_>) -> BoxFuture<Result<RouteDecision, RoutingError>> {
-        let authority = input.authority.to_string();
-        let headers = input.headers.clone();
-
-        // Fast path: config already available, no cloning needed.
-        if let Some(rc) = self.route_config.load_full() {
-            return Box::pin(async move { resolve_route(&rc, &authority, &headers) });
-        }
-
-        // Slow path: wait for the initial route config, matching standard
-        // gRPC behavior where RPCs block until the resolver provides the
-        // first update.
-        let route_config_ref = self.route_config.clone();
-        let mut ready_rx = self.ready_rx.clone();
-        Box::pin(async move {
-            tokio::time::timeout(DEFAULT_READY_TIMEOUT, ready_rx.wait_for(|ready| *ready))
-                .await
-                .map_err(|_| RoutingError::NotReady)?
-                .map_err(|_| RoutingError::NotReady)?;
-            let rc = route_config_ref.load_full().ok_or(RoutingError::NotReady)?;
-            resolve_route(&rc, &authority, &headers)
-        })
+        // Pure, synchronous match against the config bound to this request.
+        let decision = match input.config {
+            Some(config) => resolve_route(config, input.authority, input.headers),
+            None => Err(RoutingError::NotReady),
+        };
+        Box::pin(async move { decision })
     }
 }
 
@@ -348,7 +365,7 @@ mod tests {
     use super::*;
     use crate::xds::cache::XdsCache;
     use crate::xds::resource::route_config::{
-        RouteConfig, RouteConfigAction, RouteConfigMatch, VirtualHostConfig,
+        RouteConfig, RouteConfigAction, RouteConfigMatch, RouteConfigMetadata, VirtualHostConfig,
     };
     use crate::xds::resource::string_matcher::StringMatcher;
 
@@ -368,6 +385,7 @@ mod tests {
         RouteConfigResource {
             name: "test-rc".into(),
             virtual_hosts,
+            metadata: RouteConfigMetadata::default(),
         }
     }
 
@@ -1047,66 +1065,60 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn xds_router_routes_to_correct_cluster() {
+    async fn watcher_reflects_config_updates() {
         let cache = XdsCache::new();
-        cache.update_route_config(make_route_config("my-cluster"));
-
-        let router = XdsRouter::new(&cache);
-        tokio::task::yield_now().await; // let watch task propagate
-
+        let watcher = RouteConfigWatcher::new(&cache);
+        let router = XdsRouter;
         let headers = http::HeaderMap::new();
-        let input = RouteInput {
-            authority: "my-service",
-            headers: &headers,
-        };
-        let decision = router.route(&input).await.unwrap();
-        assert_eq!(decision.cluster, "my-cluster");
-    }
 
-    #[tokio::test]
-    async fn xds_router_updates_on_config_change() {
-        let cache = XdsCache::new();
         cache.update_route_config(make_route_config("cluster-a"));
-
-        let router = XdsRouter::new(&cache);
         tokio::task::yield_now().await;
-
-        let headers = http::HeaderMap::new();
+        let rc = watcher.snapshot().await.unwrap();
         let input = RouteInput {
             authority: "svc",
             headers: &headers,
+            config: Some(&rc),
         };
-
-        let decision = router.route(&input).await.unwrap();
-        assert_eq!(decision.cluster, "cluster-a");
+        assert_eq!(router.route(&input).await.unwrap().cluster, "cluster-a");
 
         cache.update_route_config(make_route_config("cluster-b"));
         tokio::task::yield_now().await;
-
-        let decision = router.route(&input).await.unwrap();
-        assert_eq!(decision.cluster, "cluster-b");
+        let rc = watcher.snapshot().await.unwrap();
+        let input = RouteInput {
+            authority: "svc",
+            headers: &headers,
+            config: Some(&rc),
+        };
+        assert_eq!(router.route(&input).await.unwrap().cluster, "cluster-b");
     }
 
     #[tokio::test]
-    async fn xds_router_returns_not_ready_without_config() {
-        let cache = XdsCache::new();
-        let router = XdsRouter::new(&cache);
+    async fn router_matches_bound_config() {
+        let rc = make_route_config("bound-cluster");
+        let router = XdsRouter;
 
         let headers = http::HeaderMap::new();
         let input = RouteInput {
             authority: "svc",
             headers: &headers,
+            config: Some(&rc),
         };
-        // The router now blocks waiting for config; verify it returns
-        // NotReady after the timeout elapses.
-        let result =
-            tokio::time::timeout(std::time::Duration::from_millis(100), router.route(&input)).await;
-        // Either the inner timeout fires (NotReady) or the outer timeout
-        // fires (config never arrived) — both are correct.
-        match result {
-            Ok(Err(RoutingError::NotReady)) => {}
-            Err(_elapsed) => {}
-            other => panic!("expected NotReady or timeout, got {other:?}"),
-        }
+        let decision = router.route(&input).await.unwrap();
+        assert_eq!(decision.cluster, "bound-cluster");
+    }
+
+    #[tokio::test]
+    async fn router_without_bound_config_is_not_ready() {
+        let router = XdsRouter;
+        let headers = http::HeaderMap::new();
+        let input = RouteInput {
+            authority: "svc",
+            headers: &headers,
+            config: None,
+        };
+        assert!(matches!(
+            router.route(&input).await,
+            Err(RoutingError::NotReady)
+        ));
     }
 }


### PR DESCRIPTION
## Motivation

`tonic-xds` currently offers no way to customize routing per request: a request is matched to a route exactly as received, with no hook to inspect or transform it first. The xDS mechanism for this is the HTTP filter framework (gRFC A39) — filters running as interceptors around routing/LB, configured via `http_filters` / `typed_per_filter_config` — but that framework is not implemented in `tonic-xds` today, and isn't currently planned.

Some use cases only need a small slice of that capability: transforming a request (e.g. rewriting or injecting a header) **before** route selection, so the standard route table can then match on the result. With no extension point at all, these are impossible to express against `tonic-xds`.

## Solution

Add a minimal, opt-in **pre-route interceptor** hook that unblocks header-driven route customization without committing to the full filter framework:

- **`PreRouteInterceptor`** trait + **`XdsChannelBuilder::with_pre_route_interceptor(...)`** — runs before route selection and may mutate request headers.
- `RouteConfigMetadata` now parsed, passed into the interceptor as a customization point.

To keep the interceptor and router consistent, the routing stack is restructured:

- A `RouteConfigSelector` layer is extracted out of the routing layer, to own the async config swaps. This is done so the config snapshot can be inserted into request extension and reused by both the interceptor layer and the routing layer, avoid double and potentially inconsistent subscriptions.

When no interceptor is registered, behavior is unchanged. This is deliberately minimal; a future A39-style filter framework can build on the same watcher/selector/metadata pieces.

## Testing

- Unit tests for the watcher / selector / pure-matcher split.
- End-to-end test: an interceptor injects a header derived from route-config metadata, and the router selects the matching cluster.