### PR TITLE
Add license boilerplate to new xds files.

### DIFF
--- a/tonic-xds/src/client/xds_e2e.rs
+++ b/tonic-xds/src/client/xds_e2e.rs
@@ -1,3 +1,26 @@
+/*
+ *
+ * Copyright 2025 gRPC authors.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to
+ * deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ *
+ */
 //! End-to-end tests: a real xDS channel resolving through a fake ADS control
 //! plane to live gRPC backends.
 //!
@@ -9,14 +32,24 @@
 mod test {
     use std::collections::HashMap;
     use std::net::SocketAddr;
-    use xds_test_util::{RunningControlPlane, XdsTestControlPlaneService, config};
 
-    use crate::testutil::grpc::{GreeterClient, HelloRequest, spawn_greeter_server};
-    use crate::{BootstrapConfig, XdsChannelBuilder, XdsChannelConfig, XdsChannelGrpc, XdsUri};
     use tokio::time::Duration;
+    use xds_test_util::RunningControlPlane;
+    use xds_test_util::XdsTestControlPlaneService;
+    use xds_test_util::config;
 
-    /// Starts the fake ADS control plane on an ephemeral port. Returns the running
-    /// control plane (which injects config and shuts down on drop) and its address.
+    use crate::BootstrapConfig;
+    use crate::XdsChannelBuilder;
+    use crate::XdsChannelConfig;
+    use crate::XdsChannelGrpc;
+    use crate::XdsUri;
+    use crate::testutil::grpc::GreeterClient;
+    use crate::testutil::grpc::HelloRequest;
+    use crate::testutil::grpc::spawn_greeter_server;
+
+    /// Starts the fake ADS control plane on an ephemeral port. Returns the
+    /// running control plane (which injects config and shuts down on drop)
+    /// and its address.
     async fn start_control_plane() -> (RunningControlPlane, SocketAddr) {
         let running = XdsTestControlPlaneService::new()
             .start()
@@ -40,8 +73,8 @@ mod test {
     }
 
     /// Sends `say_hello` in a loop until a reply starting with `want_prefix` is
-    /// observed (xDS resolution and config updates are asynchronous), returning that
-    /// reply. Panics if it never arrives.
+    /// observed (xDS resolution and config updates are asynchronous), returning
+    /// that reply. Panics if it never arrives.
     async fn say_hello_until_prefix(
         client: &mut GreeterClient<XdsChannelGrpc>,
         want_prefix: &str,
@@ -69,7 +102,8 @@ mod test {
         panic!("never observed reply starting with {want_prefix:?}; last seen: {last:?}");
     }
 
-    /// End-to-end test: verifies that an xDS channel routes traffic to the correct backend.
+    /// End-to-end test: verifies that an xDS channel routes traffic to the
+    /// correct backend.
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn xds_channel_e2e_routes_to_backend() {
         let backend = spawn_greeter_server("backend", None, None)
@@ -119,9 +153,9 @@ mod test {
     }
 
     /// The client is initially routing to
-    /// one cluster, update the RDS route to point at a different cluster and assert
-    /// traffic shifts to the new backend — exercising the control plane pushing a
-    /// live update to a connected client.
+    /// one cluster, update the RDS route to point at a different cluster and
+    /// assert traffic shifts to the new backend — exercising the control
+    /// plane pushing a live update to a connected client.
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn xds_channel_e2e_route_update_shifts_traffic() {
         let backend_a = spawn_greeter_server("backend-a", None, None)
@@ -201,9 +235,9 @@ mod test {
     }
 
     /// P2C load balancing: with several EDS endpoints behind one cluster, traffic
-    /// should spread across all of them. tonic-xds uses power-of-two-choices as its
-    /// balancer (see the unit-level `test_xds_channel_grpc_with_p2c_lb`); this is the
-    /// full-pipeline version through the control plane.
+    /// should spread across all of them. tonic-xds uses power-of-two-choices as
+    /// its balancer (see the unit-level `test_xds_channel_grpc_with_p2c_lb`);
+    /// this is the full-pipeline version through the control plane.
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn xds_channel_e2e_p2c_spreads_across_backends() {
         const NUM_BACKENDS: usize = 5;

--- a/xds-test-util/src/config.rs
+++ b/xds-test-util/src/config.rs
@@ -1,3 +1,26 @@
+/*
+ *
+ * Copyright 2025 gRPC authors.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to
+ * deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ *
+ */
 //! Helper functions for building xDS configuration resources for testing.
 
 use envoy_types::pb::envoy::config::cluster::v3::Cluster;

--- a/xds-test-util/src/control_plane.rs
+++ b/xds-test-util/src/control_plane.rs
@@ -1,22 +1,46 @@
+/*
+ *
+ * Copyright 2025 gRPC authors.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to
+ * deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ *
+ */
 //! `XdsTestControlPlaneService` is a fake xDS ADS control plane for gRPC tests.
 //!
 //! The xDS config resources are injected through
 //! [`set_xds_config`](XdsTestControlPlaneService::set_xds_config).
 //!
-//! The xDS config resources are served by ADS (Aggregated Discovery Service) protocol and
-//! State-of-the-world (SOTW): whenever any resource of a type changes, every subscriber to
-//! that type receives all of its subscribed resources of that type.
+//! The xDS config resources are served by ADS (Aggregated Discovery Service)
+//! protocol and State-of-the-world (SOTW): whenever any resource of a type
+//! changes, every subscriber to that type receives all of its subscribed
+//! resources of that type.
 
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
+use std::collections::HashSet;
 use std::net::SocketAddr;
+use std::sync::Arc;
+use std::sync::Mutex;
 use std::sync::atomic::AtomicU64;
-use std::sync::{Arc, Mutex};
 
-use crate::config::*;
-use envoy_types::pb::envoy::service::discovery::v3::{
-    DiscoveryRequest, DiscoveryResponse,
-    aggregated_discovery_service_server::AggregatedDiscoveryServiceServer,
-};
+use envoy_types::pb::envoy::service::discovery::v3::DiscoveryRequest;
+use envoy_types::pb::envoy::service::discovery::v3::DiscoveryResponse;
+use envoy_types::pb::envoy::service::discovery::v3::aggregated_discovery_service_server::AggregatedDiscoveryServiceServer;
 use envoy_types::pb::google::protobuf::Any;
 use strum::IntoEnumIterator;
 use tokio::net::TcpListener;
@@ -24,6 +48,8 @@ use tokio::sync::mpsc;
 use tokio::task::JoinHandle;
 use tokio_stream::wrappers::TcpListenerStream;
 use tonic::transport::Server;
+
+use crate::config::*;
 
 /// Sender half of a stream's outbound `DiscoveryResponse` channel.
 type ResponseSender = mpsc::UnboundedSender<DiscoveryResponse>;
@@ -47,7 +73,8 @@ struct Subscription {
 /// set") and increases monotonically, so each distinct resource state carries a
 /// distinct version.
 mod bundle {
-    use super::{Any, HashMap};
+    use super::Any;
+    use super::HashMap;
 
     /// A versioned snapshot of the resources for a single xDS type.
     #[derive(Debug, Default)]
@@ -141,8 +168,8 @@ impl Inner {
         };
 
         // Nonce check: if the request's nonce doesn't match the last response's nonce,
-        // the management server is allowed to ignore any further DiscoveryRequests for the previous version
-        // until a DiscoveryRequest bearing the nonce.
+        // the management server is allowed to ignore any further DiscoveryRequests for
+        // the previous version until a DiscoveryRequest bearing the nonce.
         // Ref: https://www.envoyproxy.io/docs/envoy/latest/api-v3/service/discovery/v3/discovery.proto#service-discovery-v3-discoveryresponse
         if !req.response_nonce.is_empty() {
             let matches = state
@@ -227,7 +254,8 @@ impl Inner {
     }
 }
 
-/// XdsTestControlPlaneService is a bidi-stream service that acts as a local xDS control plane for tests.
+/// XdsTestControlPlaneService is a bidi-stream service that acts as a local xDS
+/// control plane for tests.
 ///
 /// Clone freely: all clones share the same underlying state, so config injected
 /// through one clone is served by another. Inject config with
@@ -277,10 +305,12 @@ impl XdsTestControlPlaneService {
                     Any {
                         // Use the type_url from the message type instead of the AdsTypeUrl enum,
                         // so that the Any is tagged with the correct type for the message itself.
-                        // This is necessary because cached resource might be of a different type than
-                        // the AdsTypeUrl enum, e.g. the envoy.service.discovery.v3.Resource wrapper resource type.
-                        // Therefore, it's important to use the type_url from the message type to ensure that
-                        // clients can correctly decode the Any into the expected message type.
+                        // This is necessary because cached resource might be of a different type
+                        // than the AdsTypeUrl enum, e.g. the
+                        // envoy.service.discovery.v3.Resource wrapper resource type.
+                        // Therefore, it's important to use the type_url from the message type to
+                        // ensure that clients can correctly decode the Any
+                        // into the expected message type.
                         type_url: M::type_url(),
                         value: msg.encode_to_vec(),
                     },
@@ -290,8 +320,9 @@ impl XdsTestControlPlaneService {
         self.set_packed_xds_config(type_url, packed);
     }
 
-    /// Sets the full set of resources for `type_url`, replacing any previous resources of that type,
-    /// and pushes an update to every current subscriber.
+    /// Sets the full set of resources for `type_url`, replacing any previous
+    /// resources of that type, and pushes an update to every current
+    /// subscriber.
     fn set_packed_xds_config(&self, type_url: &AdsTypeUrl, packed: HashMap<String, Any>) {
         let mut state = self
             .inner
@@ -454,15 +485,21 @@ mod tonic_service {
     use std::pin::Pin;
     use std::sync::atomic::Ordering;
 
-    use envoy_types::pb::envoy::service::discovery::v3::{
-        DeltaDiscoveryRequest, DeltaDiscoveryResponse, DiscoveryRequest, DiscoveryResponse,
-        aggregated_discovery_service_server::AggregatedDiscoveryService,
-    };
+    use envoy_types::pb::envoy::service::discovery::v3::DeltaDiscoveryRequest;
+    use envoy_types::pb::envoy::service::discovery::v3::DeltaDiscoveryResponse;
+    use envoy_types::pb::envoy::service::discovery::v3::DiscoveryRequest;
+    use envoy_types::pb::envoy::service::discovery::v3::DiscoveryResponse;
+    use envoy_types::pb::envoy::service::discovery::v3::aggregated_discovery_service_server::AggregatedDiscoveryService;
+    use tokio_stream::Stream;
+    use tokio_stream::StreamExt;
     use tokio_stream::wrappers::UnboundedReceiverStream;
-    use tokio_stream::{Stream, StreamExt};
-    use tonic::{Request, Response, Status};
+    use tonic::Request;
+    use tonic::Response;
+    use tonic::Status;
 
-    use super::{Arc, XdsTestControlPlaneService, mpsc};
+    use super::Arc;
+    use super::XdsTestControlPlaneService;
+    use super::mpsc;
 
     #[tonic::async_trait]
     impl AggregatedDiscoveryService for XdsTestControlPlaneService {
@@ -533,8 +570,9 @@ fn build_response(
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use envoy_types::pb::envoy::config::listener::v3::Listener;
+
+    use super::*;
 
     #[test]
     fn set_and_get_config() {

--- a/xds-test-util/src/lib.rs
+++ b/xds-test-util/src/lib.rs
@@ -1,3 +1,26 @@
+/*
+ *
+ * Copyright 2025 gRPC authors.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to
+ * deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ *
+ */
 //! Test utilities for xDS implementations.
 //!
 //! This crate provides helpers for exercising xDS clients against an in-process
@@ -17,4 +40,5 @@
 pub mod config;
 mod control_plane;
 
-pub use control_plane::{RunningControlPlane, XdsTestControlPlaneService};
+pub use control_plane::RunningControlPlane;
+pub use control_plane::XdsTestControlPlaneService;


### PR DESCRIPTION
## Motivation

[PR #2748](https://github.com/grpc/grpc-rust/pull/2748) will implement a license check that these files will currently fail. 

## Solution

Adding boilerplate notices for the licenses. Some automated formatting of comments and imports happened from this as well. 