### PR TITLE
feat(tonic-xds): make cluster discovery generic over the connector factory

### DIFF
--- a/tonic-xds/src/client/channel.rs
+++ b/tonic-xds/src/client/channel.rs
@@ -30,7 +30,7 @@ use crate::xds::bootstrap::{BootstrapConfig, BootstrapError};
 use crate::xds::cache::XdsCache;
 #[cfg(feature = "_tls-any")]
 use crate::xds::cert_provider::{CertProviderError, CertProviderRegistry, CertificateProvider};
-use crate::xds::cluster_discovery::XdsClusterDiscovery;
+use crate::xds::cluster_discovery::{GrpcMakeConnector, XdsClusterDiscovery};
 use crate::xds::resource_manager::XdsResourceManager;
 use crate::xds::routing::XdsRouter;
 use crate::{TonicCallCredentials, XdsUri};
@@ -370,11 +370,14 @@ impl XdsChannelBuilder {
         #[cfg(feature = "_tls-any")]
         let discovery: Arc<
             dyn ClusterDiscovery<EndpointAddress, EndpointChannel<Channel>>,
-        > = Arc::new(XdsClusterDiscovery::new(cache, cert_provider_registry));
+        > = Arc::new(XdsClusterDiscovery::new(
+            cache,
+            GrpcMakeConnector::new(cert_provider_registry),
+        ));
         #[cfg(not(feature = "_tls-any"))]
         let discovery: Arc<
             dyn ClusterDiscovery<EndpointAddress, EndpointChannel<Channel>>,
-        > = Arc::new(XdsClusterDiscovery::new(cache));
+        > = Arc::new(XdsClusterDiscovery::new(cache, GrpcMakeConnector::new()));
         let retry_policy = GrpcRetryPolicy::default();
 
         let resources = Arc::new(XdsChannelResources {
@@ -760,7 +763,7 @@ mod tests {
     /// Builds an XdsChannelGrpc using real XdsRouter and XdsClusterDiscovery
     /// backed by the given cache.
     async fn build_xds_channel_from_cache(cache: Arc<XdsCache>) -> XdsChannelGrpc {
-        use crate::xds::cluster_discovery::XdsClusterDiscovery;
+        use crate::xds::cluster_discovery::{GrpcMakeConnector, XdsClusterDiscovery};
         use crate::xds::routing::XdsRouter;
 
         let router: Arc<dyn Router> = Arc::new(XdsRouter::new(&cache));
@@ -774,12 +777,15 @@ mod tests {
                 CertProviderRegistry::from_bootstrap(&Default::default(), Default::default())
                     .unwrap(),
             );
-            Arc::new(XdsClusterDiscovery::new(cache, registry))
+            Arc::new(XdsClusterDiscovery::new(
+                cache,
+                GrpcMakeConnector::new(registry),
+            ))
         };
         #[cfg(not(feature = "_tls-any"))]
         let discovery: Arc<
             dyn ClusterDiscovery<EndpointAddress, EndpointChannel<Channel>>,
-        > = Arc::new(XdsClusterDiscovery::new(cache));
+        > = Arc::new(XdsClusterDiscovery::new(cache, GrpcMakeConnector::new()));
 
         let builder = XdsChannelBuilder::new(test_config());
         builder.build_grpc_channel_from_parts(router, discovery, GrpcRetryPolicy::default(), None)

--- a/tonic-xds/src/client/endpoint.rs
+++ b/tonic-xds/src/client/endpoint.rs
@@ -23,10 +23,12 @@
  */
 
 use crate::common::async_util::BoxFuture;
+use crate::xds::resource::cluster::ClusterResource;
+use crate::xds::resource::security::ClusterSecurityConfig;
 use std::net::SocketAddr;
 use std::sync::{Arc, atomic::AtomicU64, atomic::Ordering};
 use std::task::{Context, Poll};
-use tower::{Service, load::Load};
+use tower::{BoxError, Service, load::Load};
 
 /// Represents the host part of an endpoint address
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
@@ -201,20 +203,65 @@ pub trait Connector {
     ) -> crate::common::async_util::BoxFuture<Self::Service>;
 }
 
+/// A read-only view of a cluster's parsed xDS configuration, handed to
+/// [`MakeConnector::make_connector`] so a factory can build a connector
+/// tailored to the cluster.
+///
+/// The view is intentionally opaque: it currently exposes only the cluster
+/// name. Read access to the parsed TLS/security settings a custom connector
+/// needs for gRFC A29 parity is exposed separately (and is not required to
+/// build a plaintext connector).
+pub struct ClusterConfig<'a> {
+    name: &'a str,
+    /// Parsed TLS config for the cluster (`None` = plaintext). Crate-internal
+    /// for now; consumed by the built-in gRPC connector factory.
+    pub(crate) security: Option<&'a ClusterSecurityConfig>,
+}
+
+impl<'a> ClusterConfig<'a> {
+    /// Builds a view over a validated [`ClusterResource`].
+    pub(crate) fn from_resource(cluster: &'a ClusterResource) -> Self {
+        Self {
+            name: &cluster.name,
+            security: cluster.security.as_ref(),
+        }
+    }
+
+    /// The cluster name.
+    pub fn name(&self) -> &str {
+        self.name
+    }
+}
+
+impl std::fmt::Debug for ClusterConfig<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ClusterConfig")
+            .field("name", &self.name)
+            .finish_non_exhaustive()
+    }
+}
+
 /// Factory for creating per-cluster [`Connector`]s.
 ///
-/// The implementation can use the cluster name to look up cluster-specific
-/// config (e.g., TLS settings from xDS CDS, cert providers from A29).
+/// Given a [`ClusterConfig`] view, the implementation builds a [`Connector`]
+/// tailored to that cluster (e.g. selecting TLS vs plaintext and wiring the
+/// gRFC A29 cert providers). Returning an `Err` rejects the current cluster
+/// update; the caller keeps the previously built connector.
 ///
-/// Both `Service` and `Connector` are exposed as associated types so callers
-/// can reference `MC::Service` directly without chaining through
-/// `<MC::Connector as Connector>::Service`.
+/// The connector is returned type-erased as `Arc<dyn Connector>` so an
+/// implementation can keep its concrete connector type(s) private and hand
+/// back different connectors for different clusters without wrapping them in
+/// a single enum.
 pub trait MakeConnector: Send + Sync + 'static {
-    /// The service type produced by the connector.
-    type Service;
-    /// The connector type produced for each cluster.
-    type Connector: Connector<Service = Self::Service>;
+    /// The service type produced by the connectors.
+    ///
+    /// Must be `Send + 'static` because discovery drives it from a spawned
+    /// task and streams endpoint changes carrying it across threads.
+    type Service: Send + 'static;
 
-    /// Create a connector for the given cluster.
-    fn make_connector(&self, cluster_name: &str) -> std::sync::Arc<Self::Connector>;
+    /// Build a connector for the given cluster.
+    fn make_connector(
+        &self,
+        cluster: ClusterConfig<'_>,
+    ) -> Result<Arc<dyn Connector<Service = Self::Service> + Send + Sync>, BoxError>;
 }

--- a/tonic-xds/src/lib.rs
+++ b/tonic-xds/src/lib.rs
@@ -171,7 +171,9 @@ pub(crate) mod xds;
 pub use client::channel::{
     BuildError, XdsChannel, XdsChannelBuilder, XdsChannelConfig, XdsChannelGrpc,
 };
-pub use client::endpoint::{Connector, EndpointAddress, EndpointChannel, MakeConnector};
+pub use client::endpoint::{
+    ClusterConfig, Connector, EndpointAddress, EndpointChannel, MakeConnector,
+};
 pub use client::route::PreRouteInterceptor;
 pub use common::async_util::BoxFuture;
 pub use xds::bootstrap::{BootstrapConfig, BootstrapError};

--- a/tonic-xds/src/xds/cluster_discovery.rs
+++ b/tonic-xds/src/xds/cluster_discovery.rs
@@ -45,8 +45,11 @@ use tokio::sync::mpsc;
 use tokio_stream::StreamExt as _;
 use tokio_stream::wrappers::ReceiverStream;
 use tonic::transport::{Channel, Endpoint};
+use tower::BoxError;
 
-use crate::client::endpoint::{Connector, EndpointAddress, EndpointChannel};
+use crate::client::endpoint::{
+    ClusterConfig, Connector, EndpointAddress, EndpointChannel, MakeConnector,
+};
 use crate::client::lb::{BoxDiscover, ClusterDiscovery};
 use crate::common::async_util::BoxFuture;
 use crate::xds::cache::XdsCache;
@@ -55,8 +58,6 @@ use crate::xds::cert_provider::verifier::XdsServerCertVerifier;
 #[cfg(feature = "_tls-any")]
 use crate::xds::cert_provider::{CertProviderRegistry, CertificateProvider};
 use crate::xds::endpoint_manager::{ConnectorSwap, EndpointManager};
-use crate::xds::resource::ClusterResource;
-#[cfg(feature = "_tls-any")]
 use crate::xds::resource::security::ClusterSecurityConfig;
 
 /// Buffer capacity for the discovery channel between the spawned task and
@@ -90,58 +91,43 @@ fn with_liveness_settings(endpoint: Endpoint) -> Endpoint {
         .keep_alive_while_idle(true)
 }
 
-/// xDS-backed cluster discovery.
+/// xDS-backed cluster discovery, generic over the connector factory `MC`.
 ///
 /// Resolves cluster names into endpoint change streams by watching the
-/// [`XdsCache`]. Builds per-cluster [`Connector`]s based on the cluster's
-/// [`ClusterSecurityConfig`] (if any) and the bootstrap-built
-/// [`CertProviderRegistry`].
-pub(crate) struct XdsClusterDiscovery {
+/// [`XdsCache`]. On each CDS update it asks `MC` to build a [`Connector`] for
+/// the cluster. The default [`GrpcMakeConnector`] produces gRPC (plaintext or
+/// TLS) connectors from the cluster's [`ClusterSecurityConfig`] (if any) and
+/// the bootstrap-built [`CertProviderRegistry`].
+pub(crate) struct XdsClusterDiscovery<MC = GrpcMakeConnector> {
     cache: Arc<XdsCache>,
-    #[cfg(feature = "_tls-any")]
-    cert_provider_registry: Arc<CertProviderRegistry>,
+    make_connector: Arc<MC>,
 }
 
-impl XdsClusterDiscovery {
-    #[cfg(feature = "_tls-any")]
-    pub(crate) fn new(cache: Arc<XdsCache>, registry: Arc<CertProviderRegistry>) -> Self {
+impl<MC> XdsClusterDiscovery<MC> {
+    pub(crate) fn new(cache: Arc<XdsCache>, make_connector: MC) -> Self {
         Self {
             cache,
-            cert_provider_registry: registry,
+            make_connector: Arc::new(make_connector),
         }
-    }
-
-    #[cfg(not(feature = "_tls-any"))]
-    pub(crate) fn new(cache: Arc<XdsCache>) -> Self {
-        Self { cache }
     }
 }
 
-impl ClusterDiscovery<EndpointAddress, EndpointChannel<Channel>> for XdsClusterDiscovery {
-    fn discover_cluster(
-        &self,
-        cluster_name: &str,
-    ) -> BoxDiscover<EndpointAddress, EndpointChannel<Channel>> {
+impl<MC: MakeConnector> ClusterDiscovery<EndpointAddress, MC::Service> for XdsClusterDiscovery<MC> {
+    fn discover_cluster(&self, cluster_name: &str) -> BoxDiscover<EndpointAddress, MC::Service> {
         let cache = self.cache.clone();
         let cluster_name = cluster_name.to_string();
-        #[cfg(feature = "_tls-any")]
-        let registry = self.cert_provider_registry.clone();
+        let make_connector = self.make_connector.clone();
 
         let (tx, rx) = mpsc::channel(DISCOVER_CHANNEL_CAPACITY);
 
         tokio::spawn(async move {
             let mut cluster_watch = cache.watch_cluster(&cluster_name);
 
-            let connector_swap: ConnectorSwap<EndpointChannel<Channel>> = loop {
+            let connector_swap: ConnectorSwap<MC::Service> = loop {
                 let Some(cluster) = cluster_watch.next().await else {
                     return;
                 };
-                let result = build_connector(
-                    &cluster,
-                    #[cfg(feature = "_tls-any")]
-                    &registry,
-                );
-                match result {
+                match make_connector.make_connector(ClusterConfig::from_resource(&cluster)) {
                     Ok(c) => break Arc::new(ArcSwap::from_pointee(c)),
                     Err(e) => tracing::warn!(
                         cluster = %cluster_name,
@@ -162,12 +148,7 @@ impl ClusterDiscovery<EndpointAddress, EndpointChannel<Channel>> for XdsClusterD
                         }
                     }
                     Some(cluster) = cluster_watch.next() => {
-                        let result = build_connector(
-                            &cluster,
-                            #[cfg(feature = "_tls-any")]
-                            &registry,
-                        );
-                        match result {
+                        match make_connector.make_connector(ClusterConfig::from_resource(&cluster)) {
                             Ok(new) => connector_swap.store(Arc::new(new)),
                             Err(e) => tracing::warn!(
                                 cluster = %cluster_name,
@@ -185,17 +166,55 @@ impl ClusterDiscovery<EndpointAddress, EndpointChannel<Channel>> for XdsClusterD
     }
 }
 
-/// Build a [`Connector`] for the given cluster.
+/// The default gRPC [`MakeConnector`].
 ///
-/// - `cluster.security == None` → [`PlaintextConnector`].
-/// - `cluster.security == Some(_)` under a TLS feature → [`TlsConnector`].
-/// - `cluster.security == Some(_)` without a TLS feature → error.
+/// Builds a plaintext or (under a TLS feature) TLS connector from a cluster's
+/// parsed CDS [`ClusterSecurityConfig`], resolving cert-provider instances
+/// against the bootstrap-built [`CertProviderRegistry`].
+pub(crate) struct GrpcMakeConnector {
+    #[cfg(feature = "_tls-any")]
+    registry: Arc<CertProviderRegistry>,
+}
+
+impl GrpcMakeConnector {
+    #[cfg(feature = "_tls-any")]
+    pub(crate) fn new(registry: Arc<CertProviderRegistry>) -> Self {
+        Self { registry }
+    }
+
+    #[cfg(not(feature = "_tls-any"))]
+    pub(crate) fn new() -> Self {
+        Self {}
+    }
+}
+
+impl MakeConnector for GrpcMakeConnector {
+    type Service = EndpointChannel<Channel>;
+
+    fn make_connector(
+        &self,
+        cluster: ClusterConfig<'_>,
+    ) -> Result<Arc<dyn Connector<Service = Self::Service> + Send + Sync>, BoxError> {
+        build_connector(
+            cluster.security,
+            #[cfg(feature = "_tls-any")]
+            &self.registry,
+        )
+        .map_err(Into::into)
+    }
+}
+
+/// Build a [`Connector`] for the given cluster's parsed security config.
+///
+/// - `security == None` → [`PlaintextConnector`].
+/// - `security == Some(_)` under a TLS feature → [`TlsConnector`].
+/// - `security == Some(_)` without a TLS feature → error.
 fn build_connector(
-    cluster: &ClusterResource,
+    security: Option<&ClusterSecurityConfig>,
     #[cfg(feature = "_tls-any")] registry: &CertProviderRegistry,
 ) -> Result<Arc<dyn Connector<Service = EndpointChannel<Channel>> + Send + Sync>, ConnectorBuildError>
 {
-    match &cluster.security {
+    match security {
         None => Ok(Arc::new(PlaintextConnector)),
         #[cfg(feature = "_tls-any")]
         Some(sec) => Ok(Arc::new(TlsConnector::new(registry, sec)?)),
@@ -204,7 +223,8 @@ fn build_connector(
     }
 }
 
-/// Errors building a per-cluster [`Connector`] from a [`ClusterResource`].
+/// Errors building a per-cluster gRPC [`Connector`] from a cluster's parsed
+/// security config.
 #[derive(Debug, thiserror::Error)]
 pub(crate) enum ConnectorBuildError {
     /// TLS connector build failed (unknown provider instance, etc.).
@@ -388,14 +408,27 @@ mod tests {
     #[cfg(feature = "_tls-any")]
     #[test]
     fn build_connector_plaintext_tls_feature_on() {
-        assert!(build_connector(&plaintext_cluster(), &empty_registry()).is_ok());
+        assert!(build_connector(plaintext_cluster().security.as_ref(), &empty_registry()).is_ok());
     }
 
     /// Plaintext dispatch without any TLS feature.
     #[cfg(not(feature = "_tls-any"))]
     #[test]
     fn build_connector_plaintext_no_tls() {
-        assert!(build_connector(&plaintext_cluster()).is_ok());
+        assert!(build_connector(plaintext_cluster().security.as_ref()).is_ok());
+    }
+
+    /// The default `GrpcMakeConnector` builds a connector from a `ClusterConfig`
+    /// view; a cluster with no security config yields a plaintext connector.
+    #[cfg(feature = "_tls-any")]
+    #[test]
+    fn grpc_make_connector_plaintext() {
+        let make = GrpcMakeConnector::new(Arc::new(empty_registry()));
+        let cluster = plaintext_cluster();
+        assert!(
+            make.make_connector(ClusterConfig::from_resource(&cluster))
+                .is_ok()
+        );
     }
 
     /// Cluster with TLS pointing at an instance not in the registry surfaces
@@ -403,15 +436,12 @@ mod tests {
     #[cfg(feature = "_tls-any")]
     #[test]
     fn build_connector_tls_unknown_ca() {
-        use crate::xds::resource::security::ClusterSecurityConfig;
-
-        let mut cluster = plaintext_cluster();
-        cluster.security = Some(ClusterSecurityConfig {
+        let security = ClusterSecurityConfig {
             ca_instance_name: "missing-ca".into(),
             identity_instance_name: None,
             san_matchers: vec![],
-        });
-        let Err(err) = build_connector(&cluster, &empty_registry()) else {
+        };
+        let Err(err) = build_connector(Some(&security), &empty_registry()) else {
             panic!("expected UnknownCaInstance error");
         };
         assert!(matches!(


### PR DESCRIPTION
## Motivation

Continues making the `tonic-xds` transport pluggable. Today `XdsClusterDiscovery` is hard-wired to the built-in gRPC connector. This makes it generic over a `MakeConnector` factory so a consumer can supply its own transport connector (e.g. an environment-specific TLS/identity story) without touching the discovery machinery.

The default type parameter preserves the current gRPC plaintext/TLS behavior exactly, so this is **additive and non-breaking**.

## Public surface (kept minimal, per the earlier connector-API review)

- Change the (previously unused) `MakeConnector` trait to take a per-cluster `ClusterConfig` view and return a **type-erased** `Result<Arc<dyn Connector<Service = Self::Service> + Send + Sync>, BoxError>`, matching the fallible, rebuilt-per-CDS-update behavior of the built-in gRPC factory. Returning `dyn Connector` (rather than an associated connector type) means an implementor can keep its concrete connector type(s) private and hand back different connectors per cluster without a wrapper enum. `Service` is bound `Send + 'static` (required by the discovery task and the endpoint-change stream).
- Add an opaque `ClusterConfig<'_>` view that currently exposes only `name()`. Read access to the parsed security settings is deferred to a later change.

## Internals (all `pub(crate)`)

- Add `GrpcMakeConnector` (the default factory); refactor `build_connector` to take the parsed security config and return `Arc<dyn Connector>`.
- `XdsClusterDiscovery` and `GrpcMakeConnector` stay `pub(crate)`; only `MakeConnector` (changed) and `ClusterConfig` (new) are public.

## Validation

- `cargo build` under default and `tls-ring,testutil`, with `-D warnings`.
- `cargo test` (`tls-ring,testutil`): all lib + doctests pass.
- `cargo doc --no-deps` under default and `tls-ring`, with `-D warnings`.
- `cargo check-external-types --all-features`: clean (no allowlist change; `BoxError` was already allowed and `ClusterConfig` is crate-owned).
