### PR TITLE
feat(tonic-xds): expose the transport (connector) API publicly

### DIFF
--- a/tonic-xds/Cargo.toml
+++ b/tonic-xds/Cargo.toml
@@ -116,6 +116,7 @@ allowed_external_types = [
 
     "tower_service::Service",
     "tower::BoxError",
+    "tower::load::Load",
     "tower::util::boxed_clone_sync::BoxCloneSyncService",
     "url::parser::ParseError",
     "serde_core::de::Deserialize",

--- a/tonic-xds/src/client/endpoint.rs
+++ b/tonic-xds/src/client/endpoint.rs
@@ -50,7 +50,7 @@ impl From<String> for EndpointHost {
 
 /// Represents a validated endpoint address extracted from xDS
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub(crate) struct EndpointAddress {
+pub struct EndpointAddress {
     /// The IP address or hostname
     host: EndpointHost,
     /// The port number
@@ -61,8 +61,7 @@ impl EndpointAddress {
     /// Creates a new `EndpointAddress` from a host string and port.
     ///
     /// Attempts to parse the host as an IP address; falls back to hostname.
-    #[allow(dead_code)]
-    pub(crate) fn new(host: impl Into<String>, port: u16) -> Self {
+    pub fn new(host: impl Into<String>, port: u16) -> Self {
         Self {
             host: EndpointHost::from(host.into()),
             port,
@@ -116,7 +115,7 @@ impl Drop for InFlightTracker {
 }
 
 /// An endpoint channel for communicating with a single gRPC endpoint, with load reporting support for load balancing.
-pub(crate) struct EndpointChannel<S> {
+pub struct EndpointChannel<S> {
     inner: S,
     in_flight: Arc<AtomicU64>,
 }
@@ -124,11 +123,19 @@ pub(crate) struct EndpointChannel<S> {
 impl<S> EndpointChannel<S> {
     /// Creates a new `EndpointChannel`.
     /// This should be used by xDS implementations to construct channels to individual endpoints.
-    pub(crate) fn new(inner: S) -> Self {
+    pub fn new(inner: S) -> Self {
         Self {
             inner,
             in_flight: Arc::new(AtomicU64::new(0)),
         }
+    }
+}
+
+impl<S> std::fmt::Debug for EndpointChannel<S> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("EndpointChannel")
+            .field("in_flight", &self.in_flight.load(Ordering::Relaxed))
+            .finish_non_exhaustive()
     }
 }
 
@@ -183,7 +190,7 @@ impl<S> Load for EndpointChannel<S> {
 /// at construction time. The implementation handles retries and concurrency
 /// internally — the returned future resolves when a connection is established
 /// (or is cancelled by dropping).
-pub(crate) trait Connector {
+pub trait Connector {
     /// The service type produced by this connector.
     type Service;
 
@@ -202,8 +209,7 @@ pub(crate) trait Connector {
 /// Both `Service` and `Connector` are exposed as associated types so callers
 /// can reference `MC::Service` directly without chaining through
 /// `<MC::Connector as Connector>::Service`.
-#[allow(dead_code)]
-pub(crate) trait MakeConnector: Send + Sync + 'static {
+pub trait MakeConnector: Send + Sync + 'static {
     /// The service type produced by the connector.
     type Service;
     /// The connector type produced for each cluster.

--- a/tonic-xds/src/common/async_util.rs
+++ b/tonic-xds/src/common/async_util.rs
@@ -27,7 +27,13 @@
 use std::future::Future;
 use std::pin::Pin;
 
-pub(crate) type BoxFuture<T> = Pin<Box<dyn Future<Output = T> + Send + 'static>>;
+/// A pinned, boxed, `Send` future.
+///
+/// This is the boxed future type surfaced by the public transport (connector)
+/// and load-balancing service interfaces (e.g. [`Connector::connect`]).
+///
+/// [`Connector::connect`]: crate::Connector::connect
+pub type BoxFuture<T> = Pin<Box<dyn Future<Output = T> + Send + 'static>>;
 
 /// A [`tokio::task::JoinHandle`] wrapper that aborts the task when dropped.
 pub(crate) struct AbortOnDrop(pub(crate) tokio::task::JoinHandle<()>);

--- a/tonic-xds/src/lib.rs
+++ b/tonic-xds/src/lib.rs
@@ -171,7 +171,9 @@ pub(crate) mod xds;
 pub use client::channel::{
     BuildError, XdsChannel, XdsChannelBuilder, XdsChannelConfig, XdsChannelGrpc,
 };
+pub use client::endpoint::{Connector, EndpointAddress, EndpointChannel, MakeConnector};
 pub use client::route::PreRouteInterceptor;
+pub use common::async_util::BoxFuture;
 pub use xds::bootstrap::{BootstrapConfig, BootstrapError};
 pub use xds::resource::route_config::{RouteConfigMetadata, TypedMetadata};
 pub use xds::uri::{XdsUri, XdsUriError};


### PR DESCRIPTION
## Summary

Makes the `tonic-xds` **transport (connector) seam** and endpoint types public and re-exports them from the crate root.

This is part of the work to make the underlying transport of tonic-xds channel to be pluggable, allowing for custom transport connector use cases.

## Testing

Toolchain builds/tests run with default and `tls-ring` features under `-D warnings`:

- `cargo build -p tonic-xds` (default and `--features tls-ring,testutil`) — clean, no warnings
- `cargo test -p tonic-xds --features tls-ring,testutil` — 377 passed, 0 failed (+ 4 doctests)
- `cargo doc -p tonic-xds --no-deps` (default and `--features tls-ring`, `RUSTDOCFLAGS=-D warnings`) — clean
- `cargo clippy -p tonic-xds` — no new warnings in the changed files